### PR TITLE
Complete JS SDK MVP publishing baseline

### DIFF
--- a/.github/workflows/publish-js-sdk.yml
+++ b/.github/workflows/publish-js-sdk.yml
@@ -20,7 +20,6 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: js
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}
@@ -35,7 +34,7 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
-          cache-dependency-path: js/package-lock.json
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci
@@ -59,7 +58,7 @@ jobs:
           package_version="$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")"
           tag_version="${GITHUB_REF_NAME#js-sdk-v}"
           if [[ "$tag_version" != "$package_version" ]]; then
-            echo "Tag version ($tag_version) does not match js/package.json version ($package_version)."
+            echo "Tag version ($tag_version) does not match package.json version ($package_version)."
             exit 1
           fi
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,7 +3,7 @@ name: Release Please
 on:
   push:
     branches:
-      - main
+      - trunk
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -50,7 +50,12 @@ The root entrypoint (`@honua/sdk-js`) remains available as an aggregate export f
 ## Install
 
 ```bash
-cd sdk/js
+npm install @honua/sdk-js
+```
+
+## Local development
+
+```bash
 npm install
 ```
 

--- a/scripts/prepare-split-packages.mjs
+++ b/scripts/prepare-split-packages.mjs
@@ -42,10 +42,12 @@ function createSdkPackage() {
   copyDirectory(path.join(DIST_SRC_ROOT, "core"), path.join(packageRoot, "core"));
   copyDirectory(path.join(DIST_SRC_ROOT, "esri-compat"), path.join(packageRoot, "esri-compat"));
   copyDirectory(path.join(DIST_SRC_ROOT, "expr"), path.join(packageRoot, "expr"));
+  copyDirectory(path.join(DIST_SRC_ROOT, "geocoding"), path.join(packageRoot, "geocoding"));
   copyDirectory(path.join(DIST_SRC_ROOT, "gen"), path.join(packageRoot, "gen"));
   copyDirectory(path.join(DIST_SRC_ROOT, "interactions"), path.join(packageRoot, "interactions"));
   copyDirectory(path.join(DIST_SRC_ROOT, "map"), path.join(packageRoot, "map"));
   copyDirectory(path.join(DIST_SRC_ROOT, "style"), path.join(packageRoot, "style"));
+  copyDirectory(path.join(DIST_SRC_ROOT, "webmap"), path.join(packageRoot, "webmap"));
   copyFile(path.join(DIST_SRC_ROOT, "honua.js"), path.join(packageRoot, "index.js"));
   copyFile(path.join(DIST_SRC_ROOT, "honua.d.ts"), path.join(packageRoot, "index.d.ts"));
 
@@ -74,6 +76,10 @@ function createSdkPackage() {
       "./style": {
         types: "./style/index.d.ts",
         default: "./style/index.js",
+      },
+      "./webmap": {
+        types: "./webmap/index.d.ts",
+        default: "./webmap/index.js",
       },
     },
     dependencies: {
@@ -140,6 +146,7 @@ function createMigrationPackage() {
   fs.mkdirSync(packageRoot, { recursive: true });
 
   copyDirectory(path.join(DIST_SRC_ROOT, "migration"), path.join(packageRoot, "migration"));
+  copyDirectory(path.join(DIST_SRC_ROOT, "webmap"), path.join(packageRoot, "webmap"));
   copyFile(path.join(DIST_SRC_ROOT, "migration-entry.js"), path.join(packageRoot, "index.js"));
   copyFile(path.join(DIST_SRC_ROOT, "migration-entry.d.ts"), path.join(packageRoot, "index.d.ts"));
   fs.chmodSync(path.join(packageRoot, "migration", "cli.js"), 0o755);


### PR DESCRIPTION
## Summary
- align the npm publish workflow with the split-repo layout
- fix split-package generation so published artifacts include all exported subpaths
- update README install guidance for package consumers

## Validation
- npm run verify:split-packages

Closes #1