### PR TITLE
feat: add JS compatibility baseline (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,53 @@ npm install @honua/sdk-js
 import { HonuaClient } from "@honua/sdk-js/honua";
 
 const client = new HonuaClient({ baseUrl: "https://your-honua-server.com" });
+const compatibility = await client.checkCompatibility();
+
+if (!compatibility.supported) {
+  throw new Error(
+    `Unsupported Honua server. Minimum supported version: ${HonuaClient.minimumSupportedServerVersion}. ` +
+      `Reasons: ${compatibility.reasons.join("; ")}`,
+  );
+}
+
 const result = await client.queryFeatures({ serviceId: "parcels", layerId: 0 });
 console.log(result.features); // fully typed HonuaFeature[]
 ```
+
+## Server Compatibility Baseline
+
+Use the server compatibility contract before enabling admin/control-plane flows:
+
+```ts
+import { HonuaClient } from "@honua/sdk-js/honua";
+
+const client = new HonuaClient({ baseUrl: "https://your-honua-server.com" });
+
+const status = await client.checkCompatibility();
+if (!status.supported) {
+  throw new Error(
+    `Server ${status.compatibility?.serverVersion ?? "unknown"} is unsupported. ` +
+      `Minimum: ${HonuaClient.minimumSupportedServerVersion}. ` +
+      `Reasons: ${status.reasons.join("; ")}`,
+  );
+}
+
+if (await client.supportsFeature("manifestApply")) {
+  console.log("Manifest apply workflows are available on this server.");
+}
+
+const rawContract = await client.getCompatibility();
+console.log(rawContract.metadataSchemas);
+```
+
+`checkCompatibility()` reports support status, `supportsFeature()` gates coarse capabilities from
+`data.compatibility.features`, and `getCompatibility()` returns the raw server contract from
+`GET /api/v1/admin/capabilities`.
+
+This SDK baseline currently expects:
+- server version `>= 1.0.0`
+- control-plane API major `v1` on `/api/v1/admin`
+- server release channel `preview` or newer
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -35,6 +35,18 @@ const client = new HonuaClient({
   baseUrl: "https://demo.honua.io",
 });
 
+const compatibility = await client.checkCompatibility();
+if (!compatibility.supported) {
+  throw new Error(
+    `Unsupported Honua server. Minimum supported version: ${HonuaClient.minimumSupportedServerVersion}. ` +
+      `Reasons: ${compatibility.reasons.join("; ")}`,
+  );
+}
+
+if (await client.supportsFeature("manifestApply")) {
+  console.log("Manifest workflows are available on this server.");
+}
+
 // Query the first 100 active features with geometry
 const result = await client.queryFeatures({
   serviceId: "natural-earth",
@@ -57,6 +69,11 @@ node index.mjs
 
 You should see feature objects with `attributes` and `geometry` properties
 logged to the console.
+
+The compatibility check uses `GET /api/v1/admin/capabilities` once, reports whether the
+server is inside the SDK baseline (`>= 1.0.0`, control-plane `v1`, release channel
+`preview` or newer), and lets you branch on coarse features without probing multiple
+endpoints.
 
 ## Step 3: Add MapLibre map (90 seconds)
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -6,7 +6,9 @@ import { HonuaFeatureLayer, HonuaMapLayer, HonuaMapService, HonuaOgcFeatures, Ho
 import type {
   ApplyEditsRequest,
   ExportMapRequest,
+  HonuaApiEnvelope,
   HonuaApplyEditsResponse,
+  HonuaCompatibilityRequest,
   HonuaClientOptions,
   HonuaErrorContext,
   HonuaExportMapResponse,
@@ -30,6 +32,10 @@ import type {
   HonuaRequestMutation,
   HonuaResponseContext,
   HonuaRetryOptions,
+  HonuaServerCapabilitiesResponse,
+  HonuaServerCompatibility,
+  HonuaServerCompatibilityFeature,
+  HonuaServerCompatibilityStatus,
   HonuaServiceMetadata,
   HonuaServicesResponse,
   HonuaTransport,
@@ -166,8 +172,16 @@ interface NormalizedRetryOptions {
 
 const DEFAULT_RETRY_STATUSES: ReadonlySet<number> = new Set([429, 502, 503, 504]);
 const DEFAULT_RETRY_METHODS: ReadonlySet<QueryMethod> = new Set(["GET", "PUT", "DELETE"]);
+const SUPPORTED_CONTROL_PLANE_API_MAJOR = 1;
+const SUPPORTED_CONTROL_PLANE_API_BASE_PATH = "/api/v1/admin";
+const MINIMUM_SUPPORTED_SERVER_RELEASE_CHANNEL = "preview";
+
+export const HONUA_MINIMUM_SUPPORTED_SERVER_VERSION = "1.0.0";
 
 export class HonuaClient {
+  public static readonly minimumSupportedServerVersion = HONUA_MINIMUM_SUPPORTED_SERVER_VERSION;
+  public static readonly minimumSupportedServerReleaseChannel = MINIMUM_SUPPORTED_SERVER_RELEASE_CHANNEL;
+
   private readonly baseUrl: string;
   private readonly fetchFn: typeof fetch;
   private readonly defaultHeaders: HeadersInit;
@@ -176,6 +190,7 @@ export class HonuaClient {
   private readonly retryOptions: NormalizedRetryOptions | undefined;
   private readonly preferBinary: boolean;
   private readonly transport: HonuaTransport;
+  private serverCompatibilityCache: HonuaServerCompatibility | undefined;
   private connectClient: Client<typeof FeatureService> | undefined;
 
   public constructor(options: HonuaClientOptions) {
@@ -288,6 +303,52 @@ export class HonuaClient {
   public async listServices(format: "json" | "pjson" = "json"): Promise<HonuaServicesResponse> {
     const query = new URLSearchParams({ f: format });
     return this.requestJson("GET", `/rest/services?${query.toString()}`) as Promise<HonuaServicesResponse>;
+  }
+
+  public async getCompatibility(options: HonuaCompatibilityRequest = {}): Promise<HonuaServerCompatibility> {
+    if (!options.refresh && this.serverCompatibilityCache) {
+      return this.serverCompatibilityCache;
+    }
+
+    const response = (await this.requestJson(
+      "GET",
+      "/api/v1/admin/capabilities",
+      undefined,
+      options.signal,
+    )) as HonuaApiEnvelope<HonuaServerCapabilitiesResponse>;
+
+    const compatibility = parseCompatibilityEnvelope(response);
+    this.serverCompatibilityCache = compatibility;
+    return compatibility;
+  }
+
+  public async checkCompatibility(
+    options: HonuaCompatibilityRequest = {},
+  ): Promise<HonuaServerCompatibilityStatus> {
+    try {
+      const compatibility = await this.getCompatibility(options);
+      const reasons = evaluateCompatibility(compatibility);
+      return {
+        supported: reasons.length === 0,
+        minimumSupportedServerVersion: HonuaClient.minimumSupportedServerVersion,
+        compatibility,
+        reasons,
+      };
+    } catch (error) {
+      return {
+        supported: false,
+        minimumSupportedServerVersion: HonuaClient.minimumSupportedServerVersion,
+        reasons: [describeCompatibilityError(error)],
+      };
+    }
+  }
+
+  public async supportsFeature(
+    feature: HonuaServerCompatibilityFeature,
+    options: HonuaCompatibilityRequest = {},
+  ): Promise<boolean> {
+    const compatibility = await this.getCompatibility(options);
+    return compatibility.features[feature];
   }
 
   public async request<T = unknown>(request: HonuaRawRequest): Promise<T> {
@@ -1136,6 +1197,283 @@ async function parseResponseBody(response: Response): Promise<unknown> {
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseCompatibilityEnvelope(payload: unknown): HonuaServerCompatibility {
+  if (!isObject(payload)) {
+    throw new TypeError("Server capabilities response must be a JSON object.");
+  }
+
+  if (payload.success === false) {
+    const message = typeof payload.message === "string" ? payload.message : "Server capabilities request failed.";
+    throw new Error(message);
+  }
+
+  if (!isObject(payload.data)) {
+    throw new TypeError("Server capabilities response is missing a data object.");
+  }
+
+  return parseCompatibilityContract(payload.data.compatibility);
+}
+
+function parseCompatibilityContract(payload: unknown): HonuaServerCompatibility {
+  if (!isObject(payload)) {
+    throw new TypeError("Server capabilities response is missing data.compatibility.");
+  }
+
+  return {
+    serverVersion: requireNonEmptyString(payload.serverVersion, "data.compatibility.serverVersion"),
+    releaseChannel: requireNonEmptyString(payload.releaseChannel, "data.compatibility.releaseChannel"),
+    controlPlaneApi: parseControlPlaneApi(payload.controlPlaneApi),
+    metadataSchemas: parseMetadataSchemas(payload.metadataSchemas),
+    features: parseCompatibilityFeatures(payload.features),
+  };
+}
+
+function parseControlPlaneApi(payload: unknown): HonuaServerCompatibility["controlPlaneApi"] {
+  if (!isObject(payload)) {
+    throw new TypeError("Server capabilities response is missing data.compatibility.controlPlaneApi.");
+  }
+
+  return {
+    major: requireInteger(payload.major, "data.compatibility.controlPlaneApi.major"),
+    basePath: requireNonEmptyString(payload.basePath, "data.compatibility.controlPlaneApi.basePath"),
+    deprecated: requireBoolean(payload.deprecated, "data.compatibility.controlPlaneApi.deprecated"),
+  };
+}
+
+function parseMetadataSchemas(payload: unknown): HonuaServerCompatibility["metadataSchemas"] {
+  if (!Array.isArray(payload)) {
+    throw new TypeError("Server capabilities response is missing data.compatibility.metadataSchemas.");
+  }
+
+  return payload.map((entry, index) => {
+    if (!isObject(entry)) {
+      throw new TypeError(`Server capabilities response metadataSchemas[${index}] must be an object.`);
+    }
+
+    return {
+      version: requireNonEmptyString(entry.version, `data.compatibility.metadataSchemas[${index}].version`),
+      deprecated: requireBoolean(entry.deprecated, `data.compatibility.metadataSchemas[${index}].deprecated`),
+    };
+  });
+}
+
+function parseCompatibilityFeatures(payload: unknown): HonuaServerCompatibility["features"] {
+  if (!isObject(payload)) {
+    throw new TypeError("Server capabilities response is missing data.compatibility.features.");
+  }
+
+  return {
+    metadataResources: requireBoolean(payload.metadataResources, "data.compatibility.features.metadataResources"),
+    manifestExport: requireBoolean(payload.manifestExport, "data.compatibility.features.manifestExport"),
+    manifestApply: requireBoolean(payload.manifestApply, "data.compatibility.features.manifestApply"),
+    manifestDryRun: requireBoolean(payload.manifestDryRun, "data.compatibility.features.manifestDryRun"),
+    manifestPrune: requireBoolean(payload.manifestPrune, "data.compatibility.features.manifestPrune"),
+  };
+}
+
+function requireNonEmptyString(value: unknown, fieldName: string): string {
+  if (typeof value !== "string") {
+    throw new TypeError(`${fieldName} must be a string.`);
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError(`${fieldName} must not be empty.`);
+  }
+
+  return trimmed;
+}
+
+function requireBoolean(value: unknown, fieldName: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new TypeError(`${fieldName} must be a boolean.`);
+  }
+  return value;
+}
+
+function requireInteger(value: unknown, fieldName: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new TypeError(`${fieldName} must be an integer.`);
+  }
+  return value;
+}
+
+function evaluateCompatibility(compatibility: HonuaServerCompatibility): string[] {
+  const reasons: string[] = [];
+  const minimumVersion = parseVersion(HONUA_MINIMUM_SUPPORTED_SERVER_VERSION);
+  const serverVersion = parseVersion(compatibility.serverVersion);
+
+  if (!minimumVersion) {
+    reasons.push(
+      `SDK minimum supported version '${HONUA_MINIMUM_SUPPORTED_SERVER_VERSION}' is not parseable for compatibility checks.`,
+    );
+    return reasons;
+  }
+
+  if (!serverVersion) {
+    reasons.push(`Server version '${compatibility.serverVersion}' is not parseable for compatibility checks.`);
+  } else if (compareVersions(serverVersion, minimumVersion) < 0) {
+    reasons.push(
+      `Server version ${compatibility.serverVersion} is older than the minimum supported ${HONUA_MINIMUM_SUPPORTED_SERVER_VERSION}.`,
+    );
+  }
+
+  if (compatibility.controlPlaneApi.major !== SUPPORTED_CONTROL_PLANE_API_MAJOR) {
+    reasons.push(
+      `Control-plane API major ${compatibility.controlPlaneApi.major} is unsupported; expected ${SUPPORTED_CONTROL_PLANE_API_MAJOR}.`,
+    );
+  }
+
+  if (normalizePathValue(compatibility.controlPlaneApi.basePath) !== SUPPORTED_CONTROL_PLANE_API_BASE_PATH) {
+    reasons.push(
+      `Control-plane API base path ${compatibility.controlPlaneApi.basePath} is unsupported; expected ${SUPPORTED_CONTROL_PLANE_API_BASE_PATH}.`,
+    );
+  }
+
+  if (compatibility.controlPlaneApi.deprecated) {
+    reasons.push(`Control-plane API major ${compatibility.controlPlaneApi.major} is marked deprecated by the server.`);
+  }
+
+  const actualReleaseChannelRank = getReleaseChannelRank(compatibility.releaseChannel);
+  const minimumReleaseChannelRank = getReleaseChannelRank(MINIMUM_SUPPORTED_SERVER_RELEASE_CHANNEL) ?? 0;
+  if (actualReleaseChannelRank === undefined) {
+    reasons.push(`Server release channel '${compatibility.releaseChannel}' is not recognized by this SDK baseline.`);
+  } else if (actualReleaseChannelRank < minimumReleaseChannelRank) {
+    reasons.push(
+      `Server release channel '${compatibility.releaseChannel}' is below the minimum supported '${MINIMUM_SUPPORTED_SERVER_RELEASE_CHANNEL}'.`,
+    );
+  }
+
+  return reasons;
+}
+
+interface ParsedVersion {
+  readonly numbers: readonly number[];
+  readonly prerelease: readonly string[];
+}
+
+function parseVersion(version: string): ParsedVersion | undefined {
+  const normalized = version.trim().replace(/^v/i, "");
+  if (normalized.length === 0) {
+    return undefined;
+  }
+
+  const coreAndPrerelease = normalized.split("+", 1)[0] ?? normalized;
+  const [core, prerelease = ""] = coreAndPrerelease.split("-", 2);
+  const numbers = core.split(".").map((segment) => Number.parseInt(segment, 10));
+  if (numbers.length === 0 || numbers.some((segment) => !Number.isFinite(segment))) {
+    return undefined;
+  }
+
+  const prereleaseParts =
+    prerelease.length > 0
+      ? prerelease.split(".").map((segment) => segment.trim()).filter((segment) => segment.length > 0)
+      : [];
+
+  return {
+    numbers,
+    prerelease: prereleaseParts,
+  };
+}
+
+function compareVersions(left: ParsedVersion, right: ParsedVersion): number {
+  const length = Math.max(left.numbers.length, right.numbers.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = left.numbers[index] ?? 0;
+    const rightPart = right.numbers[index] ?? 0;
+    if (leftPart !== rightPart) {
+      return leftPart < rightPart ? -1 : 1;
+    }
+  }
+
+  if (left.prerelease.length === 0 && right.prerelease.length === 0) {
+    return 0;
+  }
+  if (left.prerelease.length === 0) {
+    return 1;
+  }
+  if (right.prerelease.length === 0) {
+    return -1;
+  }
+
+  const prereleaseLength = Math.max(left.prerelease.length, right.prerelease.length);
+  for (let index = 0; index < prereleaseLength; index += 1) {
+    const leftPart = left.prerelease[index];
+    const rightPart = right.prerelease[index];
+    if (leftPart === undefined) {
+      return -1;
+    }
+    if (rightPart === undefined) {
+      return 1;
+    }
+    if (leftPart === rightPart) {
+      continue;
+    }
+
+    const leftNumeric = Number.parseInt(leftPart, 10);
+    const rightNumeric = Number.parseInt(rightPart, 10);
+    const leftIsNumeric = String(leftNumeric) === leftPart;
+    const rightIsNumeric = String(rightNumeric) === rightPart;
+
+    if (leftIsNumeric && rightIsNumeric) {
+      return leftNumeric < rightNumeric ? -1 : 1;
+    }
+    if (leftIsNumeric) {
+      return -1;
+    }
+    if (rightIsNumeric) {
+      return 1;
+    }
+
+    return leftPart < rightPart ? -1 : 1;
+  }
+
+  return 0;
+}
+
+function describeCompatibilityError(error: unknown): string {
+  if (error instanceof HonuaHttpError && error.statusCode === 404) {
+    return "Server does not expose GET /api/v1/admin/capabilities.";
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function normalizePathValue(path: string): string {
+  const trimmed = path.trim();
+  if (trimmed.length === 0) {
+    return "";
+  }
+
+  const prefixed = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return prefixed.replace(/\/+$/, "");
+}
+
+function getReleaseChannelRank(releaseChannel: string): number | undefined {
+  switch (releaseChannel.trim().toLowerCase()) {
+    case "nightly":
+      return 0;
+    case "dev":
+      return 1;
+    case "alpha":
+      return 2;
+    case "preview":
+      return 3;
+    case "beta":
+      return 4;
+    case "rc":
+      return 5;
+    case "stable":
+      return 6;
+    case "lts":
+      return 7;
+    default:
+      return undefined;
+  }
 }
 
 function applyRequestMutation(request: HonuaRequestContext, mutation: HonuaRequestMutation): HonuaRequestContext {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -236,6 +236,63 @@ export interface HonuaRetryOptions {
   retryStatuses?: readonly number[];
 }
 
+export interface HonuaCompatibilityRequest {
+  signal?: AbortSignal;
+  refresh?: boolean;
+}
+
+export interface HonuaServerCompatibilityControlPlaneApi {
+  major: number;
+  basePath: string;
+  deprecated: boolean;
+}
+
+export interface HonuaServerCompatibilityMetadataSchema {
+  version: string;
+  deprecated: boolean;
+}
+
+export interface HonuaServerCompatibilityFeatures {
+  metadataResources: boolean;
+  manifestExport: boolean;
+  manifestApply: boolean;
+  manifestDryRun: boolean;
+  manifestPrune: boolean;
+}
+
+export type HonuaServerCompatibilityFeature = keyof HonuaServerCompatibilityFeatures;
+
+export interface HonuaServerCompatibility {
+  serverVersion: string;
+  releaseChannel: string;
+  controlPlaneApi: HonuaServerCompatibilityControlPlaneApi;
+  metadataSchemas: HonuaServerCompatibilityMetadataSchema[];
+  features: HonuaServerCompatibilityFeatures;
+}
+
+export interface HonuaServerCapabilitiesResponse {
+  metadataApiVersions?: string[];
+  resourceKinds?: string[];
+  manifestSupported?: boolean;
+  manifestDryRunSupported?: boolean;
+  manifestPruneSupported?: boolean;
+  compatibility: HonuaServerCompatibility;
+}
+
+export interface HonuaApiEnvelope<T> {
+  success: boolean;
+  data: T;
+  message?: string;
+  timestamp?: string;
+}
+
+export interface HonuaServerCompatibilityStatus {
+  supported: boolean;
+  minimumSupportedServerVersion: string;
+  compatibility?: HonuaServerCompatibility;
+  reasons: string[];
+}
+
 export type OgcResponseFormat = "json" | "html" | "geojson" | "gml" | "csv" | "schemajson" | "schema+json";
 
 export interface OgcMetadataRequest {

--- a/src/honua.ts
+++ b/src/honua.ts
@@ -1,4 +1,4 @@
-export { HonuaClient } from "./core/client.js";
+export { HonuaClient, HONUA_MINIMUM_SUPPORTED_SERVER_VERSION } from "./core/client.js";
 export { parseWebMap } from "./webmap/index.js";
 export type { ParseWebMapOptions, ParseWebMapResult } from "./webmap/index.js";
 export {
@@ -167,6 +167,8 @@ export type {
   HonuaAttachmentGroup,
   HonuaAttachmentInfo,
   HonuaAttachmentListResponse,
+  HonuaApiEnvelope,
+  HonuaCompatibilityRequest,
   HonuaClientOptions,
   HonuaCountResponse,
   HonuaEditResult,
@@ -209,6 +211,13 @@ export type {
   HonuaRequestMutation,
   HonuaRetryOptions,
   HonuaResponseContext,
+  HonuaServerCapabilitiesResponse,
+  HonuaServerCompatibility,
+  HonuaServerCompatibilityControlPlaneApi,
+  HonuaServerCompatibilityFeature,
+  HonuaServerCompatibilityFeatures,
+  HonuaServerCompatibilityMetadataSchema,
+  HonuaServerCompatibilityStatus,
   HonuaServiceMetadata,
   HonuaSpatialReference,
   HonuaTransport,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { HonuaClient } from "./core/client.js";
+export { HonuaClient, HONUA_MINIMUM_SUPPORTED_SERVER_VERSION } from "./core/client.js";
 export {
   HonuaHttpError,
   HonuaTimeoutError,
@@ -190,6 +190,8 @@ export type {
   HonuaAttachmentGroup,
   HonuaAttachmentInfo,
   HonuaAttachmentListResponse,
+  HonuaApiEnvelope,
+  HonuaCompatibilityRequest,
   HonuaClientOptions,
   HonuaCountResponse,
   HonuaEditResult,
@@ -232,6 +234,13 @@ export type {
   HonuaRequestMutation,
   HonuaRetryOptions,
   HonuaResponseContext,
+  HonuaServerCapabilitiesResponse,
+  HonuaServerCompatibility,
+  HonuaServerCompatibilityControlPlaneApi,
+  HonuaServerCompatibilityFeature,
+  HonuaServerCompatibilityFeatures,
+  HonuaServerCompatibilityMetadataSchema,
+  HonuaServerCompatibilityStatus,
   HonuaServiceMetadata,
   HonuaSpatialReference,
   HonuaTransport,

--- a/test/server-compatibility.test.ts
+++ b/test/server-compatibility.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import { HONUA_MINIMUM_SUPPORTED_SERVER_VERSION, HonuaClient } from "../src/index.js";
+
+describe("HonuaClient server compatibility helpers", () => {
+  it("reports supported servers and reuses cached compatibility for feature checks", async () => {
+    let fetchCount = 0;
+
+    const client = new HonuaClient({
+      baseUrl: "https://example.test",
+      fetchFn: async (input) => {
+        fetchCount += 1;
+        expect(String(input)).toBe("https://example.test/api/v1/admin/capabilities");
+        return new Response(
+          JSON.stringify(
+            createCapabilitiesEnvelope({
+              serverVersion: HONUA_MINIMUM_SUPPORTED_SERVER_VERSION,
+              features: {
+                metadataResources: true,
+                manifestExport: true,
+                manifestApply: true,
+                manifestDryRun: true,
+                manifestPrune: false,
+              },
+            }),
+          ),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      },
+    });
+
+    const compatibility = await client.getCompatibility();
+    const status = await client.checkCompatibility();
+    const manifestApply = await client.supportsFeature("manifestApply");
+    const manifestPrune = await client.supportsFeature("manifestPrune");
+
+    expect(compatibility.serverVersion).toBe(HONUA_MINIMUM_SUPPORTED_SERVER_VERSION);
+    expect(status.supported).toBe(true);
+    expect(status.minimumSupportedServerVersion).toBe(HONUA_MINIMUM_SUPPORTED_SERVER_VERSION);
+    expect(status.reasons).toEqual([]);
+    expect(status.compatibility?.controlPlaneApi.major).toBe(1);
+    expect(manifestApply).toBe(true);
+    expect(manifestPrune).toBe(false);
+    expect(fetchCount).toBe(1);
+  });
+
+  it("reports unsupported when the server version is below the minimum baseline", async () => {
+    const client = new HonuaClient({
+      baseUrl: "https://example.test",
+      fetchFn: async () =>
+        new Response(JSON.stringify(createCapabilitiesEnvelope({ serverVersion: "0.9.9" })), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    const status = await client.checkCompatibility();
+
+    expect(status.supported).toBe(false);
+    expect(status.compatibility?.serverVersion).toBe("0.9.9");
+    expect(status.reasons).toContain(
+      `Server version 0.9.9 is older than the minimum supported ${HONUA_MINIMUM_SUPPORTED_SERVER_VERSION}.`,
+    );
+  });
+
+  it("reports unsupported when the release channel is below the SDK baseline", async () => {
+    const client = new HonuaClient({
+      baseUrl: "https://example.test",
+      fetchFn: async () =>
+        new Response(JSON.stringify(createCapabilitiesEnvelope({ releaseChannel: "alpha" })), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    const status = await client.checkCompatibility();
+
+    expect(status.supported).toBe(false);
+    expect(status.reasons).toContain(
+      "Server release channel 'alpha' is below the minimum supported 'preview'.",
+    );
+  });
+
+  it("reports unsupported when the server does not expose the compatibility contract", async () => {
+    const client = new HonuaClient({
+      baseUrl: "https://example.test",
+      fetchFn: async () =>
+        new Response(JSON.stringify({ message: "Not Found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    const status = await client.checkCompatibility();
+
+    expect(status.supported).toBe(false);
+    expect(status.compatibility).toBeUndefined();
+    expect(status.reasons).toEqual(["Server does not expose GET /api/v1/admin/capabilities."]);
+  });
+});
+
+function createCapabilitiesEnvelope(
+  overrides: {
+    serverVersion?: string;
+    releaseChannel?: string;
+    controlPlaneApi?: {
+      major?: number;
+      basePath?: string;
+      deprecated?: boolean;
+    };
+    metadataSchemas?: Array<{ version: string; deprecated: boolean }>;
+    features?: {
+      metadataResources: boolean;
+      manifestExport: boolean;
+      manifestApply: boolean;
+      manifestDryRun: boolean;
+      manifestPrune: boolean;
+    };
+  } = {},
+) {
+  return {
+    success: true,
+    data: {
+      metadataApiVersions: ["honua.io/v1alpha1", "honua.io/v1alpha0"],
+      resourceKinds: ["Layer"],
+      compatibility: {
+        serverVersion: overrides.serverVersion ?? HONUA_MINIMUM_SUPPORTED_SERVER_VERSION,
+        releaseChannel: overrides.releaseChannel ?? "stable",
+        controlPlaneApi: {
+          major: overrides.controlPlaneApi?.major ?? 1,
+          basePath: overrides.controlPlaneApi?.basePath ?? "/api/v1/admin",
+          deprecated: overrides.controlPlaneApi?.deprecated ?? false,
+        },
+        metadataSchemas:
+          overrides.metadataSchemas ?? [
+            { version: "honua.io/v1alpha1", deprecated: false },
+            { version: "honua.io/v1alpha0", deprecated: true },
+          ],
+        features: overrides.features ?? {
+          metadataResources: true,
+          manifestExport: true,
+          manifestApply: true,
+          manifestDryRun: true,
+          manifestPrune: true,
+        },
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add a runtime handshake for `GET /api/v1/admin/capabilities`
- expose compatibility status and coarse feature detection on `HonuaClient`
- document the compatibility flow in the README and quickstart

## Validation
- `npm run typecheck`
- `npm test -- --run test/server-compatibility.test.ts`

Closes #10
