### PR TITLE
feat: MapLibre GL JS-first runtime for HonuaMapSpec and operator map packages (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,20 @@ All notable changes to the Honua JS SDK will be documented in this file.
   fields, grouping, and aggregation; five linked-view presets (`globalLinked`, `mapDriven`, `gridDriven`,
   `chartDriven`, `decoupled`); view bindings for `map`, `grid`, `chart`, `form`, and `custom`; snapshot
   restore; `HonuaExplorationContextError` for disposed / duplicate-binding / incompatible-snapshot states.
+- MapLibre GL JS runtime at `@honua/sdk-js/runtime`: `loadMapPackage(...)` and `HonuaMapRuntime` bind a
+  server-produced `MapPackage` (format `honua_map_package.v1`) to a caller-provided `maplibre-gl.Map`.
+  Projects `sourceBindings[]` through the shared contract adapters (MapLibre-native `vector_tile` /
+  `raster_tile` / `ogc_tiles` / `ogc_maps` flow straight into the composed style; `workspace_artifact` is
+  deferred), composes the style from `mapSpec` + `styleRefs[]` + `{theme:key}` token substitution,
+  surfaces a stable operational API (`setLayerVisibility`, `bindPopup`, `setViewState`, `updatePackage`,
+  `on`, `dispose`) with lifecycle events (`package-loaded`, `source-ready`, `source-error`,
+  `package-updated`, `disposed`), diff-based incremental updates that avoid full `setStyle` on
+  theme-only / single-layer changes, and a `HonuaMapPackageError` discriminated by
+  `stage: "load" | "update" | "style-compose" | "source-bind" | "view" | "popup" | "dispose"`.
+  `maplibre-gl` stays a peer dependency (duck-typed `MaplibreMap` interface).
 - Contract docs: `docs/shared-client-contract.md`, `docs/exploration-context.md`,
-  `docs/protocol-capability-matrix.md`, and `docs/source-binding-alignment.md`.
+  `docs/protocol-capability-matrix.md`, `docs/source-binding-alignment.md`, and
+  `docs/maplibre-runtime.md`.
 - Core HTTP client (`HonuaClient`) with FeatureServer, MapServer, and OGC API Features support
 - Fluent layer wrappers (`featureLayer()`, `mapLayer()`, `mapService()`, `ogcFeatures()`)
 - Typed response models for all query, edit, metadata, and OGC endpoints

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -75,6 +75,8 @@ The SDK exposes a protocol-neutral client contract and exploration state module 
   protocol (`geoservices-feature-service`, `geoservices-map-service`, `ogc-features`, `wfs`, `wms`, `odata`).
 - [`docs/source-binding-alignment.md`](./docs/source-binding-alignment.md) — round-trip mapping between
   `SourceDescriptor` and the server `SourceBinding` document.
+- [`docs/maplibre-runtime.md`](./docs/maplibre-runtime.md) — `loadMapPackage(...)` and `HonuaMapRuntime`
+  for the MapLibre GL JS-first `MapPackage` runtime.
 
 ## Esri Migration
 

--- a/README.md
+++ b/README.md
@@ -263,10 +263,11 @@ runtime.dispose();
   mismatches without mutating the map.
 
 Binding failures throw `HonuaMapPackageError` with a `stage` of
-`"load" | "update" | "style-compose" | "source-bind" | "view" | "popup" | "dispose"`. Per-source protocol
+`"load" | "update" | "style-compose" | "source-bind" | "view" | "popup" | "dispose"`. Query-time adapter
 errors (`HonuaCapabilityNotSupportedError`, `HonuaHttpError`, adapter-specific classes) are not wrapped —
-they flow through `runtime.on(...)` as `source-error` events so callers can distinguish binding failure
-from adapter failure.
+they surface on the per-`Source` promises from `runtime.dataset` and through the shared `HonuaClient`
+interceptor chain. The `source-error` runtime event is declared for future `#22` / `#29` wiring and is
+not emitted by the loader today.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Prefer subpath entrypoints to keep Honua-first and migration layers separate:
 - Migration tooling: `@honua/sdk-js/migration`
 - Canonical shared client contract: `@honua/sdk-js/contract`
 - Exploration state + linked-view presets: `@honua/sdk-js/exploration`
+- MapLibre GL JS runtime for `MapPackage`: `@honua/sdk-js/runtime`
 
 The root entrypoint (`@honua/sdk-js`) remains available as an aggregate export for compatibility.
 
@@ -228,6 +229,44 @@ console.log(`Loaded ${result.features.length} features`);
 
 Capability misses throw `HonuaCapabilityNotSupportedError` (under `strict` policy). Exploration misuses throw
 `HonuaExplorationContextError`. Both are in the `HonuaError` union and pass `isHonuaError(e)`.
+
+## MapLibre GL JS Runtime For `MapPackage`
+
+`@honua/sdk-js/runtime` binds a server-produced `MapPackage` (from `honua-io/honua-server#731`) to a
+caller-provided `maplibre-gl.Map`. It composes the style from `mapSpec` + `styleRefs[]` + `theme` tokens,
+projects `sourceBindings[]` through the `@honua/sdk-js/contract` adapters, and exposes an operational API
+that `honua-io/honua-sdk-js#22` and `#29` build on. The runtime never instantiates the map (`maplibre-gl`
+stays a peer dependency) and never issues edit writes.
+
+```ts
+import maplibregl from "maplibre-gl";
+import { HonuaClient } from "@honua/sdk-js/honua";
+import { loadMapPackage } from "@honua/sdk-js/runtime";
+
+const map = new maplibregl.Map({ container: "map", style: { version: 8, sources: {}, layers: [] } });
+const runtime = await loadMapPackage(pkg, map, {
+  client: new HonuaClient({ baseUrl: "https://your-honua-server.example" }),
+  popupFactory: () => new maplibregl.Popup(),
+});
+
+runtime.setLayerVisibility("parcels-fill", true);
+runtime.bindPopup("parcels-fill");
+await runtime.updatePackage(nextPkg);  // diffs by stable ids, falls back to setStyle on structural change
+runtime.dispose();
+```
+
+- Full runtime reference: [`docs/maplibre-runtime.md`](./docs/maplibre-runtime.md).
+- Protocol routing (server `SourceBinding` → MapLibre / contract adapter):
+  [`docs/source-binding-alignment.md`](./docs/source-binding-alignment.md#runtime-consumer-honuasdkjsruntime).
+- `MapPackage` format tag: `honua_map_package.v1`. The loader throws
+  `HonuaMapPackageError { stage: "load" }` on any other value, and `updatePackage` rejects format
+  mismatches without mutating the map.
+
+Binding failures throw `HonuaMapPackageError` with a `stage` of
+`"load" | "update" | "style-compose" | "source-bind" | "view" | "popup" | "dispose"`. Per-source protocol
+errors (`HonuaCapabilityNotSupportedError`, `HonuaHttpError`, adapter-specific classes) are not wrapped —
+they flow through `runtime.on(...)` as `source-error` events so callers can distinguish binding failure
+from adapter failure.
 
 ## Install
 

--- a/docs/maplibre-runtime.md
+++ b/docs/maplibre-runtime.md
@@ -83,6 +83,7 @@ interface LoadMapPackageOptions {
   popupFactory?: PopupFactory;             // required only if runtime.bindPopup is called
   popupRenderer?: PopupRenderer;           // defaults to defaultPopupRenderer
   applyInitialView?: boolean;              // default true
+  onEvent?: HonuaRuntimeEventListener;     // subscribed BEFORE initial emissions
 }
 ```
 
@@ -90,6 +91,13 @@ interface LoadMapPackageOptions {
 omits the inline body. Draft-1 of `honua-server#731` attaches both
 inline; out-of-band retrieval plugs in through these hooks without
 reopening the loader.
+
+`onEvent` is registered on the runtime before the first
+`source-ready` / `package-loaded` emissions, so callers that need to
+observe the initial lifecycle without racing against `loadMapPackage`'s
+return must use this hook instead of calling `runtime.on(...)` after
+`await`. Subsequent events (`package-updated`, `disposed`, ...) also
+flow through the same listener.
 
 ## `MapPackage` version gate
 
@@ -130,6 +138,20 @@ Additional contract:
   Honua custom source spec (`definitionExpression` on
   `honua-feature-service`, `filter` on `honua-ogc-features` and the
   generic fallback). Edits never flow from the runtime.
+- Locator fields are normalized during projection so the shared
+  contract adapters can bind even when the server ships a URL-only
+  `SourceBinding.locator`:
+  - **GeoServices Feature / Map Service**: `serviceId` and numeric
+    `layerId` are parsed from the canonical
+    `/rest/services/<name>/FeatureServer/<id>` or
+    `/rest/services/<name>/MapServer/<id>` URL shape when the binding
+    omits them. Explicit locator fields always win over parsed ones.
+  - **OGC API Features**: `collectionId` is parsed from the
+    `/collections/<id>` URL segment when omitted.
+  - **`locator.layerId`**: numeric strings (e.g. `"0"`) are coerced to
+    numbers — the server C# mirror serialises `LayerId` as a string,
+    so the wire may arrive that way; non-numeric strings are left
+    unset so the adapter surfaces the typed validation error.
 - Capabilities for protocol-backed descriptors are always sourced
   from `PROTOCOL_DEFAULT_CAPABILITIES[protocol]` (see
   [`protocol-capability-matrix.md`](./protocol-capability-matrix.md)).
@@ -193,24 +215,45 @@ them.
      attribution, or protocol differences).
    - Added / removed / changed layer ids (paint, layout, filter,
      source, source-layer, min/max zoom).
-   - A `structuralReason` string and `incremental: false` when
-     `mapSpec.version` changed, the layer set changed, or the layer
-     order changed.
+   - A `structuralReason` string and `incremental: false` when any of
+     the following hold: `mapSpec.version` changed, the layer set
+     changed, the layer order changed, OR any source binding was
+     added / removed / changed. Source-binding changes force the
+     structural path because the runtime must rebuild the underlying
+     `Dataset` and `HonuaMap` so `runtime.dataset.source(id)` observes
+     the new locator / filter.
 3. **Apply.** If `diff.incremental` is false, the runtime rebuilds the
-   composed style and calls `map.setStyle(composed)`. Otherwise it
-   removes dropped sources / layers, patches changed layers in place
-   via `setPaintProperty` / `setLayoutProperty` / `setFilter`, and
-   emits a single `package-updated` event with the diff attached.
-   Theme-only tweaks and single-layer paint/filter edits never trigger
-   a full `setStyle`.
+   composed style, clears the old `HonuaMap`, calls
+   `map.setStyle(composed)`, and swaps in the freshly projected
+   `dataset` and `honuaMap` references. Otherwise it removes dropped
+   layers, patches changed layers in place via `setPaintProperty` /
+   `setLayoutProperty` / `setFilter`, and emits a single
+   `package-updated` event with the diff attached. Theme-only tweaks
+   and single-layer paint/filter edits never trigger a full
+   `setStyle`.
 
-Incremental patching compares `JSON.stringify` on `filter` /
-`paint` / `layout` shapes when deciding whether to emit a setter, so
-identical values skip the MapLibre call.
+Incremental layer patching iterates the **union** of previous and
+next paint / layout keys. Keys present in the previous layer but
+dropped in the next are cleared by calling
+`setPaintProperty(layerId, key, undefined)` /
+`setLayoutProperty(layerId, key, undefined)` so MapLibre resets them
+to the property default rather than retaining the stale value.
+Identical values are short-circuited with a strict-equality check so
+unchanged properties do not trip a MapLibre setter call.
+
+After any structural reload, `runtime.dataset` and `runtime.honuaMap`
+return the new references (both are exposed through getters, not
+fixed `readonly` fields, so live callers see the refreshed state
+immediately).
 
 ## Events
 
-`runtime.on(listener)` receives:
+Subscribe through `LoadMapPackageOptions.onEvent` to observe the
+initial emissions, or `runtime.on(listener)` for subsequent events.
+`onEvent` is the only way to capture `source-ready` /
+`package-loaded` on a successful load because those events are
+dispatched synchronously before `loadMapPackage` returns the runtime
+handle. `runtime.on(...)` handles every subsequent event.
 
 | Event | Emitted when |
 | --- | --- |

--- a/docs/maplibre-runtime.md
+++ b/docs/maplibre-runtime.md
@@ -1,0 +1,303 @@
+# MapLibre GL JS Runtime (`@honua/sdk-js/runtime`)
+
+Status: implemented in `src/runtime/` (ticket `honua-sdk-js-21`).
+Public entrypoint: `@honua/sdk-js/runtime` (subpath export only; the
+root barrel does not re-export the runtime so hosts that do not need a
+map can avoid pulling in the MapLibre-aware code).
+
+The runtime binds a server-produced `MapPackage` (from
+`honua-io/honua-server#731`) to a caller-provided `maplibre-gl.Map`. It
+composes the style, projects `sourceBindings[]` through the shared
+`@honua/sdk-js/contract` adapters, applies `StyleRef` overrides and
+`ThemeSpec` tokens, wires popups / legend / initial view, and exposes
+a stable operational API for `#22` (mixed-protocol composition) and
+`#29` (operator components) to build on.
+
+The runtime **does not** instantiate `maplibre-gl.Map`, issue edit
+writes, or duplicate query logic — `maplibre-gl` stays a peer
+dependency, edits flow through the existing adapters, and queries go
+through the contract's `Source` handles.
+
+## Module layout
+
+```
+src/runtime/
+├── index.ts           # barrel — public surface
+├── map-package.ts     # HonuaMapPackage type (mirrors honua-server#731)
+├── load-package.ts    # loadMapPackage(pkg, map, opts) → HonuaMapRuntime
+├── runtime.ts         # HonuaMapRuntime class + event/telemetry types
+├── source-bridge.ts   # SourceBinding[] → SourceDescriptor[] + native sources
+├── style-compose.ts   # applyStyleRefs + applyTheme
+├── diff.ts            # MapPackageDiff primitives for updatePackage
+├── popups.ts          # bindPopup + default unstyled DOM renderer
+├── legend.ts          # buildLegend + swatch backfill
+└── errors.ts          # HonuaMapPackageError (stages)
+```
+
+## Public surface
+
+```ts
+import maplibregl from "maplibre-gl";
+import { HonuaClient } from "@honua/sdk-js";
+import { loadMapPackage } from "@honua/sdk-js/runtime";
+
+const map = new maplibregl.Map({ container: "map" });
+const runtime = await loadMapPackage(pkg, map, {
+  client: new HonuaClient({ baseUrl: "https://honua.example.com" }),
+  popupFactory: () => new maplibregl.Popup(),
+});
+
+runtime.setLayerVisibility("parcels-fill", false);
+const legend = runtime.getLegend();
+await runtime.updatePackage(nextPkg);
+runtime.dispose();
+```
+
+| Export | Shape | Notes |
+| --- | --- | --- |
+| `loadMapPackage(pkg, map, opts)` | `Promise<HonuaMapRuntime>` | The only async entry point. Throws `HonuaMapPackageError` for binding failures; adapter failures surface on `source-error` events. |
+| `HonuaMapRuntime` | class | `map`, `honuaMap`, `dataset`, `mapPackage`, `composedStyle`, `getLegend`, `setLayerVisibility`, `bindPopup`, `setViewState`, `updatePackage`, `on`, `dispose`. |
+| `HonuaMapPackage` | type | v1 package shape. `format` is gated against `HONUA_MAP_PACKAGE_FORMAT_V1` (`"honua_map_package.v1"`). |
+| `HONUA_MAP_PACKAGE_FORMAT_V1` | const | Canonical format tag. |
+| `HonuaMapPackageError` / `HonuaMapPackageErrorStage` | class / union | Stage union: `"load" \| "update" \| "style-compose" \| "source-bind" \| "view" \| "popup" \| "dispose"`. |
+| `HonuaRuntimeEvent` / `HonuaRuntimeEventListener` | types | See Events below. |
+| `HonuaRuntimeTelemetry` | type | `before` / `after` / `error` collector, matching the `HonuaRequestInterceptor` shape. |
+| `MaplibreMap` | interface | Duck-typed subset of `maplibre-gl.Map`; keeps the SDK bundle-neutral. |
+| `SetViewStateInput` | type | `{ bbox?, center?, zoom?, pitch?, bearing?, padding?, animate? }`. |
+| `applyStyleRefs`, `applyTheme`, `composeStyle` | functions | Pure helpers — safe to call outside a runtime for testing / SSR composition. |
+| `projectSourceBindings`, `toHonuaSourceSpec` | functions | Exposed for `#22` and adapter tickets that need the bridge without loading a package. |
+| `diffPackages`, `MapPackageDiff` | function / type | Stable-id diff used by `updatePackage`. |
+| `buildLegend`, `LegendEntry` | function / type | Shared with operator components. |
+| `bindPopup`, `defaultPopupRenderer`, `PopupFactory`, `PopupRenderer` | function / types | The default DOM renderer is intentionally unstyled — rich popups belong in `#29`. |
+
+## Loader options
+
+```ts
+interface LoadMapPackageOptions {
+  client: HonuaClient;
+  resolveStyleRef?: (styleId: string, presetId?: string) => Promise<HonuaStyleRefBody>;
+  resolveTheme?: (themeId: string) => Promise<HonuaMapPackageThemeSpec>;
+  resolveSource?: SourceResolver;          // forwarded to createDataset for WFS/WMS/OData/tiles
+  skipCompatibilityCheck?: boolean;        // tests / conformance fixtures
+  telemetry?: HonuaRuntimeTelemetry;
+  popupFactory?: PopupFactory;             // required only if runtime.bindPopup is called
+  popupRenderer?: PopupRenderer;           // defaults to defaultPopupRenderer
+  applyInitialView?: boolean;              // default true
+}
+```
+
+`resolveStyleRef` and `resolveTheme` are only invoked when the package
+omits the inline body. Draft-1 of `honua-server#731` attaches both
+inline; out-of-band retrieval plugs in through these hooks without
+reopening the loader.
+
+## `MapPackage` version gate
+
+- `pkg.format` must equal `HONUA_MAP_PACKAGE_FORMAT_V1`
+  (`"honua_map_package.v1"`). The loader throws
+  `HonuaMapPackageError { stage: "load" }` for any other value.
+- `updatePackage(next)` throws `HonuaMapPackageError { stage: "update" }`
+  when `next.format` does not match the already-loaded format so
+  version mismatches surface at the call site rather than silently
+  corrupting the map.
+- Unknown fields on `HonuaMapPackage` (and on each `SourceBinding`
+  locator) are preserved on round-trip through `updatePackage`, so
+  minor additive changes on the server do not force a runtime bump.
+
+## Source binding projection
+
+`projectSourceBindings` routes each `SourceBinding` to one of three
+destinations, using the alignment table in
+[`source-binding-alignment.md`](./source-binding-alignment.md):
+
+| Server wire protocol (snake_case) | Route | SDK protocol / source type |
+| --- | --- | --- |
+| `geoservices_feature_service` | contract adapter | `geoservices-feature-service`, custom source type `honua-feature-service`. |
+| `geoservices_map_service` | contract adapter | `geoservices-map-service`, custom source type `honua-map-service`. |
+| `ogc_features` | contract adapter | `ogc-features`, custom source type `honua-ogc-features`. Collection id is copied from `locator.collectionId`. |
+| `wfs` / `wms` / `odata` | contract adapter (plug-in) | Requires `opts.resolveSource` until the adapter ships. |
+| `vector_tile` / `ogc_tiles` | MapLibre-native | Projected to a `{ type: "vector", tiles: [url], attribution? }` source entry — no contract adapter. |
+| `raster_tile` / `ogc_maps` | MapLibre-native | Projected to a `{ type: "raster", tiles: [url], attribution? }` source entry. |
+| `workspace_artifact` | deferred | Throws `HonuaMapPackageError { stage: "source-bind" }` — no artifact resolver is wired yet. |
+
+Additional contract:
+
+- Duplicate `sourceId` across bindings is rejected at
+  `stage: "source-bind"`.
+- A protocol-backed binding without a `locator.url` is rejected at
+  `stage: "source-bind"`.
+- `binding.filter` is captured per source id and passed through to the
+  Honua custom source spec (`definitionExpression` on
+  `honua-feature-service`, `filter` on `honua-ogc-features` and the
+  generic fallback). Edits never flow from the runtime.
+- Capabilities for protocol-backed descriptors are always sourced
+  from `PROTOCOL_DEFAULT_CAPABILITIES[protocol]` (see
+  [`protocol-capability-matrix.md`](./protocol-capability-matrix.md)).
+  The server `SourceBinding` shape does not carry a `capabilities`
+  field today, and the runtime does not expose a hook to downgrade
+  per-source capabilities — callers that need a narrower set must
+  call `createDataset` directly and pass explicit `SourceDescriptor`
+  entries, then bind the map through the lower-level SDK primitives.
+
+## Style composition
+
+`composeStyle` runs two passes over `pkg.mapSpec`:
+
+1. **`applyStyleRefs`** merges each `styleRefs[*].body` onto its
+   corresponding layer by id. The body is a
+   `Record<string, HonuaStyleRefLayerOverride>` where keys are
+   `mapSpec.layers[].id` and values carry any of
+   `paint`, `layout`, `minzoom`, `maxzoom`, `filter`, `metadata`.
+   Unknown layer ids are silently skipped (they may belong to a
+   downstream adapter plugin). If `ref.body` is absent and no
+   `resolveStyleRef` was supplied, the loader throws
+   `HonuaMapPackageError { stage: "style-compose" }`.
+2. **`applyTheme`** substitutes `{theme:key}` placeholders in string
+   `paint` / `layout` values against `pkg.theme.tokens` (or the
+   resolved `pkg.themeId` body). Only a full-string match on
+   `/^\{theme:([^}]+)\}$/` is replaced — substring interpolation is
+   not supported in v1. Unresolved tokens are left untouched so
+   authors can flag missing tokens at review time.
+
+Theme application recurses into nested arrays / objects inside
+`paint` / `layout` so expression literals can reference theme tokens.
+
+## Operational API
+
+| Method | Behavior |
+| --- | --- |
+| `setLayerVisibility(layerId, visible)` | `map.setLayoutProperty(layerId, "visibility", …)`. |
+| `getLegend()` | Runs `buildLegend` against the current package and composed style; backfills missing swatches from the first `fill-color` / `circle-color` / `line-color` paint property when it is a string literal. |
+| `bindPopup(layerId, binding?)` | Requires `opts.popupFactory`. When `binding` is omitted the runtime looks up `pkg.popupBindings[]` by the layer's source id. The default renderer emits an unstyled `<dl>` of the first feature's properties (or a `{field}` template when `binding.template` is set). Returns a `{ remove() }` handle; re-binding on the same layer tears down the prior handle. |
+| `setViewState(view)` | If `view.bbox` is supplied and `map.fitBounds` exists, fits the bounds (`animate: false` by default). Otherwise falls back to `map.jumpTo` for `center` / `zoom` / `pitch` / `bearing`. A final fallback applies `pkg.initialView.bbox` when no input is given. |
+| `updatePackage(next)` | See the Update lifecycle section. |
+| `on(listener)` | Subscribes to `HonuaRuntimeEvent`. Returns a `{ remove() }` handle. |
+| `dispose()` | Clears popup bindings, removes every layer and source owned by the composed style via `honuaMap.clear()` + `map.removeLayer` / `map.removeSource`, emits `disposed`, and rejects subsequent mutating calls. Idempotent. |
+
+`runtime.map`, `runtime.honuaMap`, `runtime.dataset`,
+`runtime.mapPackage`, and `runtime.composedStyle` are readable at any
+time. Feature-state interactions continue to flow through
+`src/interactions/feature-state` — the runtime does not replicate
+them.
+
+## Update lifecycle
+
+`updatePackage(next)` does three things in order:
+
+1. **Format gate.** `next.format` must match the currently loaded
+   format, or the call throws `HonuaMapPackageError { stage: "update" }`
+   before any map mutation.
+2. **Diff.** `diffPackages(previous, next)` produces a
+   `MapPackageDiff` keyed by stable ids:
+   - Added / removed / changed source bindings (locator, filter,
+     attribution, or protocol differences).
+   - Added / removed / changed layer ids (paint, layout, filter,
+     source, source-layer, min/max zoom).
+   - A `structuralReason` string and `incremental: false` when
+     `mapSpec.version` changed, the layer set changed, or the layer
+     order changed.
+3. **Apply.** If `diff.incremental` is false, the runtime rebuilds the
+   composed style and calls `map.setStyle(composed)`. Otherwise it
+   removes dropped sources / layers, patches changed layers in place
+   via `setPaintProperty` / `setLayoutProperty` / `setFilter`, and
+   emits a single `package-updated` event with the diff attached.
+   Theme-only tweaks and single-layer paint/filter edits never trigger
+   a full `setStyle`.
+
+Incremental patching compares `JSON.stringify` on `filter` /
+`paint` / `layout` shapes when deciding whether to emit a setter, so
+identical values skip the MapLibre call.
+
+## Events
+
+`runtime.on(listener)` receives:
+
+| Event | Emitted when |
+| --- | --- |
+| `{ type: "package-loaded", packageId }` | After the first `setStyle` + initial view apply succeed. Fired last, once per successful load. |
+| `{ type: "source-ready", sourceId }` | Once per source id produced by the contract `Dataset`, fired synchronously just before `package-loaded`. |
+| `{ type: "source-error", sourceId, error }` | Declared for per-source adapter failures surfaced by downstream query / stream calls. The loader itself rejects binding-time failures as `HonuaMapPackageError { stage: "source-bind" }`; this event is reserved for query-time adapter errors that future `#22` / `#29` wiring can bubble through the runtime instead of re-implementing a parallel pipeline. |
+| `{ type: "package-updated", packageId, diff }` | After `updatePackage` completes (both incremental and full-`setStyle` paths). |
+| `{ type: "layer-rendered", layerId }` | Declared for MapLibre render callbacks bridged by the host. The runtime itself does not fire it today. |
+| `{ type: "disposed", packageId }` | Once inside `dispose()`, just before listeners are cleared. |
+
+Listeners fire synchronously in subscription order. Adapter-level
+request errors continue to flow through the `HonuaClient` interceptor
+chain for trace correlation — the runtime does not add a parallel
+pipeline.
+
+## Errors
+
+`HonuaMapPackageError` wraps every runtime-binding failure and carries
+`{ packageId, stage, detail, cause }`. Stages:
+
+- `load` — format validation, `mapSpec` missing, unknown loader error.
+- `update` — `updatePackage` format mismatch or unhandled error.
+- `style-compose` — missing style-ref body with no resolver, theme
+  resolver threw, general composition failure.
+- `source-bind` — unknown protocol, missing locator, duplicate source
+  id, deferred `workspace_artifact`.
+- `view` — `initialView` application failed.
+- `popup` — `bindPopup` called without a `popupFactory`, or no binding
+  found for the layer.
+- `dispose` — mutating call after `dispose()`.
+
+Per-source protocol failures keep their existing classes
+(`HonuaCapabilityNotSupportedError`, `HonuaHttpError`, adapter-specific
+errors) and flow through `source-error` events rather than being
+wrapped.
+
+## Telemetry
+
+`HonuaRuntimeTelemetry` is a `{ before?, after?, error? }` collector
+matching the `HonuaRequestInterceptor` contract. The runtime emits
+spans for `kind: "load" | "update" | "dispose" | "source-bind" | "popup"`
+with `startedAt` / `finishedAt` / `durationMs`. Adapter traffic is
+still instrumented through the shared `HonuaClient` interceptor
+chain, so distributed-trace correlation is preserved end-to-end.
+
+## Peer dependency posture
+
+- `maplibre-gl` is a peer/dev dependency — the runtime never imports
+  it at the type or value level. `MaplibreMap` and `PopupHandle` are
+  duck-typed, matching the pattern used by
+  `src/interactions/feature-state`.
+- Hosts pass their own `maplibre-gl.Map` instance. Custom subclasses
+  and third-party wrappers (deck.gl overlay, OpenLayers bridge) are
+  supported as long as they satisfy the `MaplibreMap` method shape.
+- `popupFactory` keeps the popup dependency on the host side; omit it
+  when the app does not call `runtime.bindPopup`.
+
+## Test coverage
+
+`test/runtime/runtime.test.ts` exercises the full `load →
+updatePackage → dispose` lifecycle against a recording mock map.
+Behavior covered includes:
+
+- Format gate rejects non-v1 packages.
+- Source projection routes each protocol to the correct destination
+  and captures filters.
+- `composeStyle` applies `StyleRef` overrides and theme token
+  substitution.
+- `diffPackages` flags structural changes (layer reorder, mapSpec
+  version bump) and incremental patches update paint / layout /
+  filter without re-running `setStyle`.
+- Event stream emits `package-loaded`, `source-ready`,
+  `package-updated`, `disposed` in the documented order.
+- `dispose` removes layers and sources in reverse and ignores
+  subsequent calls.
+
+Conformance-style assertions rely only on the duck-typed `MaplibreMap`
+interface so no `maplibre-gl` dependency creeps into the SDK's
+runtime bundle.
+
+## Deferred follow-ups
+
+- `workspace_artifact` resolver wiring — blocked on server surface.
+- Partial-load recovery (skip unresolved sources, continue) — the
+  loader is strict in v1; an `opts.allowPartial` escape hatch is
+  tracked alongside `#22` mixed-source composition.
+- Refinement / preview components — opaque pass-through today;
+  `#29` operator components are the documented home.
+- Finer-grained diff primitives (layer reorder without teardown) —
+  extension point already in `diff.ts`; no consumer yet.

--- a/docs/maplibre-runtime.md
+++ b/docs/maplibre-runtime.md
@@ -55,7 +55,7 @@ runtime.dispose();
 
 | Export | Shape | Notes |
 | --- | --- | --- |
-| `loadMapPackage(pkg, map, opts)` | `Promise<HonuaMapRuntime>` | The only async entry point. Throws `HonuaMapPackageError` for binding failures; adapter failures surface on `source-error` events. |
+| `loadMapPackage(pkg, map, opts)` | `Promise<HonuaMapRuntime>` | The only async entry point. Throws `HonuaMapPackageError` for binding failures. Query-time adapter failures surface on the per-`Source` promises from `runtime.dataset` and through the shared `HonuaClient` interceptor chain; the `source-error` event is declared but reserved (see Events). |
 | `HonuaMapRuntime` | class | `map`, `honuaMap`, `dataset`, `mapPackage`, `composedStyle`, `getLegend`, `setLayerVisibility`, `bindPopup`, `setViewState`, `updatePackage`, `on`, `dispose`. |
 | `HonuaMapPackage` | type | v1 package shape. `format` is gated against `HONUA_MAP_PACKAGE_FORMAT_V1` (`"honua_map_package.v1"`). |
 | `HONUA_MAP_PACKAGE_FORMAT_V1` | const | Canonical format tag. |
@@ -216,14 +216,15 @@ them.
    - Added / removed / changed source bindings (locator, filter,
      attribution, or protocol differences).
    - Added / removed / changed layer ids (paint, layout, filter,
-     source, source-layer, min/max zoom).
+     source, source-layer, min/max zoom, metadata).
    - A `structuralReason` string and `incremental: false` when any of
      the following hold: `mapSpec.version` changed, the layer set
-     changed, the layer order changed, OR any source binding was
-     added / removed / changed. Source-binding changes force the
-     structural path because the runtime must rebuild the underlying
-     `Dataset` and `HonuaMap` so `runtime.dataset.source(id)` observes
-     the new locator / filter.
+     changed, the layer order changed, any source binding was added /
+     removed / changed, OR the composed layer changed outside the
+     runtime's paint / layout / filter patch surface. Source-binding
+     changes force the structural path because the runtime must rebuild
+     the underlying `Dataset` and `HonuaMap` so
+     `runtime.dataset.source(id)` observes the new locator / filter.
 3. **Apply.** If `diff.incremental` is false, the runtime rebuilds the
    composed style and calls `map.setStyle(composed)` first; only once
    that returns does it clear the old `HonuaMap` and swap in the
@@ -232,13 +233,15 @@ them.
    previous state — `dataset`, `honuaMap`, `mapPackage`,
    `composedStyle`, and all popup bindings — is left intact so the
    caller can retry without a half-applied update. After a successful
-   swap, any popup binding whose layer id is no longer present in the
-   new composed style is torn down so stale click listeners do not
-   linger. Otherwise it removes dropped layers, patches changed
-   layers in place via `setPaintProperty` / `setLayoutProperty` /
-   `setFilter`, and emits a single `package-updated` event with the
-   diff attached. Theme-only tweaks and single-layer paint/filter
-   edits never trigger a full `setStyle`.
+   swap, any popup binding whose layer id is no longer present, whose
+   layer source changed, or whose package-resolved binding changed is
+   torn down so stale click listeners do not linger. Otherwise it
+   removes dropped layers, patches changed layers in place via
+   `setPaintProperty` / `setLayoutProperty` / `setFilter`, and emits a
+   single `package-updated` event with the diff attached. Theme-only
+   tweaks and single-layer paint/filter edits never trigger a full
+   `setStyle`; root layer changes such as `minzoom`, `maxzoom`,
+   `metadata`, `source`, `source-layer`, or `type` do.
 
 Incremental layer patching iterates the **union** of previous and
 next paint / layout keys. Keys present in the previous layer but
@@ -326,7 +329,7 @@ chain, so distributed-trace correlation is preserved end-to-end.
 
 `test/runtime/runtime.test.ts` exercises the full `load →
 updatePackage → dispose` lifecycle against a recording mock map
-(29 tests). Behavior covered includes:
+(31 tests). Behavior covered includes:
 
 - Format gate rejects non-v1 packages and `workspace_artifact`
   bindings surface `HonuaMapPackageError { stage: "source-bind" }`.
@@ -336,15 +339,17 @@ updatePackage → dispose` lifecycle against a recording mock map
 - `composeStyle` applies `StyleRef` overrides; `applyTheme` substitutes
   `{theme:key}` placeholders and leaves unknown tokens in place.
 - `diffPackages` flags structural changes (layer reorder, mapSpec
-  version bump, source bindings added / removed / changed); incremental
-  patches update paint / layout / filter without re-running `setStyle`.
+  version bump, source bindings added / removed / changed), and the
+  runtime promotes composed root-layer changes to the same path;
+  incremental patches update paint / layout / filter without
+  re-running `setStyle`.
 - Event stream emits `package-loaded`, `source-ready`,
   `package-updated`, `disposed` in the documented order.
 - `dispose` removes layers and sources in reverse and ignores
   subsequent calls; further mutating calls throw
   `stage: "dispose"`.
 
-Regression coverage added alongside this release (+9 tests) locks in
+Regression coverage added alongside this release (+11 tests) locks in
 the fix-pass behaviors:
 
 - **Source-binding structural fallback.** A locator change or a new
@@ -377,6 +382,13 @@ the fix-pass behaviors:
 - **Popup reap on layer removal.** A structural update that drops
   a previously bound layer tears down the layer's popup click
   listener before emitting `package-updated`.
+- **Non-patchable composed layer changes.** A package update that
+  changes a root layer field such as `minzoom` routes through
+  `setStyle` rather than claiming an incremental paint/layout/filter
+  patch applied it.
+- **Popup reap on binding changes.** Updating `popupBindings[]` for an
+  active package-resolved popup tears down the existing click listener
+  so the closed-over binding cannot go stale.
 
 Conformance-style assertions rely only on the duck-typed `MaplibreMap`
 interface so no `maplibre-gl` dependency creeps into the SDK's

--- a/docs/maplibre-runtime.md
+++ b/docs/maplibre-runtime.md
@@ -148,10 +148,12 @@ Additional contract:
     omits them. Explicit locator fields always win over parsed ones.
   - **OGC API Features**: `collectionId` is parsed from the
     `/collections/<id>` URL segment when omitted.
-  - **`locator.layerId`**: numeric strings (e.g. `"0"`) are coerced to
-    numbers — the server C# mirror serialises `LayerId` as a string,
-    so the wire may arrive that way; non-numeric strings are left
-    unset so the adapter surfaces the typed validation error.
+  - **`locator.layerId`**: the server's canonical
+    `SourceLocator.LayerId` is `string?`, so
+    `HonuaMapPackageLocator.layerId` is typed `number | string`.
+    Numeric strings (e.g. `"0"`) are coerced to numbers during
+    projection; non-numeric strings are left unset so the adapter
+    surfaces the typed validation error.
 - Capabilities for protocol-backed descriptors are always sourced
   from `PROTOCOL_DEFAULT_CAPABILITIES[protocol]` (see
   [`protocol-capability-matrix.md`](./protocol-capability-matrix.md)).
@@ -223,14 +225,20 @@ them.
      `Dataset` and `HonuaMap` so `runtime.dataset.source(id)` observes
      the new locator / filter.
 3. **Apply.** If `diff.incremental` is false, the runtime rebuilds the
-   composed style, clears the old `HonuaMap`, calls
-   `map.setStyle(composed)`, and swaps in the freshly projected
-   `dataset` and `honuaMap` references. Otherwise it removes dropped
-   layers, patches changed layers in place via `setPaintProperty` /
-   `setLayoutProperty` / `setFilter`, and emits a single
-   `package-updated` event with the diff attached. Theme-only tweaks
-   and single-layer paint/filter edits never trigger a full
-   `setStyle`.
+   composed style and calls `map.setStyle(composed)` first; only once
+   that returns does it clear the old `HonuaMap` and swap in the
+   freshly projected `dataset` / `honuaMap` references. This ordering
+   guarantees that if the host map's `setStyle` throws, the runtime's
+   previous state — `dataset`, `honuaMap`, `mapPackage`,
+   `composedStyle`, and all popup bindings — is left intact so the
+   caller can retry without a half-applied update. After a successful
+   swap, any popup binding whose layer id is no longer present in the
+   new composed style is torn down so stale click listeners do not
+   linger. Otherwise it removes dropped layers, patches changed
+   layers in place via `setPaintProperty` / `setLayoutProperty` /
+   `setFilter`, and emits a single `package-updated` event with the
+   diff attached. Theme-only tweaks and single-layer paint/filter
+   edits never trigger a full `setStyle`.
 
 Incremental layer patching iterates the **union** of previous and
 next paint / layout keys. Keys present in the previous layer but
@@ -287,8 +295,11 @@ pipeline.
 
 Per-source protocol failures keep their existing classes
 (`HonuaCapabilityNotSupportedError`, `HonuaHttpError`, adapter-specific
-errors) and flow through `source-error` events rather than being
-wrapped.
+errors) and are not wrapped by the runtime. They continue to surface
+on the per-`Source` promises exposed by `runtime.dataset` and through
+the shared `HonuaClient` interceptor chain. The `source-error` event
+on `HonuaRuntimeEvent` is reserved for a future `#22` / `#29` bridge
+and is not emitted by the loader today.
 
 ## Telemetry
 
@@ -314,21 +325,58 @@ chain, so distributed-trace correlation is preserved end-to-end.
 ## Test coverage
 
 `test/runtime/runtime.test.ts` exercises the full `load →
-updatePackage → dispose` lifecycle against a recording mock map.
-Behavior covered includes:
+updatePackage → dispose` lifecycle against a recording mock map
+(29 tests). Behavior covered includes:
 
-- Format gate rejects non-v1 packages.
-- Source projection routes each protocol to the correct destination
-  and captures filters.
-- `composeStyle` applies `StyleRef` overrides and theme token
-  substitution.
+- Format gate rejects non-v1 packages and `workspace_artifact`
+  bindings surface `HonuaMapPackageError { stage: "source-bind" }`.
+- Source projection routes each protocol to the correct destination,
+  captures filters, translates `snake_case` server protocol names to
+  `kebab-case` SDK protocols, and rejects duplicate source ids.
+- `composeStyle` applies `StyleRef` overrides; `applyTheme` substitutes
+  `{theme:key}` placeholders and leaves unknown tokens in place.
 - `diffPackages` flags structural changes (layer reorder, mapSpec
-  version bump) and incremental patches update paint / layout /
-  filter without re-running `setStyle`.
+  version bump, source bindings added / removed / changed); incremental
+  patches update paint / layout / filter without re-running `setStyle`.
 - Event stream emits `package-loaded`, `source-ready`,
   `package-updated`, `disposed` in the documented order.
 - `dispose` removes layers and sources in reverse and ignores
-  subsequent calls.
+  subsequent calls; further mutating calls throw
+  `stage: "dispose"`.
+
+Regression coverage added alongside this release (+9 tests) locks in
+the fix-pass behaviors:
+
+- **Source-binding structural fallback.** A locator change or a new
+  binding forces a full `setStyle` *and* swaps
+  `runtime.dataset` / `runtime.honuaMap` to fresh references so
+  `runtime.dataset.source(id)` observes the new locator / filter.
+- **Paint / layout key removal.** Removing a paint or layout key
+  (e.g. dropping `fill-opacity` or `fill-sort-key` from the next
+  layer) calls `setPaintProperty` / `setLayoutProperty` with
+  `undefined` so MapLibre resets the property instead of retaining
+  the stale value.
+- **URL-only locator backfill.** `projectSourceBindings` parses
+  `serviceId` / numeric `layerId` from a canonical
+  `/rest/services/<name>/FeatureServer/<id>` (and `MapServer` variant)
+  URL when the binding omits them, parses `collectionId` from
+  `/collections/<id>` for OGC API Features bindings, and coerces
+  numeric-string `layerId` values to numbers so the C# server mirror
+  (which serialises `LayerId` as a string) still binds through the
+  built-in adapters. An end-to-end test loads a URL-only GeoServices
+  binding and verifies `runtime.dataset.source(id).adapter(...)` is
+  reachable.
+- **`onEvent` captures initial lifecycle.**
+  `LoadMapPackageOptions.onEvent` receives `source-ready` and
+  `package-loaded` without racing against `loadMapPackage`'s
+  `await`-return.
+- **Structural-update error containment.** When `map.setStyle`
+  throws during a structural `updatePackage`, the previous
+  `honuaMap` / `dataset` / `mapPackage` references are preserved so
+  the runtime is not left half-applied.
+- **Popup reap on layer removal.** A structural update that drops
+  a previously bound layer tears down the layer's popup click
+  listener before emitting `package-updated`.
 
 Conformance-style assertions rely only on the duck-typed `MaplibreMap`
 interface so no `maplibre-gl` dependency creeps into the SDK's

--- a/docs/shared-client-contract.md
+++ b/docs/shared-client-contract.md
@@ -52,7 +52,7 @@ top-level `@honua/sdk-js` and `@honua/sdk-js/honua` barrels).
 | `Dataset` | Logical grouping of sources sharing identity. Methods: `source(id)`, `sourceIds()`, `isCompatible()`, `supportsFeature()`. |
 | `Query<T>` | `{ where?, spatialFilter?, outFields?, orderBy?, pagination?, aggregation?, returnGeometry?, outSr?, signal? }`. |
 | `Result<T>` | `{ features, exceededTransferLimit, totalCount?, aggregateRows?, extent?, fields?, degraded? }`. |
-| `MapBinding` | `{ sourceId, layerIds, style?, minzoom?, maxzoom? }`. Maps onto `MapPackage.sourceBindings` + `MapPackage.mapSpec` server-side. |
+| `MapBinding` | `{ sourceId, layerIds, style?, minzoom?, maxzoom? }`. Maps onto `MapPackage.sourceBindings` + `MapPackage.mapSpec` server-side. The `@honua/sdk-js/runtime` module consumes a full `MapPackage` on the client — see [`maplibre-runtime.md`](./maplibre-runtime.md). |
 
 ## Capability negotiation
 

--- a/docs/source-binding-alignment.md
+++ b/docs/source-binding-alignment.md
@@ -98,6 +98,7 @@ runtime's `source-bridge.ts`:
 
 Unknown fields on a `SourceBinding` are preserved on the
 `HonuaMapPackage` round-trip so server additions do not break runtime
-consumers. See `src/runtime/index.ts` for the full surface and
+consumers. See [`maplibre-runtime.md`](./maplibre-runtime.md) for the
+full runtime surface, `src/runtime/index.ts` for the module barrel, and
 `test/runtime/runtime.test.ts` for the lifecycle contract (`load →
 updatePackage → dispose`).

--- a/docs/source-binding-alignment.md
+++ b/docs/source-binding-alignment.md
@@ -78,3 +78,26 @@ scenario per protocol that takes a `SourceDescriptor`, projects it to a
 `SourceBinding`-shaped object, and re-imports it. If the server-side
 shape changes, that fixture must be updated in lockstep with this
 document and `PROTOCOL_DEFAULT_CAPABILITIES`.
+
+## Runtime consumer: `@honua/sdk-js/runtime`
+
+The MapLibre GL JS-first runtime (`loadMapPackage`) consumes a
+server-produced `MapPackage` and projects its `sourceBindings[]` through
+the same alignment table. Protocol name translation happens inside the
+runtime's `source-bridge.ts`:
+
+| Server wire (snake_case) | SDK `Protocol` (kebab-case) |
+| --- | --- |
+| `geoservices_feature_service` | `geoservices-feature-service` |
+| `geoservices_map_service` | `geoservices-map-service` |
+| `ogc_features` | `ogc-features` |
+| `wfs` / `wms` / `odata` | `wfs` / `wms` / `odata` |
+| `vector_tile` / `ogc_tiles` | MapLibre-native `vector` source (no SDK adapter) |
+| `raster_tile` / `ogc_maps` | MapLibre-native `raster` source (no SDK adapter) |
+| `workspace_artifact` | Deferred — throws `HonuaMapPackageError { stage: "source-bind" }` until a workspace resolver is wired. |
+
+Unknown fields on a `SourceBinding` are preserved on the
+`HonuaMapPackage` round-trip so server additions do not break runtime
+consumers. See `src/runtime/index.ts` for the full surface and
+`test/runtime/runtime.test.ts` for the lifecycle contract (`load →
+updatePackage → dispose`).

--- a/package.json
+++ b/package.json
@@ -58,6 +58,10 @@
     "./exploration": {
       "types": "./dist/src/exploration/index.d.ts",
       "default": "./dist/src/exploration/index.js"
+    },
+    "./runtime": {
+      "types": "./dist/src/runtime/index.d.ts",
+      "default": "./dist/src/runtime/index.js"
     }
   },
   "scripts": {

--- a/src/runtime/diff.ts
+++ b/src/runtime/diff.ts
@@ -23,7 +23,7 @@ export interface MapPackageDiff {
   addedLayerIds: string[];
   /** Layer ids removed in `next`. */
   removedLayerIds: string[];
-  /** Layer ids whose paint/layout/filter changed. */
+  /** Layer ids whose raw layer spec changed. */
   changedLayerIds: string[];
   /** Whether the diff is safe to apply incrementally. */
   incremental: boolean;

--- a/src/runtime/diff.ts
+++ b/src/runtime/diff.ts
@@ -1,0 +1,131 @@
+/**
+ * Diff primitives for incremental `updatePackage` application.
+ *
+ * The runtime uses stable IDs (`sourceId`, `layer.id`) as the diff key
+ * and falls back to a full `map.setStyle` only when structural change
+ * makes incremental patching unsafe (e.g. layer reorder, mapSpec version
+ * mismatch, source type change).
+ *
+ * @module
+ */
+
+import type { HonuaLayerSpecification, HonuaStyleSpecification } from "../style/specification.js";
+import type { HonuaMapPackage, HonuaMapPackageSourceBinding } from "./map-package.js";
+
+export interface MapPackageDiff {
+  /** Bindings present in `next` but not `previous`. */
+  addedSourceBindings: HonuaMapPackageSourceBinding[];
+  /** sourceIds present in `previous` but not `next`. */
+  removedSourceIds: string[];
+  /** sourceIds whose locator / filter changed — requires add-then-remove. */
+  changedSourceIds: string[];
+  /** Layer ids newly added in `next`. */
+  addedLayerIds: string[];
+  /** Layer ids removed in `next`. */
+  removedLayerIds: string[];
+  /** Layer ids whose paint/layout/filter changed. */
+  changedLayerIds: string[];
+  /** Whether the diff is safe to apply incrementally. */
+  incremental: boolean;
+  /** Human-readable reason when `incremental` is false. */
+  structuralReason?: string;
+}
+
+export function diffPackages(previous: HonuaMapPackage, next: HonuaMapPackage): MapPackageDiff {
+  const prevBindings = new Map(previous.sourceBindings.map((b) => [b.sourceId, b]));
+  const nextBindings = new Map(next.sourceBindings.map((b) => [b.sourceId, b]));
+
+  const addedSourceBindings: HonuaMapPackageSourceBinding[] = [];
+  const removedSourceIds: string[] = [];
+  const changedSourceIds: string[] = [];
+
+  for (const [id, binding] of nextBindings) {
+    if (!prevBindings.has(id)) addedSourceBindings.push(binding);
+    else if (!sameBinding(prevBindings.get(id)!, binding)) changedSourceIds.push(id);
+  }
+  for (const id of prevBindings.keys()) {
+    if (!nextBindings.has(id)) removedSourceIds.push(id);
+  }
+
+  const prevLayers = new Map(previous.mapSpec.layers.map((l) => [l.id, l]));
+  const nextLayers = new Map(next.mapSpec.layers.map((l) => [l.id, l]));
+
+  const addedLayerIds: string[] = [];
+  const removedLayerIds: string[] = [];
+  const changedLayerIds: string[] = [];
+
+  for (const [id, layer] of nextLayers) {
+    if (!prevLayers.has(id)) addedLayerIds.push(id);
+    else if (!sameLayer(prevLayers.get(id)!, layer)) changedLayerIds.push(id);
+  }
+  for (const id of prevLayers.keys()) {
+    if (!nextLayers.has(id)) removedLayerIds.push(id);
+  }
+
+  const structuralReason = detectStructuralChange(previous.mapSpec, next.mapSpec);
+
+  return {
+    addedSourceBindings,
+    removedSourceIds,
+    changedSourceIds,
+    addedLayerIds,
+    removedLayerIds,
+    changedLayerIds,
+    incremental: structuralReason === undefined,
+    structuralReason,
+  };
+}
+
+function sameBinding(a: HonuaMapPackageSourceBinding, b: HonuaMapPackageSourceBinding): boolean {
+  if (a.protocol !== b.protocol) return false;
+  if ((a.filter ?? "") !== (b.filter ?? "")) return false;
+  if ((a.attribution ?? "") !== (b.attribution ?? "")) return false;
+  return shallowEqual(a.locator as Record<string, unknown>, b.locator as Record<string, unknown>);
+}
+
+function sameLayer(a: HonuaLayerSpecification, b: HonuaLayerSpecification): boolean {
+  if (a.type !== b.type) return false;
+  if ((a.source ?? "") !== (b.source ?? "")) return false;
+  if (a["source-layer"] !== b["source-layer"]) return false;
+  if (!stableEqual(a.paint, b.paint)) return false;
+  if (!stableEqual(a.layout, b.layout)) return false;
+  if (!stableEqual(a.filter, b.filter)) return false;
+  if (a.minzoom !== b.minzoom) return false;
+  if (a.maxzoom !== b.maxzoom) return false;
+  return true;
+}
+
+function detectStructuralChange(prev: HonuaStyleSpecification, next: HonuaStyleSpecification): string | undefined {
+  if (prev.version !== next.version) return "mapSpec.version changed";
+
+  const prevIds = prev.layers.map((l) => l.id);
+  const nextIds = next.layers.map((l) => l.id);
+  if (prevIds.length !== nextIds.length || prevIds.some((id) => !nextIds.includes(id))) {
+    return "layer set changed";
+  }
+
+  const commonPrev = prevIds.filter((id) => nextIds.includes(id));
+  const commonNext = nextIds.filter((id) => prevIds.includes(id));
+  for (let i = 0; i < commonPrev.length; i++) {
+    if (commonPrev[i] !== commonNext[i]) return "layer order changed";
+  }
+  return undefined;
+}
+
+function stableEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === undefined || b === undefined) return a === b;
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}
+
+function shallowEqual(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+  const ak = Object.keys(a);
+  const bk = Object.keys(b);
+  if (ak.length !== bk.length) return false;
+  for (const k of ak) if (a[k] !== b[k]) return false;
+  return true;
+}

--- a/src/runtime/diff.ts
+++ b/src/runtime/diff.ts
@@ -62,7 +62,13 @@ export function diffPackages(previous: HonuaMapPackage, next: HonuaMapPackage): 
     if (!nextLayers.has(id)) removedLayerIds.push(id);
   }
 
-  const structuralReason = detectStructuralChange(previous.mapSpec, next.mapSpec);
+  const styleStructuralReason = detectStructuralChange(previous.mapSpec, next.mapSpec);
+  const sourceStructuralReason = detectSourceBindingChange(
+    addedSourceBindings,
+    removedSourceIds,
+    changedSourceIds,
+  );
+  const structuralReason = styleStructuralReason ?? sourceStructuralReason;
 
   return {
     addedSourceBindings,
@@ -74,6 +80,17 @@ export function diffPackages(previous: HonuaMapPackage, next: HonuaMapPackage): 
     incremental: structuralReason === undefined,
     structuralReason,
   };
+}
+
+function detectSourceBindingChange(
+  added: readonly HonuaMapPackageSourceBinding[],
+  removed: readonly string[],
+  changed: readonly string[],
+): string | undefined {
+  if (added.length > 0) return "source bindings added";
+  if (removed.length > 0) return "source bindings removed";
+  if (changed.length > 0) return "source bindings changed";
+  return undefined;
 }
 
 function sameBinding(a: HonuaMapPackageSourceBinding, b: HonuaMapPackageSourceBinding): boolean {

--- a/src/runtime/errors.ts
+++ b/src/runtime/errors.ts
@@ -1,0 +1,52 @@
+/**
+ * Runtime-specific error surface. Other Honua SDK errors
+ * (`HonuaCapabilityNotSupportedError`, `HonuaHttpError`, etc.) bubble
+ * through unchanged; this class wraps only the runtime-binding failures
+ * so callers can discriminate stage of failure.
+ *
+ * @module
+ */
+
+/**
+ * Stage of the runtime pipeline a failure occurred in. Keeping this as a
+ * string union lets callers switch on it without a dependency on the
+ * error class itself.
+ */
+export type HonuaMapPackageErrorStage =
+  | "load"
+  | "update"
+  | "style-compose"
+  | "source-bind"
+  | "view"
+  | "popup"
+  | "dispose";
+
+/**
+ * Thrown for runtime-level binding failures. Per-source / per-request
+ * protocol failures keep their existing error classes
+ * (`HonuaCapabilityNotSupportedError`, `HonuaHttpError`) and bubble
+ * through `runtime.on("source-error")`.
+ */
+export class HonuaMapPackageError extends Error {
+  public readonly packageId: string | undefined;
+  public readonly stage: HonuaMapPackageErrorStage;
+  public readonly detail: unknown;
+  public override readonly cause: unknown;
+
+  public constructor(
+    message: string,
+    options: {
+      packageId?: string;
+      stage: HonuaMapPackageErrorStage;
+      detail?: unknown;
+      cause?: unknown;
+    },
+  ) {
+    super(message);
+    this.name = "HonuaMapPackageError";
+    this.packageId = options.packageId;
+    this.stage = options.stage;
+    this.detail = options.detail;
+    this.cause = options.cause;
+  }
+}

--- a/src/runtime/errors.ts
+++ b/src/runtime/errors.ts
@@ -24,8 +24,11 @@ export type HonuaMapPackageErrorStage =
 /**
  * Thrown for runtime-level binding failures. Per-source / per-request
  * protocol failures keep their existing error classes
- * (`HonuaCapabilityNotSupportedError`, `HonuaHttpError`) and bubble
- * through `runtime.on("source-error")`.
+ * (`HonuaCapabilityNotSupportedError`, `HonuaHttpError`) and surface on
+ * the per-`Source` promises from `runtime.dataset` and through the
+ * shared `HonuaClient` interceptor chain. The `source-error` event is
+ * declared on `HonuaRuntimeEvent` but is reserved for future `#22` /
+ * `#29` wiring and is not emitted by the loader today.
  */
 export class HonuaMapPackageError extends Error {
   public readonly packageId: string | undefined;

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -27,6 +27,7 @@ export type { LoadMapPackageOptions } from "./load-package.js";
 export { HonuaMapRuntime } from "./runtime.js";
 export type {
   HonuaMapRuntimeInternals,
+  HonuaMapRuntimeReload,
   HonuaRuntimeEvent,
   HonuaRuntimeEventListener,
   HonuaRuntimeTelemetry,

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,0 +1,81 @@
+/**
+ * `@honua/sdk-js/runtime` — MapLibre GL JS-first runtime for Honua
+ * `MapPackage`. Consumes a server-produced `MapPackage` and binds it to
+ * a caller-provided `MaplibreMap` instance.
+ *
+ * @example
+ * ```ts
+ * import { HonuaClient } from "@honua/sdk-js";
+ * import { loadMapPackage } from "@honua/sdk-js/runtime";
+ * import maplibregl from "maplibre-gl";
+ *
+ * const map = new maplibregl.Map({ container: "map" });
+ * const runtime = await loadMapPackage(pkg, map, {
+ *   client: new HonuaClient({ baseUrl: "https://honua.example.com" }),
+ *   popupFactory: () => new maplibregl.Popup(),
+ * });
+ * runtime.setLayerVisibility("parcels-fill", false);
+ * await runtime.updatePackage(nextPkg);
+ * ```
+ *
+ * @module
+ */
+
+export { loadMapPackage } from "./load-package.js";
+export type { LoadMapPackageOptions } from "./load-package.js";
+
+export { HonuaMapRuntime } from "./runtime.js";
+export type {
+  HonuaMapRuntimeInternals,
+  HonuaRuntimeEvent,
+  HonuaRuntimeEventListener,
+  HonuaRuntimeTelemetry,
+  HonuaRuntimeTelemetrySpan,
+  HonuaRuntimeTelemetrySpanResult,
+  MaplibreMap,
+  SetViewStateInput,
+} from "./runtime.js";
+
+export { HONUA_MAP_PACKAGE_FORMAT_V1 } from "./map-package.js";
+export type {
+  HonuaMapPackage,
+  HonuaMapPackageFormat,
+  HonuaMapPackageInitialView,
+  HonuaMapPackageLabelBinding,
+  HonuaMapPackageLegendEntry,
+  HonuaMapPackageLocator,
+  HonuaMapPackagePopupBinding,
+  HonuaMapPackageProtocol,
+  HonuaMapPackageSourceBinding,
+  HonuaMapPackageStatus,
+  HonuaMapPackageStyleRef,
+  HonuaMapPackageThemeSpec,
+  HonuaStyleRefBody,
+  HonuaStyleRefLayerOverride,
+} from "./map-package.js";
+
+export { HonuaMapPackageError } from "./errors.js";
+export type { HonuaMapPackageErrorStage } from "./errors.js";
+
+export { buildLegend } from "./legend.js";
+export type { LegendEntry } from "./legend.js";
+
+export { bindPopup, defaultPopupRenderer } from "./popups.js";
+export type {
+  BindPopupOptions,
+  PopupBindingHandle,
+  PopupFactory,
+  PopupFeature,
+  PopupHandle,
+  PopupRenderContext,
+  PopupRenderer,
+} from "./popups.js";
+
+export { applyStyleRefs, applyTheme, composeStyle } from "./style-compose.js";
+export type { StyleComposeOptions, StyleRefResolver, ThemeResolver } from "./style-compose.js";
+
+export { projectSourceBindings, toHonuaSourceSpec } from "./source-bridge.js";
+export type { NativeMapLibreSourceEntry, SourceBridgeProjection } from "./source-bridge.js";
+
+export { diffPackages } from "./diff.js";
+export type { MapPackageDiff } from "./diff.js";

--- a/src/runtime/legend.ts
+++ b/src/runtime/legend.ts
@@ -1,0 +1,55 @@
+/**
+ * Legend helpers. The runtime surfaces a `LegendEntry[]` derived from
+ * `MapPackage.legend[]` (authoritative) with optional swatches pulled
+ * from the composed style for layers that did not supply an explicit
+ * color.
+ *
+ * @module
+ */
+
+import type { HonuaStyleSpecification } from "../style/specification.js";
+import type { HonuaMapPackageLegendEntry } from "./map-package.js";
+
+/** Runtime-facing legend entry. */
+export interface LegendEntry {
+  /** Stable id for UI list keys. Derived from label when absent. */
+  id: string;
+  label: string;
+  color?: string;
+  minValue?: number;
+  maxValue?: number;
+  iconUrl?: string;
+}
+
+/** Build a legend list from the package entries, backfilling colors from the style when possible. */
+export function buildLegend(
+  packageEntries: readonly HonuaMapPackageLegendEntry[] | undefined,
+  style: HonuaStyleSpecification,
+): LegendEntry[] {
+  const entries = packageEntries ?? [];
+  const fallbackColors = collectFirstFillColors(style);
+
+  return entries.map((entry, index) => ({
+    id: legendEntryId(entry, index),
+    label: entry.label,
+    color: entry.color ?? fallbackColors[index],
+    ...(entry.minValue !== undefined ? { minValue: entry.minValue } : {}),
+    ...(entry.maxValue !== undefined ? { maxValue: entry.maxValue } : {}),
+    ...(entry.iconUrl !== undefined ? { iconUrl: entry.iconUrl } : {}),
+  }));
+}
+
+function legendEntryId(entry: HonuaMapPackageLegendEntry, index: number): string {
+  const slug = entry.label.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return slug ? `${slug}-${index}` : `legend-${index}`;
+}
+
+function collectFirstFillColors(style: HonuaStyleSpecification): Array<string | undefined> {
+  const colors: Array<string | undefined> = [];
+  for (const layer of style.layers) {
+    const paint = layer.paint ?? {};
+    const value = (paint["fill-color"] ?? paint["circle-color"] ?? paint["line-color"]) as unknown;
+    colors.push(typeof value === "string" ? value : undefined);
+  }
+  return colors;
+}

--- a/src/runtime/load-package.ts
+++ b/src/runtime/load-package.ts
@@ -1,0 +1,212 @@
+/**
+ * `loadMapPackage` — the first-class entry point that turns a server
+ * `MapPackage` into a running MapLibre GL JS map. The caller owns the
+ * `MaplibreMap` instance (peer dependency); the runtime composes the
+ * style, resolves bindings through the shared contract, and hands the
+ * composed style to `map.setStyle`.
+ *
+ * @module
+ */
+
+import { createDataset, type Dataset, type SourceResolver } from "../contract/index.js";
+import type { HonuaClient } from "../core/client.js";
+import { HonuaMap } from "../map/honua-map.js";
+import type { HonuaStyleSpecification } from "../style/specification.js";
+import { HonuaMapPackageError } from "./errors.js";
+import { HONUA_MAP_PACKAGE_FORMAT_V1, type HonuaMapPackage } from "./map-package.js";
+import {
+  HonuaMapRuntime,
+  type HonuaRuntimeTelemetry,
+  type MaplibreMap,
+} from "./runtime.js";
+import type { PopupFactory, PopupRenderer } from "./popups.js";
+import { projectSourceBindings, toHonuaSourceSpec } from "./source-bridge.js";
+import { composeStyle, type StyleRefResolver, type ThemeResolver } from "./style-compose.js";
+
+export interface LoadMapPackageOptions {
+  /** Active `HonuaClient`; used for protocol adapter binding. */
+  client: HonuaClient;
+  /** Out-of-band style-ref body resolver. Only called when the ref has no inline body. */
+  resolveStyleRef?: StyleRefResolver;
+  /** Out-of-band theme resolver. Only called when `pkg.theme` is absent and `pkg.themeId` is set. */
+  resolveTheme?: ThemeResolver;
+  /**
+   * Resolver passed to `createDataset` for adapters the built-in set
+   * (`geoservices-*`, `ogc-features`) does not cover — typically the
+   * WFS/WMS/OData/tile-layer adapters contributed by `#24`–`#28`.
+   */
+  resolveSource?: SourceResolver;
+  /** Skip `client.checkCompatibility()` — useful in tests and conformance fixtures. */
+  skipCompatibilityCheck?: boolean;
+  /** Telemetry collector; wired through the `HonuaClient` interceptor chain. */
+  telemetry?: HonuaRuntimeTelemetry;
+  /** Optional popup factory; required only if the caller calls `runtime.bindPopup`. */
+  popupFactory?: PopupFactory;
+  /** Optional popup renderer; defaults to an unstyled `<dl>` of feature properties. */
+  popupRenderer?: PopupRenderer;
+  /**
+   * When true, apply `pkg.initialView` to the map immediately after load.
+   * Defaults to `true`.
+   */
+  applyInitialView?: boolean;
+}
+
+/**
+ * Load a `MapPackage` onto a caller-provided `MaplibreMap`. Returns a
+ * runtime handle that exposes the operational API. Throws
+ * `HonuaMapPackageError` on binding failure; bubbles adapter errors
+ * (`HonuaHttpError`, `HonuaCapabilityNotSupportedError`, ...) through
+ * `source-error` events but does not swallow them.
+ */
+export async function loadMapPackage(
+  pkg: HonuaMapPackage,
+  map: MaplibreMap,
+  options: LoadMapPackageOptions,
+): Promise<HonuaMapRuntime> {
+  assertPackageFormat(pkg);
+
+  const startedAt = Date.now();
+  options.telemetry?.before?.({
+    kind: "load",
+    packageId: pkg.mapPackageId,
+    startedAt,
+  });
+
+  const compose = async (target: HonuaMapPackage): Promise<{ composed: HonuaStyleSpecification; dataset: Dataset; honuaMap: HonuaMap }> => {
+    const projection = projectSourceBindings(target.mapPackageId, target.sourceBindings);
+
+    const dataset = createDataset({
+      id: target.mapPackageId,
+      client: options.client,
+      sources: projection.descriptors,
+      resolveSource: options.resolveSource,
+      skipCompatibilityCheck: options.skipCompatibilityCheck,
+    });
+
+    const honuaMap = new HonuaMap({ client: options.client });
+
+    const styleSources: HonuaStyleSpecification["sources"] = { ...target.mapSpec.sources };
+    for (const descriptor of projection.descriptors) {
+      const filter = projection.filtersBySourceId.get(descriptor.id);
+      const honuaSpec = toHonuaSourceSpec(descriptor, filter);
+      styleSources[descriptor.id] = honuaSpec;
+      honuaMap.addSource(descriptor.id, honuaSpec);
+    }
+    for (const native of projection.nativeSources) {
+      styleSources[native.sourceId] = native.spec;
+      honuaMap.addSource(native.sourceId, native.spec);
+    }
+
+    const preComposed: HonuaStyleSpecification = {
+      ...target.mapSpec,
+      sources: styleSources,
+    };
+
+    for (const layer of preComposed.layers) {
+      if (!honuaMap.hasLayer(layer.id)) honuaMap.addLayer(layer);
+    }
+
+    const composed = await composeStyle(target, preComposed, {
+      resolveStyleRef: options.resolveStyleRef,
+      resolveTheme: options.resolveTheme,
+    });
+    return { composed, dataset, honuaMap };
+  };
+
+  try {
+    const { composed, dataset, honuaMap } = await compose(pkg);
+
+    map.setStyle(composed);
+
+    const packageRef = { current: pkg };
+    const runtime = new HonuaMapRuntime({
+      map,
+      honuaMap,
+      dataset,
+      composedStyle: composed,
+      packageRef,
+      telemetry: options.telemetry,
+      popupFactory: options.popupFactory,
+      popupRenderer: options.popupRenderer,
+      reload: async (next) => {
+        const result = await compose(next);
+        return result.composed;
+      },
+    });
+
+    if (options.applyInitialView !== false && pkg.initialView) {
+      try {
+        runtime.setViewState({
+          ...(pkg.initialView.bbox ? { bbox: pkg.initialView.bbox } : {}),
+          ...(pkg.initialView.center ? { center: pkg.initialView.center } : {}),
+          ...(pkg.initialView.zoom !== undefined ? { zoom: pkg.initialView.zoom } : {}),
+          ...(pkg.initialView.pitch !== undefined ? { pitch: pkg.initialView.pitch } : {}),
+          ...(pkg.initialView.bearing !== undefined ? { bearing: pkg.initialView.bearing } : {}),
+        });
+      } catch (cause) {
+        throw new HonuaMapPackageError("applying initialView failed", {
+          packageId: pkg.mapPackageId,
+          stage: "view",
+          cause,
+        });
+      }
+    }
+
+    for (const sourceId of dataset.sourceIds()) {
+      runtime._emit({ type: "source-ready", sourceId });
+    }
+    runtime._emit({ type: "package-loaded", packageId: pkg.mapPackageId });
+
+    const finishedAt = Date.now();
+    options.telemetry?.after?.({
+      kind: "load",
+      packageId: pkg.mapPackageId,
+      startedAt,
+      finishedAt,
+      durationMs: finishedAt - startedAt,
+    });
+
+    return runtime;
+  } catch (error) {
+    const finishedAt = Date.now();
+    options.telemetry?.error?.({
+      kind: "load",
+      packageId: pkg.mapPackageId,
+      startedAt,
+      finishedAt,
+      durationMs: finishedAt - startedAt,
+      error,
+    });
+    if (error instanceof HonuaMapPackageError) throw error;
+    throw new HonuaMapPackageError("loadMapPackage failed", {
+      packageId: pkg.mapPackageId,
+      stage: "load",
+      cause: error,
+    });
+  }
+}
+
+function assertPackageFormat(pkg: HonuaMapPackage): void {
+  if (pkg.format !== HONUA_MAP_PACKAGE_FORMAT_V1) {
+    throw new HonuaMapPackageError(
+      `unsupported MapPackage format "${String(pkg.format)}"; runtime supports "${HONUA_MAP_PACKAGE_FORMAT_V1}"`,
+      {
+        packageId: pkg.mapPackageId,
+        stage: "load",
+        detail: { received: pkg.format, expected: HONUA_MAP_PACKAGE_FORMAT_V1 },
+      },
+    );
+  }
+  if (!Array.isArray(pkg.sourceBindings)) {
+    throw new HonuaMapPackageError("MapPackage.sourceBindings must be an array", {
+      packageId: pkg.mapPackageId,
+      stage: "load",
+    });
+  }
+  if (!pkg.mapSpec || typeof pkg.mapSpec !== "object") {
+    throw new HonuaMapPackageError("MapPackage.mapSpec is required", {
+      packageId: pkg.mapPackageId,
+      stage: "load",
+    });
+  }
+}

--- a/src/runtime/load-package.ts
+++ b/src/runtime/load-package.ts
@@ -65,9 +65,13 @@ export interface LoadMapPackageOptions {
 /**
  * Load a `MapPackage` onto a caller-provided `MaplibreMap`. Returns a
  * runtime handle that exposes the operational API. Throws
- * `HonuaMapPackageError` on binding failure; bubbles adapter errors
- * (`HonuaHttpError`, `HonuaCapabilityNotSupportedError`, ...) through
- * `source-error` events but does not swallow them.
+ * `HonuaMapPackageError` on binding failure. Query-time adapter errors
+ * (`HonuaHttpError`, `HonuaCapabilityNotSupportedError`, ...) continue
+ * to flow through the returned `Source` promises on `runtime.dataset`
+ * and through the shared `HonuaClient` interceptor chain; the
+ * `source-error` event is declared on `HonuaRuntimeEvent` but is
+ * reserved for future `#22` / `#29` wiring and is not emitted by the
+ * loader today.
  */
 export async function loadMapPackage(
   pkg: HonuaMapPackage,

--- a/src/runtime/load-package.ts
+++ b/src/runtime/load-package.ts
@@ -16,6 +16,8 @@ import { HonuaMapPackageError } from "./errors.js";
 import { HONUA_MAP_PACKAGE_FORMAT_V1, type HonuaMapPackage } from "./map-package.js";
 import {
   HonuaMapRuntime,
+  type HonuaMapRuntimeReload,
+  type HonuaRuntimeEventListener,
   type HonuaRuntimeTelemetry,
   type MaplibreMap,
 } from "./runtime.js";
@@ -49,6 +51,15 @@ export interface LoadMapPackageOptions {
    * Defaults to `true`.
    */
   applyInitialView?: boolean;
+  /**
+   * Listener registered on the runtime **before** the first
+   * `source-ready` / `package-loaded` emissions so callers can observe
+   * the initial lifecycle without race-binding through
+   * `runtime.on(...)`. Equivalent to calling `runtime.on(listener)`
+   * immediately after construction. Subsequent events (updatePackage,
+   * disposed, …) also flow through this listener.
+   */
+  onEvent?: HonuaRuntimeEventListener;
 }
 
 /**
@@ -128,11 +139,18 @@ export async function loadMapPackage(
       telemetry: options.telemetry,
       popupFactory: options.popupFactory,
       popupRenderer: options.popupRenderer,
-      reload: async (next) => {
+      reload: async (next): Promise<HonuaMapRuntimeReload> => {
         const result = await compose(next);
-        return result.composed;
+        return { composed: result.composed, dataset: result.dataset, honuaMap: result.honuaMap };
       },
     });
+
+    // Register the caller's listener before emitting initial lifecycle
+    // events so callers can observe source-ready / package-loaded once
+    // per load instead of losing them to a race before runtime.on(...).
+    if (options.onEvent) {
+      runtime.on(options.onEvent);
+    }
 
     if (options.applyInitialView !== false && pkg.initialView) {
       try {

--- a/src/runtime/map-package.ts
+++ b/src/runtime/map-package.ts
@@ -45,7 +45,14 @@ export type HonuaMapPackageProtocol =
 export interface HonuaMapPackageLocator {
   url?: string;
   serviceId?: string;
-  layerId?: number;
+  /**
+   * The server's canonical `SourceLocator.LayerId` is `string?`
+   * (`honua-server/src/Honua.Core/Features/Geoprocessing/Domain/SourceBinding.cs`).
+   * Numeric forms (`0`) are accepted to match the SDK's historical
+   * shape; both variants are coerced to a number inside
+   * `projectSourceBindings` before hitting `createDataset`.
+   */
+  layerId?: number | string;
   collectionId?: string | number;
   typeName?: string;
   entitySet?: string;

--- a/src/runtime/map-package.ts
+++ b/src/runtime/map-package.ts
@@ -1,0 +1,189 @@
+/**
+ * Typed mirror of the server-produced `MapPackage` (honua-server #731). The
+ * package shape is `honua_map_package.v1` — the format string is the
+ * canonical version gate and the runtime loader refuses other values.
+ *
+ * Field names mirror the server's camelCase JSON; see
+ * `/honua-server/docs/developer/AI_OPERATOR_CONTRACT.md#MapPackage` for the
+ * authoritative definition. The runtime preserves unknown fields on the
+ * package through `updatePackage` so minor additive changes do not break
+ * callers.
+ *
+ * @module
+ */
+
+import type { HonuaStyleSpecification } from "../style/specification.js";
+
+/** Canonical format string for the v1 MapPackage shape. */
+export const HONUA_MAP_PACKAGE_FORMAT_V1 = "honua_map_package.v1" as const;
+
+/** Canonical format string for the v1 MapPackage shape. */
+export type HonuaMapPackageFormat = typeof HONUA_MAP_PACKAGE_FORMAT_V1;
+
+/** Lifecycle states a MapPackage may occupy server-side. */
+export type HonuaMapPackageStatus = "Draft" | "Composing" | "Ready" | "Failed" | "Expired";
+
+/**
+ * Server `SourceBinding.protocol` enum. Uses snake_case to match the
+ * server wire format. Translated to the SDK's kebab-case `Protocol`
+ * union in `source-bridge.ts`.
+ */
+export type HonuaMapPackageProtocol =
+  | "geoservices_feature_service"
+  | "geoservices_map_service"
+  | "ogc_features"
+  | "ogc_maps"
+  | "ogc_tiles"
+  | "wfs"
+  | "wms"
+  | "odata"
+  | "vector_tile"
+  | "raster_tile"
+  | "workspace_artifact";
+
+/** Protocol-specific endpoint information attached to a binding. */
+export interface HonuaMapPackageLocator {
+  url?: string;
+  serviceId?: string;
+  layerId?: number;
+  collectionId?: string | number;
+  typeName?: string;
+  entitySet?: string;
+  /** Allow additive fields from newer server revisions. */
+  [extra: string]: unknown;
+}
+
+/** One inlined `SourceBinding` entry on a MapPackage. */
+export interface HonuaMapPackageSourceBinding {
+  sourceId: string;
+  protocol: HonuaMapPackageProtocol;
+  locator: HonuaMapPackageLocator;
+  /** Server-side filter expression (protocol-specific). */
+  filter?: string;
+  /** Optional free-form attribution text. */
+  attribution?: string;
+  /** Out-of-band binding metadata. Preserved round-trip. */
+  metadata?: Record<string, string>;
+}
+
+/** A style reference carried inline on the package body. */
+export interface HonuaMapPackageStyleRef {
+  styleId: string;
+  label?: string;
+  presetId?: string;
+  /**
+   * Inline body — MapLibre `paint` / `layout` overrides keyed by layer id.
+   * Draft-1 of honua-server#731 attaches bodies inline; when the server
+   * moves to out-of-band retrieval, callers supply `resolveStyleRef` on the
+   * loader instead.
+   */
+  body?: HonuaStyleRefBody;
+}
+
+/**
+ * Resolved `StyleRef` body. Keys name MapLibre layers; values are partial
+ * layer overrides (paint/layout/minzoom/maxzoom/filter/metadata). Token
+ * placeholders in the form `{theme:key}` are substituted during
+ * composition from the active {@link HonuaMapPackageThemeSpec}.
+ */
+export type HonuaStyleRefBody = Record<string, HonuaStyleRefLayerOverride>;
+
+/** Partial layer specification applied on top of `mapSpec.layers[i]`. */
+export interface HonuaStyleRefLayerOverride {
+  paint?: Record<string, unknown>;
+  layout?: Record<string, unknown>;
+  minzoom?: number;
+  maxzoom?: number;
+  filter?: unknown;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Resolved `ThemeSpec`. v1 uses a flat, name-keyed token map. Richer
+ * ramp / typography shapes can be added without breaking the runtime
+ * public surface.
+ */
+export interface HonuaMapPackageThemeSpec {
+  themeId?: string;
+  tokens?: Record<string, string | number>;
+}
+
+/** Initial camera / extent for the composed map. */
+export interface HonuaMapPackageInitialView {
+  bbox?: readonly [number, number, number, number];
+  center?: readonly [number, number];
+  zoom?: number;
+  pitch?: number;
+  bearing?: number;
+  crs?: string;
+}
+
+/** Legend swatch rendered by the runtime. */
+export interface HonuaMapPackageLegendEntry {
+  label: string;
+  color?: string;
+  minValue?: number;
+  maxValue?: number;
+  /** Optional symbol URL for icon-based legends. */
+  iconUrl?: string;
+}
+
+/** Popup binding surface; resolved into a click handler by the runtime. */
+export interface HonuaMapPackagePopupBinding {
+  sourceId: string;
+  /** Name of the source field to render. Optional when `template` is set. */
+  fieldName?: string;
+  /**
+   * Optional template. Default is a list of `key: value` rows rendered in
+   * a neutral, unstyled DOM subtree — `#29` operator components replace it.
+   */
+  template?: string;
+  /** Optional HTML title for the popup. */
+  title?: string;
+}
+
+/** Label binding surface (v1 is pass-through metadata for the runtime). */
+export interface HonuaMapPackageLabelBinding {
+  sourceId: string;
+  fieldName: string;
+  placement?: "point" | "line" | "polygon";
+}
+
+/**
+ * v1 MapPackage shape — mirrors the draft server type in
+ * `/home/makani/honua-server/src/Honua.Core/Features/Geoprocessing/Domain/MapPackage.cs`.
+ * Unknown fields are preserved through `updatePackage` round-trip so
+ * minor additive changes do not break runtime consumers.
+ */
+export interface HonuaMapPackage {
+  mapPackageId: string;
+  format: HonuaMapPackageFormat;
+  status?: HonuaMapPackageStatus;
+  createdAt?: string;
+  updatedAt?: string;
+
+  templateId?: string;
+  themeId?: string;
+  /** Optional inline theme body. Overrides out-of-band theme lookup. */
+  theme?: HonuaMapPackageThemeSpec;
+  previewArtifactId?: string;
+
+  sourceBindings: readonly HonuaMapPackageSourceBinding[];
+  styleRefs?: readonly HonuaMapPackageStyleRef[];
+
+  /**
+   * MapLibre-compatible style document. The runtime composes style-ref
+   * overrides and theme tokens into this body before handing it to
+   * `maplibre-gl.Map.setStyle`.
+   */
+  mapSpec: HonuaStyleSpecification;
+
+  initialView?: HonuaMapPackageInitialView;
+  legend?: readonly HonuaMapPackageLegendEntry[];
+  popupBindings?: readonly HonuaMapPackagePopupBinding[];
+  labelBindings?: readonly HonuaMapPackageLabelBinding[];
+  boundArtifacts?: readonly string[];
+
+  /** Preserve additive fields through round-trip without forcing a type bump. */
+  [extra: string]: unknown;
+}

--- a/src/runtime/popups.ts
+++ b/src/runtime/popups.ts
@@ -1,0 +1,154 @@
+/**
+ * Popup bindings. The runtime wires `MapPackage.popupBindings[]` into
+ * MapLibre `click` handlers using a duck-typed map interface (no runtime
+ * dependency on `maplibre-gl`). The default DOM renderer is intentionally
+ * unstyled — `#29` operator components replace it with richer popup UIs.
+ *
+ * @module
+ */
+
+import type { MapEventTarget } from "../interactions/feature-state.js";
+import type { HonuaMapPackagePopupBinding } from "./map-package.js";
+
+/**
+ * Minimal subset of `maplibre-gl.Popup` needed to open a popup at
+ * click coordinates. Any object implementing these methods works.
+ */
+export interface PopupHandle {
+  setLngLat(coord: [number, number]): this;
+  setDOMContent(node: Node): this;
+  setHTML(html: string): this;
+  addTo(map: unknown): this;
+  remove(): void;
+}
+
+/** Factory a host supplies so the runtime never imports `maplibre-gl` directly. */
+export type PopupFactory = () => PopupHandle;
+
+/** Custom popup renderer that receives the click event features. */
+export type PopupRenderer = (context: PopupRenderContext) => Node | string | undefined;
+
+export interface PopupRenderContext {
+  binding: HonuaMapPackagePopupBinding;
+  features: ReadonlyArray<PopupFeature>;
+  lngLat: [number, number];
+}
+
+export interface PopupFeature {
+  id?: string | number;
+  properties?: Record<string, unknown>;
+  geometry?: unknown;
+}
+
+export interface BindPopupOptions {
+  binding: HonuaMapPackagePopupBinding;
+  /** MapLibre layer id to listen to for clicks. */
+  layerId: string;
+  /** Create a new popup handle (usually `new maplibregl.Popup()`). */
+  popupFactory: PopupFactory;
+  /** Custom renderer; defaults to unstyled key/value list. */
+  render?: PopupRenderer;
+}
+
+/** Handle returned by {@link bindPopup} — call `remove()` on teardown. */
+export interface PopupBindingHandle {
+  remove(): void;
+  readonly layerId: string;
+}
+
+/**
+ * Subscribe to `click` events on `layerId` and render a popup at the
+ * click point. Assumes the host passes a map that matches `MapEventTarget`
+ * (all MapLibre `Map` instances do).
+ */
+export function bindPopup(
+  map: MapEventTarget & { /* passed through to popup.addTo */ },
+  options: BindPopupOptions,
+): PopupBindingHandle {
+  const { binding, layerId, popupFactory, render = defaultPopupRenderer } = options;
+  let current: PopupHandle | undefined;
+
+  function onClick(...args: unknown[]): void {
+    const event = args[0] as {
+      lngLat?: { lng: number; lat: number };
+      features?: PopupFeature[];
+    } | undefined;
+    if (!event?.lngLat || !event.features || event.features.length === 0) return;
+
+    const lngLat: [number, number] = [event.lngLat.lng, event.lngLat.lat];
+    const rendered = render({ binding, features: event.features, lngLat });
+    if (!rendered) return;
+
+    current?.remove();
+    current = popupFactory().setLngLat(lngLat);
+    if (typeof rendered === "string") current.setHTML(rendered);
+    else current.setDOMContent(rendered);
+    current.addTo(map);
+  }
+
+  map.on("click", layerId, onClick);
+
+  return {
+    layerId,
+    remove() {
+      current?.remove();
+      current = undefined;
+      map.off("click", layerId, onClick);
+    },
+  };
+}
+
+/**
+ * Default renderer: an unstyled `<dl>` list of `binding.fieldName` (when
+ * set) or all properties on the first feature. Use a custom renderer for
+ * anything production-quality.
+ */
+export function defaultPopupRenderer(context: PopupRenderContext): Node | undefined {
+  const doc = resolveDocument();
+  if (!doc) return undefined;
+
+  const root = doc.createElement("div");
+  if (context.binding.title) {
+    const title = doc.createElement("h3");
+    title.textContent = context.binding.title;
+    root.appendChild(title);
+  }
+
+  const feature = context.features[0];
+  if (!feature || !feature.properties) return root;
+
+  if (context.binding.template) {
+    const body = doc.createElement("div");
+    body.textContent = renderStringTemplate(context.binding.template, feature.properties);
+    root.appendChild(body);
+    return root;
+  }
+
+  const fields = context.binding.fieldName
+    ? [context.binding.fieldName].filter((f) => Object.hasOwn(feature.properties ?? {}, f))
+    : Object.keys(feature.properties);
+
+  const dl = doc.createElement("dl");
+  for (const field of fields) {
+    const dt = doc.createElement("dt");
+    dt.textContent = field;
+    const dd = doc.createElement("dd");
+    dd.textContent = String(feature.properties[field]);
+    dl.appendChild(dt);
+    dl.appendChild(dd);
+  }
+  root.appendChild(dl);
+  return root;
+}
+
+function renderStringTemplate(template: string, properties: Record<string, unknown>): string {
+  return template.replace(/\{([^}]+)\}/g, (_, key) => {
+    const value = properties[key];
+    return value === undefined || value === null ? "" : String(value);
+  });
+}
+
+function resolveDocument(): Document | undefined {
+  if (typeof document !== "undefined") return document;
+  return undefined;
+}

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -283,12 +283,19 @@ export class HonuaMapRuntime {
       const reload = await this.#reload(next);
 
       if (!diff.incremental) {
-        this.#honuaMap.clear();
+        // setStyle first so a host-map failure leaves the previous
+        // runtime state intact. Only after it succeeds do we clear the
+        // old HonuaMap, swap in the new dataset / honuaMap, and tear
+        // down popup bindings that reference layers the new composed
+        // style no longer contains.
+        const previousHonuaMap = this.#honuaMap;
         this.map.setStyle(reload.composed);
+        previousHonuaMap.clear();
         this.#honuaMap = reload.honuaMap;
         this.#dataset = reload.dataset;
         this.#packageRef.current = next;
         this.#composedStyle = reload.composed;
+        this.#reapPopupBindings(reload.composed);
         this.#emit({ type: "package-updated", packageId: next.mapPackageId, diff });
         this.#finishSpan(span);
         return;
@@ -406,6 +413,17 @@ export class HonuaMapRuntime {
 
     if (this.map.setFilter && JSON.stringify(prev.filter) !== JSON.stringify(next.filter)) {
       this.map.setFilter(layerId, next.filter);
+    }
+  }
+
+  #reapPopupBindings(composed: HonuaStyleSpecification): void {
+    if (this.#popupBindings.size === 0) return;
+    const nextLayerIds = new Set(composed.layers.map((l) => l.id));
+    for (const [layerId, handle] of Array.from(this.#popupBindings)) {
+      if (!nextLayerIds.has(layerId)) {
+        handle.remove();
+        this.#popupBindings.delete(layerId);
+      }
     }
   }
 

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -11,7 +11,7 @@
 
 import type { Dataset } from "../contract/index.js";
 import type { FeatureStateMap, MapEventTarget } from "../interactions/feature-state.js";
-import { HonuaMap } from "../map/honua-map.js";
+import type { HonuaMap } from "../map/honua-map.js";
 import type { HonuaStyleSpecification } from "../style/specification.js";
 import { diffPackages, type MapPackageDiff } from "./diff.js";
 import { HonuaMapPackageError } from "./errors.js";

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -85,6 +85,18 @@ export type HonuaRuntimeEventListener = (event: HonuaRuntimeEvent) => void;
 
 // ── Options ──────────────────────────────────────────────────
 
+/**
+ * Result of a reload pass produced by the loader. `updatePackage` uses
+ * this to replace the runtime's dataset / honuaMap on structural
+ * refresh, so `runtime.dataset` and `runtime.honuaMap` observe changes
+ * to `sourceBindings[]` instead of going stale.
+ */
+export interface HonuaMapRuntimeReload {
+  composed: HonuaStyleSpecification;
+  dataset: Dataset;
+  honuaMap: HonuaMap;
+}
+
 /** Options passed to the `HonuaMapRuntime` constructor; the loader fills these in. */
 export interface HonuaMapRuntimeInternals {
   map: MaplibreMap;
@@ -95,7 +107,7 @@ export interface HonuaMapRuntimeInternals {
   telemetry?: HonuaRuntimeTelemetry;
   popupFactory?: PopupFactory;
   popupRenderer?: PopupRenderer;
-  reload: (next: HonuaMapPackage) => Promise<HonuaStyleSpecification>;
+  reload: (next: HonuaMapPackage) => Promise<HonuaMapRuntimeReload>;
 }
 
 export interface SetViewStateInput {
@@ -112,8 +124,6 @@ export interface SetViewStateInput {
 
 export class HonuaMapRuntime {
   public readonly map: MaplibreMap;
-  public readonly honuaMap: HonuaMap;
-  public readonly dataset: Dataset;
 
   readonly #packageRef: { current: HonuaMapPackage };
   readonly #listeners = new Set<HonuaRuntimeEventListener>();
@@ -121,21 +131,43 @@ export class HonuaMapRuntime {
   readonly #popupFactory: PopupFactory | undefined;
   readonly #popupRenderer: PopupRenderer | undefined;
   readonly #popupBindings = new Map<string, PopupBindingHandle>();
-  readonly #reload: (next: HonuaMapPackage) => Promise<HonuaStyleSpecification>;
+  readonly #reload: (next: HonuaMapPackage) => Promise<HonuaMapRuntimeReload>;
+  #honuaMap: HonuaMap;
+  #dataset: Dataset;
   #composedStyle: HonuaStyleSpecification;
   #disposed = false;
 
   /** @internal — constructed by {@link loadMapPackage}. */
   public constructor(internals: HonuaMapRuntimeInternals) {
     this.map = internals.map;
-    this.honuaMap = internals.honuaMap;
-    this.dataset = internals.dataset;
+    this.#honuaMap = internals.honuaMap;
+    this.#dataset = internals.dataset;
     this.#composedStyle = internals.composedStyle;
     this.#packageRef = internals.packageRef;
     this.#telemetry = internals.telemetry;
     this.#popupFactory = internals.popupFactory;
     this.#popupRenderer = internals.popupRenderer;
     this.#reload = internals.reload;
+  }
+
+  /**
+   * The `HonuaMap` owning the current package's sources and layers. The
+   * reference is replaced on any structural `updatePackage` call so
+   * consumers always observe the live source set rather than the one
+   * captured at first load.
+   */
+  public get honuaMap(): HonuaMap {
+    return this.#honuaMap;
+  }
+
+  /**
+   * The `Dataset` bound to the current package's source bindings. The
+   * reference is replaced on any structural `updatePackage` call so a
+   * source-binding locator or filter change is visible through
+   * `runtime.dataset.source(id)`.
+   */
+  public get dataset(): Dataset {
+    return this.#dataset;
   }
 
   /** The currently applied package. */
@@ -248,20 +280,23 @@ export class HonuaMapRuntime {
 
       const diff = diffPackages(this.#packageRef.current, next);
 
-      const composed = await this.#reload(next);
+      const reload = await this.#reload(next);
 
       if (!diff.incremental) {
-        this.map.setStyle(composed);
+        this.#honuaMap.clear();
+        this.map.setStyle(reload.composed);
+        this.#honuaMap = reload.honuaMap;
+        this.#dataset = reload.dataset;
         this.#packageRef.current = next;
-        this.#composedStyle = composed;
+        this.#composedStyle = reload.composed;
         this.#emit({ type: "package-updated", packageId: next.mapPackageId, diff });
         this.#finishSpan(span);
         return;
       }
 
-      this.#applyIncremental(composed, diff);
+      this.#applyIncremental(reload.composed, diff);
       this.#packageRef.current = next;
-      this.#composedStyle = composed;
+      this.#composedStyle = reload.composed;
       this.#emit({ type: "package-updated", packageId: next.mapPackageId, diff });
       this.#finishSpan(span);
     } catch (error) {
@@ -302,7 +337,7 @@ export class HonuaMapRuntime {
       for (const sourceId of Object.keys(this.#composedStyle.sources)) {
         this.map.removeSource?.(sourceId);
       }
-      this.honuaMap.clear();
+      this.#honuaMap.clear();
       this.#emit({ type: "disposed", packageId: this.#packageRef.current.mapPackageId });
       this.#listeners.clear();
       this.#disposed = true;
@@ -318,12 +353,8 @@ export class HonuaMapRuntime {
   #applyIncremental(composed: HonuaStyleSpecification, diff: MapPackageDiff): void {
     const prevStyle = this.#composedStyle;
 
-    for (const sourceId of diff.removedSourceIds) {
-      this.honuaMap.removeSource(sourceId);
-      this.map.removeSource?.(sourceId);
-    }
     for (const layerId of diff.removedLayerIds) {
-      this.honuaMap.removeLayer(layerId);
+      this.#honuaMap.removeLayer(layerId);
       this.map.removeLayer?.(layerId);
     }
 
@@ -349,16 +380,30 @@ export class HonuaMapRuntime {
   }
 
   #patchLayer(layerId: string, prev: Readonly<{ paint?: Record<string, unknown>; layout?: Record<string, unknown>; filter?: unknown }>, next: Readonly<{ paint?: Record<string, unknown>; layout?: Record<string, unknown>; filter?: unknown }>): void {
+    const prevPaint = prev.paint ?? {};
+    const nextPaint = next.paint ?? {};
     if (this.map.setPaintProperty) {
-      for (const [key, value] of Object.entries(next.paint ?? {})) {
-        if (!prev.paint || prev.paint[key] !== value) this.map.setPaintProperty(layerId, key, value);
+      const keys = unionKeys(prevPaint, nextPaint);
+      for (const key of keys) {
+        const prevValue = prevPaint[key];
+        const nextValue = Object.hasOwn(nextPaint, key) ? nextPaint[key] : undefined;
+        if (prevValue === nextValue) continue;
+        this.map.setPaintProperty(layerId, key, nextValue);
       }
     }
+
+    const prevLayout = prev.layout ?? {};
+    const nextLayout = next.layout ?? {};
     if (this.map.setLayoutProperty) {
-      for (const [key, value] of Object.entries(next.layout ?? {})) {
-        if (!prev.layout || prev.layout[key] !== value) this.map.setLayoutProperty(layerId, key, value);
+      const keys = unionKeys(prevLayout, nextLayout);
+      for (const key of keys) {
+        const prevValue = prevLayout[key];
+        const nextValue = Object.hasOwn(nextLayout, key) ? nextLayout[key] : undefined;
+        if (prevValue === nextValue) continue;
+        this.map.setLayoutProperty(layerId, key, nextValue);
       }
     }
+
     if (this.map.setFilter && JSON.stringify(prev.filter) !== JSON.stringify(next.filter)) {
       this.map.setFilter(layerId, next.filter);
     }
@@ -418,6 +463,13 @@ function shallowPaintLayoutEqual(
     JSON.stringify(a.layout ?? {}) === JSON.stringify(b.layout ?? {}) &&
     JSON.stringify(a.filter) === JSON.stringify(b.filter)
   );
+}
+
+function unionKeys(a: Record<string, unknown>, b: Record<string, unknown>): string[] {
+  const seen = new Set<string>();
+  for (const key of Object.keys(a)) seen.add(key);
+  for (const key of Object.keys(b)) seen.add(key);
+  return [...seen];
 }
 
 // ── Re-exports for barrel ────────────────────────────────────

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -1,0 +1,427 @@
+/**
+ * `HonuaMapRuntime` — the operational API surface `#22` mixed-protocol
+ * composition and `#29` operator components compose on top of. The
+ * runtime never instantiates a MapLibre `Map`; the host passes one in.
+ *
+ * Types use a duck-typed `MaplibreMap` so the SDK stays bundle-neutral
+ * and does not hard-couple to a specific maplibre-gl version.
+ *
+ * @module
+ */
+
+import type { Dataset } from "../contract/index.js";
+import type { FeatureStateMap, MapEventTarget } from "../interactions/feature-state.js";
+import { HonuaMap } from "../map/honua-map.js";
+import type { HonuaStyleSpecification } from "../style/specification.js";
+import { diffPackages, type MapPackageDiff } from "./diff.js";
+import { HonuaMapPackageError } from "./errors.js";
+import { buildLegend, type LegendEntry } from "./legend.js";
+import type { HonuaMapPackage, HonuaMapPackageInitialView, HonuaMapPackagePopupBinding } from "./map-package.js";
+import {
+  bindPopup,
+  type PopupBindingHandle,
+  type PopupFactory,
+  type PopupRenderer,
+} from "./popups.js";
+
+/**
+ * Minimal subset of `maplibre-gl.Map` required by the runtime. Mirrors
+ * the duck-typed interface pattern used in `src/interactions/feature-state.ts`.
+ * Any object implementing these methods — including a MapLibre-GL `Map`
+ * instance — works.
+ */
+export interface MaplibreMap extends FeatureStateMap, MapEventTarget {
+  setStyle(style: HonuaStyleSpecification | unknown, options?: { diff?: boolean }): unknown;
+  getStyle?(): HonuaStyleSpecification | unknown;
+  addSource?(id: string, source: unknown): void;
+  removeSource?(id: string): void;
+  addLayer?(layer: unknown, beforeId?: string): void;
+  removeLayer?(id: string): void;
+  getLayer?(id: string): unknown;
+  setLayoutProperty?(layerId: string, name: string, value: unknown): void;
+  setPaintProperty?(layerId: string, name: string, value: unknown): void;
+  setFilter?(layerId: string, filter: unknown): void;
+  getSource?(id: string): unknown;
+
+  fitBounds?(bounds: [[number, number], [number, number]] | [number, number, number, number], options?: Record<string, unknown>): void;
+  jumpTo?(options: { center?: [number, number]; zoom?: number; bearing?: number; pitch?: number }): void;
+  easeTo?(options: Record<string, unknown>): void;
+  flyTo?(options: Record<string, unknown>): void;
+}
+
+// ── Telemetry ────────────────────────────────────────────────
+
+export interface HonuaRuntimeTelemetrySpan {
+  kind: "load" | "update" | "dispose" | "source-bind" | "popup";
+  packageId: string | undefined;
+  startedAt: number;
+  detail?: Record<string, unknown>;
+}
+
+export interface HonuaRuntimeTelemetrySpanResult extends HonuaRuntimeTelemetrySpan {
+  finishedAt: number;
+  durationMs: number;
+  error?: unknown;
+}
+
+/** Before/after/error collector, matches `HonuaRequestInterceptor` shape. */
+export interface HonuaRuntimeTelemetry {
+  before?: (span: HonuaRuntimeTelemetrySpan) => void;
+  after?: (span: HonuaRuntimeTelemetrySpanResult) => void;
+  error?: (span: HonuaRuntimeTelemetrySpanResult) => void;
+}
+
+// ── Runtime events ───────────────────────────────────────────
+
+export type HonuaRuntimeEvent =
+  | { type: "package-loaded"; packageId: string }
+  | { type: "package-updated"; packageId: string; diff: MapPackageDiff }
+  | { type: "source-ready"; sourceId: string }
+  | { type: "source-error"; sourceId: string; error: unknown }
+  | { type: "layer-rendered"; layerId: string }
+  | { type: "disposed"; packageId: string | undefined };
+
+export type HonuaRuntimeEventListener = (event: HonuaRuntimeEvent) => void;
+
+// ── Options ──────────────────────────────────────────────────
+
+/** Options passed to the `HonuaMapRuntime` constructor; the loader fills these in. */
+export interface HonuaMapRuntimeInternals {
+  map: MaplibreMap;
+  honuaMap: HonuaMap;
+  dataset: Dataset;
+  composedStyle: HonuaStyleSpecification;
+  packageRef: { current: HonuaMapPackage };
+  telemetry?: HonuaRuntimeTelemetry;
+  popupFactory?: PopupFactory;
+  popupRenderer?: PopupRenderer;
+  reload: (next: HonuaMapPackage) => Promise<HonuaStyleSpecification>;
+}
+
+export interface SetViewStateInput {
+  bbox?: readonly [number, number, number, number];
+  center?: readonly [number, number];
+  zoom?: number;
+  pitch?: number;
+  bearing?: number;
+  padding?: number | { top?: number; right?: number; bottom?: number; left?: number };
+  animate?: boolean;
+}
+
+// ── Runtime ──────────────────────────────────────────────────
+
+export class HonuaMapRuntime {
+  public readonly map: MaplibreMap;
+  public readonly honuaMap: HonuaMap;
+  public readonly dataset: Dataset;
+
+  readonly #packageRef: { current: HonuaMapPackage };
+  readonly #listeners = new Set<HonuaRuntimeEventListener>();
+  readonly #telemetry: HonuaRuntimeTelemetry | undefined;
+  readonly #popupFactory: PopupFactory | undefined;
+  readonly #popupRenderer: PopupRenderer | undefined;
+  readonly #popupBindings = new Map<string, PopupBindingHandle>();
+  readonly #reload: (next: HonuaMapPackage) => Promise<HonuaStyleSpecification>;
+  #composedStyle: HonuaStyleSpecification;
+  #disposed = false;
+
+  /** @internal — constructed by {@link loadMapPackage}. */
+  public constructor(internals: HonuaMapRuntimeInternals) {
+    this.map = internals.map;
+    this.honuaMap = internals.honuaMap;
+    this.dataset = internals.dataset;
+    this.#composedStyle = internals.composedStyle;
+    this.#packageRef = internals.packageRef;
+    this.#telemetry = internals.telemetry;
+    this.#popupFactory = internals.popupFactory;
+    this.#popupRenderer = internals.popupRenderer;
+    this.#reload = internals.reload;
+  }
+
+  /** The currently applied package. */
+  public get mapPackage(): HonuaMapPackage {
+    return this.#packageRef.current;
+  }
+
+  /** The composed MapLibre style last handed to the underlying map. */
+  public get composedStyle(): HonuaStyleSpecification {
+    return this.#composedStyle;
+  }
+
+  // ── Operational API ─────────────────────────────────────────
+
+  public getLegend(): LegendEntry[] {
+    return buildLegend(this.#packageRef.current.legend, this.#composedStyle);
+  }
+
+  public setLayerVisibility(layerId: string, visible: boolean): void {
+    this.#assertLive();
+    this.map.setLayoutProperty?.(layerId, "visibility", visible ? "visible" : "none");
+  }
+
+  public bindPopup(layerId: string, binding?: HonuaMapPackagePopupBinding): { remove(): void } {
+    this.#assertLive();
+    if (!this.#popupFactory) {
+      throw new HonuaMapPackageError(
+        "bindPopup requires opts.popupFactory to be set on loadMapPackage",
+        { packageId: this.#packageRef.current.mapPackageId, stage: "popup", detail: { layerId } },
+      );
+    }
+    const resolved =
+      binding ?? this.#packageRef.current.popupBindings?.find((b) => b.sourceId === layerIdToSource(this.#composedStyle, layerId));
+    if (!resolved) {
+      throw new HonuaMapPackageError(
+        `no popupBinding found for layer "${layerId}"; supply a binding argument or add one to MapPackage.popupBindings`,
+        { packageId: this.#packageRef.current.mapPackageId, stage: "popup", detail: { layerId } },
+      );
+    }
+
+    this.#popupBindings.get(layerId)?.remove();
+    const handle = bindPopup(this.map, {
+      binding: resolved,
+      layerId,
+      popupFactory: this.#popupFactory,
+      render: this.#popupRenderer,
+    });
+    this.#popupBindings.set(layerId, handle);
+    return {
+      remove: () => {
+        handle.remove();
+        this.#popupBindings.delete(layerId);
+      },
+    };
+  }
+
+  public setViewState(view: SetViewStateInput): void {
+    this.#assertLive();
+    const bbox = view.bbox ?? this.#packageRef.current.initialView?.bbox;
+    if (view.bbox && this.map.fitBounds) {
+      const [west, south, east, north] = view.bbox;
+      this.map.fitBounds(
+        [
+          [west, south],
+          [east, north],
+        ],
+        {
+          animate: view.animate ?? false,
+          ...(view.padding !== undefined ? { padding: view.padding } : {}),
+        },
+      );
+      return;
+    }
+    if (view.center) {
+      this.map.jumpTo?.({
+        center: view.center as [number, number],
+        ...(view.zoom !== undefined ? { zoom: view.zoom } : {}),
+        ...(view.bearing !== undefined ? { bearing: view.bearing } : {}),
+        ...(view.pitch !== undefined ? { pitch: view.pitch } : {}),
+      });
+      return;
+    }
+    if (bbox && this.map.fitBounds) {
+      const [west, south, east, north] = bbox;
+      this.map.fitBounds(
+        [
+          [west, south],
+          [east, north],
+        ],
+        { animate: false },
+      );
+    }
+  }
+
+  /**
+   * Diff the current package against `next`. Applies the change
+   * incrementally when safe; falls back to `map.setStyle` for structural
+   * changes. Preserves unknown fields from `next` on round-trip.
+   */
+  public async updatePackage(next: HonuaMapPackage): Promise<void> {
+    this.#assertLive();
+    const span = this.#startSpan("update", next.mapPackageId, { previousId: this.#packageRef.current.mapPackageId });
+    try {
+      if (next.format !== this.#packageRef.current.format) {
+        throw new HonuaMapPackageError(
+          `updatePackage: format "${next.format}" is incompatible with "${this.#packageRef.current.format}"`,
+          { packageId: next.mapPackageId, stage: "update", detail: { expected: this.#packageRef.current.format, received: next.format } },
+        );
+      }
+
+      const diff = diffPackages(this.#packageRef.current, next);
+
+      const composed = await this.#reload(next);
+
+      if (!diff.incremental) {
+        this.map.setStyle(composed);
+        this.#packageRef.current = next;
+        this.#composedStyle = composed;
+        this.#emit({ type: "package-updated", packageId: next.mapPackageId, diff });
+        this.#finishSpan(span);
+        return;
+      }
+
+      this.#applyIncremental(composed, diff);
+      this.#packageRef.current = next;
+      this.#composedStyle = composed;
+      this.#emit({ type: "package-updated", packageId: next.mapPackageId, diff });
+      this.#finishSpan(span);
+    } catch (error) {
+      this.#finishSpan(span, error);
+      if (error instanceof HonuaMapPackageError) throw error;
+      throw new HonuaMapPackageError("updatePackage failed", {
+        packageId: next.mapPackageId,
+        stage: "update",
+        cause: error,
+      });
+    }
+  }
+
+  public on(listener: HonuaRuntimeEventListener): { remove(): void } {
+    this.#listeners.add(listener);
+    return {
+      remove: () => {
+        this.#listeners.delete(listener);
+      },
+    };
+  }
+
+  /** @internal used by the loader to emit `package-loaded`. */
+  public _emit(event: HonuaRuntimeEvent): void {
+    this.#emit(event);
+  }
+
+  public dispose(): void {
+    if (this.#disposed) return;
+    const span = this.#startSpan("dispose", this.#packageRef.current.mapPackageId);
+    try {
+      for (const handle of this.#popupBindings.values()) handle.remove();
+      this.#popupBindings.clear();
+
+      for (const layer of this.#composedStyle.layers) {
+        this.map.removeLayer?.(layer.id);
+      }
+      for (const sourceId of Object.keys(this.#composedStyle.sources)) {
+        this.map.removeSource?.(sourceId);
+      }
+      this.honuaMap.clear();
+      this.#emit({ type: "disposed", packageId: this.#packageRef.current.mapPackageId });
+      this.#listeners.clear();
+      this.#disposed = true;
+      this.#finishSpan(span);
+    } catch (error) {
+      this.#finishSpan(span, error);
+      throw error;
+    }
+  }
+
+  // ── Private helpers ─────────────────────────────────────────
+
+  #applyIncremental(composed: HonuaStyleSpecification, diff: MapPackageDiff): void {
+    const prevStyle = this.#composedStyle;
+
+    for (const sourceId of diff.removedSourceIds) {
+      this.honuaMap.removeSource(sourceId);
+      this.map.removeSource?.(sourceId);
+    }
+    for (const layerId of diff.removedLayerIds) {
+      this.honuaMap.removeLayer(layerId);
+      this.map.removeLayer?.(layerId);
+    }
+
+    const prevLayers = new Map(prevStyle.layers.map((l) => [l.id, l]));
+    const nextLayers = new Map(composed.layers.map((l) => [l.id, l]));
+
+    for (const layerId of diff.changedLayerIds) {
+      const nextLayer = nextLayers.get(layerId);
+      const prevLayer = prevLayers.get(layerId);
+      if (!nextLayer || !prevLayer) continue;
+      this.#patchLayer(layerId, prevLayer, nextLayer);
+    }
+
+    for (const layerId of prevLayers.keys()) {
+      if (diff.removedLayerIds.includes(layerId) || diff.changedLayerIds.includes(layerId)) continue;
+      const nextLayer = nextLayers.get(layerId);
+      const prevLayer = prevLayers.get(layerId);
+      if (!nextLayer || !prevLayer) continue;
+      if (!shallowPaintLayoutEqual(prevLayer, nextLayer)) {
+        this.#patchLayer(layerId, prevLayer, nextLayer);
+      }
+    }
+  }
+
+  #patchLayer(layerId: string, prev: Readonly<{ paint?: Record<string, unknown>; layout?: Record<string, unknown>; filter?: unknown }>, next: Readonly<{ paint?: Record<string, unknown>; layout?: Record<string, unknown>; filter?: unknown }>): void {
+    if (this.map.setPaintProperty) {
+      for (const [key, value] of Object.entries(next.paint ?? {})) {
+        if (!prev.paint || prev.paint[key] !== value) this.map.setPaintProperty(layerId, key, value);
+      }
+    }
+    if (this.map.setLayoutProperty) {
+      for (const [key, value] of Object.entries(next.layout ?? {})) {
+        if (!prev.layout || prev.layout[key] !== value) this.map.setLayoutProperty(layerId, key, value);
+      }
+    }
+    if (this.map.setFilter && JSON.stringify(prev.filter) !== JSON.stringify(next.filter)) {
+      this.map.setFilter(layerId, next.filter);
+    }
+  }
+
+  #emit(event: HonuaRuntimeEvent): void {
+    for (const listener of this.#listeners) listener(event);
+  }
+
+  #assertLive(): void {
+    if (this.#disposed) {
+      throw new HonuaMapPackageError("runtime is disposed", {
+        packageId: this.#packageRef.current.mapPackageId,
+        stage: "dispose",
+      });
+    }
+  }
+
+  #startSpan(
+    kind: HonuaRuntimeTelemetrySpan["kind"],
+    packageId: string | undefined,
+    detail?: Record<string, unknown>,
+  ): HonuaRuntimeTelemetrySpan {
+    const span: HonuaRuntimeTelemetrySpan = { kind, packageId, startedAt: Date.now(), detail };
+    this.#telemetry?.before?.(span);
+    return span;
+  }
+
+  #finishSpan(span: HonuaRuntimeTelemetrySpan, error?: unknown): void {
+    const finishedAt = Date.now();
+    const result: HonuaRuntimeTelemetrySpanResult = {
+      ...span,
+      finishedAt,
+      durationMs: finishedAt - span.startedAt,
+    };
+    if (error !== undefined) {
+      result.error = error;
+      this.#telemetry?.error?.(result);
+    } else {
+      this.#telemetry?.after?.(result);
+    }
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function layerIdToSource(style: HonuaStyleSpecification, layerId: string): string | undefined {
+  return style.layers.find((l) => l.id === layerId)?.source;
+}
+
+function shallowPaintLayoutEqual(
+  a: Readonly<{ paint?: Record<string, unknown>; layout?: Record<string, unknown>; filter?: unknown }>,
+  b: Readonly<{ paint?: Record<string, unknown>; layout?: Record<string, unknown>; filter?: unknown }>,
+): boolean {
+  return (
+    JSON.stringify(a.paint ?? {}) === JSON.stringify(b.paint ?? {}) &&
+    JSON.stringify(a.layout ?? {}) === JSON.stringify(b.layout ?? {}) &&
+    JSON.stringify(a.filter) === JSON.stringify(b.filter)
+  );
+}
+
+// ── Re-exports for barrel ────────────────────────────────────
+
+export type { MapPackageDiff } from "./diff.js";
+export type { PopupFactory, PopupRenderer, PopupBindingHandle } from "./popups.js";
+export type { LegendEntry } from "./legend.js";

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -120,6 +120,13 @@ export interface SetViewStateInput {
   animate?: boolean;
 }
 
+interface ActivePopupBinding {
+  handle: PopupBindingHandle;
+  sourceId: string | undefined;
+  binding: HonuaMapPackagePopupBinding;
+  resolvedFromPackage: boolean;
+}
+
 // ── Runtime ──────────────────────────────────────────────────
 
 export class HonuaMapRuntime {
@@ -130,7 +137,7 @@ export class HonuaMapRuntime {
   readonly #telemetry: HonuaRuntimeTelemetry | undefined;
   readonly #popupFactory: PopupFactory | undefined;
   readonly #popupRenderer: PopupRenderer | undefined;
-  readonly #popupBindings = new Map<string, PopupBindingHandle>();
+  readonly #popupBindings = new Map<string, ActivePopupBinding>();
   readonly #reload: (next: HonuaMapPackage) => Promise<HonuaMapRuntimeReload>;
   #honuaMap: HonuaMap;
   #dataset: Dataset;
@@ -199,8 +206,10 @@ export class HonuaMapRuntime {
         { packageId: this.#packageRef.current.mapPackageId, stage: "popup", detail: { layerId } },
       );
     }
+    const sourceId = layerIdToSource(this.#composedStyle, layerId);
+    const resolvedFromPackage = binding === undefined;
     const resolved =
-      binding ?? this.#packageRef.current.popupBindings?.find((b) => b.sourceId === layerIdToSource(this.#composedStyle, layerId));
+      binding ?? popupBindingForSource(this.#packageRef.current, sourceId);
     if (!resolved) {
       throw new HonuaMapPackageError(
         `no popupBinding found for layer "${layerId}"; supply a binding argument or add one to MapPackage.popupBindings`,
@@ -208,18 +217,20 @@ export class HonuaMapRuntime {
       );
     }
 
-    this.#popupBindings.get(layerId)?.remove();
+    this.#popupBindings.get(layerId)?.handle.remove();
     const handle = bindPopup(this.map, {
       binding: resolved,
       layerId,
       popupFactory: this.#popupFactory,
       render: this.#popupRenderer,
     });
-    this.#popupBindings.set(layerId, handle);
+    this.#popupBindings.set(layerId, { handle, sourceId, binding: resolved, resolvedFromPackage });
     return {
       remove: () => {
         handle.remove();
-        this.#popupBindings.delete(layerId);
+        if (this.#popupBindings.get(layerId)?.handle === handle) {
+          this.#popupBindings.delete(layerId);
+        }
       },
     };
   }
@@ -278,16 +289,25 @@ export class HonuaMapRuntime {
         );
       }
 
-      const diff = diffPackages(this.#packageRef.current, next);
+      let diff = diffPackages(this.#packageRef.current, next);
 
       const reload = await this.#reload(next);
+      const composedStructuralReason =
+        diff.incremental ? detectUnpatchableLayerChange(this.#composedStyle, reload.composed) : undefined;
+      if (composedStructuralReason) {
+        diff = {
+          ...diff,
+          incremental: false,
+          structuralReason: composedStructuralReason,
+        };
+      }
 
       if (!diff.incremental) {
         // setStyle first so a host-map failure leaves the previous
         // runtime state intact. Only after it succeeds do we clear the
         // old HonuaMap, swap in the new dataset / honuaMap, and tear
-        // down popup bindings that reference layers the new composed
-        // style no longer contains.
+        // down popup bindings whose layer, source, or package binding
+        // changed.
         const previousHonuaMap = this.#honuaMap;
         this.map.setStyle(reload.composed);
         previousHonuaMap.clear();
@@ -295,7 +315,7 @@ export class HonuaMapRuntime {
         this.#dataset = reload.dataset;
         this.#packageRef.current = next;
         this.#composedStyle = reload.composed;
-        this.#reapPopupBindings(reload.composed);
+        this.#reapPopupBindings(reload.composed, next);
         this.#emit({ type: "package-updated", packageId: next.mapPackageId, diff });
         this.#finishSpan(span);
         return;
@@ -304,6 +324,7 @@ export class HonuaMapRuntime {
       this.#applyIncremental(reload.composed, diff);
       this.#packageRef.current = next;
       this.#composedStyle = reload.composed;
+      this.#reapPopupBindings(reload.composed, next);
       this.#emit({ type: "package-updated", packageId: next.mapPackageId, diff });
       this.#finishSpan(span);
     } catch (error) {
@@ -335,7 +356,7 @@ export class HonuaMapRuntime {
     if (this.#disposed) return;
     const span = this.#startSpan("dispose", this.#packageRef.current.mapPackageId);
     try {
-      for (const handle of this.#popupBindings.values()) handle.remove();
+      for (const binding of this.#popupBindings.values()) binding.handle.remove();
       this.#popupBindings.clear();
 
       for (const layer of this.#composedStyle.layers) {
@@ -416,12 +437,15 @@ export class HonuaMapRuntime {
     }
   }
 
-  #reapPopupBindings(composed: HonuaStyleSpecification): void {
+  #reapPopupBindings(composed: HonuaStyleSpecification, pkg: HonuaMapPackage): void {
     if (this.#popupBindings.size === 0) return;
-    const nextLayerIds = new Set(composed.layers.map((l) => l.id));
-    for (const [layerId, handle] of Array.from(this.#popupBindings)) {
-      if (!nextLayerIds.has(layerId)) {
-        handle.remove();
+    for (const [layerId, active] of Array.from(this.#popupBindings)) {
+      const nextSourceId = layerIdToSource(composed, layerId);
+      const packageBindingChanged =
+        active.resolvedFromPackage &&
+        !sameJson(active.binding, popupBindingForSource(pkg, nextSourceId));
+      if (!nextSourceId || nextSourceId !== active.sourceId || packageBindingChanged) {
+        active.handle.remove();
         this.#popupBindings.delete(layerId);
       }
     }
@@ -472,14 +496,45 @@ function layerIdToSource(style: HonuaStyleSpecification, layerId: string): strin
   return style.layers.find((l) => l.id === layerId)?.source;
 }
 
+function popupBindingForSource(pkg: HonuaMapPackage, sourceId: string | undefined): HonuaMapPackagePopupBinding | undefined {
+  if (!sourceId) return undefined;
+  return pkg.popupBindings?.find((binding) => binding.sourceId === sourceId);
+}
+
+function detectUnpatchableLayerChange(previous: HonuaStyleSpecification, next: HonuaStyleSpecification): string | undefined {
+  const previousLayers = new Map(previous.layers.map((layer) => [layer.id, layer]));
+  for (const nextLayer of next.layers) {
+    const previousLayer = previousLayers.get(nextLayer.id);
+    if (!previousLayer) continue;
+    if (!patchableLayerShapeEqual(previousLayer, nextLayer)) {
+      return `layer "${nextLayer.id}" changed outside paint/layout/filter`;
+    }
+  }
+  return undefined;
+}
+
+function patchableLayerShapeEqual(
+  a: HonuaStyleSpecification["layers"][number],
+  b: HonuaStyleSpecification["layers"][number],
+): boolean {
+  return (
+    a.type === b.type &&
+    (a.source ?? "") === (b.source ?? "") &&
+    a["source-layer"] === b["source-layer"] &&
+    a.minzoom === b.minzoom &&
+    a.maxzoom === b.maxzoom &&
+    sameJson(a.metadata, b.metadata)
+  );
+}
+
 function shallowPaintLayoutEqual(
   a: Readonly<{ paint?: Record<string, unknown>; layout?: Record<string, unknown>; filter?: unknown }>,
   b: Readonly<{ paint?: Record<string, unknown>; layout?: Record<string, unknown>; filter?: unknown }>,
 ): boolean {
   return (
-    JSON.stringify(a.paint ?? {}) === JSON.stringify(b.paint ?? {}) &&
-    JSON.stringify(a.layout ?? {}) === JSON.stringify(b.layout ?? {}) &&
-    JSON.stringify(a.filter) === JSON.stringify(b.filter)
+    sameJson(a.paint ?? {}, b.paint ?? {}) &&
+    sameJson(a.layout ?? {}, b.layout ?? {}) &&
+    sameJson(a.filter, b.filter)
   );
 }
 
@@ -488,6 +543,15 @@ function unionKeys(a: Record<string, unknown>, b: Record<string, unknown>): stri
   for (const key of Object.keys(a)) seen.add(key);
   for (const key of Object.keys(b)) seen.add(key);
   return [...seen];
+}
+
+function sameJson(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
 }
 
 // ── Re-exports for barrel ────────────────────────────────────

--- a/src/runtime/source-bridge.ts
+++ b/src/runtime/source-bridge.ts
@@ -1,0 +1,242 @@
+/**
+ * Translates `MapPackage.sourceBindings[]` (server shape) into SDK-side
+ * `SourceDescriptor[]` consumed by `createDataset`, and keeps a parallel
+ * record of MapLibre-native source entries that flow straight into the
+ * composed style.
+ *
+ * Contract:
+ *  - Protocol-backed bindings (`geoservices_*`, `ogc_features`, `wfs`,
+ *    `wms`, `odata`) produce a `SourceDescriptor` whose locator mirrors
+ *    the server's field shape verbatim per `docs/source-binding-alignment.md`.
+ *  - MapLibre-native bindings (`vector_tile`, `raster_tile`) skip the
+ *    contract pipeline and surface as MapLibre source entries.
+ *  - `ogc_maps` / `ogc_tiles` project onto MapLibre-native sources
+ *    (raster or vector) since the SDK does not model them as first-party
+ *    data protocols.
+ *  - `workspace_artifact` is deferred (no adapter); load fails with a
+ *    clear `HonuaMapPackageError` stage="source-bind" so callers can
+ *    detect missing server artifacts.
+ *
+ * @module
+ */
+
+import {
+  PROTOCOL_DEFAULT_CAPABILITIES,
+  type Protocol,
+  type SourceDescriptor,
+  type SourceLocator,
+} from "../contract/index.js";
+import { HonuaMapPackageError } from "./errors.js";
+import type {
+  HonuaMapPackageLocator,
+  HonuaMapPackageProtocol,
+  HonuaMapPackageSourceBinding,
+} from "./map-package.js";
+
+/** One MapLibre-native source entry derived from a binding. */
+export interface NativeMapLibreSourceEntry {
+  sourceId: string;
+  spec: { type: string; [key: string]: unknown };
+  attribution?: string;
+}
+
+/** Result of projecting a package's source bindings. */
+export interface SourceBridgeProjection {
+  /** Protocol-backed descriptors destined for `createDataset`. */
+  descriptors: SourceDescriptor[];
+  /**
+   * MapLibre-native source entries keyed by sourceId. These flow straight
+   * into the composed style's `sources` map without going through
+   * `Dataset`.
+   */
+  nativeSources: NativeMapLibreSourceEntry[];
+  /** Binding filter expressions captured per source id. */
+  filtersBySourceId: Map<string, string>;
+}
+
+/**
+ * Project the bindings on a MapPackage into SDK contract descriptors and
+ * MapLibre-native source entries. Throws `HonuaMapPackageError` for
+ * bindings the runtime cannot route (unknown protocol, missing locator,
+ * deferred `workspace_artifact`).
+ */
+export function projectSourceBindings(
+  packageId: string | undefined,
+  bindings: readonly HonuaMapPackageSourceBinding[],
+): SourceBridgeProjection {
+  const descriptors: SourceDescriptor[] = [];
+  const nativeSources: NativeMapLibreSourceEntry[] = [];
+  const filtersBySourceId = new Map<string, string>();
+  const seen = new Set<string>();
+
+  for (const binding of bindings) {
+    if (seen.has(binding.sourceId)) {
+      throw new HonuaMapPackageError(`duplicate sourceBinding id "${binding.sourceId}"`, {
+        packageId,
+        stage: "source-bind",
+        detail: { sourceId: binding.sourceId },
+      });
+    }
+    seen.add(binding.sourceId);
+
+    if (binding.filter) {
+      filtersBySourceId.set(binding.sourceId, binding.filter);
+    }
+
+    const mlNative = toMapLibreNativeSource(binding);
+    if (mlNative) {
+      nativeSources.push(mlNative);
+      continue;
+    }
+
+    const sdkProtocol = toSdkProtocol(binding.protocol);
+    if (!sdkProtocol) {
+      throw new HonuaMapPackageError(
+        `unsupported SourceBinding protocol "${binding.protocol}" on source "${binding.sourceId}"`,
+        { packageId, stage: "source-bind", detail: { sourceId: binding.sourceId, protocol: binding.protocol } },
+      );
+    }
+
+    descriptors.push({
+      id: binding.sourceId,
+      protocol: sdkProtocol,
+      locator: toSourceLocator(packageId, binding),
+      capabilities: PROTOCOL_DEFAULT_CAPABILITIES[sdkProtocol],
+      attribution: binding.attribution,
+    });
+  }
+
+  return { descriptors, nativeSources, filtersBySourceId };
+}
+
+/**
+ * Build the Honua custom-source spec (to be inserted into `style.sources`)
+ * for a protocol-backed descriptor.
+ */
+export function toHonuaSourceSpec(descriptor: SourceDescriptor, filter?: string): { type: string; [key: string]: unknown } {
+  switch (descriptor.protocol) {
+    case "geoservices-feature-service": {
+      const url = requireLocatorUrl(descriptor);
+      return {
+        type: "honua-feature-service",
+        url,
+        ...(filter ? { definitionExpression: filter } : {}),
+        ...(descriptor.attribution ? { attribution: descriptor.attribution } : {}),
+      };
+    }
+    case "geoservices-map-service": {
+      const url = requireLocatorUrl(descriptor);
+      return {
+        type: "honua-map-service",
+        url,
+        ...(descriptor.attribution ? { attribution: descriptor.attribution } : {}),
+      };
+    }
+    case "ogc-features": {
+      const url = requireLocatorUrl(descriptor);
+      return {
+        type: "honua-ogc-features",
+        url,
+        ...(descriptor.locator.collectionId !== undefined
+          ? { collectionId: String(descriptor.locator.collectionId) }
+          : {}),
+        ...(filter ? { filter } : {}),
+        ...(descriptor.attribution ? { attribution: descriptor.attribution } : {}),
+      };
+    }
+    default:
+      return {
+        type: `honua-${descriptor.protocol}`,
+        ...descriptor.locator,
+        ...(filter ? { filter } : {}),
+        ...(descriptor.attribution ? { attribution: descriptor.attribution } : {}),
+      };
+  }
+}
+
+function toSdkProtocol(protocol: HonuaMapPackageProtocol): Protocol | undefined {
+  switch (protocol) {
+    case "geoservices_feature_service":
+      return "geoservices-feature-service";
+    case "geoservices_map_service":
+      return "geoservices-map-service";
+    case "ogc_features":
+      return "ogc-features";
+    case "wfs":
+      return "wfs";
+    case "wms":
+      return "wms";
+    case "odata":
+      return "odata";
+    default:
+      return undefined;
+  }
+}
+
+function toMapLibreNativeSource(binding: HonuaMapPackageSourceBinding): NativeMapLibreSourceEntry | undefined {
+  switch (binding.protocol) {
+    case "vector_tile":
+    case "ogc_tiles":
+      return {
+        sourceId: binding.sourceId,
+        attribution: binding.attribution,
+        spec: {
+          type: "vector",
+          ...(binding.locator.url ? { tiles: [binding.locator.url] } : {}),
+          ...(binding.attribution ? { attribution: binding.attribution } : {}),
+        },
+      };
+    case "raster_tile":
+    case "ogc_maps":
+      return {
+        sourceId: binding.sourceId,
+        attribution: binding.attribution,
+        spec: {
+          type: "raster",
+          ...(binding.locator.url ? { tiles: [binding.locator.url] } : {}),
+          ...(binding.attribution ? { attribution: binding.attribution } : {}),
+        },
+      };
+    default:
+      return undefined;
+  }
+}
+
+function toSourceLocator(packageId: string | undefined, binding: HonuaMapPackageSourceBinding): SourceLocator {
+  const loc = binding.locator;
+  if (binding.protocol === "workspace_artifact") {
+    throw new HonuaMapPackageError(
+      `"workspace_artifact" binding on source "${binding.sourceId}" requires a server-side artifact resolver that is not yet wired`,
+      { packageId, stage: "source-bind", detail: { sourceId: binding.sourceId, protocol: binding.protocol } },
+    );
+  }
+
+  if (typeof loc.url !== "string" || loc.url.length === 0) {
+    throw new HonuaMapPackageError(
+      `SourceBinding "${binding.sourceId}" is missing locator.url`,
+      { packageId, stage: "source-bind", detail: { sourceId: binding.sourceId, protocol: binding.protocol } },
+    );
+  }
+
+  const locator: SourceLocator = { url: loc.url };
+  if (loc.serviceId !== undefined) locator.serviceId = loc.serviceId;
+  if (loc.layerId !== undefined) locator.layerId = loc.layerId;
+  if (loc.collectionId !== undefined) locator.collectionId = loc.collectionId;
+  if (loc.typeName !== undefined) locator.typeName = loc.typeName;
+  if (loc.entitySet !== undefined) locator.entitySet = loc.entitySet;
+  return locator;
+}
+
+function requireLocatorUrl(descriptor: SourceDescriptor): string {
+  const url = descriptor.locator.url;
+  if (typeof url !== "string" || url.length === 0) {
+    throw new HonuaMapPackageError(
+      `descriptor for "${descriptor.id}" is missing locator.url`,
+      { stage: "source-bind", detail: { sourceId: descriptor.id, protocol: descriptor.protocol } },
+    );
+  }
+  return url;
+}
+
+/** Re-export the server-shape locator type so callers do not import a deep path. */
+export type { HonuaMapPackageLocator };

--- a/src/runtime/source-bridge.ts
+++ b/src/runtime/source-bridge.ts
@@ -100,7 +100,7 @@ export function projectSourceBindings(
     descriptors.push({
       id: binding.sourceId,
       protocol: sdkProtocol,
-      locator: toSourceLocator(packageId, binding),
+      locator: toSourceLocator(packageId, binding, sdkProtocol),
       capabilities: PROTOCOL_DEFAULT_CAPABILITIES[sdkProtocol],
       attribution: binding.attribution,
     });
@@ -202,7 +202,11 @@ function toMapLibreNativeSource(binding: HonuaMapPackageSourceBinding): NativeMa
   }
 }
 
-function toSourceLocator(packageId: string | undefined, binding: HonuaMapPackageSourceBinding): SourceLocator {
+function toSourceLocator(
+  packageId: string | undefined,
+  binding: HonuaMapPackageSourceBinding,
+  sdkProtocol: Protocol,
+): SourceLocator {
   const loc = binding.locator;
   if (binding.protocol === "workspace_artifact") {
     throw new HonuaMapPackageError(
@@ -220,11 +224,84 @@ function toSourceLocator(packageId: string | undefined, binding: HonuaMapPackage
 
   const locator: SourceLocator = { url: loc.url };
   if (loc.serviceId !== undefined) locator.serviceId = loc.serviceId;
-  if (loc.layerId !== undefined) locator.layerId = loc.layerId;
+  const normalizedLayerId = normalizeLayerId(loc.layerId);
+  if (normalizedLayerId !== undefined) locator.layerId = normalizedLayerId;
   if (loc.collectionId !== undefined) locator.collectionId = loc.collectionId;
   if (loc.typeName !== undefined) locator.typeName = loc.typeName;
   if (loc.entitySet !== undefined) locator.entitySet = loc.entitySet;
+
+  // Backfill protocol-specific fields from the URL when the server ships
+  // only `locator.url`. The built-in GeoServices and OGC adapters require
+  // `serviceId` + `layerId` / `collectionId`, so projection must fill them
+  // in here rather than failing later inside `createDataset`.
+  if (sdkProtocol === "geoservices-feature-service" || sdkProtocol === "geoservices-map-service") {
+    const parsed = parseGeoServicesUrl(loc.url);
+    if (parsed) {
+      if (locator.serviceId === undefined && parsed.serviceId !== undefined) {
+        locator.serviceId = parsed.serviceId;
+      }
+      if (locator.layerId === undefined && parsed.layerId !== undefined) {
+        locator.layerId = parsed.layerId;
+      }
+    }
+  } else if (sdkProtocol === "ogc-features") {
+    if (locator.collectionId === undefined) {
+      const parsedCollectionId = parseOgcCollectionId(loc.url);
+      if (parsedCollectionId !== undefined) locator.collectionId = parsedCollectionId;
+    }
+  }
   return locator;
+}
+
+/**
+ * Coerce `layerId` to a number when the server wire format serialises it
+ * as a numeric string (the C# mirror declares it as a string so the
+ * JSON wire may arrive as `"0"`). Non-numeric strings are left as-is so
+ * the built-in adapters can surface a typed validation error.
+ */
+function normalizeLayerId(value: unknown): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+  if (typeof value === "string" && value.length > 0) {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return undefined;
+    if (!/^-?\d+$/.test(trimmed)) return undefined;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+const GEOSERVICES_URL_RE = /\/rest\/services\/([^/?#]+)\/(?:FeatureServer|MapServer)(?:\/(\d+))?/i;
+
+function parseGeoServicesUrl(url: string): { serviceId?: string; layerId?: number } | undefined {
+  const match = GEOSERVICES_URL_RE.exec(url);
+  if (!match) return undefined;
+  const result: { serviceId?: string; layerId?: number } = {};
+  if (match[1]) {
+    try {
+      result.serviceId = decodeURIComponent(match[1]);
+    } catch {
+      result.serviceId = match[1];
+    }
+  }
+  if (match[2]) {
+    const parsed = Number(match[2]);
+    if (Number.isFinite(parsed)) result.layerId = parsed;
+  }
+  return result;
+}
+
+const OGC_COLLECTION_URL_RE = /\/collections\/([^/?#]+)/i;
+
+function parseOgcCollectionId(url: string): string | undefined {
+  const match = OGC_COLLECTION_URL_RE.exec(url);
+  if (!match || !match[1]) return undefined;
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
 }
 
 function requireLocatorUrl(descriptor: SourceDescriptor): string {

--- a/src/runtime/style-compose.ts
+++ b/src/runtime/style-compose.ts
@@ -1,0 +1,183 @@
+/**
+ * Compose the runtime MapLibre style document from a `MapPackage`:
+ *
+ *   mapSpec  ─┐
+ *   styleRefs ─┤──> applyStyleRefs ──> applyTheme ──> composed style
+ *   theme     ─┘
+ *
+ * `mapSpec` is already MapLibre-compatible (it is a `HonuaStyleSpecification`).
+ * Style refs attach paint/layout overrides per layer id; theme tokens are
+ * substituted by name against `{theme:key}` placeholders.
+ *
+ * Resolvers are async so the loader can plug into server-hosted lookup
+ * without reopening this module.
+ *
+ * @module
+ */
+
+import type { HonuaLayerSpecification, HonuaStyleSpecification } from "../style/specification.js";
+import { HonuaMapPackageError } from "./errors.js";
+import type {
+  HonuaMapPackage,
+  HonuaMapPackageThemeSpec,
+  HonuaStyleRefBody,
+  HonuaStyleRefLayerOverride,
+} from "./map-package.js";
+
+/**
+ * Resolver for out-of-band style-ref bodies. Returns the per-layer
+ * override map keyed by MapLibre layer id. The default loader assumes
+ * inline bodies attached to the package and calls this resolver only
+ * when the inline body is absent.
+ */
+export type StyleRefResolver = (styleId: string, presetId?: string) => Promise<HonuaStyleRefBody>;
+
+/** Resolver for out-of-band theme bodies; called only when `mapPackage.theme` is absent. */
+export type ThemeResolver = (themeId: string) => Promise<HonuaMapPackageThemeSpec>;
+
+export interface StyleComposeOptions {
+  resolveStyleRef?: StyleRefResolver;
+  resolveTheme?: ThemeResolver;
+}
+
+/** Compose a MapLibre-ready style from the `MapPackage`. */
+export async function composeStyle(
+  pkg: HonuaMapPackage,
+  mapSpecWithSources: HonuaStyleSpecification,
+  options: StyleComposeOptions,
+): Promise<HonuaStyleSpecification> {
+  try {
+    const withStyleRefs = await applyStyleRefs(mapSpecWithSources, pkg, options.resolveStyleRef);
+    const theme = await resolveTheme(pkg, options.resolveTheme);
+    return theme ? applyTheme(withStyleRefs, theme) : withStyleRefs;
+  } catch (cause) {
+    if (cause instanceof HonuaMapPackageError) throw cause;
+    throw new HonuaMapPackageError("style composition failed", {
+      packageId: pkg.mapPackageId,
+      stage: "style-compose",
+      cause,
+    });
+  }
+}
+
+/**
+ * Merge style-ref layer overrides onto the base style. Each ref's body is
+ * keyed by layer id; unknown layer ids are ignored (they may target
+ * layers emitted by an adapter plugin).
+ */
+export async function applyStyleRefs(
+  base: HonuaStyleSpecification,
+  pkg: HonuaMapPackage,
+  resolve?: StyleRefResolver,
+): Promise<HonuaStyleSpecification> {
+  const refs = pkg.styleRefs ?? [];
+  if (refs.length === 0) return base;
+
+  const nextLayers: HonuaLayerSpecification[] = base.layers.map((layer) => cloneLayer(layer));
+
+  for (const ref of refs) {
+    const body = ref.body ?? (resolve ? await resolve(ref.styleId, ref.presetId) : undefined);
+    if (!body) {
+      throw new HonuaMapPackageError(
+        `StyleRef "${ref.styleId}" has no inline body and no resolver was provided`,
+        { packageId: pkg.mapPackageId, stage: "style-compose", detail: { styleId: ref.styleId } },
+      );
+    }
+    for (const [layerId, override] of Object.entries(body)) {
+      const idx = nextLayers.findIndex((layer) => layer.id === layerId);
+      if (idx === -1) continue;
+      nextLayers[idx] = mergeLayerOverride(nextLayers[idx], override);
+    }
+  }
+
+  return { ...base, layers: nextLayers };
+}
+
+/**
+ * Substitute `{theme:key}` placeholders in string paint/layout values with
+ * the corresponding theme token. Values that resolve to nothing are left
+ * untouched so authors can spot missing tokens at review time.
+ */
+export function applyTheme(style: HonuaStyleSpecification, theme: HonuaMapPackageThemeSpec): HonuaStyleSpecification {
+  const tokens = theme.tokens;
+  if (!tokens) return style;
+
+  const nextLayers = style.layers.map((layer) => substituteLayerTokens(layer, tokens));
+  return { ...style, layers: nextLayers };
+}
+
+async function resolveTheme(
+  pkg: HonuaMapPackage,
+  resolve?: ThemeResolver,
+): Promise<HonuaMapPackageThemeSpec | undefined> {
+  if (pkg.theme) return pkg.theme;
+  if (!pkg.themeId) return undefined;
+  if (!resolve) return undefined;
+  try {
+    return await resolve(pkg.themeId);
+  } catch (cause) {
+    throw new HonuaMapPackageError(`theme resolution failed for themeId "${pkg.themeId}"`, {
+      packageId: pkg.mapPackageId,
+      stage: "style-compose",
+      detail: { themeId: pkg.themeId },
+      cause,
+    });
+  }
+}
+
+function mergeLayerOverride(layer: HonuaLayerSpecification, override: HonuaStyleRefLayerOverride): HonuaLayerSpecification {
+  return {
+    ...layer,
+    ...(override.filter !== undefined ? { filter: override.filter } : {}),
+    ...(override.minzoom !== undefined ? { minzoom: override.minzoom } : {}),
+    ...(override.maxzoom !== undefined ? { maxzoom: override.maxzoom } : {}),
+    paint: { ...(layer.paint ?? {}), ...(override.paint ?? {}) },
+    layout: { ...(layer.layout ?? {}), ...(override.layout ?? {}) },
+    metadata: { ...(layer.metadata ?? {}), ...(override.metadata ?? {}) },
+  };
+}
+
+function cloneLayer(layer: HonuaLayerSpecification): HonuaLayerSpecification {
+  return {
+    ...layer,
+    paint: layer.paint ? { ...layer.paint } : undefined,
+    layout: layer.layout ? { ...layer.layout } : undefined,
+    metadata: layer.metadata ? { ...layer.metadata } : undefined,
+  };
+}
+
+function substituteLayerTokens(layer: HonuaLayerSpecification, tokens: Record<string, string | number>): HonuaLayerSpecification {
+  return {
+    ...layer,
+    paint: layer.paint ? substituteTokens(layer.paint, tokens) : layer.paint,
+    layout: layer.layout ? substituteTokens(layer.layout, tokens) : layer.layout,
+  };
+}
+
+function substituteTokens(obj: Record<string, unknown>, tokens: Record<string, string | number>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    out[key] = substituteTokenValue(value, tokens);
+  }
+  return out;
+}
+
+const TOKEN_RE = /^\{theme:([^}]+)\}$/;
+
+function substituteTokenValue(value: unknown, tokens: Record<string, string | number>): unknown {
+  if (typeof value === "string") {
+    const match = value.match(TOKEN_RE);
+    if (match) {
+      const token = tokens[match[1]];
+      return token !== undefined ? token : value;
+    }
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => substituteTokenValue(item, tokens));
+  }
+  if (value && typeof value === "object") {
+    return substituteTokens(value as Record<string, unknown>, tokens);
+  }
+  return value;
+}

--- a/test/runtime/runtime.test.ts
+++ b/test/runtime/runtime.test.ts
@@ -182,9 +182,8 @@ describe("loadMapPackage", () => {
       client: makeClient(),
       skipCompatibilityCheck: true,
       applyInitialView: false,
+      onEvent: (event) => events.push(event),
     });
-    runtime.on((event) => events.push(event));
-    runtime._emit({ type: "source-ready", sourceId: "replay" });
 
     const setStyle = map._calls.find((c) => c.method === "setStyle");
     expect(setStyle, "setStyle should be called").toBeDefined();
@@ -192,7 +191,10 @@ describe("loadMapPackage", () => {
     expect(runtime.composedStyle.layers).toHaveLength(1);
     expect(runtime.dataset.sourceIds()).toEqual(["parcels"]);
 
-    expect(events.some((e) => e.type === "source-ready")).toBe(true);
+    expect(events.some((e) => e.type === "source-ready" && e.sourceId === "parcels")).toBe(true);
+    expect(
+      events.some((e) => e.type === "package-loaded" && e.packageId === pkg.mapPackageId),
+    ).toBe(true);
   });
 
   test("rejects unsupported package format via HonuaMapPackageError", async () => {
@@ -454,6 +456,248 @@ describe("buildLegend", () => {
       },
     );
     expect(entries[0].color).toBe("#ff00ff");
+  });
+});
+
+// ── Regression coverage for review findings ──────────────────
+
+describe("updatePackage: source-binding changes swap runtime dataset/honuaMap", () => {
+  test("locator change triggers setStyle and refreshes runtime.dataset", async () => {
+    const map = makeMockMap();
+    const runtime = await loadMapPackage(makePackage(), map, {
+      client: makeClient(),
+      skipCompatibilityCheck: true,
+      applyInitialView: false,
+    });
+    const datasetBefore = runtime.dataset;
+    const honuaMapBefore = runtime.honuaMap;
+    map._calls.length = 0;
+
+    const next = makePackage({
+      sourceBindings: [
+        {
+          sourceId: "parcels",
+          protocol: "geoservices_feature_service",
+          locator: { url: "https://server.example.com/rest/services/ParcelsV2/FeatureServer/0" },
+          attribution: "© Example County Assessor",
+        },
+      ],
+    });
+
+    const diff = diffPackages(runtime.mapPackage, next);
+    expect(diff.incremental).toBe(false);
+    expect(diff.structuralReason).toBeDefined();
+    expect(diff.changedSourceIds).toContain("parcels");
+
+    await runtime.updatePackage(next);
+
+    expect(map._calls.some((c) => c.method === "setStyle")).toBe(true);
+    expect(runtime.dataset).not.toBe(datasetBefore);
+    expect(runtime.honuaMap).not.toBe(honuaMapBefore);
+    const refreshed = runtime.dataset.source("parcels");
+    expect(refreshed).toBeDefined();
+  });
+
+  test("added source binding triggers structural fallback even without style changes", async () => {
+    const map = makeMockMap();
+    const runtime = await loadMapPackage(makePackage(), map, {
+      client: makeClient(),
+      skipCompatibilityCheck: true,
+      applyInitialView: false,
+    });
+    map._calls.length = 0;
+
+    const next = makePackage({
+      sourceBindings: [
+        ...runtime.mapPackage.sourceBindings,
+        {
+          sourceId: "owners",
+          protocol: "geoservices_feature_service",
+          locator: { url: "https://server.example.com/rest/services/Owners/FeatureServer/1" },
+        },
+      ],
+    });
+
+    const diff = diffPackages(runtime.mapPackage, next);
+    expect(diff.incremental).toBe(false);
+    expect(diff.addedSourceBindings.map((b) => b.sourceId)).toEqual(["owners"]);
+
+    await runtime.updatePackage(next);
+    expect(map._calls.some((c) => c.method === "setStyle")).toBe(true);
+    expect(runtime.dataset.sourceIds()).toContain("owners");
+  });
+});
+
+describe("#patchLayer: paint/layout key removal", () => {
+  test("removing a paint key calls setPaintProperty with undefined to clear it", async () => {
+    const map = makeMockMap();
+    const runtime = await loadMapPackage(makePackage(), map, {
+      client: makeClient(),
+      skipCompatibilityCheck: true,
+      applyInitialView: false,
+    });
+    map._calls.length = 0;
+
+    const next = makePackage({
+      mapSpec: {
+        version: 8,
+        sources: {},
+        layers: [
+          {
+            id: "parcels-fill",
+            type: "fill",
+            source: "parcels",
+            paint: { "fill-color": "#cccccc" }, // fill-opacity removed
+            layout: { visibility: "visible" },
+          },
+        ],
+      },
+    });
+    await runtime.updatePackage(next);
+
+    const removedPaint = map._calls.find(
+      (c) => c.method === "setPaintProperty" && c.args[1] === "fill-opacity",
+    );
+    expect(removedPaint, "setPaintProperty should be called for removed fill-opacity").toBeDefined();
+    expect(removedPaint?.args[2]).toBeUndefined();
+  });
+
+  test("removing a layout key calls setLayoutProperty with undefined to clear it", async () => {
+    const pkg = makePackage({
+      mapSpec: {
+        version: 8,
+        sources: {},
+        layers: [
+          {
+            id: "parcels-fill",
+            type: "fill",
+            source: "parcels",
+            paint: { "fill-color": "#cccccc" },
+            layout: { visibility: "visible", "fill-sort-key": 2 },
+          },
+        ],
+      },
+    });
+    const map = makeMockMap();
+    const runtime = await loadMapPackage(pkg, map, {
+      client: makeClient(),
+      skipCompatibilityCheck: true,
+      applyInitialView: false,
+    });
+    map._calls.length = 0;
+
+    const next = makePackage({
+      mapSpec: {
+        version: 8,
+        sources: {},
+        layers: [
+          {
+            id: "parcels-fill",
+            type: "fill",
+            source: "parcels",
+            paint: { "fill-color": "#cccccc" },
+            layout: { visibility: "visible" }, // fill-sort-key removed
+          },
+        ],
+      },
+    });
+    await runtime.updatePackage(next);
+
+    const removedLayout = map._calls.find(
+      (c) => c.method === "setLayoutProperty" && c.args[1] === "fill-sort-key",
+    );
+    expect(removedLayout, "setLayoutProperty should be called for removed fill-sort-key").toBeDefined();
+    expect(removedLayout?.args[2]).toBeUndefined();
+  });
+});
+
+describe("projectSourceBindings: locator normalization", () => {
+  test("parses GeoServices serviceId and numeric layerId from URL when omitted", () => {
+    const projection = projectSourceBindings("pkg", [
+      {
+        sourceId: "parcels",
+        protocol: "geoservices_feature_service",
+        locator: { url: "https://server.example.com/rest/services/ParcelsV2/FeatureServer/0" },
+      },
+    ]);
+    expect(projection.descriptors[0].locator).toMatchObject({
+      url: "https://server.example.com/rest/services/ParcelsV2/FeatureServer/0",
+      serviceId: "ParcelsV2",
+      layerId: 0,
+    });
+  });
+
+  test("coerces string layerId from server JSON to number", () => {
+    const projection = projectSourceBindings("pkg", [
+      {
+        sourceId: "parcels",
+        protocol: "geoservices_map_service",
+        locator: {
+          url: "https://server.example.com/rest/services/Parcels/MapServer",
+          serviceId: "Parcels",
+          layerId: "3" as unknown as number,
+        },
+      },
+    ]);
+    expect(projection.descriptors[0].locator.layerId).toBe(3);
+  });
+
+  test("parses OGC collectionId from URL when omitted", () => {
+    const projection = projectSourceBindings("pkg", [
+      {
+        sourceId: "boundaries",
+        protocol: "ogc_features",
+        locator: {
+          url: "https://server.example.com/ogc/collections/admin-boundaries",
+        },
+      },
+    ]);
+    expect(projection.descriptors[0].locator.collectionId).toBe("admin-boundaries");
+  });
+
+  test("runtime.dataset.source(...) is usable when the package ships URL-only GeoServices locators", async () => {
+    const map = makeMockMap();
+    const runtime = await loadMapPackage(
+      makePackage({
+        sourceBindings: [
+          {
+            sourceId: "parcels",
+            protocol: "geoservices_feature_service",
+            locator: { url: "https://server.example.com/rest/services/Parcels/FeatureServer/0" },
+          },
+        ],
+      }),
+      map,
+      {
+        client: makeClient(),
+        skipCompatibilityCheck: true,
+        applyInitialView: false,
+      },
+    );
+    const source = runtime.dataset.source("parcels");
+    expect(source).toBeDefined();
+    const adapter = source?.adapter("geoservices-feature-service");
+    expect(adapter).toBeDefined();
+  });
+});
+
+describe("loadMapPackage: onEvent captures initial lifecycle events", () => {
+  test("source-ready and package-loaded reach a listener registered via options.onEvent", async () => {
+    const map = makeMockMap();
+    const pkg = makePackage();
+    const captured: HonuaRuntimeEvent[] = [];
+
+    await loadMapPackage(pkg, map, {
+      client: makeClient(),
+      skipCompatibilityCheck: true,
+      applyInitialView: false,
+      onEvent: (event) => captured.push(event),
+    });
+
+    expect(captured.some((e) => e.type === "source-ready" && e.sourceId === "parcels")).toBe(true);
+    expect(
+      captured.some((e) => e.type === "package-loaded" && e.packageId === pkg.mapPackageId),
+    ).toBe(true);
   });
 });
 

--- a/test/runtime/runtime.test.ts
+++ b/test/runtime/runtime.test.ts
@@ -1,0 +1,472 @@
+/**
+ * Conformance tests for the MapLibre GL JS-first runtime. Exercises the
+ * load → updatePackage → dispose lifecycle against a mock map that
+ * records every call so we can assert the bridge behaviour without
+ * pulling `maplibre-gl` in as a runtime dep.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+
+import { HonuaClient } from "../../src/core/client.js";
+import {
+  HONUA_MAP_PACKAGE_FORMAT_V1,
+  HonuaMapPackageError,
+  type HonuaMapPackage,
+  type HonuaRuntimeEvent,
+  type MaplibreMap,
+  loadMapPackage,
+} from "../../src/runtime/index.js";
+import {
+  applyTheme,
+  buildLegend,
+  diffPackages,
+  projectSourceBindings,
+} from "../../src/runtime/index.js";
+import type { PopupFactory, PopupHandle } from "../../src/runtime/popups.js";
+
+// ── Mock map ─────────────────────────────────────────────────
+
+interface MockCall {
+  method: string;
+  args: unknown[];
+}
+
+interface MockMap extends MaplibreMap {
+  _calls: MockCall[];
+  _style: unknown;
+  _listeners: Array<{ event: string; layer?: string; handler: (...args: unknown[]) => void }>;
+  _featureState: Map<string, Record<string, unknown>>;
+}
+
+function makeMockMap(): MockMap {
+  const calls: MockCall[] = [];
+  const listeners: MockMap["_listeners"] = [];
+  let style: unknown = {};
+  const state = new Map<string, Record<string, unknown>>();
+
+  const record = (method: string, args: unknown[]): void => {
+    calls.push({ method, args });
+  };
+
+  const map: MockMap = {
+    _calls: calls,
+    _style: style,
+    _listeners: listeners,
+    _featureState: state,
+    setStyle(next) {
+      record("setStyle", [next]);
+      style = next;
+      map._style = next;
+      return undefined;
+    },
+    getStyle() {
+      return map._style;
+    },
+    addSource(id, source) {
+      record("addSource", [id, source]);
+    },
+    removeSource(id) {
+      record("removeSource", [id]);
+    },
+    addLayer(layer, beforeId) {
+      record("addLayer", [layer, beforeId]);
+    },
+    removeLayer(id) {
+      record("removeLayer", [id]);
+    },
+    getLayer(id) {
+      record("getLayer", [id]);
+      return undefined;
+    },
+    setLayoutProperty(layerId, name, value) {
+      record("setLayoutProperty", [layerId, name, value]);
+    },
+    setPaintProperty(layerId, name, value) {
+      record("setPaintProperty", [layerId, name, value]);
+    },
+    setFilter(layerId, filter) {
+      record("setFilter", [layerId, filter]);
+    },
+    getSource(id) {
+      record("getSource", [id]);
+      return undefined;
+    },
+    fitBounds(bounds, options) {
+      record("fitBounds", [bounds, options]);
+    },
+    jumpTo(options) {
+      record("jumpTo", [options]);
+    },
+    easeTo(options) {
+      record("easeTo", [options]);
+    },
+    flyTo(options) {
+      record("flyTo", [options]);
+    },
+    setFeatureState(target, next) {
+      state.set(`${target.source}:${target.id}`, { ...(state.get(`${target.source}:${target.id}`) ?? {}), ...next });
+    },
+    getFeatureState(target) {
+      return state.get(`${target.source}:${target.id}`) ?? {};
+    },
+    removeFeatureState(target) {
+      state.delete(`${target.source}:${target.id}`);
+    },
+    on(event, layerOrHandler, handler) {
+      if (typeof layerOrHandler === "string" && handler) {
+        listeners.push({ event, layer: layerOrHandler, handler });
+      } else if (typeof layerOrHandler === "function") {
+        listeners.push({ event, handler: layerOrHandler });
+      }
+    },
+    off(event, layerOrHandler, handler) {
+      const target = typeof layerOrHandler === "function" ? layerOrHandler : handler;
+      const idx = listeners.findIndex((entry) => entry.event === event && entry.handler === target);
+      if (idx >= 0) listeners.splice(idx, 1);
+    },
+  };
+
+  return map;
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeClient(): HonuaClient {
+  return new HonuaClient({
+    baseUrl: "https://mock.honua.test",
+    fetchFn: async () => new Response("not used in tests", { status: 200 }),
+  });
+}
+
+function makePackage(overrides: Partial<HonuaMapPackage> = {}): HonuaMapPackage {
+  return {
+    mapPackageId: "pkg-001",
+    format: HONUA_MAP_PACKAGE_FORMAT_V1,
+    sourceBindings: [
+      {
+        sourceId: "parcels",
+        protocol: "geoservices_feature_service",
+        locator: { url: "https://server.example.com/rest/services/Parcels/FeatureServer/0" },
+        attribution: "© Example County Assessor",
+      },
+    ],
+    mapSpec: {
+      version: 8,
+      sources: {},
+      layers: [
+        {
+          id: "parcels-fill",
+          type: "fill",
+          source: "parcels",
+          paint: { "fill-color": "#cccccc", "fill-opacity": 0.5 },
+          layout: { visibility: "visible" },
+        },
+      ],
+    },
+    legend: [{ label: "Parcels" }],
+    initialView: { bbox: [-123, 37, -120, 45] },
+    popupBindings: [{ sourceId: "parcels", fieldName: "OBJECTID", title: "Parcel" }],
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("loadMapPackage", () => {
+  test("binds package sources, composes style, and emits lifecycle events", async () => {
+    const map = makeMockMap();
+    const pkg = makePackage();
+    const events: HonuaRuntimeEvent[] = [];
+
+    const runtime = await loadMapPackage(pkg, map, {
+      client: makeClient(),
+      skipCompatibilityCheck: true,
+      applyInitialView: false,
+    });
+    runtime.on((event) => events.push(event));
+    runtime._emit({ type: "source-ready", sourceId: "replay" });
+
+    const setStyle = map._calls.find((c) => c.method === "setStyle");
+    expect(setStyle, "setStyle should be called").toBeDefined();
+    expect(runtime.composedStyle.sources).toHaveProperty("parcels");
+    expect(runtime.composedStyle.layers).toHaveLength(1);
+    expect(runtime.dataset.sourceIds()).toEqual(["parcels"]);
+
+    expect(events.some((e) => e.type === "source-ready")).toBe(true);
+  });
+
+  test("rejects unsupported package format via HonuaMapPackageError", async () => {
+    const map = makeMockMap();
+    const bad = makePackage({ format: "honua_map_package.v999" as unknown as typeof HONUA_MAP_PACKAGE_FORMAT_V1 });
+    await expect(
+      loadMapPackage(bad, map, { client: makeClient(), skipCompatibilityCheck: true }),
+    ).rejects.toBeInstanceOf(HonuaMapPackageError);
+  });
+
+  test("rejects workspace_artifact bindings without a server resolver", async () => {
+    const map = makeMockMap();
+    const pkg = makePackage({
+      sourceBindings: [
+        {
+          sourceId: "draft",
+          protocol: "workspace_artifact",
+          locator: { url: "honua://workspace/artifact/1" },
+        },
+      ],
+    });
+    await expect(
+      loadMapPackage(pkg, map, { client: makeClient(), skipCompatibilityCheck: true }),
+    ).rejects.toMatchObject({ stage: "source-bind" });
+  });
+
+  test("applies initialView on first load when applyInitialView is not disabled", async () => {
+    const map = makeMockMap();
+    const pkg = makePackage();
+    await loadMapPackage(pkg, map, { client: makeClient(), skipCompatibilityCheck: true });
+    const fit = map._calls.find((c) => c.method === "fitBounds");
+    expect(fit).toBeDefined();
+  });
+});
+
+describe("HonuaMapRuntime", () => {
+  test("getLegend backfills color from composed style", async () => {
+    const map = makeMockMap();
+    const pkg = makePackage();
+    const runtime = await loadMapPackage(pkg, map, {
+      client: makeClient(),
+      skipCompatibilityCheck: true,
+      applyInitialView: false,
+    });
+    const legend = runtime.getLegend();
+    expect(legend).toHaveLength(1);
+    expect(legend[0]).toMatchObject({ label: "Parcels", color: "#cccccc" });
+  });
+
+  test("setLayerVisibility proxies to setLayoutProperty", async () => {
+    const map = makeMockMap();
+    const runtime = await loadMapPackage(makePackage(), map, {
+      client: makeClient(),
+      skipCompatibilityCheck: true,
+      applyInitialView: false,
+    });
+    runtime.setLayerVisibility("parcels-fill", false);
+    const call = map._calls.find((c) => c.method === "setLayoutProperty");
+    expect(call?.args).toEqual(["parcels-fill", "visibility", "none"]);
+  });
+
+  test("incremental updatePackage applies paint-only changes via setPaintProperty", async () => {
+    const map = makeMockMap();
+    const runtime = await loadMapPackage(makePackage(), map, {
+      client: makeClient(),
+      skipCompatibilityCheck: true,
+      applyInitialView: false,
+    });
+    map._calls.length = 0;
+
+    const next = makePackage({
+      mapSpec: {
+        version: 8,
+        sources: {},
+        layers: [
+          {
+            id: "parcels-fill",
+            type: "fill",
+            source: "parcels",
+            paint: { "fill-color": "#ff0000", "fill-opacity": 0.5 },
+            layout: { visibility: "visible" },
+          },
+        ],
+      },
+    });
+    await runtime.updatePackage(next);
+
+    expect(map._calls.some((c) => c.method === "setStyle")).toBe(false);
+    const paint = map._calls.find((c) => c.method === "setPaintProperty");
+    expect(paint?.args).toEqual(["parcels-fill", "fill-color", "#ff0000"]);
+  });
+
+  test("structural update (layer added) falls back to full setStyle", async () => {
+    const map = makeMockMap();
+    const runtime = await loadMapPackage(makePackage(), map, {
+      client: makeClient(),
+      skipCompatibilityCheck: true,
+      applyInitialView: false,
+    });
+    map._calls.length = 0;
+
+    const next = makePackage({
+      mapSpec: {
+        version: 8,
+        sources: {},
+        layers: [
+          { id: "parcels-outline", type: "line", source: "parcels", paint: { "line-color": "#000000" } },
+          { id: "parcels-fill", type: "fill", source: "parcels", paint: { "fill-color": "#cccccc" } },
+        ],
+      },
+    });
+
+    const diff = diffPackages(runtime.mapPackage, next);
+    expect(diff.incremental).toBe(false);
+    expect(diff.structuralReason).toBeDefined();
+
+    await runtime.updatePackage(next);
+    expect(map._calls.some((c) => c.method === "setStyle")).toBe(true);
+  });
+
+  test("bindPopup requires a popupFactory and wires a click listener", async () => {
+    const popups: Array<ReturnType<typeof makePopupHandle>> = [];
+    const popupFactory: PopupFactory = () => {
+      const handle = makePopupHandle();
+      popups.push(handle);
+      return handle;
+    };
+    const map = makeMockMap();
+    const runtime = await loadMapPackage(makePackage(), map, {
+      client: makeClient(),
+      skipCompatibilityCheck: true,
+      applyInitialView: false,
+      popupFactory,
+      popupRenderer: ({ features }) => `feature=${features[0]?.properties?.OBJECTID}`,
+    });
+
+    const handle = runtime.bindPopup("parcels-fill");
+
+    const click = map._listeners.find((l) => l.event === "click" && l.layer === "parcels-fill");
+    expect(click).toBeDefined();
+
+    click?.handler({
+      lngLat: { lng: -121, lat: 38 },
+      features: [{ properties: { OBJECTID: 42 } }],
+    });
+    expect(popups).toHaveLength(1);
+
+    handle.remove();
+    expect(map._listeners.find((l) => l.layer === "parcels-fill")).toBeUndefined();
+  });
+
+  test("bindPopup without popupFactory raises HonuaMapPackageError stage=popup", async () => {
+    const runtime = await loadMapPackage(makePackage(), makeMockMap(), {
+      client: makeClient(),
+      skipCompatibilityCheck: true,
+      applyInitialView: false,
+    });
+    expect(() => runtime.bindPopup("parcels-fill")).toThrow(HonuaMapPackageError);
+  });
+
+  test("dispose removes layers, sources, and listeners; further calls throw", async () => {
+    const map = makeMockMap();
+    const runtime = await loadMapPackage(makePackage(), map, {
+      client: makeClient(),
+      skipCompatibilityCheck: true,
+      applyInitialView: false,
+    });
+    const events: HonuaRuntimeEvent[] = [];
+    runtime.on((e) => events.push(e));
+
+    runtime.dispose();
+
+    expect(map._calls.some((c) => c.method === "removeLayer" && c.args[0] === "parcels-fill")).toBe(true);
+    expect(map._calls.some((c) => c.method === "removeSource" && c.args[0] === "parcels")).toBe(true);
+    expect(events.some((e) => e.type === "disposed")).toBe(true);
+
+    expect(() => runtime.setLayerVisibility("parcels-fill", false)).toThrow(HonuaMapPackageError);
+
+    runtime.dispose();
+  });
+});
+
+describe("projectSourceBindings", () => {
+  test("translates snake_case server protocol to kebab-case SDK protocol", () => {
+    const projection = projectSourceBindings("pkg", [
+      {
+        sourceId: "parcels",
+        protocol: "geoservices_feature_service",
+        locator: { url: "https://example.com/services/Parcels/FeatureServer/0" },
+      },
+    ]);
+    expect(projection.descriptors[0].protocol).toBe("geoservices-feature-service");
+  });
+
+  test("routes vector_tile bindings to MapLibre-native sources", () => {
+    const projection = projectSourceBindings("pkg", [
+      {
+        sourceId: "satellite",
+        protocol: "vector_tile",
+        locator: { url: "https://tiles.example.com/{z}/{x}/{y}.pbf" },
+      },
+    ]);
+    expect(projection.descriptors).toHaveLength(0);
+    expect(projection.nativeSources).toHaveLength(1);
+    expect(projection.nativeSources[0].spec).toMatchObject({ type: "vector" });
+  });
+
+  test("rejects duplicate sourceIds", () => {
+    expect(() =>
+      projectSourceBindings("pkg", [
+        { sourceId: "a", protocol: "ogc_features", locator: { url: "https://a" } },
+        { sourceId: "a", protocol: "ogc_features", locator: { url: "https://b" } },
+      ]),
+    ).toThrow(HonuaMapPackageError);
+  });
+});
+
+describe("composeStyle: applyTheme", () => {
+  test("substitutes {theme:key} placeholders in paint values", () => {
+    const composed = applyTheme(
+      {
+        version: 8,
+        sources: {},
+        layers: [
+          { id: "x", type: "fill", paint: { "fill-color": "{theme:primary}", "fill-opacity": 0.5 } },
+        ],
+      },
+      { tokens: { primary: "#112233" } },
+    );
+    expect(composed.layers[0].paint).toEqual({ "fill-color": "#112233", "fill-opacity": 0.5 });
+  });
+
+  test("leaves unknown tokens in place so authors can spot them", () => {
+    const composed = applyTheme(
+      {
+        version: 8,
+        sources: {},
+        layers: [{ id: "x", type: "fill", paint: { "fill-color": "{theme:mystery}" } }],
+      },
+      { tokens: { other: "#ffffff" } },
+    );
+    expect(composed.layers[0].paint).toEqual({ "fill-color": "{theme:mystery}" });
+  });
+});
+
+describe("buildLegend", () => {
+  test("returns empty list when package has no legend entries", () => {
+    const entries = buildLegend(undefined, { version: 8, sources: {}, layers: [] });
+    expect(entries).toEqual([]);
+  });
+
+  test("honors explicit color over style fallback", () => {
+    const entries = buildLegend(
+      [{ label: "Highlighted", color: "#ff00ff" }],
+      {
+        version: 8,
+        sources: {},
+        layers: [{ id: "l", type: "fill", paint: { "fill-color": "#ffffff" } }],
+      },
+    );
+    expect(entries[0].color).toBe("#ff00ff");
+  });
+});
+
+// ── Local popup mock ─────────────────────────────────────────
+
+function makePopupHandle(): PopupHandle {
+  const fn = vi.fn();
+  const handle: PopupHandle = {
+    setLngLat: vi.fn().mockReturnThis(),
+    setDOMContent: vi.fn().mockReturnThis(),
+    setHTML: vi.fn().mockReturnThis(),
+    addTo: vi.fn().mockReturnThis(),
+    remove: fn,
+  };
+  return handle;
+}

--- a/test/runtime/runtime.test.ts
+++ b/test/runtime/runtime.test.ts
@@ -287,6 +287,42 @@ describe("HonuaMapRuntime", () => {
     expect(paint?.args).toEqual(["parcels-fill", "fill-color", "#ff0000"]);
   });
 
+  test("composed root layer changes fall back to full setStyle", async () => {
+    const map = makeMockMap();
+    const runtime = await loadMapPackage(makePackage(), map, {
+      client: makeClient(),
+      skipCompatibilityCheck: true,
+      applyInitialView: false,
+    });
+    map._calls.length = 0;
+
+    const next = makePackage({
+      mapSpec: {
+        version: 8,
+        sources: {},
+        layers: [
+          {
+            id: "parcels-fill",
+            type: "fill",
+            source: "parcels",
+            minzoom: 7,
+            paint: { "fill-color": "#cccccc", "fill-opacity": 0.5 },
+            layout: { visibility: "visible" },
+          },
+        ],
+      },
+    });
+
+    await runtime.updatePackage(next);
+
+    const setStyle = map._calls.find((c) => c.method === "setStyle");
+    expect(setStyle, "minzoom cannot be patched through paint/layout/filter setters").toBeDefined();
+    expect(
+      map._calls.some((c) => c.method === "setPaintProperty" || c.method === "setLayoutProperty" || c.method === "setFilter"),
+    ).toBe(false);
+    expect((setStyle?.args[0] as { layers?: Array<{ minzoom?: number }> }).layers?.[0]?.minzoom).toBe(7);
+  });
+
   test("structural update (layer added) falls back to full setStyle", async () => {
     const map = makeMockMap();
     const runtime = await loadMapPackage(makePackage(), map, {
@@ -770,6 +806,32 @@ describe("updatePackage: structural fallback error paths and popup reaping", () 
         ],
       },
     });
+    await runtime.updatePackage(next);
+
+    expect(
+      map._listeners.find((l) => l.event === "click" && l.layer === "parcels-fill"),
+    ).toBeUndefined();
+  });
+
+  test("changing a package popup binding tears down the active package-resolved listener", async () => {
+    const popupFactory: PopupFactory = () => makePopupHandle();
+    const map = makeMockMap();
+    const runtime = await loadMapPackage(makePackage(), map, {
+      client: makeClient(),
+      skipCompatibilityCheck: true,
+      applyInitialView: false,
+      popupFactory,
+    });
+
+    runtime.bindPopup("parcels-fill");
+    expect(
+      map._listeners.find((l) => l.event === "click" && l.layer === "parcels-fill"),
+    ).toBeDefined();
+
+    const next = makePackage({
+      popupBindings: [{ sourceId: "parcels", fieldName: "OWNER", title: "Owner" }],
+    });
+
     await runtime.updatePackage(next);
 
     expect(

--- a/test/runtime/runtime.test.ts
+++ b/test/runtime/runtime.test.ts
@@ -635,7 +635,7 @@ describe("projectSourceBindings: locator normalization", () => {
         locator: {
           url: "https://server.example.com/rest/services/Parcels/MapServer",
           serviceId: "Parcels",
-          layerId: "3" as unknown as number,
+          layerId: "3",
         },
       },
     ]);
@@ -698,6 +698,83 @@ describe("loadMapPackage: onEvent captures initial lifecycle events", () => {
     expect(
       captured.some((e) => e.type === "package-loaded" && e.packageId === pkg.mapPackageId),
     ).toBe(true);
+  });
+});
+
+describe("updatePackage: structural fallback error paths and popup reaping", () => {
+  test("setStyle failure on structural update leaves previous honuaMap intact", async () => {
+    const map = makeMockMap();
+    const runtime = await loadMapPackage(makePackage(), map, {
+      client: makeClient(),
+      skipCompatibilityCheck: true,
+      applyInitialView: false,
+    });
+    const previousHonuaMap = runtime.honuaMap;
+    const previousPackage = runtime.mapPackage;
+    expect(previousHonuaMap.sourceIds).toContain("parcels");
+
+    // Force setStyle to throw on the next (structural) update. The
+    // runtime should preserve the prior state instead of leaving the
+    // honuaMap cleared mid-swap.
+    map.setStyle = () => {
+      throw new Error("host setStyle blew up");
+    };
+
+    const next = makePackage({
+      sourceBindings: [
+        ...makePackage().sourceBindings,
+        {
+          sourceId: "owners",
+          protocol: "geoservices_feature_service",
+          locator: { url: "https://server.example.com/rest/services/Owners/FeatureServer/1" },
+        },
+      ],
+    });
+
+    await expect(runtime.updatePackage(next)).rejects.toBeInstanceOf(HonuaMapPackageError);
+
+    expect(runtime.honuaMap).toBe(previousHonuaMap);
+    expect(runtime.mapPackage).toBe(previousPackage);
+    expect(runtime.honuaMap.sourceIds).toContain("parcels");
+  });
+
+  test("removing a layer in a structural update tears down its popup binding", async () => {
+    const popupFactory: PopupFactory = () => makePopupHandle();
+    const map = makeMockMap();
+    const runtime = await loadMapPackage(makePackage(), map, {
+      client: makeClient(),
+      skipCompatibilityCheck: true,
+      applyInitialView: false,
+      popupFactory,
+    });
+
+    runtime.bindPopup("parcels-fill");
+    expect(
+      map._listeners.find((l) => l.event === "click" && l.layer === "parcels-fill"),
+    ).toBeDefined();
+
+    // Remove the bound layer in the next package so the diff goes
+    // structural (layer set changed) and the popup binding should be
+    // reaped — the map-level click listener must come down with it.
+    const next = makePackage({
+      mapSpec: {
+        version: 8,
+        sources: {},
+        layers: [
+          {
+            id: "parcels-outline",
+            type: "line",
+            source: "parcels",
+            paint: { "line-color": "#000000" },
+          },
+        ],
+      },
+    });
+    await runtime.updatePackage(next);
+
+    expect(
+      map._listeners.find((l) => l.event === "click" && l.layer === "parcels-fill"),
+    ).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #21
## Summary

MapLibre GL JS-first runtime for HonuaMapSpec and operator map packages
## Changes Made

- MapLibre GL JS-first runtime for HonuaMapSpec and operator map packages
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally
## Additional Context

Decisions:
Kept the fix conservative: non-patchable layer deltas go through full `setStyle` rather than adding partial MapLibre operations. Popup bindings are torn down when stale rather than auto-rebound, avoiding hidden behavior changes in caller-provided renderers.

Follow-ons:
None for the active finding set.

Code kaizen:
Deferred 1 low-priority finding(s) to cleanup backlog. Runtime fixes validated and targeted runtime tests pass; only remaining issue is the maplibre-gl peer dependency docs/package mismatch.
