### PR TITLE
feat: First-party WMS client on the shared JS client contract (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ This package currently provides:
 
 - core HTTP client (`HonuaClient`) for FeatureServer, MapServer export/query/related-record operations, and catalog operations, plus fluent layer wrappers (`client.featureLayer(...)`, `client.mapLayer(...)`, `service.featureLayer(...)`, `service.featureLayers()`, `service.mapLayer(...)`, `service.mapLayers()`, `service.mapService().layer(...)`),
 - first-class OGC API clients/wrappers for Features (`client.ogcFeatures()`), Tiles (`client.ogcTiles()`), Maps (`client.ogcMaps()`), Processes (`client.ogcProcesses()`), and STAC (`client.stac()`), including landing/conformance discovery, feature items, tile and map bytes, async `IJobRun` process execution, and STAC search,
+- first-party OGC web-map clients/wrappers for WMS 1.3.0 (`client.wms(serviceId)` → `HonuaWms` / `HonuaWmsLayer`) and WMTS 1.0.0 (`client.wmts(serviceId)` → `HonuaWmts` / `HonuaWmtsLayer` / `HonuaWmtsTileset`) covering Capabilities, `GetMap` (with `TIME` / `ELEVATION` dimension handling and CRS axis-order swap per WMS 1.3 §6.7.3.2), `GetFeatureInfo`, `GetLegendGraphic` (when the server advertises it; otherwise `HonuaCapabilityNotSupportedError`), RESTful + KVP tile fetch, plus MapLibre source helpers `buildWmsRasterSourceSpec(descriptor)` / `buildWmtsRasterSourceSpec(descriptor)` from `@honua/sdk-js/runtime`,
 - Esri-style compatibility wrappers (`FeatureLayerCompat`, `MapImageLayerCompat`, `TileLayerCompat`, `RouteLayerCompat`, `MapCompat`, `MapViewCompat`, `SceneViewCompat`, `WebMapCompat`) for migration-critical patterns,
   including basic `when()` lifecycle support, `FeatureLayer.refresh()/createQuery()/queryFeaturesAll()/queryObjectIds()/queryFeatureCount()/queryExtent()/queryRelatedFeatures()/addAttachment()/updateAttachment()/listFields()/getField()`, `MapImageLayer.when()/refresh()/createQuery()/exportImage()/getLegend()/find()/identify()/queryFeatures()/queryFeaturesAll()/queryFeatureCount()/queryObjectIds()/queryExtent()/queryRelatedFeatures()/findSublayerById()/sublayer(...).query*()` where writable `layer.sublayers` and sublayer lookups return query-capable `MapImageSublayerCompat` wrappers (and auto-hydrate from metadata when not explicitly configured) with nested `sublayer.sublayers/allSublayers`, `sublayer.visible`, and `sublayer.definitionExpression` bridging to query defaults, `FeatureTableCompat` row/query helpers with runtime `layer` switching (`table.layer = nextLayer` / `table.setLayer(nextLayer)`), `Map` layer collection helpers, `GraphicsLayerCompat`/`GroupLayerCompat`, and `MapView` watch/event handles with popup/layer-view bridges plus `toMap`/`toScreen`/`hitTest`/`takeScreenshot()` and `view.ui.add/remove/move/getComponents` compatibility,
 - identify controller (`IdentifyCompat`) for cross-layer MapServer identify workflows with optional popup auto-open,
@@ -174,26 +175,23 @@ The root entrypoint (`@honua/sdk-js`) remains available as an aggregate export f
 ## Shared Client Contract And Exploration
 
 `HonuaFeatureLayer`, `HonuaMapService`, and `HonuaOgcFeatureCollection` continue to be the runtime classes. For
-cross-protocol code — exploration views, visual builders, server packaging, and the WFS / WMS / OData adapter
+cross-protocol code — exploration views, visual builders, server packaging, and the WFS / OData adapter
 tickets — the SDK also exposes a protocol-neutral contract and exploration state module that wrap (not replace)
 those classes.
 
 - `@honua/sdk-js/contract` — canonical `Dataset`, `Source`, `SourceDescriptor`, `Capabilities`, `Query`, `Result`,
-  and `MapBinding` types, plus `createDataset(...)` and built-in adapters for the five GeoServices service
-  types (`geoservices-feature-service`, `geoservices-map-service`, `geoservices-image-service`,
-  `geoservices-geometry-service`, `geoservices-gp-service`) and `ogc-features`. Image / Geometry / GP services
+  `IJobRun`, and `MapBinding` types, plus `createDataset(...)` and built-in adapters for the five GeoServices
+  service types (`geoservices-feature-service`, `geoservices-map-service`, `geoservices-image-service`,
+  `geoservices-geometry-service`, `geoservices-gp-service`), the four OGC API + STAC adapters (`ogc-features`,
+  `ogc-tiles`, `ogc-maps`, `stac`), and the OGC web-map adapters (`wms`, `wmts`). Image / Geometry / GP services
   expose their protocol-specific surface (raster `exportImage` / `identify`, geometry `project` / `buffer` /
   `simplify` / `intersect` / `union` / `clip` / `difference`, GP `submitJob` / `jobStatus` / `cancelJob` /
   `jobResult`) through the typed `Source.protocol()` escape hatch — the canonical query family throws
   `HonuaCapabilityNotSupportedError` for utility-only services so mixed-source apps surface the limitation
   explicitly. The ImageServer adapter rejects `Query.spatialFilter` / `orderBy` / `outFields` rather than
-  silently widening the catalog result. Capability negotiation is `strict` by
-  default; `degraded` opts into client-side fallbacks that surface `Result.degraded[]`. WFS / WMS / OData
-  adapters plug in via `CreateDatasetOptions.resolveSource`. Full contract reference:
-  `IJobRun`, and `MapBinding` types, plus `createDataset(...)` and built-in adapters for
-  `geoservices-feature-service`, `geoservices-map-service`, `ogc-features`, `ogc-tiles`, `ogc-maps`, and `stac`.
-  Capability negotiation is `strict` by default; `degraded` opts
-  into client-side fallbacks that surface `Result.degraded[]`. WFS / WMS / OData adapters plug in via
+  silently widening the catalog result. WMS surfaces `query` through point-only `GetFeatureInfo`; WMTS is
+  render-only (`Source.query()` throws). Capability negotiation is `strict` by default; `degraded` opts into
+  client-side fallbacks that surface `Result.degraded[]`. WFS / OData adapters plug in via
   `CreateDatasetOptions.resolveSource`. Full contract reference:
   [`docs/shared-client-contract.md`](./docs/shared-client-contract.md).
 - `@honua/sdk-js/exploration` — `createExplorationContext(...)` returning an observable, microtask-coalesced

--- a/docs/maplibre-runtime.md
+++ b/docs/maplibre-runtime.md
@@ -66,6 +66,7 @@ runtime.dispose();
 | `SetViewStateInput` | type | `{ bbox?, center?, zoom?, pitch?, bearing?, padding?, animate? }`. |
 | `applyStyleRefs`, `applyTheme`, `composeStyle` | functions | Pure helpers — safe to call outside a runtime for testing / SSR composition. |
 | `projectSourceBindings`, `toHonuaSourceSpec` | functions | Exposed for `#22` and adapter tickets that need the bridge without loading a package. |
+| `buildWmsRasterSourceSpec`, `buildWmtsRasterSourceSpec` | functions | Pre-bake a MapLibre `raster` source spec from a WMS / WMTS `SourceDescriptor`. Used by callers that compose a map outside `loadMapPackage`. See the source-binding projection table for the URL templates emitted on each protocol. |
 | `diffPackages`, `MapPackageDiff` | function / type | Stable-id diff used by `updatePackage`. |
 | `buildLegend`, `LegendEntry` | function / type | Shared with operator components. |
 | `bindPopup`, `defaultPopupRenderer`, `PopupFactory`, `PopupRenderer` | function / types | The default DOM renderer is intentionally unstyled — rich popups belong in `#29`. |
@@ -160,6 +161,12 @@ Additional contract:
     omits them. Explicit locator fields always win over parsed ones.
   - **OGC API Features**: `collectionId` is parsed from the
     `/collections/<id>` URL segment when omitted.
+  - **WMS / WMTS**: `serviceId` is parsed from
+    `/rest/services/<name>/MapServer/WMS` (and `/WMTS`) and from
+    `/ogc/services/<name>/wms` (and `/wmts`) when the binding omits
+    it. `locator.typeName` and `locator.styleId` are not URL-derived
+    today; the server ships them when a binding pins a specific layer
+    or style.
   - **`locator.layerId`**: the server's canonical
     `SourceLocator.LayerId` is `string?`, so
     `HonuaMapPackageLocator.layerId` is typed `number | string`.

--- a/docs/maplibre-runtime.md
+++ b/docs/maplibre-runtime.md
@@ -123,7 +123,9 @@ destinations, using the alignment table in
 | `geoservices_feature_service` | contract adapter | `geoservices-feature-service`, custom source type `honua-feature-service`. |
 | `geoservices_map_service` | contract adapter | `geoservices-map-service`, custom source type `honua-map-service`. |
 | `ogc_features` | contract adapter | `ogc-features`, custom source type `honua-ogc-features`. Collection id is copied from `locator.collectionId`. |
-| `wfs` / `wms` / `odata` | contract adapter (plug-in) | Requires `opts.resolveSource` until the adapter ships. |
+| `wms` | contract adapter | `wms`, custom source type `honua-wms`. `locator.typeName` projects as `layers`, `locator.styleId` as `styles`. Use `buildWmsRasterSourceSpec(descriptor)` to produce a MapLibre-ready `{ type: "raster", tiles, tileSize }` spec with a pre-baked KVP `GetMap` template that uses MapLibre's `{bbox-epsg3857}` / `{width}` / `{height}` placeholders. |
+| `wmts` | contract adapter | `wmts`, custom source type `honua-wmts`. `locator.typeName` / `locator.styleId` / `locator.tileMatrixSetId` project as `layer` / `style` / `tileMatrixSet`. Use `buildWmtsRasterSourceSpec(descriptor)` to produce a MapLibre-ready `{ type: "raster", tiles, tileSize, scheme: "xyz" }` spec using the RESTful `{layer}/{style}/{tms}/{z}/{y}/{x}.{ext}` route. |
+| `wfs` / `odata` | contract adapter (plug-in) | Requires `opts.resolveSource` until the adapter ships. |
 | `vector_tile` / `ogc_tiles` | MapLibre-native | Projected to a `{ type: "vector", tiles: [url], attribution? }` source entry — no contract adapter. |
 | `raster_tile` / `ogc_maps` | MapLibre-native | Projected to a `{ type: "raster", tiles: [url], attribution? }` source entry. |
 | `workspace_artifact` | deferred | Throws `HonuaMapPackageError { stage: "source-bind" }` — no artifact resolver is wired yet. |

--- a/docs/protocol-capability-matrix.md
+++ b/docs/protocol-capability-matrix.md
@@ -264,10 +264,25 @@ Other canonical `Query` fields that GetFeatureInfo cannot honor are
 rejected up front rather than silently dropped: `query({ aggregation })`
 throws `HonuaCapabilityNotSupportedError("queryAggregate", ...)`, and
 `Query.where` / `Query.outFields` / `Query.orderBy` /
-`Query.pagination.offset` / `Query.returnGeometry === false` throw
-typed `Error` messages so a mixed-source caller cannot get an
-unfiltered or differently-shaped result. `Query.pagination.limit` is
-honored — it maps to `FEATURE_COUNT` on the wire.
+`Query.pagination.offset` / `Query.returnGeometry === false` /
+`Query.outSr` throw typed `Error` messages so a mixed-source caller
+cannot get an unfiltered, reprojected, or differently-shaped result.
+`Query.outSr` fails fast because honua-server's WMS GetFeatureInfo
+projects the response in the request CRS itself and exposes no
+separate output-SR knob — callers that need a specific projection
+must stamp the spatial filter geometry's `spatialReference` with the
+desired CRS (the wire CRS is derived from there) or reproject the
+result client-side. `Query.pagination.limit` is honored — it maps to
+`FEATURE_COUNT` on the wire.
+
+`Source.protocol("wms-layer")` is registered only when
+`locator.typeName` parses to a single non-empty layer token because
+`HonuaWmsLayer` is a single-layer handle (its `describe()` resolves
+exactly one `<Layer>` from the parsed Capabilities). Multi-layer
+composites (`typeName: "a,b"`) keep `Source.protocol("wms-layer")`
+unset and route through the service-level `Source.protocol("wms")`
+handle, which can target the composite verbatim via
+`featureInfo()` / `map()`.
 
 Styled-map selection enumerates per-layer styles from
 `HonuaWms.capabilities()` and is bound on the layer handle (`layer.map`,
@@ -308,6 +323,13 @@ sets without a client refactor. Protocol escape hatches:
 `fetchWmtsTile` defaults to the RESTful route (`{layer}/{style}/{tms}/{z}/{y}/{x}.{ext}`)
 because it is a single string substitution per tile and skips
 `URLSearchParams`; `mode: "kvp"` is opt-in for KVP-only proxies.
+The `Format` MIME → RESTful `.ext` mapping is canonical and shared
+between the wire client and the MapLibre helper via
+`wmtsExtensionForFormat` (`src/core/wms-types.ts`): `image/png` →
+`png`, `image/jpeg` / `image/jpg` → `jpeg`, `image/webp` → `webp`;
+unknown formats fall back to `png`. The same caller-supplied `format`
+therefore lands on the same path extension whether the URL is composed
+by `fetchWmtsTile` or `buildWmtsRasterSourceSpec`.
 `request.extraParams` is honored on both routing modes — under
 `mode: "kvp"` keys are merged into the query string verbatim; under
 the default RESTful route the path-encoded WMTS keys (`LAYER`,

--- a/docs/protocol-capability-matrix.md
+++ b/docs/protocol-capability-matrix.md
@@ -269,7 +269,17 @@ through the typed `WmsMapRequest` envelope; defaults come from
 `Capabilities`, request overrides go on the wire. honua-server does not
 implement `GetLegendGraphic` today, so the adapter raises
 `HonuaCapabilityNotSupportedError` from `legend()` when the parsed
-Capabilities advertise no `<GetLegendGraphic>` request element. CRS axis
+Capabilities advertise no `<GetLegendGraphic>` request element. The
+gating always runs: when the caller does not pre-supply
+`options.capabilities`, the handle lazy-loads them once via
+`getWmsCapabilities` and caches the in-flight promise on the instance
+so repeat `legend()` calls reuse the same fetch (transient failures
+clear the cache so the next call retries). The `HonuaWms` parser
+extracts each `<Layer>`'s own `<Name>`, `<Title>`, `<CRS>`,
+`<BoundingBox>`, `<Style>`, and `<Dimension>` from the layer's direct
+children only — descendant `<Layer>` subtrees are stripped before
+metadata reads so child fields never leak upward into the parent (or,
+through ancestor-merge, sideways into sibling layers). CRS axis
 order is honored per WMS 1.3 §6.7.3.2 — `EPSG:4326` is swapped to
 (lat, lon) on the wire while `CRS:84` and `EPSG:3857` keep canonical
 (x, y) tuples. MapLibre integration ships through

--- a/docs/protocol-capability-matrix.md
+++ b/docs/protocol-capability-matrix.md
@@ -250,7 +250,13 @@ First-party WMS 1.3.0 adapter. `render` and `tiles` come from `GetMap`;
 filter (`Query.spatialFilter.geometryType === "esriGeometryPoint"`). The
 adapter constructs a 1×1 render envelope around the requested point,
 asks for `INFO_FORMAT=application/json`, and decodes the JSON response
-into the canonical `Result<T>` envelope. Non-point queries throw
+into the canonical `Result<T>` envelope. The wire CRS is derived from
+the spatial filter geometry's `spatialReference` (`latestWkid` first,
+then `wkid`, then `wkt`) and falls back to `CRS:84` (the WMS 1.3.0
+longitude/latitude code that preserves the canonical `(x, y)` axis
+order). `Query.outSr` is intentionally not consulted on this path
+because it is the **output** spatial reference, not the input CRS for
+GetFeatureInfo. Non-point queries throw
 `HonuaCapabilityNotSupportedError("query", "wms", id)` because WMS has
 no spatial-rel semantics for envelopes / polygons; raw multi-pixel
 GetFeatureInfo lives behind `Source.protocol("wms").featureInfo()`.
@@ -284,8 +290,16 @@ sets without a client refactor. Protocol escape hatches:
 `fetchWmtsTile` defaults to the RESTful route (`{layer}/{style}/{tms}/{z}/{y}/{x}.{ext}`)
 because it is a single string substitution per tile and skips
 `URLSearchParams`; `mode: "kvp"` is opt-in for KVP-only proxies.
-`buildWmtsRasterSourceSpec(descriptor)` emits a MapLibre `raster`
-source spec using the same RESTful path with `{z}/{y}/{x}` placeholders.
+`request.extraParams` is honored on both routing modes — under
+`mode: "kvp"` keys are merged into the query string verbatim; under
+the default RESTful route the path-encoded WMTS keys (`LAYER`,
+`STYLE`, `TILEMATRIXSET`, `TILEMATRIX`, `TILEROW`, `TILECOL`,
+`FORMAT`, `INFOFORMAT`, `I`, `J`, plus `SERVICE` / `VERSION` /
+`REQUEST`) take precedence and any conflicting `extraParams` keys
+(case-insensitive) are dropped so the same URL never carries the
+value twice. `buildWmtsRasterSourceSpec(descriptor)` emits a
+MapLibre `raster` source spec using the same RESTful path with
+`{z}/{y}/{x}` placeholders.
 
 ### OData
 Tabular query with $filter, $select, $orderby, $top, $skip — maps cleanly

--- a/docs/protocol-capability-matrix.md
+++ b/docs/protocol-capability-matrix.md
@@ -260,6 +260,14 @@ GetFeatureInfo. Non-point queries throw
 `HonuaCapabilityNotSupportedError("query", "wms", id)` because WMS has
 no spatial-rel semantics for envelopes / polygons; raw multi-pixel
 GetFeatureInfo lives behind `Source.protocol("wms").featureInfo()`.
+Other canonical `Query` fields that GetFeatureInfo cannot honor are
+rejected up front rather than silently dropped: `query({ aggregation })`
+throws `HonuaCapabilityNotSupportedError("queryAggregate", ...)`, and
+`Query.where` / `Query.outFields` / `Query.orderBy` /
+`Query.pagination.offset` / `Query.returnGeometry === false` throw
+typed `Error` messages so a mixed-source caller cannot get an
+unfiltered or differently-shaped result. `Query.pagination.limit` is
+honored — it maps to `FEATURE_COUNT` on the wire.
 
 Styled-map selection enumerates per-layer styles from
 `HonuaWms.capabilities()` and is bound on the layer handle (`layer.map`,

--- a/docs/protocol-capability-matrix.md
+++ b/docs/protocol-capability-matrix.md
@@ -20,25 +20,25 @@ without a canonical `Source` method today are negotiated for
 `◐` = supported only under `degraded` capability policy (client-side fallback).
 `—` = not supported.
 
-| Capability | GS Feature | GS Map | GS Image | GS Geometry | GS GP | OGC Features | OGC Tiles | OGC Maps | STAC | WFS | WMS | OData |
-| --- | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-| `query` | ✓ | ✓ | ✓ | — | — | ✓ | — | — | ✓ | ✓ | — | ✓ |
-| `queryAggregate` | ✓ | ✓ | — | — | — | ◐ | — | — | — | — | — | — |
-| `queryExtent` | ✓ | ✓ | ✓ | — | — | ◐ | — | — | — | ✓ | — | — |
-| `queryObjectIds` | ✓ | ✓ | ✓ | — | — | ✓ | — | — | ✓ | ✓ | — | ✓ |
-| `queryRelated` | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — |
-| `applyEdits` | ✓ | — | — | — | — | ✓ | — | — | — | ✓ | — | — |
-| `attachments` | ✓ | — | — | — | — | — | — | — | — | — | — | — |
-| `render` | — | ✓ | ✓ | — | — | — | ✓ | ✓ | — | — | ✓ | — |
-| `tiles` | ◐ | ✓ | ✓ | — | — | — | ✓ | — | — | — | ✓ | — |
-| `sql` | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — |
-| `stream` | ✓ | ✓ | — | — | — | ✓ | — | — | ✓ | — | — | — |
-| `pbf` | ✓ | — | — | — | — | — | — | — | — | — | — | — |
-| `connect` | ✓ | — | ✓ | ✓ | ✓ | — | — | — | — | — | — | — |
-| `image` | — | — | ✓ | — | — | — | — | — | — | — | — | — |
-| `geometry` | — | — | — | ✓ | — | — | — | — | — | — | — | — |
-| `geoprocess` | — | — | — | — | ✓ | — | — | — | — | — | — | — |
-| `processes` | — | — | — | — | — | — | — | — | — | — | — | — |
+| Capability | GS Feature | GS Map | GS Image | GS Geometry | GS GP | OGC Features | OGC Tiles | OGC Maps | STAC | WFS | WMS | WMTS | OData |
+| --- | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
+| `query` | ✓ | ✓ | ✓ | — | — | ✓ | — | — | ✓ | ✓ | ✓ | — | ✓ |
+| `queryAggregate` | ✓ | ✓ | — | — | — | ◐ | — | — | — | — | — | — | — |
+| `queryExtent` | ✓ | ✓ | ✓ | — | — | ◐ | — | — | — | ✓ | — | — | — |
+| `queryObjectIds` | ✓ | ✓ | ✓ | — | — | ✓ | — | — | ✓ | ✓ | — | — | ✓ |
+| `queryRelated` | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — |
+| `applyEdits` | ✓ | — | — | — | — | ✓ | — | — | — | ✓ | — | — | — |
+| `attachments` | ✓ | — | — | — | — | — | — | — | — | — | — | — | — |
+| `render` | — | ✓ | ✓ | — | — | — | ✓ | ✓ | — | — | ✓ | ✓ | — |
+| `tiles` | ◐ | ✓ | ✓ | — | — | — | ✓ | — | — | — | ✓ | ✓ | — |
+| `sql` | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — |
+| `stream` | ✓ | ✓ | — | — | — | ✓ | — | — | ✓ | — | — | — | — |
+| `pbf` | ✓ | — | — | — | — | — | — | — | — | — | — | — | — |
+| `connect` | ✓ | — | ✓ | ✓ | ✓ | — | — | — | — | — | — | — | — |
+| `image` | — | — | ✓ | — | — | — | — | — | — | — | — | — | — |
+| `geometry` | — | — | — | ✓ | — | — | — | — | — | — | — | — | — |
+| `geoprocess` | — | — | — | — | ✓ | — | — | — | — | — | — | — | — |
+| `processes` | — | — | — | — | — | — | — | — | — | — | — | — | — |
 
 MapLibre-native sources (`maplibre-vector`, `maplibre-raster`,
 `maplibre-geojson`) are render-only and contribute `render` and (where
@@ -245,11 +245,47 @@ Read + edit, no aggregation, no relates. `queryExtent` is supported via
 Adapter ticket should map `Query.where` to OGC Filter Encoding XML.
 
 ### WMS
-Render-only. The `query` column is `—` because WMS does not expose a
-feature-query path; the GetFeatureInfo response is converted to features
-in the adapter under the `attachments`-adjacent path but not exposed via
-`Source.query`. The adapter ticket may add a `wms-feature-info` capability
-if richer reuse is needed.
+First-party WMS 1.3.0 adapter. `render` and `tiles` come from `GetMap`;
+`query` is supported through `GetFeatureInfo` with a point spatial
+filter (`Query.spatialFilter.geometryType === "esriGeometryPoint"`). The
+adapter constructs a 1×1 render envelope around the requested point,
+asks for `INFO_FORMAT=application/json`, and decodes the JSON response
+into the canonical `Result<T>` envelope. Non-point queries throw
+`HonuaCapabilityNotSupportedError("query", "wms", id)` because WMS has
+no spatial-rel semantics for envelopes / polygons; raw multi-pixel
+GetFeatureInfo lives behind `Source.protocol("wms").featureInfo()`.
+
+Styled-map selection enumerates per-layer styles from
+`HonuaWms.capabilities()` and is bound on the layer handle (`layer.map`,
+`layer.featureInfo`) via the `style` parameter or descriptor
+`locator.styleId`. Dimension handling (`TIME` / `ELEVATION`) flows
+through the typed `WmsMapRequest` envelope; defaults come from
+`Capabilities`, request overrides go on the wire. honua-server does not
+implement `GetLegendGraphic` today, so the adapter raises
+`HonuaCapabilityNotSupportedError` from `legend()` when the parsed
+Capabilities advertise no `<GetLegendGraphic>` request element. CRS axis
+order is honored per WMS 1.3 §6.7.3.2 — `EPSG:4326` is swapped to
+(lat, lon) on the wire while `CRS:84` and `EPSG:3857` keep canonical
+(x, y) tuples. MapLibre integration ships through
+`buildWmsRasterSourceSpec(descriptor)`, which emits a `raster` source
+spec with a pre-baked KVP `tiles` template using MapLibre's runtime
+`{bbox-epsg3857}` / `{width}` / `{height}` placeholders.
+
+### WMTS
+First-party WMTS 1.0.0 adapter. Render-only — `Source.query()` throws
+because WMTS GetFeatureInfo is keyed on tile pixels (which doesn't fit
+the canonical `Query.spatialFilter`). Capabilities expose advertised
+TileMatrixSets through the typed surface; honua-server only advertises
+`WebMercatorQuad` today and the parser-driven design tolerates additional
+sets without a client refactor. Protocol escape hatches:
+`Source.protocol("wmts")` returns the service handle,
+`Source.protocol("wmts-layer")` a layer-bound handle, and
+`Source.protocol("wmts-tileset")` a (layer × style × TMS) tileset handle.
+`fetchWmtsTile` defaults to the RESTful route (`{layer}/{style}/{tms}/{z}/{y}/{x}.{ext}`)
+because it is a single string substitution per tile and skips
+`URLSearchParams`; `mode: "kvp"` is opt-in for KVP-only proxies.
+`buildWmtsRasterSourceSpec(descriptor)` emits a MapLibre `raster`
+source spec using the same RESTful path with `{z}/{y}/{x}` placeholders.
 
 ### OData
 Tabular query with $filter, $select, $orderby, $top, $skip — maps cleanly

--- a/docs/shared-client-contract.md
+++ b/docs/shared-client-contract.md
@@ -5,7 +5,7 @@ Status: implemented in `src/contract/` (ticket `honua-sdk-js-23`).
 The shared contract is the protocol-neutral vocabulary every Honua data
 adapter speaks. It exists so cross-protocol code — exploration views,
 visual builders, the server `SourceBinding`/`MapPackage` exporters, and
-downstream WFS / WMS / OData adapter tickets — can be written once
+downstream WFS / OData adapter tickets — can be written once
 against `Dataset` / `Source` / `Query` / `Result` / `MapBinding` rather
 than re-litigating the surface in each ticket.
 
@@ -14,8 +14,9 @@ than re-litigating the surface in each ticket.
 - **Goal:** one canonical name for "the dataset", "the source", "the
   capability", "the query", "the result", "the map binding", and "the
   exploration state" across `HonuaFeatureLayer`, `HonuaMapService`,
-  `HonuaOgcFeatures`, first-party OGC render/search adapters, and the
-  upcoming WFS / WMS / OData adapters.
+  `HonuaOgcFeatures`, first-party OGC render/search adapters,
+  first-party WMS / WMTS adapters, and the upcoming WFS / OData
+  adapters.
 - **Goal:** wrap (do not replace) the existing runtime classes in
   `src/core/surfaces.ts`. Existing callers continue to work; adapter
   tickets opt in to the canonical surface.
@@ -27,7 +28,7 @@ than re-litigating the surface in each ticket.
   (`geoServicesFeatureSource`, `geoServicesMapServiceSource`,
   `geoServicesImageSource`, `geoServicesGeometryServiceSource`,
   `geoServicesGPServiceSource`, `ogcFeaturesSource`, `ogcTilesSource`,
-  `ogcMapsSource`, `stacSearchSource`).
+  `ogcMapsSource`, `stacSearchSource`, `wmsSource`, `wmtsSource`).
 - **Non-goal:** a query DSL. `Query.where` is still a SQL-92 / CQL2
   string; adapters translate to their wire format.
 
@@ -47,7 +48,7 @@ top-level `@honua/sdk-js` and `@honua/sdk-js/honua` barrels).
 
 | Type | What it is |
 | --- | --- |
-| `Protocol` | One of fifteen identifiers — five GeoServices service types (`geoservices-feature-service`, `geoservices-map-service`, `geoservices-image-service`, `geoservices-geometry-service`, `geoservices-gp-service`), four OGC API + STAC adapters (`ogc-features`, `ogc-tiles`, `ogc-maps`, `stac`), `wfs`, `wms`, `odata`, plus three MapLibre-native (`maplibre-vector`, `maplibre-raster`, `maplibre-geojson`). |
+| `Protocol` | One of sixteen identifiers — five GeoServices service types (`geoservices-feature-service`, `geoservices-map-service`, `geoservices-image-service`, `geoservices-geometry-service`, `geoservices-gp-service`), four OGC API + STAC adapters (`ogc-features`, `ogc-tiles`, `ogc-maps`, `stac`), `wfs`, `wms`, `wmts`, `odata`, plus three MapLibre-native (`maplibre-vector`, `maplibre-raster`, `maplibre-geojson`). |
 | `Capability` | A coarse-grained protocol capability (`query`, `queryAggregate`, `queryExtent`, `queryObjectIds`, `queryRelated`, `applyEdits`, `attachments`, `render`, `tiles`, `sql`, `stream`, `pbf`, `connect`, `image`, `geometry`, `geoprocess`, `processes`). The canonical `Source` surface standardizes the query / edit / related / attachment / object-id subset today; `image` / `geometry` / `geoprocess` / `processes` are negotiated for `Source.protocol()` escape hatches and for the `IJobRun`-based OGC API Processes runner because their request shapes are too protocol-specific to belong on the unified envelope. |
 | `Capabilities` | `ReadonlySet<Capability>`. Set membership = first-party protocol support, whether the caller consumes it through a canonical `Source` method or the typed protocol escape hatch. Under `strict` (default) a missing capability throws `HonuaCapabilityNotSupportedError`. Under `degraded` only call sites with a defined fallback proceed (today: OGC `queryAggregate` and `queryExtent`); every other missing capability still throws. |
 | `SourceLocator` | Protocol-specific endpoint info (`url`, `serviceId`, `layerId`, `collectionId`, `tileMatrixSetId`, `styleId`, `typeName`, `entitySet`, `taskName`). Field-compatible with the server `SourceBinding.locator`; `tileMatrixSetId` / `styleId` carry OGC API Tiles / Maps route hints for downstream `SourceBinding` work tracked in [`source-binding-alignment.md`](./source-binding-alignment.md). |
@@ -115,8 +116,8 @@ const result = await parcels.query({ where: "STATE = 'CA'", pagination: { limit:
 The built-in resolver handles `geoservices-feature-service`,
 `geoservices-map-service`, `geoservices-image-service`,
 `geoservices-geometry-service`, `geoservices-gp-service`, `ogc-features`,
-`ogc-tiles`, `ogc-maps`, and `stac`. WFS / WMS / OData adapters register
-themselves through `CreateDatasetOptions.resolveSource`. OGC API
+`ogc-tiles`, `ogc-maps`, `stac`, `wms`, and `wmts`. WFS / OData adapters
+register themselves through `CreateDatasetOptions.resolveSource`. OGC API
 Processes is a job runner rather than a queryable source — reach it
 through `HonuaClient.ogcProcesses().execute(...)` (returns the canonical
 `IJobRun<T>`) instead of `Dataset.source()`.
@@ -145,6 +146,17 @@ The OGC API and STAC factories cover `docs/ogc-api.md`:
 - `ogcMapsSource` — OGC API Maps (render-only; same shape as Tiles).
 - `stacSearchSource` — STAC API search (`/search` query, queryObjectIds,
   stream; cross-collection scope via `locator.collectionId`).
+
+The WMS / WMTS factories cover the OGC web-map services per
+`docs/protocol-capability-matrix.md`:
+
+- `wmsSource` — WMS 1.3.0 (render + tiles via `GetMap`; `query` via
+  point-only `GetFeatureInfo`; raw multi-pixel `featureInfo()` and the
+  per-layer service handles reachable via
+  `Source.protocol("wms" | "wms-layer")`).
+- `wmtsSource` — WMTS 1.0.0 (render + tiles via RESTful tiles; query
+  family throws; service / layer / tileset handles reachable via
+  `Source.protocol("wmts" | "wmts-layer" | "wmts-tileset")`).
 
 `Source.queryAll()` and `Source.stream()` drain every page the server
 returns — the built-in adapters override the core helpers' 100-page
@@ -195,12 +207,14 @@ The shipped map covers `geoservices-feature-service` →
 `geoservices-map-layer` → `HonuaMapLayer`, `geoservices-image-service`
 → `HonuaImageService`, `geoservices-geometry-service` →
 `HonuaGeometryService`, `geoservices-gp-service` →
-`HonuaGeoprocessingService`, and `ogc-features` →
-`HonuaOgcFeatureCollection`.
+`HonuaGeoprocessingService`, `ogc-features` →
+`HonuaOgcFeatureCollection`, `wms` → `HonuaWms`, `wms-layer` →
+`HonuaWmsLayer`, `wmts` → `HonuaWmts`, `wmts-layer` →
+`HonuaWmtsLayer`, and `wmts-tileset` → `HonuaWmtsTileset`.
 
 ## What downstream tickets must consume
 
-1. WFS, WMS, OData adapter tickets must implement `Source<T>` and
+1. WFS and OData adapter tickets must implement `Source<T>` and
    register through `resolveSource`. They must declare their default
    capability set in `PROTOCOL_DEFAULT_CAPABILITIES` (this file owns
    that table — adapter PRs extend it).
@@ -273,6 +287,28 @@ search flows through the canonical `Source.query()` like every other
 tabular protocol. OGC API Processes does not register as a `Source`
 because its inputs are not queryable; it produces `IJobRun<T>` from
 `execute(...)`.
+
+## WMS / WMTS web-map services
+
+The first-party OGC web-map adapters share the contract surface:
+
+| Service | Entry point | Source protocol | Contract capabilities |
+| --- | --- | --- | --- |
+| WMS 1.3.0 | `client.wms(serviceId)` / `HonuaWms`, `HonuaWmsLayer` | `wms` | `render`, `tiles`, `query` (point-only `GetFeatureInfo`) |
+| WMTS 1.0.0 | `client.wmts(serviceId)` / `HonuaWmts`, `HonuaWmtsLayer`, `HonuaWmtsTileset` | `wmts` | `render`, `tiles` |
+
+`Source.protocol("wms")` returns the service handle and
+`Source.protocol("wms-layer")` a layer-bound handle (when
+`locator.typeName` is set). WMTS exposes three handles —
+`Source.protocol("wmts")` (service), `"wmts-layer"` (layer-bound), and
+`"wmts-tileset"` (layer × style × tile-matrix-set bound). MapLibre
+integration ships through the runtime helpers
+`buildWmsRasterSourceSpec(descriptor)` /
+`buildWmtsRasterSourceSpec(descriptor)` from `@honua/sdk-js/runtime` —
+they emit a `raster` source spec without forcing callers to hand-assemble
+a `GetMap` URL or RESTful tile template. See
+[`docs/protocol-capability-matrix.md`](./protocol-capability-matrix.md)
+for axis-order, dimension, legend, and TileMatrixSet notes.
 
 OGC conformance class identifiers are intentionally kept *internal*.
 `negotiateOgcCapabilities(protocol, conformsTo)` from

--- a/docs/shared-client-contract.md
+++ b/docs/shared-client-contract.md
@@ -309,8 +309,19 @@ integration ships through the runtime helpers
 `buildWmsRasterSourceSpec(descriptor)` /
 `buildWmtsRasterSourceSpec(descriptor)` from `@honua/sdk-js/runtime` —
 they emit a `raster` source spec without forcing callers to hand-assemble
-a `GetMap` URL or RESTful tile template. See
-[`docs/protocol-capability-matrix.md`](./protocol-capability-matrix.md)
+a `GetMap` URL or RESTful tile template. The style-spec resolver
+`createSources(client, style)` (from `@honua/sdk-js`) and
+`HonuaMap.getSource(name)` both produce the same `HonuaWms` /
+`HonuaWmsLayer` / `HonuaWmts` / `HonuaWmtsTileset` handles when a
+style declares a `honua-wms` / `honua-wmts` source type — the shared
+`src/style/wms-wmts-resolvers.ts` module owns the URL parsing and
+layer / tileset selection rules so the two surfaces never diverge.
+The WMS `LAYERS=` / `locator.typeName` / `spec.layers` value is
+parsed through the canonical `parseWmsLayerNames` helper (in
+`src/core/wms.ts`); the layer-bound `HonuaWmsLayer` handle is only
+returned for a single non-empty token, while multi-layer composites
+(`"a,b"`) stay on the service-level `HonuaWms` handle.
+See [`docs/protocol-capability-matrix.md`](./protocol-capability-matrix.md)
 for axis-order, dimension, legend, and TileMatrixSet notes.
 
 OGC conformance class identifiers are intentionally kept *internal*.

--- a/docs/shared-client-contract.md
+++ b/docs/shared-client-contract.md
@@ -224,7 +224,10 @@ The shipped map covers `geoservices-feature-service` →
    shapes are still available via `Source.adapter()` for legacy paths.
 3. New error types must flow through `HonuaError` and `isHonuaError`.
    This ticket added `HonuaCapabilityNotSupportedError` and
-   `HonuaExplorationContextError`.
+   `HonuaExplorationContextError`. The first-party WMS / WMTS adapter
+   ticket extended the union with `HonuaWmsCapabilitiesParseError` and
+   `HonuaWmtsCapabilitiesParseError` so callers can classify XML parser
+   failures through the same guard.
 
 ## Async operations: `IJobRun`
 

--- a/docs/source-binding-alignment.md
+++ b/docs/source-binding-alignment.md
@@ -22,7 +22,7 @@ locator fields until the server schema exposes them explicitly.
 | `locator.collectionId` | `locator.collectionId` | OGC API Features / Tiles / Maps / STAC collection. |
 | `locator.tileMatrixSetId` | `locator.tileMatrixSetId` | OGC API Tiles tile-matrix-set identifier. When set, `Source.adapter("ogc-tiles")` returns a bound `HonuaOgcTileset`; when omitted, it returns the root `HonuaOgcTiles` handle for tile-matrix-set discovery. Preserved as an additive locator field when present. |
 | `locator.styleId` | `locator.styleId` | OGC API Maps styled-output identifier. Consumed by `Source.adapter("ogc-maps")` to build the `/styles/{styleId}/map` route. Not consumed by the OGC Tiles adapter today: honua-server does not expose a `/styles/{styleId}/tiles/...` route, so the SDK keeps the tile path canonical. Preserved as an additive locator field when present. |
-| `locator.typeName` | `locator.typeName` | WFS / WMS type-name. |
+| `locator.typeName` | `locator.typeName` | WFS / WMS / WMTS layer name (the WMS `LAYERS=` value, the WMTS `Layer` identifier). |
 | `locator.entitySet` | `locator.entitySet` | OData entity set. |
 | `locator.taskName` | `locator.taskName` | GP Service task identifier; combined with `serviceId` it uniquely identifies one async task without leaking task parameters into the descriptor. Required on descriptors that advertise the `geoprocess` capability — `createDataset` rejects bindings without it because the lifecycle routes (`/GPServer/<taskName>/submitJob` etc.) do not exist at the service root. |
 | `capabilities` | `capabilities` | Set serialized as a sorted string array on the wire. The server is authoritative for what it serves; the SDK's set is what the **adapter** can produce. |
@@ -106,7 +106,9 @@ runtime's `source-bridge.ts`:
 | `geoservices_feature_service` | `geoservices-feature-service` |
 | `geoservices_map_service` | `geoservices-map-service` |
 | `ogc_features` | `ogc-features` |
-| `wfs` / `wms` / `odata` | `wfs` / `wms` / `odata` |
+| `wms` | `wms` (custom MapLibre source `honua-wms`; `locator.typeName` → `layers`, `locator.styleId` → `styles`) |
+| `wmts` | `wmts` (custom MapLibre source `honua-wmts`; `locator.typeName` / `locator.styleId` / `locator.tileMatrixSetId` → `layer` / `style` / `tileMatrixSet`) |
+| `wfs` / `odata` | `wfs` / `odata` |
 | `vector_tile` / `ogc_tiles` | MapLibre-native `vector` source (no SDK adapter) |
 | `raster_tile` / `ogc_maps` | MapLibre-native `raster` source (no SDK adapter) |
 | `workspace_artifact` | Deferred — throws `HonuaMapPackageError { stage: "source-bind" }` until a workspace resolver is wired. |

--- a/src/contract/index.ts
+++ b/src/contract/index.ts
@@ -74,6 +74,8 @@ export {
   ogcTilesSource,
   ogcMapsSource,
   stacSearchSource,
+  wmsSource,
+  wmtsSource,
 } from "./source.js";
 
 export type {

--- a/src/contract/source.ts
+++ b/src/contract/source.ts
@@ -13,17 +13,15 @@
 
 import type { HonuaClient } from "../core/client.js";
 import { HonuaCapabilityNotSupportedError, HonuaHttpError } from "../core/errors.js";
-import { HonuaOgcMaps, HonuaOgcCollectionMap } from "../core/ogc-maps.js";
+import { HonuaOgcCollectionMap, HonuaOgcMaps } from "../core/ogc-maps.js";
 import type { HonuaOgcProcesses } from "../core/ogc-processes.js";
 import { HonuaOgcTiles, HonuaOgcTileset } from "../core/ogc-tiles.js";
 import { HonuaStacSearch } from "../core/stac.js";
-import { HonuaWms, HonuaWmsLayer } from "../core/wms.js";
-import { HonuaWmts, HonuaWmtsLayer, HonuaWmtsTileset } from "../core/wmts.js";
 import {
   HonuaFeatureLayer,
-  HonuaImageService,
   HonuaGeometryService,
   HonuaGeoprocessingService,
+  HonuaImageService,
   HonuaMapLayer,
   HonuaMapService,
   HonuaOgcFeatureCollection,
@@ -40,9 +38,9 @@ import type {
   HonuaTypedQueryResponse,
   StacSearchRequest,
 } from "../core/types.js";
+import { HonuaWms, HonuaWmsLayer, parseWmsLayerNames } from "../core/wms.js";
+import { HonuaWmts, HonuaWmtsLayer, HonuaWmtsTileset } from "../core/wmts.js";
 import {
-  CAPABILITIES,
-  PROTOCOL_DEFAULT_CAPABILITIES,
   type AdapterFor,
   type AdapterKind,
   type AggregationFn,
@@ -56,6 +54,7 @@ import {
   type AttachmentInfo,
   type AttachmentQuery,
   type AttachmentUpdate,
+  CAPABILITIES,
   type Capability,
   type CapabilityPolicy,
   type CreateDatasetOptions,
@@ -65,6 +64,7 @@ import {
   type EditOutcome,
   type EditResult,
   type FeatureId,
+  PROTOCOL_DEFAULT_CAPABILITIES,
   type Protocol,
   type Query,
   type RelatedGroup,
@@ -764,11 +764,18 @@ export function wmsSource<T>(descriptor: SourceDescriptor, client: HonuaClient, 
   const styleId = descriptor.locator.styleId;
   const root = new HonuaWms({ client, serviceId });
   const adapterRegistry: Partial<Record<AdapterKind, unknown>> = { wms: root };
-  if (typeof layerName === "string" && layerName.length > 0) {
+  // `HonuaWmsLayer` is a single-layer handle (its `describe()` resolves
+  // exactly one `<Layer>` from the parsed Capabilities). Multi-layer
+  // composites (`LAYERS=a,b`) must stay on the service-level `wms`
+  // handle and use `featureInfo()` directly; registering them as a
+  // `wms-layer` would silently mis-route `describe()` / `stylesIn()` /
+  // `legend()` to a single layer name that does not exist on the wire.
+  const parsedLayers = parseWmsLayerNames(layerName);
+  if (parsedLayers.length === 1) {
     const layerOpts: { client: HonuaClient; serviceId: string; layerName: string; defaultStyleId?: string } = {
       client,
       serviceId,
-      layerName,
+      layerName: parsedLayers[0]!,
     };
     if (typeof styleId === "string") layerOpts.defaultStyleId = styleId;
     adapterRegistry["wms-layer"] = new HonuaWmsLayer(layerOpts);
@@ -1217,26 +1224,26 @@ function requireWmtsLocator(descriptor: SourceDescriptor): { serviceId: string }
 }
 
 function wmsRequireLayers(descriptor: SourceDescriptor, locatorTypeName: string | undefined): readonly string[] {
-  if (typeof locatorTypeName !== "string" || locatorTypeName.length === 0) {
+  const parsed = parseWmsLayerNames(locatorTypeName);
+  if (parsed.length === 0) {
     throw new Error(
       `createDataset: source "${descriptor.id}" (wms) requires locator.typeName (the WMS LAYER name) for canonical query()`,
     );
   }
-  return locatorTypeName
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
+  return parsed;
 }
 
 /**
  * Reject canonical `Query` fields that WMS GetFeatureInfo cannot honor so a
- * mixed-source caller does not silently receive an unfiltered or
- * differently-shaped result. WMS GetFeatureInfo only consumes the (i, j)
- * pixel pair plus the rendered envelope; there is no SQL/CQL filter, no
- * field projection, no order, no offset paging, and no geometry toggle on
- * the wire. `aggregation` is mapped to `queryAggregate` so the error
- * carries the same capability vocabulary as the rest of the contract.
- * `pagination.limit` is honored (it maps to `FEATURE_COUNT`).
+ * mixed-source caller does not silently receive an unfiltered, reprojected,
+ * or differently-shaped result. WMS GetFeatureInfo only consumes the
+ * (i, j) pixel pair plus the rendered envelope; there is no SQL/CQL filter,
+ * no field projection, no order, no offset paging, no geometry toggle, and
+ * no separate output-SR knob on the wire — honua-server projects the
+ * response in the request CRS itself. `aggregation` is mapped to
+ * `queryAggregate` so the error carries the same capability vocabulary as
+ * the rest of the contract. `pagination.limit` is honored (it maps to
+ * `FEATURE_COUNT`).
  */
 function requireWmsCompatibleQuery<T>(descriptor: SourceDescriptor, request: Query<T> | undefined): void {
   if (!request) return;
@@ -1266,6 +1273,11 @@ function requireWmsCompatibleQuery<T>(descriptor: SourceDescriptor, request: Que
   if (request.returnGeometry === false) {
     throw new Error(
       `wms: Query.returnGeometry=false is not supported on GetFeatureInfo for source "${descriptor.id}"; the server controls geometry inclusion via INFO_FORMAT and the layer template. Drop returnGeometry or strip geometry client-side.`,
+    );
+  }
+  if (request.outSr !== undefined) {
+    throw new Error(
+      `wms: Query.outSr is not supported on GetFeatureInfo for source "${descriptor.id}"; honua-server projects the response in the request CRS and has no separate output-SR knob. Stamp the spatial filter geometry's spatialReference with the desired CRS instead, or reproject the result client-side.`,
     );
   }
 }

--- a/src/contract/source.ts
+++ b/src/contract/source.ts
@@ -17,6 +17,8 @@ import { HonuaOgcMaps, HonuaOgcCollectionMap } from "../core/ogc-maps.js";
 import type { HonuaOgcProcesses } from "../core/ogc-processes.js";
 import { HonuaOgcTiles, HonuaOgcTileset } from "../core/ogc-tiles.js";
 import { HonuaStacSearch } from "../core/stac.js";
+import { HonuaWms, HonuaWmsLayer } from "../core/wms.js";
+import { HonuaWmts, HonuaWmtsLayer, HonuaWmtsTileset } from "../core/wmts.js";
 import {
   HonuaFeatureLayer,
   HonuaImageService,
@@ -96,14 +98,11 @@ export function createDataset(options: CreateDatasetOptions): Dataset {
     const cached = handles.get(descriptor.id);
     if (cached) return cached as Source<T>;
 
-    const built = buildBuiltInSource<T>(descriptor, client, policy)
-      ?? resolveSource?.(descriptor, { client, capabilityPolicy: policy }) as Source<T> | undefined;
+    const built =
+      buildBuiltInSource<T>(descriptor, client, policy) ??
+      (resolveSource?.(descriptor, { client, capabilityPolicy: policy }) as Source<T> | undefined);
     if (!built) {
-      throw new HonuaCapabilityNotSupportedError(
-        "query",
-        descriptor.protocol,
-        descriptor.id,
-      );
+      throw new HonuaCapabilityNotSupportedError("query", descriptor.protocol, descriptor.id);
     }
     handles.set(descriptor.id, built as Source);
     return built;
@@ -124,7 +123,10 @@ export function createDataset(options: CreateDatasetOptions): Dataset {
     isCompatible(): Promise<boolean> {
       if (options.skipCompatibilityCheck) return Promise.resolve(true);
       if (!compatibilityPromise) {
-        compatibilityPromise = client.checkCompatibility().then((status) => status.supported).catch(() => false);
+        compatibilityPromise = client
+          .checkCompatibility()
+          .then((status) => status.supported)
+          .catch(() => false);
       }
       return compatibilityPromise;
     },
@@ -158,6 +160,10 @@ function buildBuiltInSource<T>(
       return ogcTilesSource<T>(descriptor, client, policy);
     case "ogc-maps":
       return ogcMapsSource<T>(descriptor, client, policy);
+    case "wms":
+      return wmsSource<T>(descriptor, client, policy);
+    case "wmts":
+      return wmtsSource<T>(descriptor, client, policy);
     case "stac":
       return stacSearchSource<T>(descriptor, client, policy);
     default:
@@ -220,7 +226,9 @@ export function geoServicesFeatureSource<T>(
     },
     async *stream(request) {
       ensureCapability(descriptor, caps, "stream");
-      const stream = layer.queryFeaturesStream(withStreamPageSize(toFeatureLayerRequest(request), request?.pagination?.limit));
+      const stream = layer.queryFeaturesStream(
+        withStreamPageSize(toFeatureLayerRequest(request), request?.pagination?.limit),
+      );
       for await (const page of stream) {
         yield {
           features: page,
@@ -301,7 +309,9 @@ export function geoServicesMapServiceSource<T>(
     },
     async *stream(request) {
       ensureCapability(descriptor, caps, "stream");
-      const stream = layer.queryFeaturesStream(withStreamPageSize(toFeatureLayerRequest(request), request?.pagination?.limit));
+      const stream = layer.queryFeaturesStream(
+        withStreamPageSize(toFeatureLayerRequest(request), request?.pagination?.limit),
+      );
       for await (const page of stream) {
         yield {
           features: page.map(toTypedFeature<T>),
@@ -362,7 +372,8 @@ export function ogcFeaturesSource<T>(
         const aggregateRows = clientSideAggregate(features, request.aggregation);
         degraded.push({
           capability: "queryAggregate",
-          reason: "OGC API Features does not expose server-side aggregation; aggregating client-side over the returned page.",
+          reason:
+            "OGC API Features does not expose server-side aggregation; aggregating client-side over the returned page.",
           protocol: "ogc-features",
         });
         return {
@@ -604,9 +615,7 @@ export function geoServicesImageSource<T>(
     async queryExtent(request) {
       ensureCapability(descriptor, caps, "queryExtent");
       requireImageServerCompatibleQuery(request);
-      const response = await service.queryRasterCatalog(
-        toExtentOnlyRequest(toFeatureLayerRequest(request)),
-      );
+      const response = await service.queryRasterCatalog(toExtentOnlyRequest(toFeatureLayerRequest(request)));
       return extractExtentEnvelope(response);
     },
     // biome-ignore lint/correctness/useYield: ImageServer has no streaming raster-catalog mode; this generator refuses iteration rather than silently emit a single page
@@ -737,6 +746,131 @@ export function ogcMapsSource<T>(
   return makeSource<T>(descriptor, caps, policy, adapterRegistry, unsupportedFeatureSurface<T>(descriptor));
 }
 
+// ── WMS 1.3 ───────────────────────────────────────────────────
+
+/**
+ * `Source` adapter for first-party WMS 1.3.0 services. The render path
+ * routes through `HonuaWms` / `HonuaWmsLayer` (both of which sit
+ * behind the canonical `Source.protocol("wms" | "wms-layer")` escape
+ * hatch); `Source.query()` translates a point spatial filter into a
+ * `GetFeatureInfo` call. Non-point queries throw
+ * `HonuaCapabilityNotSupportedError` so the canonical query envelope
+ * stays honest — multi-pixel feature info lives on
+ * `Source.protocol("wms").featureInfo()`.
+ */
+export function wmsSource<T>(descriptor: SourceDescriptor, client: HonuaClient, policy: CapabilityPolicy): Source<T> {
+  const { serviceId } = requireWmsLocator(descriptor);
+  const layerName = descriptor.locator.typeName;
+  const styleId = descriptor.locator.styleId;
+  const root = new HonuaWms({ client, serviceId });
+  const adapterRegistry: Partial<Record<AdapterKind, unknown>> = { wms: root };
+  if (typeof layerName === "string" && layerName.length > 0) {
+    const layerOpts: { client: HonuaClient; serviceId: string; layerName: string; defaultStyleId?: string } = {
+      client,
+      serviceId,
+      layerName,
+    };
+    if (typeof styleId === "string") layerOpts.defaultStyleId = styleId;
+    adapterRegistry["wms-layer"] = new HonuaWmsLayer(layerOpts);
+  }
+  const caps = descriptor.capabilities ?? PROTOCOL_DEFAULT_CAPABILITIES.wms;
+
+  return makeSource<T>(descriptor, caps, policy, adapterRegistry, {
+    async query(request) {
+      ensureCapability(descriptor, caps, "query");
+      const layers = wmsRequireLayers(descriptor, layerName);
+      const point = wmsExtractPointFromQuery(request, descriptor);
+      const crs = (request?.outSr !== undefined ? wmsCrsFromOutSr(request.outSr) : "EPSG:3857") as string;
+      const bboxRadius = 0.0001; // tiny envelope around the point keeps the request a 1×1 image.
+      const [px, py] = point;
+      const widthHeight = 1;
+      const featureCount = request?.pagination?.limit;
+      const response = await client.getWmsFeatureInfo<T>({
+        serviceId,
+        layers,
+        ...(styleId !== undefined ? { styles: [styleId] } : {}),
+        queryLayers: layers,
+        crs,
+        bbox: [px - bboxRadius, py - bboxRadius, px + bboxRadius, py + bboxRadius],
+        width: widthHeight,
+        height: widthHeight,
+        i: 0,
+        j: 0,
+        infoFormat: "application/json",
+        ...(featureCount !== undefined ? { featureCount } : {}),
+        ...(request?.signal ? { signal: request.signal } : {}),
+      });
+      return {
+        features: response.features ?? [],
+        exceededTransferLimit: false,
+      } satisfies Result<T>;
+    },
+    async queryAll(request) {
+      ensureCapability(descriptor, caps, "query");
+      // GetFeatureInfo returns a single response set; queryAll degenerates
+      // to query() because there is no paging on the wire.
+      const result = await this.query(request);
+      return result;
+    },
+    async queryAggregate() {
+      throw new HonuaCapabilityNotSupportedError("queryAggregate", descriptor.protocol, descriptor.id);
+    },
+    async queryExtent() {
+      throw new HonuaCapabilityNotSupportedError("queryExtent", descriptor.protocol, descriptor.id);
+    },
+    // biome-ignore lint/correctness/useYield: WMS exposes only single-shot GetFeatureInfo, which is delivered through query()
+    async *stream() {
+      throw new HonuaCapabilityNotSupportedError("stream", descriptor.protocol, descriptor.id);
+    },
+    async queryObjectIds() {
+      throw new HonuaCapabilityNotSupportedError("queryObjectIds", descriptor.protocol, descriptor.id);
+    },
+    async applyEdits() {
+      throw new HonuaCapabilityNotSupportedError("applyEdits", descriptor.protocol, descriptor.id);
+    },
+    async queryRelated() {
+      throw new HonuaCapabilityNotSupportedError("queryRelated", descriptor.protocol, descriptor.id);
+    },
+    attachments: unsupportedAttachmentApi(descriptor),
+  });
+}
+
+// ── WMTS 1.0 ──────────────────────────────────────────────────
+
+/**
+ * Render-only `Source` adapter for first-party WMTS 1.0.0 services.
+ * `Source.query()` throws because WMTS GetFeatureInfo is keyed on tile
+ * pixels (not a canonical spatial filter); raw access lives on
+ * `Source.protocol("wmts" | "wmts-layer" | "wmts-tileset")`.
+ */
+export function wmtsSource<T>(descriptor: SourceDescriptor, client: HonuaClient, policy: CapabilityPolicy): Source<T> {
+  const { serviceId } = requireWmtsLocator(descriptor);
+  const layerName = descriptor.locator.typeName;
+  const tileMatrixSetId = descriptor.locator.tileMatrixSetId ?? "WebMercatorQuad";
+  const styleId = descriptor.locator.styleId ?? "default";
+  const root = new HonuaWmts({ client, serviceId });
+  const adapterRegistry: Partial<Record<AdapterKind, unknown>> = { wmts: root };
+  if (typeof layerName === "string" && layerName.length > 0) {
+    adapterRegistry["wmts-layer"] = new HonuaWmtsLayer({
+      client,
+      serviceId,
+      layerName,
+      defaultStyleId: styleId,
+      defaultTileMatrixSetId: tileMatrixSetId,
+    });
+    adapterRegistry["wmts-tileset"] = new HonuaWmtsTileset({
+      client,
+      serviceId,
+      layerName,
+      styleId,
+      tileMatrixSetId,
+    });
+  }
+  const caps = descriptor.capabilities ?? PROTOCOL_DEFAULT_CAPABILITIES.wmts;
+
+  return makeSource<T>(descriptor, caps, policy, adapterRegistry, unsupportedFeatureSurface<T>(descriptor));
+}
+
 // ── STAC API ──────────────────────────────────────────────────
 
 export function stacSearchSource<T>(
@@ -761,8 +895,7 @@ export function stacSearchSource<T>(
       const response = await stac.search(stacRequest);
       const features = (response.features ?? []).map(toTypedFeatureFromStac<T>);
       const totalCount = response.numberMatched ?? response.context?.matched;
-      const exceededTransferLimit =
-        totalCount !== undefined && features.length < totalCount;
+      const exceededTransferLimit = totalCount !== undefined && features.length < totalCount;
       return {
         features,
         exceededTransferLimit,
@@ -948,11 +1081,7 @@ function unsupportedFeatureSurface<T>(descriptor: SourceDescriptor): SourceImple
   };
 }
 
-function ensureCapability(
-  descriptor: SourceDescriptor,
-  caps: ReadonlySet<Capability>,
-  capability: Capability,
-): void {
+function ensureCapability(descriptor: SourceDescriptor, caps: ReadonlySet<Capability>, capability: Capability): void {
   if (caps.has(capability)) return;
   throw new HonuaCapabilityNotSupportedError(capability, descriptor.protocol, descriptor.id);
 }
@@ -1005,9 +1134,7 @@ function requireOgcLocator(descriptor: SourceDescriptor): { collectionId: string
 function requireImageServiceLocator(descriptor: SourceDescriptor): { serviceId: string } {
   const { serviceId } = descriptor.locator;
   if (typeof serviceId !== "string") {
-    throw new Error(
-      `createDataset: source "${descriptor.id}" (geoservices-image-service) requires locator.serviceId`,
-    );
+    throw new Error(`createDataset: source "${descriptor.id}" (geoservices-image-service) requires locator.serviceId`);
   }
   return { serviceId };
 }
@@ -1047,9 +1174,7 @@ function requireGPServiceLocator(
 ): { serviceId: string; taskName: string | undefined } {
   const { serviceId, taskName } = descriptor.locator;
   if (typeof serviceId !== "string") {
-    throw new Error(
-      `createDataset: source "${descriptor.id}" (geoservices-gp-service) requires locator.serviceId`,
-    );
+    throw new Error(`createDataset: source "${descriptor.id}" (geoservices-gp-service) requires locator.serviceId`);
   }
   // Honua Server publishes submitJob / jobs / cancel / results only under
   // /rest/services/<serviceId>/GPServer/<taskName>/..., so descriptors that
@@ -1074,6 +1199,76 @@ function requireOgcTilesLocator(descriptor: SourceDescriptor): {
     throw new Error(`createDataset: source "${descriptor.id}" (ogc-tiles) requires locator.collectionId`);
   }
   return { collectionId, tileMatrixSetId };
+}
+
+function requireWmsLocator(descriptor: SourceDescriptor): { serviceId: string } {
+  const { serviceId } = descriptor.locator;
+  if (typeof serviceId !== "string" || serviceId.length === 0) {
+    throw new Error(`createDataset: source "${descriptor.id}" (wms) requires locator.serviceId`);
+  }
+  return { serviceId };
+}
+
+function requireWmtsLocator(descriptor: SourceDescriptor): { serviceId: string } {
+  const { serviceId } = descriptor.locator;
+  if (typeof serviceId !== "string" || serviceId.length === 0) {
+    throw new Error(`createDataset: source "${descriptor.id}" (wmts) requires locator.serviceId`);
+  }
+  return { serviceId };
+}
+
+function wmsRequireLayers(descriptor: SourceDescriptor, locatorTypeName: string | undefined): readonly string[] {
+  if (typeof locatorTypeName !== "string" || locatorTypeName.length === 0) {
+    throw new Error(
+      `createDataset: source "${descriptor.id}" (wms) requires locator.typeName (the WMS LAYER name) for canonical query()`,
+    );
+  }
+  return locatorTypeName
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Extract a single (x, y) point from `Query.spatialFilter`. WMS only
+ * exposes feature-info on a pixel coordinate, so the canonical
+ * `Source.query()` is restricted to point spatial filters. Non-point
+ * geometries throw `HonuaCapabilityNotSupportedError`.
+ */
+function wmsExtractPointFromQuery<T>(
+  request: Query<T> | undefined,
+  descriptor: SourceDescriptor,
+): readonly [number, number] {
+  const filter = request?.spatialFilter;
+  if (!filter) {
+    throw new HonuaCapabilityNotSupportedError("query", descriptor.protocol, descriptor.id);
+  }
+  const geom = filter.geometry as { x?: unknown; y?: unknown; coordinates?: unknown } | undefined;
+  if (filter.geometryType !== "esriGeometryPoint") {
+    throw new HonuaCapabilityNotSupportedError("query", descriptor.protocol, descriptor.id);
+  }
+  if (geom && typeof geom.x === "number" && typeof geom.y === "number") {
+    return [geom.x, geom.y] as const;
+  }
+  if (geom && Array.isArray(geom.coordinates) && geom.coordinates.length >= 2) {
+    const [x, y] = geom.coordinates as readonly unknown[];
+    if (typeof x === "number" && typeof y === "number") return [x, y] as const;
+  }
+  throw new HonuaCapabilityNotSupportedError("query", descriptor.protocol, descriptor.id);
+}
+
+/**
+ * Translate a canonical `Query.outSr` (WKID or full SR object) into a
+ * WMS-compatible CRS code. Only the codes honua-server advertises
+ * (`EPSG:4326`, `EPSG:3857`, `CRS:84`) are first-party; anything else
+ * passes through verbatim and the server's CRS validator decides.
+ */
+function wmsCrsFromOutSr(outSr: string | number | undefined): string | undefined {
+  if (outSr === undefined) return undefined;
+  if (typeof outSr === "number") return `EPSG:${outSr}`;
+  const trimmed = outSr.trim();
+  if (/^\d+$/.test(trimmed)) return `EPSG:${trimmed}`;
+  return trimmed;
 }
 
 function toStacRequest<T>(
@@ -1215,9 +1410,7 @@ function toFeatureLayerRequest<T>(request?: Query<T>): {
   if (request.returnGeometry !== undefined) out.returnGeometry = request.returnGeometry;
   if (request.outSr !== undefined) out.outSr = request.outSr;
   if (request.orderBy && request.orderBy.length > 0) {
-    out.orderByFields = request.orderBy
-      .map((s) => `${s.field}${s.direction === "desc" ? " DESC" : ""}`)
-      .join(",");
+    out.orderByFields = request.orderBy.map((s) => `${s.field}${s.direction === "desc" ? " DESC" : ""}`).join(",");
   }
   if (request.spatialFilter) {
     out.geometry = request.spatialFilter.geometry;
@@ -1271,9 +1464,10 @@ function hasExtentFilter<T>(request?: Query<T>): boolean {
   return false;
 }
 
-function computeExtentFromOgcFeatures(
-  features: ReadonlyArray<import("../core/types.js").HonuaOgcFeatureResponse>,
-): { extent: import("../core/types.js").HonuaExtent | null; count: number } {
+function computeExtentFromOgcFeatures(features: ReadonlyArray<import("../core/types.js").HonuaOgcFeatureResponse>): {
+  extent: import("../core/types.js").HonuaExtent | null;
+  count: number;
+} {
   let xmin = Number.POSITIVE_INFINITY;
   let ymin = Number.POSITIVE_INFINITY;
   let xmax = Number.NEGATIVE_INFINITY;
@@ -1336,9 +1530,7 @@ function toOgcRequest<T>(request?: Query<T>): Record<string, unknown> {
     if (request.pagination.offset !== undefined) out.offset = request.pagination.offset;
   }
   if (request.orderBy && request.orderBy.length > 0) {
-    out.sortby = request.orderBy
-      .map((s) => `${s.direction === "desc" ? "-" : ""}${s.field}`)
-      .join(",");
+    out.sortby = request.orderBy.map((s) => `${s.direction === "desc" ? "-" : ""}${s.field}`).join(",");
   }
   if (request.spatialFilter) {
     // OGC API Features only exposes bbox at /items; arbitrary geometry types
@@ -1607,7 +1799,11 @@ function toApplyEditsRequest<T>(envelope: EditEnvelope<T>): {
   return out;
 }
 
-function canonicalToHonuaFeature<T>(feature: { id?: FeatureId; attributes: T; geometry?: Record<string, unknown> | null }): HonuaFeature {
+function canonicalToHonuaFeature<T>(feature: {
+  id?: FeatureId;
+  attributes: T;
+  geometry?: Record<string, unknown> | null;
+}): HonuaFeature {
   const attributes = { ...(feature.attributes as Record<string, unknown>) };
   // GeoServices addresses updates by `OBJECTID` inside attributes; populate it
   // from the canonical `id` when the caller supplied one but did not embed it
@@ -1692,7 +1888,11 @@ function canonicalRelatedResult<R>(response: import("../core/types.js").HonuaRel
   return out;
 }
 
-function featureToGeoJsonFeature<T>(feature: { id?: FeatureId; attributes: T; geometry?: Record<string, unknown> | null }): {
+function featureToGeoJsonFeature<T>(feature: {
+  id?: FeatureId;
+  attributes: T;
+  geometry?: Record<string, unknown> | null;
+}): {
   type: "Feature";
   id?: FeatureId;
   geometry: Record<string, unknown> | null;
@@ -1750,7 +1950,9 @@ function featureLayerAttachmentApi<T>(
     async query(request) {
       ensureAttachments();
       const response = await layer.queryAttachments({
-        ...(request?.parentIds ? { objectIds: request.parentIds.map(toAttachmentNumericId).filter(isFiniteNumberStrict) } : {}),
+        ...(request?.parentIds
+          ? { objectIds: request.parentIds.map(toAttachmentNumericId).filter(isFiniteNumberStrict) }
+          : {}),
         ...(request?.where !== undefined ? { where: request.where } : {}),
         ...(request?.signal ? { signal: request.signal } : {}),
       });
@@ -1798,7 +2000,8 @@ function featureLayerAttachmentApi<T>(
       const numericIds = request.attachmentIds.map(toAttachmentNumericId).filter(isFiniteNumberStrict);
       const response = await layer.deleteAttachments({
         objectId: request.parentId,
-        attachmentIds: numericIds.length === request.attachmentIds.length ? numericIds : request.attachmentIds.map(String).join(","),
+        attachmentIds:
+          numericIds.length === request.attachmentIds.length ? numericIds : request.attachmentIds.map(String).join(","),
         ...(request.signal ? { signal: request.signal } : {}),
       });
       return (response.deleteAttachmentResults ?? []).map((r) => toAttachmentEditOutcome(r, request.parentId));
@@ -1862,6 +2065,11 @@ declare module "./types.js" {
     "ogc-maps": HonuaOgcMaps | HonuaOgcCollectionMap;
     "ogc-processes": HonuaOgcProcesses;
     stac: HonuaStacSearch;
+    wms: HonuaWms;
+    "wms-layer": HonuaWmsLayer;
+    wmts: HonuaWmts;
+    "wmts-layer": HonuaWmtsLayer;
+    "wmts-tileset": HonuaWmtsTileset;
   }
 }
 
@@ -1881,4 +2089,6 @@ export const FIRST_PARTY_PROTOCOLS: ReadonlySet<Protocol> = new Set([
   "ogc-tiles",
   "ogc-maps",
   "stac",
+  "wms",
+  "wmts",
 ] as const);

--- a/src/contract/source.ts
+++ b/src/contract/source.ts
@@ -779,10 +779,8 @@ export function wmsSource<T>(descriptor: SourceDescriptor, client: HonuaClient, 
     async query(request) {
       ensureCapability(descriptor, caps, "query");
       const layers = wmsRequireLayers(descriptor, layerName);
-      const point = wmsExtractPointFromQuery(request, descriptor);
-      const crs = (request?.outSr !== undefined ? wmsCrsFromOutSr(request.outSr) : "EPSG:3857") as string;
+      const { x: px, y: py, crs } = wmsExtractPointFromQuery(request, descriptor);
       const bboxRadius = 0.0001; // tiny envelope around the point keeps the request a 1×1 image.
-      const [px, py] = point;
       const widthHeight = 1;
       const featureCount = request?.pagination?.limit;
       const response = await client.getWmsFeatureInfo<T>({
@@ -1230,45 +1228,65 @@ function wmsRequireLayers(descriptor: SourceDescriptor, locatorTypeName: string 
 }
 
 /**
- * Extract a single (x, y) point from `Query.spatialFilter`. WMS only
+ * Extract `(x, y)` and the WMS CRS from `Query.spatialFilter`. WMS only
  * exposes feature-info on a pixel coordinate, so the canonical
- * `Source.query()` is restricted to point spatial filters. Non-point
- * geometries throw `HonuaCapabilityNotSupportedError`.
+ * `Source.query()` is restricted to point spatial filters. The CRS is
+ * derived from the geometry's `spatialReference` (`wkid` / `latestWkid` /
+ * `wkt`) and falls back to `CRS:84` — the WMS 1.3.0 longitude/latitude
+ * code that preserves the canonical `(x, y)` axis order — when the
+ * caller did not stamp the geometry with a spatial reference. Non-point
+ * geometries throw `HonuaCapabilityNotSupportedError`. `Query.outSr` is
+ * intentionally not consulted here: it is the **output** spatial
+ * reference for projected results, not the input CRS for the
+ * GetFeatureInfo wire request.
  */
 function wmsExtractPointFromQuery<T>(
   request: Query<T> | undefined,
   descriptor: SourceDescriptor,
-): readonly [number, number] {
+): { x: number; y: number; crs: string } {
   const filter = request?.spatialFilter;
   if (!filter) {
     throw new HonuaCapabilityNotSupportedError("query", descriptor.protocol, descriptor.id);
   }
-  const geom = filter.geometry as { x?: unknown; y?: unknown; coordinates?: unknown } | undefined;
+  const geom = filter.geometry as
+    | { x?: unknown; y?: unknown; coordinates?: unknown; spatialReference?: unknown }
+    | undefined;
   if (filter.geometryType !== "esriGeometryPoint") {
     throw new HonuaCapabilityNotSupportedError("query", descriptor.protocol, descriptor.id);
   }
+  const crs = wmsCrsFromGeometrySpatialReference(geom?.spatialReference);
   if (geom && typeof geom.x === "number" && typeof geom.y === "number") {
-    return [geom.x, geom.y] as const;
+    return { x: geom.x, y: geom.y, crs };
   }
   if (geom && Array.isArray(geom.coordinates) && geom.coordinates.length >= 2) {
     const [x, y] = geom.coordinates as readonly unknown[];
-    if (typeof x === "number" && typeof y === "number") return [x, y] as const;
+    if (typeof x === "number" && typeof y === "number") return { x, y, crs };
   }
   throw new HonuaCapabilityNotSupportedError("query", descriptor.protocol, descriptor.id);
 }
 
 /**
- * Translate a canonical `Query.outSr` (WKID or full SR object) into a
- * WMS-compatible CRS code. Only the codes honua-server advertises
- * (`EPSG:4326`, `EPSG:3857`, `CRS:84`) are first-party; anything else
- * passes through verbatim and the server's CRS validator decides.
+ * Translate a geometry's `spatialReference` (Esri-style `{ wkid?,
+ * latestWkid?, wkt? }`) into a WMS-compatible CRS code. `wkid` /
+ * `latestWkid` map to `EPSG:N`. A non-empty `wkt` is passed through
+ * verbatim — the server validates it. When no recognizable hint is
+ * present the function returns `CRS:84` so the canonical (x, y) axis
+ * order is preserved on the wire.
  */
-function wmsCrsFromOutSr(outSr: string | number | undefined): string | undefined {
-  if (outSr === undefined) return undefined;
-  if (typeof outSr === "number") return `EPSG:${outSr}`;
-  const trimmed = outSr.trim();
-  if (/^\d+$/.test(trimmed)) return `EPSG:${trimmed}`;
-  return trimmed;
+function wmsCrsFromGeometrySpatialReference(spatialReference: unknown): string {
+  if (spatialReference && typeof spatialReference === "object") {
+    const sr = spatialReference as { wkid?: unknown; latestWkid?: unknown; wkt?: unknown };
+    if (typeof sr.latestWkid === "number" && Number.isFinite(sr.latestWkid)) {
+      return `EPSG:${sr.latestWkid}`;
+    }
+    if (typeof sr.wkid === "number" && Number.isFinite(sr.wkid)) {
+      return `EPSG:${sr.wkid}`;
+    }
+    if (typeof sr.wkt === "string" && sr.wkt.trim().length > 0) {
+      return sr.wkt.trim();
+    }
+  }
+  return "CRS:84";
 }
 
 function toStacRequest<T>(

--- a/src/contract/source.ts
+++ b/src/contract/source.ts
@@ -778,6 +778,7 @@ export function wmsSource<T>(descriptor: SourceDescriptor, client: HonuaClient, 
   return makeSource<T>(descriptor, caps, policy, adapterRegistry, {
     async query(request) {
       ensureCapability(descriptor, caps, "query");
+      requireWmsCompatibleQuery(descriptor, request);
       const layers = wmsRequireLayers(descriptor, layerName);
       const { x: px, y: py, crs } = wmsExtractPointFromQuery(request, descriptor);
       const bboxRadius = 0.0001; // tiny envelope around the point keeps the request a 1×1 image.
@@ -1225,6 +1226,48 @@ function wmsRequireLayers(descriptor: SourceDescriptor, locatorTypeName: string 
     .split(",")
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
+}
+
+/**
+ * Reject canonical `Query` fields that WMS GetFeatureInfo cannot honor so a
+ * mixed-source caller does not silently receive an unfiltered or
+ * differently-shaped result. WMS GetFeatureInfo only consumes the (i, j)
+ * pixel pair plus the rendered envelope; there is no SQL/CQL filter, no
+ * field projection, no order, no offset paging, and no geometry toggle on
+ * the wire. `aggregation` is mapped to `queryAggregate` so the error
+ * carries the same capability vocabulary as the rest of the contract.
+ * `pagination.limit` is honored (it maps to `FEATURE_COUNT`).
+ */
+function requireWmsCompatibleQuery<T>(descriptor: SourceDescriptor, request: Query<T> | undefined): void {
+  if (!request) return;
+  if (request.aggregation) {
+    throw new HonuaCapabilityNotSupportedError("queryAggregate", descriptor.protocol, descriptor.id);
+  }
+  if (typeof request.where === "string" && request.where.length > 0) {
+    throw new Error(
+      `wms: Query.where is not supported on GetFeatureInfo for source "${descriptor.id}"; WMS has no SQL/CQL filter on the wire. Pre-filter via Query.spatialFilter (point) or use a tabular protocol.`,
+    );
+  }
+  if (request.outFields && request.outFields.length > 0) {
+    throw new Error(
+      `wms: Query.outFields is not supported on GetFeatureInfo for source "${descriptor.id}"; the server returns the layer's full attribute schema. Project client-side after the result lands.`,
+    );
+  }
+  if (request.orderBy && request.orderBy.length > 0) {
+    throw new Error(
+      `wms: Query.orderBy is not supported on GetFeatureInfo for source "${descriptor.id}"; the server has no sort surface. Sort client-side after the result lands.`,
+    );
+  }
+  if (typeof request.pagination?.offset === "number" && request.pagination.offset > 0) {
+    throw new Error(
+      `wms: Query.pagination.offset is not supported on GetFeatureInfo for source "${descriptor.id}"; the request returns at most FEATURE_COUNT records and does not paginate. Drop pagination.offset.`,
+    );
+  }
+  if (request.returnGeometry === false) {
+    throw new Error(
+      `wms: Query.returnGeometry=false is not supported on GetFeatureInfo for source "${descriptor.id}"; the server controls geometry inclusion via INFO_FORMAT and the layer template. Drop returnGeometry or strip geometry client-side.`,
+    );
+  }
 }
 
 /**

--- a/src/contract/types.ts
+++ b/src/contract/types.ts
@@ -17,12 +17,7 @@
 
 import type { HonuaClient } from "../core/client.js";
 import type { SpatialFilter } from "../core/spatial-filter.js";
-import type {
-  HonuaExtent,
-  HonuaFieldInfo,
-  HonuaServerCompatibilityFeature,
-  HonuaTypedFeature,
-} from "../core/types.js";
+import type { HonuaExtent, HonuaFieldInfo, HonuaServerCompatibilityFeature, HonuaTypedFeature } from "../core/types.js";
 
 // ── Protocol identifiers ──────────────────────────────────────
 
@@ -53,6 +48,7 @@ export type Protocol =
   | "stac"
   | "wfs"
   | "wms"
+  | "wmts"
   | "odata"
   | "maplibre-vector"
   | "maplibre-raster"
@@ -71,6 +67,7 @@ export const PROTOCOLS: readonly Protocol[] = [
   "stac",
   "wfs",
   "wms",
+  "wmts",
   "odata",
   "maplibre-vector",
   "maplibre-raster",
@@ -197,7 +194,8 @@ export const PROTOCOL_DEFAULT_CAPABILITIES: Readonly<Record<Protocol, Capabiliti
   "ogc-maps": capabilities(["render"]),
   stac: capabilities(["query", "queryObjectIds", "stream"]),
   wfs: capabilities(["query", "queryExtent", "queryObjectIds", "applyEdits"]),
-  wms: capabilities(["render", "tiles"]),
+  wms: capabilities(["render", "tiles", "query"]),
+  wmts: capabilities(["render", "tiles"]),
   odata: capabilities(["query", "queryObjectIds"]),
   "maplibre-vector": capabilities(["render", "tiles"]),
   "maplibre-raster": capabilities(["render", "tiles"]),
@@ -534,6 +532,10 @@ export type AdapterKind =
   | "stac"
   | "wfs"
   | "wms"
+  | "wms-layer"
+  | "wmts"
+  | "wmts-layer"
+  | "wmts-tileset"
   | "odata";
 
 /**
@@ -644,10 +646,7 @@ export interface ResolveSourceContext {
  * tickets register their adapters by passing one through
  * `CreateDatasetOptions.resolveSource`.
  */
-export type SourceResolver = (
-  descriptor: SourceDescriptor,
-  ctx: ResolveSourceContext,
-) => Source | undefined;
+export type SourceResolver = (descriptor: SourceDescriptor, ctx: ResolveSourceContext) => Source | undefined;
 
 export interface CreateDatasetOptions {
   id: DatasetId;

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -839,14 +839,15 @@ export class HonuaClient {
       return this.requestBytes("GET", path, format, undefined, request.signal);
     }
     const ext = wmtsExtensionForFormat(format);
-    const path =
-      `${wmtsBasePath(request.serviceId)}` +
-      `/${encodeURIComponent(request.layer)}` +
-      `/${encodeURIComponent(style)}` +
-      `/${encodeURIComponent(tileMatrixSet)}` +
-      `/${encodeURIComponent(String(request.tileMatrix))}` +
-      `/${encodeURIComponent(String(request.tileRow))}` +
-      `/${encodeURIComponent(String(request.tileCol))}.${ext}`;
+    const base = wmtsBasePath(request.serviceId);
+    const layer = encodeURIComponent(request.layer);
+    const styleSeg = encodeURIComponent(style);
+    const tmsSeg = encodeURIComponent(tileMatrixSet);
+    const tm = encodeURIComponent(String(request.tileMatrix));
+    const tr = encodeURIComponent(String(request.tileRow));
+    const tc = encodeURIComponent(String(request.tileCol));
+    const extra = wmtsRestExtraParamsSuffix(request.extraParams);
+    const path = `${base}/${layer}/${styleSeg}/${tmsSeg}/${tm}/${tr}/${tc}.${ext}${extra}`;
     return this.requestBytes("GET", path, format, undefined, request.signal);
   }
 
@@ -887,16 +888,17 @@ export class HonuaClient {
       return decodeWmsFeatureInfoResponse<T>(response.bytes, response.contentType, infoFormat);
     }
     const ext = wmtsFeatureInfoExtensionForFormat(infoFormat);
-    const path =
-      `${wmtsBasePath(request.serviceId)}` +
-      `/${encodeURIComponent(request.layer)}` +
-      `/${encodeURIComponent(style)}` +
-      `/${encodeURIComponent(tileMatrixSet)}` +
-      `/${encodeURIComponent(String(request.tileMatrix))}` +
-      `/${encodeURIComponent(String(request.tileRow))}` +
-      `/${encodeURIComponent(String(request.tileCol))}` +
-      `/${encodeURIComponent(String(Math.trunc(request.j)))}` +
-      `/${encodeURIComponent(String(Math.trunc(request.i)))}.${ext}`;
+    const base = wmtsBasePath(request.serviceId);
+    const layer = encodeURIComponent(request.layer);
+    const styleSeg = encodeURIComponent(style);
+    const tmsSeg = encodeURIComponent(tileMatrixSet);
+    const tm = encodeURIComponent(String(request.tileMatrix));
+    const tr = encodeURIComponent(String(request.tileRow));
+    const tc = encodeURIComponent(String(request.tileCol));
+    const jSeg = encodeURIComponent(String(Math.trunc(request.j)));
+    const iSeg = encodeURIComponent(String(Math.trunc(request.i)));
+    const extra = wmtsRestExtraParamsSuffix(request.extraParams);
+    const path = `${base}/${layer}/${styleSeg}/${tmsSeg}/${tm}/${tr}/${tc}/${jSeg}/${iSeg}.${ext}${extra}`;
     const response = await this.requestBytes("GET", path, infoFormat, undefined, request.signal);
     return decodeWmsFeatureInfoResponse<T>(response.bytes, response.contentType, infoFormat);
   }
@@ -2650,4 +2652,39 @@ const WMTS_FEATURE_INFO_FORMAT_TO_EXTENSION: ReadonlyMap<string, string> = new M
 
 function wmtsFeatureInfoExtensionForFormat(format: string): string {
   return WMTS_FEATURE_INFO_FORMAT_TO_EXTENSION.get(format.toLowerCase()) ?? "txt";
+}
+
+const WMTS_REST_RESERVED_KEYS: ReadonlySet<string> = new Set([
+  "service",
+  "version",
+  "request",
+  "layer",
+  "style",
+  "format",
+  "infoformat",
+  "tilematrixset",
+  "tilematrix",
+  "tilerow",
+  "tilecol",
+  "i",
+  "j",
+]);
+
+/**
+ * Serialize `extraParams` for the RESTful WMTS routes. Path-encoded WMTS
+ * keys take precedence — any extraParams whose key (case-insensitively)
+ * matches a path-derived value is dropped so the same URL never carries
+ * the value twice. Returns the query-string suffix to append (empty
+ * string when there is nothing left after filtering).
+ */
+function wmtsRestExtraParamsSuffix(extraParams: Record<string, unknown> | undefined): string {
+  if (!extraParams) return "";
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(extraParams)) {
+    if (value === undefined || value === null) continue;
+    if (WMTS_REST_RESERVED_KEYS.has(key.toLowerCase())) continue;
+    params.set(key, String(value));
+  }
+  const serialized = params.toString();
+  return serialized.length > 0 ? `?${serialized}` : "";
 }

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -11,16 +11,17 @@ import { HonuaWms } from "./wms.js";
 import { type WmsCapabilities, parseWmsCapabilities } from "./wms-capabilities.js";
 import { HonuaWmts } from "./wmts.js";
 import { type WmtsCapabilities, parseWmtsCapabilities } from "./wmts-capabilities.js";
-import type {
-  HonuaWmsFeatureInfoResponse,
-  HonuaWmsImageResponse,
-  HonuaWmtsFeatureInfoResponse,
-  HonuaWmtsTileResponse,
-  WmsFeatureInfoRequest,
-  WmsLegendRequest,
-  WmsMapRequest,
-  WmtsFeatureInfoRequest,
-  WmtsTileRequest,
+import {
+  type HonuaWmsFeatureInfoResponse,
+  type HonuaWmsImageResponse,
+  type HonuaWmtsFeatureInfoResponse,
+  type HonuaWmtsTileResponse,
+  type WmsFeatureInfoRequest,
+  type WmsLegendRequest,
+  type WmsMapRequest,
+  type WmtsFeatureInfoRequest,
+  type WmtsTileRequest,
+  wmtsExtensionForFormat,
 } from "./wms-types.js";
 import type {
   ApplyEditsRequest,
@@ -2630,17 +2631,6 @@ function extractFeatureInfoFeatures<T>(parsed: unknown): ReadonlyArray<import(".
     out.push({ attributes, geometry });
   }
   return out;
-}
-
-const WMTS_TILE_FORMAT_TO_EXTENSION: ReadonlyMap<string, string> = new Map([
-  ["image/png", "png"],
-  ["image/jpeg", "jpeg"],
-  ["image/jpg", "jpeg"],
-  ["image/webp", "webp"],
-]);
-
-function wmtsExtensionForFormat(format: string): string {
-  return WMTS_TILE_FORMAT_TO_EXTENSION.get(format.toLowerCase()) ?? "png";
 }
 
 const WMTS_FEATURE_INFO_FORMAT_TO_EXTENSION: ReadonlyMap<string, string> = new Map([

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -7,6 +7,21 @@ import { HonuaOgcProcesses } from "./ogc-processes.js";
 import { HonuaOgcTiles } from "./ogc-tiles.js";
 import { HonuaStacSearch } from "./stac.js";
 import { HonuaFeatureLayer, HonuaMapLayer, HonuaMapService, HonuaOgcFeatures, HonuaService } from "./surfaces.js";
+import { HonuaWms } from "./wms.js";
+import { type WmsCapabilities, parseWmsCapabilities } from "./wms-capabilities.js";
+import { HonuaWmts } from "./wmts.js";
+import { type WmtsCapabilities, parseWmtsCapabilities } from "./wmts-capabilities.js";
+import type {
+  HonuaWmsFeatureInfoResponse,
+  HonuaWmsImageResponse,
+  HonuaWmtsFeatureInfoResponse,
+  HonuaWmtsTileResponse,
+  WmsFeatureInfoRequest,
+  WmsLegendRequest,
+  WmsMapRequest,
+  WmtsFeatureInfoRequest,
+  WmtsTileRequest,
+} from "./wms-types.js";
 import type {
   ApplyEditsRequest,
   ExportMapRequest,
@@ -342,6 +357,14 @@ export class HonuaClient {
     return new HonuaOgcMaps({ client: this });
   }
 
+  public wms(serviceId: string): HonuaWms {
+    return new HonuaWms({ client: this, serviceId });
+  }
+
+  public wmts(serviceId: string): HonuaWmts {
+    return new HonuaWmts({ client: this, serviceId });
+  }
+
   public ogcProcesses(): HonuaOgcProcesses {
     return new HonuaOgcProcesses({ client: this });
   }
@@ -372,9 +395,7 @@ export class HonuaClient {
     return compatibility;
   }
 
-  public async checkCompatibility(
-    options: HonuaCompatibilityRequest = {},
-  ): Promise<HonuaServerCompatibilityStatus> {
+  public async checkCompatibility(options: HonuaCompatibilityRequest = {}): Promise<HonuaServerCompatibilityStatus> {
     try {
       const compatibility = await this.getCompatibility(options);
       const reasons = evaluateCompatibility(compatibility);
@@ -605,9 +626,7 @@ export class HonuaClient {
     ) as Promise<HonuaOgcConformanceResponse>;
   }
 
-  public async listOgcTileMatrixSets(
-    request: OgcMetadataRequest = {},
-  ): Promise<HonuaOgcTileMatrixSetsResponse> {
+  public async listOgcTileMatrixSets(request: OgcMetadataRequest = {}): Promise<HonuaOgcTileMatrixSetsResponse> {
     const params = createOgcMetadataParams(request);
     return this.requestJson(
       "GET",
@@ -674,14 +693,212 @@ export class HonuaClient {
   public async getOgcMapImage(request: OgcMapImageRequest): Promise<HonuaOgcMapImageResponse> {
     const params = serializeOgcMapImageParams(request);
     const collectionPart =
-      request.collectionId !== undefined
-        ? `/collections/${encodeURIComponent(String(request.collectionId))}`
-        : "";
+      request.collectionId !== undefined ? `/collections/${encodeURIComponent(String(request.collectionId))}` : "";
     const stylePart = request.styleId ? `/styles/${encodeURIComponent(request.styleId)}` : "";
     const path = `/ogc/maps${collectionPart}${stylePart}/map${params.size > 0 ? `?${params.toString()}` : ""}`;
     const accept = ogcMapAcceptHeader(request.format) ?? "image/png";
     const response = await this.requestBytes("GET", path, accept, undefined, request.signal);
     return { bytes: response.bytes, contentType: response.contentType };
+  }
+
+  // ── WMS 1.3 ─────────────────────────────────────────────────
+
+  /**
+   * Fetch and parse a WMS `GetCapabilities` document for the addressed
+   * service. The XML body decodes through `requestText`; the parsed
+   * shape is the typed `WmsCapabilities` envelope (no XML node leaks
+   * through the public surface).
+   */
+  public async getWmsCapabilities(request: {
+    serviceId: string;
+    version?: string;
+    signal?: AbortSignal;
+    extraParams?: Record<string, string | number | boolean>;
+  }): Promise<WmsCapabilities> {
+    const params = new URLSearchParams();
+    params.set("SERVICE", "WMS");
+    params.set("REQUEST", "GetCapabilities");
+    params.set("VERSION", request.version ?? "1.3.0");
+    if (request.extraParams) {
+      for (const [key, value] of Object.entries(request.extraParams)) {
+        params.set(key, String(value));
+      }
+    }
+    const path = `${wmsBasePath(request.serviceId)}?${params.toString()}`;
+    const xml = await this.requestText("GET", path, "text/xml,application/xml", undefined, request.signal);
+    return parseWmsCapabilities(xml);
+  }
+
+  /** Render a WMS `GetMap`. Returns the raw image bytes. */
+  public async getWmsMap(request: { serviceId: string } & WmsMapRequest): Promise<HonuaWmsImageResponse> {
+    const params = serializeWmsMapParams(request);
+    params.set("REQUEST", "GetMap");
+    const path = `${wmsBasePath(request.serviceId)}?${params.toString()}`;
+    const accept = request.format ?? "image/png";
+    const response = await this.requestBytes("GET", path, accept, undefined, request.signal);
+    return { bytes: response.bytes, contentType: response.contentType };
+  }
+
+  /**
+   * Issue a WMS `GetFeatureInfo`. When `INFO_FORMAT=application/json`
+   * the JSON body decodes into the canonical `HonuaTypedFeature[]`
+   * shape; non-JSON formats round-trip on `bytes` so callers retain the
+   * raw payload behind the protocol escape hatch.
+   */
+  public async getWmsFeatureInfo<T = Record<string, unknown>>(
+    request: { serviceId: string } & WmsFeatureInfoRequest,
+  ): Promise<HonuaWmsFeatureInfoResponse<T>> {
+    const params = serializeWmsMapParams(request);
+    params.set("REQUEST", "GetFeatureInfo");
+    params.set("QUERY_LAYERS", request.queryLayers.join(","));
+    params.set("I", String(Math.trunc(request.i)));
+    params.set("J", String(Math.trunc(request.j)));
+    const infoFormat = request.infoFormat ?? "application/json";
+    params.set("INFO_FORMAT", infoFormat);
+    if (request.featureCount !== undefined) {
+      params.set("FEATURE_COUNT", String(Math.trunc(request.featureCount)));
+    }
+    const path = `${wmsBasePath(request.serviceId)}?${params.toString()}`;
+    const response = await this.requestBytes("GET", path, infoFormat, undefined, request.signal);
+    return decodeWmsFeatureInfoResponse<T>(response.bytes, response.contentType, infoFormat);
+  }
+
+  /**
+   * Fetch a WMS `GetLegendGraphic`. honua-server does not implement
+   * GetLegendGraphic today; callers should branch on
+   * `WmsCapabilities.request.getLegendGraphic` before invoking. When
+   * the wire returns 5xx the underlying `HonuaHttpError` flows through.
+   */
+  public async getWmsLegend(request: { serviceId: string } & WmsLegendRequest): Promise<HonuaWmsImageResponse> {
+    const params = new URLSearchParams();
+    params.set("SERVICE", "WMS");
+    params.set("VERSION", "1.3.0");
+    params.set("REQUEST", "GetLegendGraphic");
+    params.set("LAYER", request.layer);
+    if (request.style) params.set("STYLE", request.style);
+    const format = request.format ?? "image/png";
+    params.set("FORMAT", format);
+    if (request.width !== undefined) params.set("WIDTH", String(Math.trunc(request.width)));
+    if (request.height !== undefined) params.set("HEIGHT", String(Math.trunc(request.height)));
+    if (request.extraParams) {
+      for (const [key, value] of Object.entries(request.extraParams)) {
+        params.set(key, String(value));
+      }
+    }
+    const path = `${wmsBasePath(request.serviceId)}?${params.toString()}`;
+    const response = await this.requestBytes("GET", path, format, undefined, request.signal);
+    return { bytes: response.bytes, contentType: response.contentType };
+  }
+
+  // ── WMTS 1.0 ────────────────────────────────────────────────
+
+  public async getWmtsCapabilities(request: {
+    serviceId: string;
+    signal?: AbortSignal;
+  }): Promise<WmtsCapabilities> {
+    const params = new URLSearchParams();
+    params.set("SERVICE", "WMTS");
+    params.set("REQUEST", "GetCapabilities");
+    params.set("VERSION", "1.0.0");
+    const path = `${wmtsBasePath(request.serviceId)}?${params.toString()}`;
+    const xml = await this.requestText("GET", path, "text/xml,application/xml", undefined, request.signal);
+    return parseWmtsCapabilities(xml);
+  }
+
+  /**
+   * Fetch a single WMTS tile. `mode` selects between KVP
+   * (`?REQUEST=GetTile&...`) and the RESTful path
+   * (`/{layer}/{style}/{tms}/{z}/{y}/{x}.{ext}`). honua-server
+   * advertises both; the SDK defaults to RESTful because the wire path
+   * is a single string substitution per tile and skips
+   * URLSearchParams serialisation on the hot path.
+   */
+  public async fetchWmtsTile(request: { serviceId: string } & WmtsTileRequest): Promise<HonuaWmtsTileResponse> {
+    const mode: "kvp" | "rest" = request.mode ?? "rest";
+    const format = request.format ?? "image/png";
+    const style = request.style ?? "default";
+    const tileMatrixSet = request.tileMatrixSet ?? "WebMercatorQuad";
+    if (mode === "kvp") {
+      const params = new URLSearchParams();
+      params.set("SERVICE", "WMTS");
+      params.set("VERSION", "1.0.0");
+      params.set("REQUEST", "GetTile");
+      params.set("LAYER", request.layer);
+      params.set("STYLE", style);
+      params.set("FORMAT", format);
+      params.set("TILEMATRIXSET", tileMatrixSet);
+      params.set("TILEMATRIX", String(request.tileMatrix));
+      params.set("TILEROW", String(request.tileRow));
+      params.set("TILECOL", String(request.tileCol));
+      if (request.extraParams) {
+        for (const [key, value] of Object.entries(request.extraParams)) {
+          params.set(key, String(value));
+        }
+      }
+      const path = `${wmtsBasePath(request.serviceId)}?${params.toString()}`;
+      return this.requestBytes("GET", path, format, undefined, request.signal);
+    }
+    const ext = wmtsExtensionForFormat(format);
+    const path =
+      `${wmtsBasePath(request.serviceId)}` +
+      `/${encodeURIComponent(request.layer)}` +
+      `/${encodeURIComponent(style)}` +
+      `/${encodeURIComponent(tileMatrixSet)}` +
+      `/${encodeURIComponent(String(request.tileMatrix))}` +
+      `/${encodeURIComponent(String(request.tileRow))}` +
+      `/${encodeURIComponent(String(request.tileCol))}.${ext}`;
+    return this.requestBytes("GET", path, format, undefined, request.signal);
+  }
+
+  /**
+   * WMTS GetFeatureInfo. honua-server accepts both KVP and RESTful
+   * routing; mode default mirrors `fetchWmtsTile`.
+   */
+  public async getWmtsFeatureInfo<T = Record<string, unknown>>(
+    request: { serviceId: string } & WmtsFeatureInfoRequest,
+  ): Promise<HonuaWmtsFeatureInfoResponse<T>> {
+    const mode: "kvp" | "rest" = request.mode ?? "rest";
+    const infoFormat = request.infoFormat ?? "application/json";
+    const format = request.format ?? "image/png";
+    const style = request.style ?? "default";
+    const tileMatrixSet = request.tileMatrixSet ?? "WebMercatorQuad";
+    if (mode === "kvp") {
+      const params = new URLSearchParams();
+      params.set("SERVICE", "WMTS");
+      params.set("VERSION", "1.0.0");
+      params.set("REQUEST", "GetFeatureInfo");
+      params.set("LAYER", request.layer);
+      params.set("STYLE", style);
+      params.set("FORMAT", format);
+      params.set("TILEMATRIXSET", tileMatrixSet);
+      params.set("TILEMATRIX", String(request.tileMatrix));
+      params.set("TILEROW", String(request.tileRow));
+      params.set("TILECOL", String(request.tileCol));
+      params.set("I", String(Math.trunc(request.i)));
+      params.set("J", String(Math.trunc(request.j)));
+      params.set("INFOFORMAT", infoFormat);
+      if (request.extraParams) {
+        for (const [key, value] of Object.entries(request.extraParams)) {
+          params.set(key, String(value));
+        }
+      }
+      const path = `${wmtsBasePath(request.serviceId)}?${params.toString()}`;
+      const response = await this.requestBytes("GET", path, infoFormat, undefined, request.signal);
+      return decodeWmsFeatureInfoResponse<T>(response.bytes, response.contentType, infoFormat);
+    }
+    const ext = wmtsFeatureInfoExtensionForFormat(infoFormat);
+    const path =
+      `${wmtsBasePath(request.serviceId)}` +
+      `/${encodeURIComponent(request.layer)}` +
+      `/${encodeURIComponent(style)}` +
+      `/${encodeURIComponent(tileMatrixSet)}` +
+      `/${encodeURIComponent(String(request.tileMatrix))}` +
+      `/${encodeURIComponent(String(request.tileRow))}` +
+      `/${encodeURIComponent(String(request.tileCol))}` +
+      `/${encodeURIComponent(String(Math.trunc(request.j)))}` +
+      `/${encodeURIComponent(String(Math.trunc(request.i)))}.${ext}`;
+    const response = await this.requestBytes("GET", path, infoFormat, undefined, request.signal);
+    return decodeWmsFeatureInfoResponse<T>(response.bytes, response.contentType, infoFormat);
   }
 
   // ── OGC API Processes ───────────────────────────────────────
@@ -729,12 +946,7 @@ export class HonuaClient {
       outputs: request.outputs,
       response: "document",
     });
-    return this.requestJson(
-      "POST",
-      path,
-      { headers, body },
-      request.signal,
-    ) as Promise<HonuaOgcProcessJobAccepted>;
+    return this.requestJson("POST", path, { headers, body }, request.signal) as Promise<HonuaOgcProcessJobAccepted>;
   }
 
   public async getOgcProcessJob(request: {
@@ -791,10 +1003,7 @@ export class HonuaClient {
 
   public async listStacCollections(request: OgcMetadataRequest = {}): Promise<HonuaOgcCollectionsResponse> {
     const params = createOgcMetadataParams(request);
-    return this.requestJson(
-      "GET",
-      `/stac/collections?${params.toString()}`,
-    ) as Promise<HonuaOgcCollectionsResponse>;
+    return this.requestJson("GET", `/stac/collections?${params.toString()}`) as Promise<HonuaOgcCollectionsResponse>;
   }
 
   public async getStacCollection(request: OgcCollectionRequest): Promise<HonuaOgcCollectionMetadata> {
@@ -816,7 +1025,12 @@ export class HonuaClient {
     const path =
       `/stac/collections/${encodeURIComponent(String(request.collectionId))}` +
       `/items/${encodeURIComponent(String(request.itemId))}`;
-    return this.requestJson("GET", `${path}?${params.toString()}`, undefined, request.signal) as Promise<HonuaStacItemResponse>;
+    return this.requestJson(
+      "GET",
+      `${path}?${params.toString()}`,
+      undefined,
+      request.signal,
+    ) as Promise<HonuaStacItemResponse>;
   }
 
   public async searchStac(request: StacSearchRequest = {}): Promise<HonuaStacItemCollectionResponse> {
@@ -1392,6 +1606,23 @@ export class HonuaClient {
   }
 
   /**
+   * Fetch a text/XML response. Used by the WMS / WMTS Capabilities
+   * pipeline to drain the body as a UTF-8 string (the parsers consume
+   * the raw text). Reuses `requestBytes` so interceptors, retry, and
+   * timeout plumbing stay consistent with the JSON / binary paths.
+   */
+  private async requestText(
+    method: QueryMethod,
+    path: string,
+    accept: string | undefined,
+    init?: RequestInit,
+    callerSignal?: AbortSignal,
+  ): Promise<string> {
+    const response = await this.requestBytes(method, path, accept, init, callerSignal);
+    return new TextDecoder("utf-8").decode(response.bytes);
+  }
+
+  /**
    * Fetch a binary response (raw bytes plus content type). Used by the
    * OGC API Tiles and OGC API Maps wire methods, both of which negotiate
    * non-JSON output formats. The interceptor / retry / abort plumbing
@@ -1764,7 +1995,10 @@ function parseVersion(version: string): ParsedVersion | undefined {
 
   const prereleaseParts =
     prerelease.length > 0
-      ? prerelease.split(".").map((segment) => segment.trim()).filter((segment) => segment.length > 0)
+      ? prerelease
+          .split(".")
+          .map((segment) => segment.trim())
+          .filter((segment) => segment.length > 0)
       : [];
 
   return {
@@ -2113,7 +2347,9 @@ function serializeQueryParams(params: URLSearchParams, request: QueryFeaturesReq
   if (request.outSr !== undefined) {
     params.set(
       "outSR",
-      typeof request.outSr === "object" && request.outSr !== null ? JSON.stringify(request.outSr) : String(request.outSr),
+      typeof request.outSr === "object" && request.outSr !== null
+        ? JSON.stringify(request.outSr)
+        : String(request.outSr),
     );
   }
   if (request.orderByFields !== undefined) {
@@ -2288,9 +2524,7 @@ function stacSearchBody(request: StacSearchRequest): Record<string, unknown> {
   return out;
 }
 
-function stacFieldsCsv(
-  fields: StacSearchRequest["fields"] | undefined,
-): string | undefined {
+function stacFieldsCsv(fields: StacSearchRequest["fields"] | undefined): string | undefined {
   if (!fields) return undefined;
   const parts: string[] = [];
   if (fields.include) {
@@ -2304,4 +2538,116 @@ function stacFieldsCsv(
     }
   }
   return parts.length > 0 ? parts.join(",") : undefined;
+}
+
+// ── WMS / WMTS helpers ──────────────────────────────────────────
+
+/** Canonical WMS endpoint path. honua-server publishes both `/rest/services/{id}/MapServer/WMS` and `/ogc/services/{id}/wms`; the SDK targets the GeoServices-aliased path because every Honua deployment exposes it. */
+function wmsBasePath(serviceId: string): string {
+  return `/rest/services/${encodeURIComponent(serviceId)}/MapServer/WMS`;
+}
+
+/** Canonical WMTS endpoint path. */
+function wmtsBasePath(serviceId: string): string {
+  return `/rest/services/${encodeURIComponent(serviceId)}/MapServer/WMTS`;
+}
+
+/**
+ * CRS table for WMS 1.3 axis order. WMS 1.3 honors authority axis order,
+ * which means `EPSG:4326` is `(lat, lon)` and `CRS:84` / `EPSG:3857` are
+ * `(x, y)`. The `BBOX` envelope tuple supplied by callers is the
+ * canonical `[minx, miny, maxx, maxy]`; this map decides whether the
+ * tuple is swapped on the wire.
+ */
+const WMS_AXIS_SWAP_CRS: ReadonlySet<string> = new Set(["EPSG:4326"]);
+
+function serializeWmsMapParams(request: WmsMapRequest & { serviceId: string }): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set("SERVICE", "WMS");
+  params.set("VERSION", "1.3.0");
+  params.set("LAYERS", request.layers.join(","));
+  params.set("STYLES", request.styles ? request.styles.join(",") : "");
+  const crs = request.crs ?? "EPSG:3857";
+  params.set("CRS", crs);
+  const [minx, miny, maxx, maxy] = request.bbox;
+  const wireBbox = WMS_AXIS_SWAP_CRS.has(crs) ? [miny, minx, maxy, maxx] : [minx, miny, maxx, maxy];
+  params.set("BBOX", wireBbox.join(","));
+  params.set("WIDTH", String(Math.trunc(request.width)));
+  params.set("HEIGHT", String(Math.trunc(request.height)));
+  params.set("FORMAT", request.format ?? "image/png");
+  params.set("TRANSPARENT", String(request.transparent ?? true).toUpperCase());
+  if (request.bgcolor !== undefined) params.set("BGCOLOR", request.bgcolor);
+  if (request.time !== undefined) params.set("TIME", request.time);
+  if (request.elevation !== undefined) params.set("ELEVATION", request.elevation);
+  if (request.extraParams) {
+    for (const [key, value] of Object.entries(request.extraParams)) {
+      params.set(key, String(value));
+    }
+  }
+  return params;
+}
+
+function decodeWmsFeatureInfoResponse<T>(
+  bytes: Uint8Array,
+  contentType: string,
+  requestedFormat: string,
+): HonuaWmsFeatureInfoResponse<T> {
+  const isJson =
+    contentType.toLowerCase().includes("application/json") ||
+    requestedFormat.toLowerCase().includes("application/json");
+  if (!isJson) {
+    return { contentType, bytes };
+  }
+  const text = new TextDecoder("utf-8").decode(bytes);
+  if (text.length === 0) {
+    return { contentType, features: [] };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    // Server emitted a non-JSON body despite the JSON Accept; preserve as bytes.
+    return { contentType, bytes };
+  }
+  const features = extractFeatureInfoFeatures<T>(parsed);
+  return { contentType, features };
+}
+
+function extractFeatureInfoFeatures<T>(parsed: unknown): ReadonlyArray<import("./types.js").HonuaTypedFeature<T>> {
+  if (!parsed || typeof parsed !== "object") return [];
+  // honua-server emits `{ type: "FeatureInfoResponse", features: [{ layer, attributes }, ...] }`
+  // and a fallback GeoJSON `{ type: "FeatureCollection", features: [...] }`; both decode here.
+  const obj = parsed as Record<string, unknown>;
+  const featuresRaw = Array.isArray(obj.features) ? obj.features : [];
+  const out: import("./types.js").HonuaTypedFeature<T>[] = [];
+  for (const raw of featuresRaw) {
+    if (!raw || typeof raw !== "object") continue;
+    const feat = raw as Record<string, unknown>;
+    const attributes = (feat.attributes ?? feat.properties ?? {}) as T;
+    const geometry = (feat.geometry as Record<string, unknown> | null | undefined) ?? null;
+    out.push({ attributes, geometry });
+  }
+  return out;
+}
+
+const WMTS_TILE_FORMAT_TO_EXTENSION: ReadonlyMap<string, string> = new Map([
+  ["image/png", "png"],
+  ["image/jpeg", "jpeg"],
+  ["image/jpg", "jpeg"],
+  ["image/webp", "webp"],
+]);
+
+function wmtsExtensionForFormat(format: string): string {
+  return WMTS_TILE_FORMAT_TO_EXTENSION.get(format.toLowerCase()) ?? "png";
+}
+
+const WMTS_FEATURE_INFO_FORMAT_TO_EXTENSION: ReadonlyMap<string, string> = new Map([
+  ["application/json", "json"],
+  ["text/plain", "txt"],
+  ["text/html", "html"],
+  ["application/geo+json", "geojson"],
+]);
+
+function wmtsFeatureInfoExtensionForFormat(format: string): string {
+  return WMTS_FEATURE_INFO_FORMAT_TO_EXTENSION.get(format.toLowerCase()) ?? "txt";
 }

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,3 +1,6 @@
+import { HonuaWmsCapabilitiesParseError } from "./wms-capabilities.js";
+import { HonuaWmtsCapabilitiesParseError } from "./wmts-capabilities.js";
+
 export class HonuaHttpError extends Error {
   public readonly statusCode: number;
   public readonly body: unknown;
@@ -102,7 +105,9 @@ export type HonuaError =
   | HonuaAbortError
   | HonuaGrpcError
   | HonuaCapabilityNotSupportedError
-  | HonuaExplorationContextError;
+  | HonuaExplorationContextError
+  | HonuaWmsCapabilitiesParseError
+  | HonuaWmtsCapabilitiesParseError;
 
 /** Type guard that narrows any value to one of the Honua SDK error types. */
 export function isHonuaError(error: unknown): error is HonuaError {
@@ -113,6 +118,8 @@ export function isHonuaError(error: unknown): error is HonuaError {
     error instanceof HonuaAbortError ||
     error instanceof HonuaGrpcError ||
     error instanceof HonuaCapabilityNotSupportedError ||
-    error instanceof HonuaExplorationContextError
+    error instanceof HonuaExplorationContextError ||
+    error instanceof HonuaWmsCapabilitiesParseError ||
+    error instanceof HonuaWmtsCapabilitiesParseError
   );
 }

--- a/src/core/wms-capabilities.ts
+++ b/src/core/wms-capabilities.ts
@@ -189,13 +189,20 @@ function* iterChildLayers(
     if (!layer) break;
     const queryableAttr = readAttribute(layer.openTag, "queryable");
     const inherited = mergeAncestors(ancestors);
-    const name = readTextElement(layer.inner, "Name") ?? "";
-    const title = readTextElement(layer.inner, "Title");
-    const abstract = readTextElement(layer.inner, "Abstract");
-    const localCrs = collectChildText(layer.inner, "CRS");
-    const localBbox = collectBoundingBoxes(layer.inner);
-    const localStyles = collectStyles(layer.inner);
-    const localDimensions = collectDimensions(layer.inner);
+    // Strip nested <Layer>...</Layer> subtrees from the layer's own inner so
+    // descendant Name / Title / CRS / BoundingBox / Style / Dimension nodes
+    // do not leak upward into the parent (and from there into siblings via
+    // `mergeAncestors`). WMS 1.3 §7.2.4.6 inheritance is ancestor → descendant
+    // only; without this guard, an unnamed group layer takes its first child's
+    // name and bleeds the child's style across siblings.
+    const ownInner = stripNestedLayers(layer.inner);
+    const name = readTextElement(ownInner, "Name") ?? "";
+    const title = readTextElement(ownInner, "Title");
+    const abstract = readTextElement(ownInner, "Abstract");
+    const localCrs = collectChildText(ownInner, "CRS");
+    const localBbox = collectBoundingBoxes(ownInner);
+    const localStyles = collectStyles(ownInner);
+    const localDimensions = collectDimensions(ownInner);
     const mergedCrs = uniqueOrder([...inherited.crs, ...localCrs]);
     const mergedBbox = mergeBoundingBoxes(inherited.bbox, localBbox);
     const mergedStyles = mergeStyles(inherited.styles, localStyles);
@@ -409,6 +416,27 @@ function collectChildText(inner: string, tag: string): readonly string[] {
   return out;
 }
 
+/**
+ * Return `inner` with every nested `<Layer>...</Layer>` (and self-closed
+ * `<Layer .../>`) subtree elided. Used by `iterChildLayers` to read the
+ * layer's *own* metadata without walking into descendant layers.
+ */
+function stripNestedLayers(inner: string): string {
+  if (inner.indexOf("<Layer") < 0) return inner;
+  let cursor = 0;
+  let out = "";
+  while (cursor < inner.length) {
+    const node = findElement(inner, cursor, "Layer");
+    if (!node) {
+      out += inner.slice(cursor);
+      break;
+    }
+    out += inner.slice(cursor, node.startIndex);
+    cursor = node.endIndex;
+  }
+  return out;
+}
+
 // ── Tiny named-element walker ─────────────────────────────────
 
 interface FoundElement {
@@ -416,6 +444,8 @@ interface FoundElement {
   openTag: string;
   /** Inner text/markup (between open and close tags). */
   inner: string;
+  /** Index of the opening `<` of this element. */
+  startIndex: number;
   /** Index immediately after the closing tag. */
   endIndex: number;
 }
@@ -467,7 +497,7 @@ function findElement(xml: string, from: number, tag: string): FoundElement | und
     const openTag = xml.slice(i, close + 1);
     const selfClosing = !isClosing && xml.charCodeAt(close - 1) === 47; // '/'
     if (selfClosing) {
-      return { openTag, inner: "", endIndex: close + 1 };
+      return { openTag, inner: "", startIndex: i, endIndex: close + 1 };
     }
     if (isClosing) {
       // unmatched closing tag at this level — caller advanced past the
@@ -507,6 +537,7 @@ function findElement(xml: string, from: number, tag: string): FoundElement | und
             return {
               openTag,
               inner: xml.slice(close + 1, angle),
+              startIndex: i,
               endIndex: angleClose + 1,
             };
           }

--- a/src/core/wms-capabilities.ts
+++ b/src/core/wms-capabilities.ts
@@ -1,0 +1,625 @@
+/**
+ * WMS 1.3.0 Capabilities parser. Hand-rolled, narrow-scope text-walker
+ * over a `WMS_Capabilities` document. Returns a typed shape (layers,
+ * styles, bbox-per-CRS, dimensions, advertised formats) that the SDK
+ * can route through the canonical `Source` surface without leaking XML
+ * nodes into its public API.
+ *
+ * The parser is closed-schema (WMS 1.3 + the ISO 19128 service-metadata
+ * subset honua-server emits) and tolerates missing optional nodes
+ * gracefully. Vendor-extension elements outside the named set are
+ * ignored. A `HonuaWmsCapabilitiesParseError` (extends `HonuaError`) is
+ * thrown when a required root or top-level node is missing.
+ *
+ * @module
+ */
+
+/**
+ * Top-level WMS Capabilities surface.
+ */
+export interface WmsCapabilities {
+  /** WMS protocol version. honua-server advertises `1.3.0`. */
+  version: string;
+  service: WmsCapabilitiesService;
+  layers: ReadonlyArray<WmsCapabilityLayer>;
+  formats: WmsCapabilitiesFormats;
+  request: WmsCapabilitiesRequestSupport;
+}
+
+export interface WmsCapabilitiesService {
+  title?: string;
+  abstract?: string;
+}
+
+export interface WmsCapabilitiesFormats {
+  /** Image MIME types accepted by `GetMap`. */
+  map: readonly string[];
+  /** Info-format MIME types accepted by `GetFeatureInfo`. */
+  featureInfo: readonly string[];
+  /** Image MIME types accepted by `GetLegendGraphic`. */
+  legend: readonly string[];
+}
+
+export interface WmsCapabilitiesRequestSupport {
+  /** Capability advertises a `GetFeatureInfo` request element. */
+  getFeatureInfo: boolean;
+  /** Capability advertises a `GetLegendGraphic` request element. */
+  getLegendGraphic: boolean;
+}
+
+export interface WmsCapabilityLayer {
+  name: string;
+  title?: string;
+  abstract?: string;
+  /** CRS codes advertised on this layer (and inherited from ancestors). */
+  crs: readonly string[];
+  /** Bounding boxes per CRS. Multiple entries permitted. */
+  bbox: ReadonlyArray<WmsCapabilityBoundingBox>;
+  /** Styles advertised on this layer. The first entry is the default. */
+  styles: ReadonlyArray<WmsCapabilityStyle>;
+  /** Dimensions (`time`, `elevation`, vendor names). */
+  dimensions: ReadonlyArray<WmsCapabilityDimension>;
+  queryable: boolean;
+  /** Sub-layers nested under this entry. */
+  children: ReadonlyArray<WmsCapabilityLayer>;
+}
+
+export interface WmsCapabilityBoundingBox {
+  crs: string;
+  minx: number;
+  miny: number;
+  maxx: number;
+  maxy: number;
+}
+
+export interface WmsCapabilityStyle {
+  name: string;
+  title?: string;
+  /** Externally-served legend URL (`OnlineResource@xlink:href`) when advertised. */
+  legendUrl?: string;
+}
+
+export interface WmsCapabilityDimension {
+  name: string;
+  units?: string;
+  default?: string;
+  /** Discrete values; for time this is typically a comma-separated list. */
+  values: readonly string[];
+}
+
+/**
+ * Thrown when WMS Capabilities XML is missing required root structure or
+ * is otherwise malformed in a way that prevents extracting the typed
+ * shape above. Recoverable per-node gaps (missing `<Title>`,
+ * `<Abstract>`, etc.) are tolerated and return defaults.
+ */
+export class HonuaWmsCapabilitiesParseError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "HonuaWmsCapabilitiesParseError";
+  }
+}
+
+/**
+ * Parse a `WMS_Capabilities` text body into the typed `WmsCapabilities`
+ * shape. The input is the raw XML string returned by `requestText`; the
+ * parser walks it once with a small named-element matcher and tolerates
+ * vendor extensions (unknown elements are skipped).
+ */
+export function parseWmsCapabilities(xml: string): WmsCapabilities {
+  if (typeof xml !== "string" || xml.length === 0) {
+    throw new HonuaWmsCapabilitiesParseError("WMS Capabilities body is empty");
+  }
+  const root = findElement(xml, 0, "WMS_Capabilities") ?? findElement(xml, 0, "WMT_MS_Capabilities");
+  if (!root) {
+    throw new HonuaWmsCapabilitiesParseError(
+      "missing <WMS_Capabilities> root element (received WMS Capabilities XML?)",
+    );
+  }
+  const version = readAttribute(root.openTag, "version") ?? "1.3.0";
+  const service = parseServiceMetadata(root.inner);
+  const capabilityNode = findElement(root.inner, 0, "Capability");
+  const requestNode = capabilityNode ? findElement(capabilityNode.inner, 0, "Request") : undefined;
+  const formats = parseFormats(requestNode?.inner ?? "");
+  const requestSupport: WmsCapabilitiesRequestSupport = {
+    getFeatureInfo: requestNode ? findElement(requestNode.inner, 0, "GetFeatureInfo") !== undefined : false,
+    getLegendGraphic: requestNode ? findElement(requestNode.inner, 0, "GetLegendGraphic") !== undefined : false,
+  };
+  const layers: WmsCapabilityLayer[] = [];
+  if (capabilityNode) {
+    for (const layer of iterChildLayers(capabilityNode.inner, [])) {
+      layers.push(layer);
+    }
+  }
+  return {
+    version,
+    service,
+    layers,
+    formats,
+    request: requestSupport,
+  };
+}
+
+function parseServiceMetadata(capabilityXml: string): WmsCapabilitiesService {
+  const node = findElement(capabilityXml, 0, "Service");
+  if (!node) return {};
+  const out: WmsCapabilitiesService = {};
+  const title = readTextElement(node.inner, "Title");
+  if (title !== undefined) out.title = title;
+  const abstract = readTextElement(node.inner, "Abstract");
+  if (abstract !== undefined) out.abstract = abstract;
+  return out;
+}
+
+function parseFormats(requestInnerXml: string): WmsCapabilitiesFormats {
+  const map = collectFormats(requestInnerXml, "GetMap");
+  const featureInfo = collectFormats(requestInnerXml, "GetFeatureInfo");
+  const legend = collectFormats(requestInnerXml, "GetLegendGraphic");
+  return { map, featureInfo, legend };
+}
+
+function collectFormats(requestInnerXml: string, requestName: string): readonly string[] {
+  const node = findElement(requestInnerXml, 0, requestName);
+  if (!node) return [];
+  const formats: string[] = [];
+  let cursor = 0;
+  while (cursor < node.inner.length) {
+    const fmt = findElement(node.inner, cursor, "Format");
+    if (!fmt) break;
+    const text = decodeXmlText(fmt.inner.trim());
+    if (text.length > 0) formats.push(text);
+    cursor = fmt.endIndex;
+  }
+  return formats;
+}
+
+/**
+ * Walk every `<Layer>` element directly inside `parentInner`, applying
+ * inherited CRS / dimension / style fields from ancestors per WMS 1.3
+ * §7.2.4.6 inheritance rules. Iterative (no recursion through closures)
+ * to keep the parse hot path small.
+ */
+function* iterChildLayers(
+  parentInner: string,
+  ancestors: readonly WmsCapabilityLayer[],
+): Generator<WmsCapabilityLayer> {
+  let cursor = 0;
+  while (cursor < parentInner.length) {
+    const layer = findElement(parentInner, cursor, "Layer");
+    if (!layer) break;
+    const queryableAttr = readAttribute(layer.openTag, "queryable");
+    const inherited = mergeAncestors(ancestors);
+    const name = readTextElement(layer.inner, "Name") ?? "";
+    const title = readTextElement(layer.inner, "Title");
+    const abstract = readTextElement(layer.inner, "Abstract");
+    const localCrs = collectChildText(layer.inner, "CRS");
+    const localBbox = collectBoundingBoxes(layer.inner);
+    const localStyles = collectStyles(layer.inner);
+    const localDimensions = collectDimensions(layer.inner);
+    const mergedCrs = uniqueOrder([...inherited.crs, ...localCrs]);
+    const mergedBbox = mergeBoundingBoxes(inherited.bbox, localBbox);
+    const mergedStyles = mergeStyles(inherited.styles, localStyles);
+    const mergedDimensions = mergeDimensions(inherited.dimensions, localDimensions);
+    const queryable =
+      queryableAttr === "1" || /^true$/i.test(queryableAttr ?? "")
+        ? true
+        : queryableAttr === "0"
+          ? false
+          : inherited.queryable;
+    const node: WmsCapabilityLayer = {
+      name,
+      ...(title !== undefined ? { title } : {}),
+      ...(abstract !== undefined ? { abstract } : {}),
+      crs: mergedCrs,
+      bbox: mergedBbox,
+      styles: mergedStyles,
+      dimensions: mergedDimensions,
+      queryable,
+      children: [],
+    };
+    const ancestorsForChildren = [...ancestors, node];
+    const children: WmsCapabilityLayer[] = [];
+    for (const child of iterChildLayers(layer.inner, ancestorsForChildren)) {
+      children.push(child);
+    }
+    yield { ...node, children };
+    cursor = layer.endIndex;
+  }
+}
+
+interface MergedAncestorState {
+  crs: readonly string[];
+  bbox: readonly WmsCapabilityBoundingBox[];
+  styles: readonly WmsCapabilityStyle[];
+  dimensions: readonly WmsCapabilityDimension[];
+  queryable: boolean;
+}
+
+function mergeAncestors(ancestors: readonly WmsCapabilityLayer[]): MergedAncestorState {
+  if (ancestors.length === 0) {
+    return { crs: [], bbox: [], styles: [], dimensions: [], queryable: false };
+  }
+  let crs: string[] = [];
+  let bbox: WmsCapabilityBoundingBox[] = [];
+  let styles: WmsCapabilityStyle[] = [];
+  let dimensions: WmsCapabilityDimension[] = [];
+  let queryable = false;
+  for (const ancestor of ancestors) {
+    crs = uniqueOrder([...crs, ...ancestor.crs]) as string[];
+    bbox = mergeBoundingBoxes(bbox, ancestor.bbox) as WmsCapabilityBoundingBox[];
+    styles = mergeStyles(styles, ancestor.styles) as WmsCapabilityStyle[];
+    dimensions = mergeDimensions(dimensions, ancestor.dimensions) as WmsCapabilityDimension[];
+    queryable = queryable || ancestor.queryable;
+  }
+  return { crs, bbox, styles, dimensions, queryable };
+}
+
+function uniqueOrder<T>(values: readonly T[]): readonly T[] {
+  const seen = new Set<T>();
+  const out: T[] = [];
+  for (const v of values) {
+    if (seen.has(v)) continue;
+    seen.add(v);
+    out.push(v);
+  }
+  return out;
+}
+
+function mergeBoundingBoxes(
+  parent: readonly WmsCapabilityBoundingBox[],
+  local: readonly WmsCapabilityBoundingBox[],
+): readonly WmsCapabilityBoundingBox[] {
+  if (local.length === 0) return parent;
+  const out: WmsCapabilityBoundingBox[] = [];
+  const seen = new Set<string>();
+  for (const bb of local) {
+    seen.add(bb.crs);
+    out.push(bb);
+  }
+  for (const bb of parent) {
+    if (!seen.has(bb.crs)) out.push(bb);
+  }
+  return out;
+}
+
+function mergeStyles(
+  parent: readonly WmsCapabilityStyle[],
+  local: readonly WmsCapabilityStyle[],
+): readonly WmsCapabilityStyle[] {
+  if (parent.length === 0) return local;
+  const seen = new Set<string>(local.map((s) => s.name));
+  const out: WmsCapabilityStyle[] = [...local];
+  for (const s of parent) {
+    if (!seen.has(s.name)) out.push(s);
+  }
+  return out;
+}
+
+function mergeDimensions(
+  parent: readonly WmsCapabilityDimension[],
+  local: readonly WmsCapabilityDimension[],
+): readonly WmsCapabilityDimension[] {
+  if (parent.length === 0) return local;
+  const seen = new Set<string>(local.map((d) => d.name));
+  const out: WmsCapabilityDimension[] = [...local];
+  for (const d of parent) {
+    if (!seen.has(d.name)) out.push(d);
+  }
+  return out;
+}
+
+function collectBoundingBoxes(inner: string): WmsCapabilityBoundingBox[] {
+  const out: WmsCapabilityBoundingBox[] = [];
+  let cursor = 0;
+  while (cursor < inner.length) {
+    const node = findElement(inner, cursor, "BoundingBox");
+    if (!node) break;
+    const crs = readAttribute(node.openTag, "CRS") ?? readAttribute(node.openTag, "SRS");
+    const minx = parseFloatAttr(node.openTag, "minx");
+    const miny = parseFloatAttr(node.openTag, "miny");
+    const maxx = parseFloatAttr(node.openTag, "maxx");
+    const maxy = parseFloatAttr(node.openTag, "maxy");
+    if (crs && Number.isFinite(minx) && Number.isFinite(miny) && Number.isFinite(maxx) && Number.isFinite(maxy)) {
+      out.push({ crs, minx, miny, maxx, maxy });
+    }
+    cursor = node.endIndex;
+  }
+  // EX_GeographicBoundingBox is the WMS 1.3 alternative geographic bbox node
+  // (always WGS84). honua-server emits both; we pull it as a CRS:84 entry
+  // when the layer has not advertised one already.
+  const geo = findElement(inner, 0, "EX_GeographicBoundingBox");
+  if (geo) {
+    const w = parseFloatText(readTextElement(geo.inner, "westBoundLongitude"));
+    const e = parseFloatText(readTextElement(geo.inner, "eastBoundLongitude"));
+    const s = parseFloatText(readTextElement(geo.inner, "southBoundLatitude"));
+    const n = parseFloatText(readTextElement(geo.inner, "northBoundLatitude"));
+    if (
+      Number.isFinite(w) &&
+      Number.isFinite(e) &&
+      Number.isFinite(s) &&
+      Number.isFinite(n) &&
+      !out.some((bb) => bb.crs === "CRS:84")
+    ) {
+      out.push({ crs: "CRS:84", minx: w, miny: s, maxx: e, maxy: n });
+    }
+  }
+  return out;
+}
+
+function collectStyles(inner: string): WmsCapabilityStyle[] {
+  const out: WmsCapabilityStyle[] = [];
+  let cursor = 0;
+  while (cursor < inner.length) {
+    const node = findElement(inner, cursor, "Style");
+    if (!node) break;
+    const name = readTextElement(node.inner, "Name") ?? "";
+    const title = readTextElement(node.inner, "Title");
+    const legend = findElement(node.inner, 0, "LegendURL");
+    const onlineResource = legend ? findElement(legend.inner, 0, "OnlineResource") : undefined;
+    const legendUrl = onlineResource ? readAttribute(onlineResource.openTag, "xlink:href") : undefined;
+    if (name.length > 0) {
+      const entry: WmsCapabilityStyle = { name };
+      if (title !== undefined) entry.title = title;
+      if (legendUrl !== undefined) entry.legendUrl = legendUrl;
+      out.push(entry);
+    }
+    cursor = node.endIndex;
+  }
+  return out;
+}
+
+function collectDimensions(inner: string): WmsCapabilityDimension[] {
+  const out: WmsCapabilityDimension[] = [];
+  let cursor = 0;
+  while (cursor < inner.length) {
+    const node = findElement(inner, cursor, "Dimension");
+    if (!node) break;
+    const name = readAttribute(node.openTag, "name");
+    if (typeof name === "string" && name.length > 0) {
+      const units = readAttribute(node.openTag, "units");
+      const def = readAttribute(node.openTag, "default");
+      const text = decodeXmlText(node.inner.trim());
+      const values: readonly string[] =
+        text.length > 0
+          ? text
+              .split(",")
+              .map((v) => v.trim())
+              .filter((v) => v.length > 0)
+          : [];
+      const dim: WmsCapabilityDimension = { name, values };
+      if (units !== undefined) dim.units = units;
+      if (def !== undefined) dim.default = def;
+      out.push(dim);
+    }
+    cursor = node.endIndex;
+  }
+  return out;
+}
+
+function collectChildText(inner: string, tag: string): readonly string[] {
+  const out: string[] = [];
+  let cursor = 0;
+  while (cursor < inner.length) {
+    const node = findElement(inner, cursor, tag);
+    if (!node) break;
+    const text = decodeXmlText(node.inner.trim());
+    if (text.length > 0) out.push(text);
+    cursor = node.endIndex;
+  }
+  return out;
+}
+
+// ── Tiny named-element walker ─────────────────────────────────
+
+interface FoundElement {
+  /** The opening tag including angle brackets and attributes. */
+  openTag: string;
+  /** Inner text/markup (between open and close tags). */
+  inner: string;
+  /** Index immediately after the closing tag. */
+  endIndex: number;
+}
+
+/**
+ * Find the next `<tag …>…</tag>` (or `<tag …/>`) starting at `from`. The
+ * search ignores element nesting other than the requested tag and walks
+ * a balanced depth counter for the same tag so nested same-name elements
+ * (`<Layer>` inside `<Layer>`) terminate against the correct close. Skips
+ * XML comments (`<!-- … -->`) and CDATA sections (`<![CDATA[ … ]]>`).
+ */
+function findElement(xml: string, from: number, tag: string): FoundElement | undefined {
+  let i = from;
+  while (i < xml.length) {
+    if (xml[i] !== "<") {
+      i += 1;
+      continue;
+    }
+    const next = xml[i + 1];
+    if (next === "!" && xml.startsWith("<!--", i)) {
+      const end = xml.indexOf("-->", i + 4);
+      if (end < 0) return undefined;
+      i = end + 3;
+      continue;
+    }
+    if (next === "!" && xml.startsWith("<![CDATA[", i)) {
+      const end = xml.indexOf("]]>", i + 9);
+      if (end < 0) return undefined;
+      i = end + 3;
+      continue;
+    }
+    if (next === "?" || next === "!") {
+      const end = xml.indexOf(">", i);
+      if (end < 0) return undefined;
+      i = end + 1;
+      continue;
+    }
+    const isClosing = next === "/";
+    const nameStart = isClosing ? i + 2 : i + 1;
+    const matchesTag = xml.startsWith(tag, nameStart) && isTagBoundary(xml.charCodeAt(nameStart + tag.length));
+    if (!matchesTag) {
+      const close = xml.indexOf(">", i);
+      if (close < 0) return undefined;
+      i = close + 1;
+      continue;
+    }
+    const close = xml.indexOf(">", i);
+    if (close < 0) return undefined;
+    const openTag = xml.slice(i, close + 1);
+    const selfClosing = !isClosing && xml.charCodeAt(close - 1) === 47; // '/'
+    if (selfClosing) {
+      return { openTag, inner: "", endIndex: close + 1 };
+    }
+    if (isClosing) {
+      // unmatched closing tag at this level — caller advanced past the
+      // opener. Skip past and keep searching.
+      i = close + 1;
+      continue;
+    }
+    // Walk forward looking for the matching close tag, accounting for
+    // nested same-name openings.
+    let depth = 1;
+    let cursor = close + 1;
+    while (cursor < xml.length && depth > 0) {
+      const angle = xml.indexOf("<", cursor);
+      if (angle < 0) break;
+      const next2 = xml[angle + 1];
+      if (next2 === "!" && xml.startsWith("<!--", angle)) {
+        const end = xml.indexOf("-->", angle + 4);
+        if (end < 0) return undefined;
+        cursor = end + 3;
+        continue;
+      }
+      if (next2 === "!" && xml.startsWith("<![CDATA[", angle)) {
+        const end = xml.indexOf("]]>", angle + 9);
+        if (end < 0) return undefined;
+        cursor = end + 3;
+        continue;
+      }
+      const isCloser = next2 === "/";
+      const inspectStart = isCloser ? angle + 2 : angle + 1;
+      const matchesSame = xml.startsWith(tag, inspectStart) && isTagBoundary(xml.charCodeAt(inspectStart + tag.length));
+      const angleClose = xml.indexOf(">", angle);
+      if (angleClose < 0) return undefined;
+      if (matchesSame) {
+        if (isCloser) {
+          depth -= 1;
+          if (depth === 0) {
+            return {
+              openTag,
+              inner: xml.slice(close + 1, angle),
+              endIndex: angleClose + 1,
+            };
+          }
+        } else {
+          const innerSelfClose = xml.charCodeAt(angleClose - 1) === 47;
+          if (!innerSelfClose) depth += 1;
+        }
+      }
+      cursor = angleClose + 1;
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
+function isTagBoundary(code: number): boolean {
+  // Whitespace, '/', or '>' terminate a tag name.
+  return code === 32 || code === 9 || code === 10 || code === 13 || code === 47 || code === 62;
+}
+
+function readAttribute(openTag: string, name: string): string | undefined {
+  // Match `name="value"` or `name='value'`. Tolerates leading whitespace
+  // and case-sensitive name match (WMS attribute names are case-sensitive).
+  const idx = findAttributeIndex(openTag, name);
+  if (idx < 0) return undefined;
+  const after = openTag.slice(idx + name.length);
+  const eq = after.indexOf("=");
+  if (eq < 0) return undefined;
+  let cursor = eq + 1;
+  while (cursor < after.length && /\s/.test(after[cursor]!)) cursor += 1;
+  const quote = after[cursor];
+  if (quote !== '"' && quote !== "'") return undefined;
+  const end = after.indexOf(quote, cursor + 1);
+  if (end < 0) return undefined;
+  return decodeXmlText(after.slice(cursor + 1, end));
+}
+
+function findAttributeIndex(openTag: string, name: string): number {
+  let i = 0;
+  while (i < openTag.length) {
+    const found = openTag.indexOf(name, i);
+    if (found < 0) return -1;
+    const before = openTag.charCodeAt(found - 1);
+    const isBoundaryStart = found === 0 || before === 32 || before === 9 || before === 10 || before === 13;
+    const after = openTag.charCodeAt(found + name.length);
+    const isBoundaryEnd = after === 61 || after === 32 || after === 9 || after === 10 || after === 13;
+    if (isBoundaryStart && isBoundaryEnd) {
+      return found;
+    }
+    i = found + 1;
+  }
+  return -1;
+}
+
+function readTextElement(xml: string, tag: string): string | undefined {
+  const node = findElement(xml, 0, tag);
+  if (!node) return undefined;
+  const decoded = decodeXmlText(node.inner.trim());
+  return decoded;
+}
+
+function parseFloatAttr(openTag: string, name: string): number {
+  const value = readAttribute(openTag, name);
+  if (value === undefined) return Number.NaN;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : Number.NaN;
+}
+
+function parseFloatText(value: string | undefined): number {
+  if (value === undefined) return Number.NaN;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : Number.NaN;
+}
+
+function decodeXmlText(text: string): string {
+  if (text.indexOf("&") < 0 && text.indexOf("<![CDATA[") < 0) return text;
+  return text
+    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, "$1")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&#(\d+);/g, (_match, dec: string) => String.fromCodePoint(Number(dec)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_match, hex: string) => String.fromCodePoint(Number.parseInt(hex, 16)));
+}
+
+/**
+ * Walk a parsed `WmsCapabilities` tree and yield every named layer
+ * (skipping container layers without a `name`). Useful for descriptor
+ * resolution: callers want to bind a `LAYER` name without re-walking
+ * the parent hierarchy.
+ */
+export function* iterateWmsLayers(capabilities: WmsCapabilities): Generator<WmsCapabilityLayer> {
+  const stack: WmsCapabilityLayer[] = [...capabilities.layers];
+  while (stack.length > 0) {
+    const next = stack.shift();
+    if (!next) break;
+    if (next.name.length > 0) yield next;
+    for (const child of next.children) {
+      stack.push(child);
+    }
+  }
+}
+
+/**
+ * Find the first named layer with a matching name, or `undefined` if the
+ * capabilities document does not advertise it. Walks both root layers and
+ * children. Intended for the `HonuaWms.layer(name)` resolver path.
+ */
+export function findWmsLayer(capabilities: WmsCapabilities, name: string): WmsCapabilityLayer | undefined {
+  for (const layer of iterateWmsLayers(capabilities)) {
+    if (layer.name === name) return layer;
+  }
+  return undefined;
+}

--- a/src/core/wms-types.ts
+++ b/src/core/wms-types.ts
@@ -1,0 +1,141 @@
+/**
+ * Public request/response envelopes for the WMS / WMTS first-party
+ * adapter. Kept in their own module so the canonical SDK surface
+ * (`src/contract/index.ts`, `src/runtime/index.ts`, `src/index.ts`) can
+ * re-export them without dragging the runtime classes into trees that
+ * never reference WMS.
+ *
+ * @module
+ */
+
+import type { HonuaTypedFeature } from "./types.js";
+
+// ── WMS request/response envelopes ────────────────────────────
+
+/**
+ * Coordinate reference system identifier accepted by WMS 1.3 endpoints.
+ * `EPSG:4326`, `EPSG:3857`, `CRS:84` are first-party; any other string is
+ * accepted but the adapter will trust the caller for axis order.
+ */
+export type WmsCrs = "EPSG:4326" | "EPSG:3857" | "CRS:84" | (string & {});
+
+/** WMS 1.3 GetMap request envelope. */
+export interface WmsMapRequest {
+  /** Layer names. Multiple layers are serialized as a comma-separated `LAYERS=` value. */
+  layers: readonly string[];
+  /**
+   * Style names. When present the array length must match `layers`. An
+   * empty array (or a missing entry) selects the layer's default style.
+   */
+  styles?: readonly string[];
+  /** CRS code. Defaults to `EPSG:3857`. */
+  crs?: WmsCrs;
+  /**
+   * Bounding box in the requested CRS. Tuple is the canonical
+   * `[minx, miny, maxx, maxy]` shape; the adapter swaps axis order when
+   * the CRS is `EPSG:4326` (lat,lon) per WMS 1.3 §6.7.3.2.
+   */
+  bbox: readonly [number, number, number, number];
+  width: number;
+  height: number;
+  /** Image MIME type. Defaults to `image/png`. */
+  format?: string;
+  /** Whether the rendered image should be transparent. Defaults to `true`. */
+  transparent?: boolean;
+  /** WMS `TIME` dimension override; falls back to the layer default. */
+  time?: string;
+  /** WMS `ELEVATION` dimension override. */
+  elevation?: string;
+  /** Background colour as `0xRRGGBB` or `#RRGGBB`. */
+  bgcolor?: string;
+  /** Vendor extras forwarded verbatim on the wire. */
+  extraParams?: Record<string, string | number | boolean>;
+  signal?: AbortSignal;
+}
+
+/** WMS 1.3 GetFeatureInfo request envelope. */
+export interface WmsFeatureInfoRequest extends WmsMapRequest {
+  /** Layers to query. Subset of `layers`. */
+  queryLayers: readonly string[];
+  /** Pixel column offset within the rendered image. */
+  i: number;
+  /** Pixel row offset within the rendered image. */
+  j: number;
+  /** `INFO_FORMAT` MIME type. Defaults to `application/json`. */
+  infoFormat?: "application/json" | "text/plain" | "text/html" | (string & {});
+  /** Maximum features to return. */
+  featureCount?: number;
+}
+
+/** WMS GetLegendGraphic request envelope. */
+export interface WmsLegendRequest {
+  layer: string;
+  style?: string;
+  format?: string;
+  width?: number;
+  height?: number;
+  signal?: AbortSignal;
+  extraParams?: Record<string, string | number | boolean>;
+}
+
+/**
+ * Decoded GetFeatureInfo response. `features` carries the canonical
+ * typed-feature shape when the wire response was JSON; non-JSON content
+ * is exposed through `bytes` so the protocol escape hatch still owns the
+ * raw payload.
+ */
+export interface HonuaWmsFeatureInfoResponse<T = Record<string, unknown>> {
+  contentType: string;
+  /** Decoded features when `infoFormat` was `application/json`. */
+  features?: ReadonlyArray<HonuaTypedFeature<T>>;
+  /** Raw bytes for non-JSON info formats (text/plain, html, …). */
+  bytes?: Uint8Array;
+}
+
+/** Raw bytes returned by `GetMap` / `GetLegendGraphic`. */
+export interface HonuaWmsImageResponse {
+  bytes: Uint8Array;
+  contentType: string;
+}
+
+// ── WMTS request envelopes ────────────────────────────────────
+
+/** Routing mode for `GetTile`. honua-server advertises both. */
+export type WmtsTileMode = "kvp" | "rest";
+
+/** WMTS 1.0 GetTile request envelope. */
+export interface WmtsTileRequest {
+  layer: string;
+  /** Style identifier. Defaults to `default`. */
+  style?: string;
+  /** TileMatrixSet identifier. Defaults to `WebMercatorQuad`. */
+  tileMatrixSet?: string;
+  /** TileMatrix identifier (zoom level). */
+  tileMatrix: string | number;
+  tileRow: number;
+  tileCol: number;
+  /** Image MIME type. Defaults to `image/png`. */
+  format?: string;
+  /** Routing mode. Defaults to `rest`. */
+  mode?: WmtsTileMode;
+  signal?: AbortSignal;
+  extraParams?: Record<string, string | number | boolean>;
+}
+
+/** WMTS 1.0 GetFeatureInfo request envelope. */
+export interface WmtsFeatureInfoRequest extends WmtsTileRequest {
+  i: number;
+  j: number;
+  infoFormat?: "application/json" | "text/plain" | "text/html" | (string & {});
+}
+
+/** Raw bytes returned by a WMTS `GetTile`. */
+export interface HonuaWmtsTileResponse {
+  bytes: Uint8Array;
+  contentType: string;
+  /** True when the server returned a non-error empty payload (sparse tile). */
+  empty: boolean;
+}
+
+/** WMTS GetFeatureInfo response (mirrors WMS). */
+export type HonuaWmtsFeatureInfoResponse<T = Record<string, unknown>> = HonuaWmsFeatureInfoResponse<T>;

--- a/src/core/wms-types.ts
+++ b/src/core/wms-types.ts
@@ -139,3 +139,29 @@ export interface HonuaWmtsTileResponse {
 
 /** WMTS GetFeatureInfo response (mirrors WMS). */
 export type HonuaWmtsFeatureInfoResponse<T = Record<string, unknown>> = HonuaWmsFeatureInfoResponse<T>;
+
+// ── WMTS wire-format helpers ──────────────────────────────────
+
+/**
+ * Canonical mapping from WMTS `Format` MIME types to RESTful path
+ * extensions. Shared between the wire client (`getWmtsTile` /
+ * `featureInfo` URL builders in `src/core/client.ts`) and the MapLibre
+ * raster source helper (`buildWmtsRasterSourceSpec` in
+ * `src/runtime/source-bridge.ts`) so a caller-supplied `format` lands on
+ * the same extension regardless of which surface composes the URL.
+ *
+ * The map is intentionally narrow — formats not listed here fall back
+ * to `png` per the conservative WMTS default. Add a new entry only when
+ * honua-server adds first-party support for the encoding.
+ */
+const WMTS_TILE_FORMAT_TO_EXTENSION: ReadonlyMap<string, string> = new Map([
+  ["image/png", "png"],
+  ["image/jpeg", "jpeg"],
+  ["image/jpg", "jpeg"],
+  ["image/webp", "webp"],
+]);
+
+/** Resolve the RESTful path extension for a WMTS tile `Format` MIME type. */
+export function wmtsExtensionForFormat(format: string): string {
+  return WMTS_TILE_FORMAT_TO_EXTENSION.get(format.toLowerCase()) ?? "png";
+}

--- a/src/core/wms.ts
+++ b/src/core/wms.ts
@@ -28,6 +28,20 @@ export interface HonuaWmsOptions {
   serviceId: string;
 }
 
+/**
+ * Split a WMS `LAYERS=` value (or `locator.typeName` / `spec.layers` of
+ * the same shape) into the list of non-empty trimmed layer tokens. Used
+ * by the contract WMS adapter and shared style resolver so the
+ * single-layer handle rule stays in one place.
+ */
+export function parseWmsLayerNames(value: string | undefined): readonly string[] {
+  if (typeof value !== "string" || value.length === 0) return [];
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
 export interface HonuaWmsLayerOptions extends HonuaWmsOptions {
   /** WMS LAYER name (single layer; multi-layer renders use the parent handle). */
   layerName: string;

--- a/src/core/wms.ts
+++ b/src/core/wms.ts
@@ -1,0 +1,187 @@
+/**
+ * First-party WMS 1.3.0 adapter. `HonuaWms` is the service-level handle
+ * returned by `client.wms(serviceId)`; `HonuaWmsLayer` is the bound
+ * handle returned by `HonuaWms.layer(name)` that pre-fills the LAYER and
+ * default STYLE so per-call envelopes can drop the routing fields.
+ *
+ * Wire transport lives on `HonuaClient` (`getWmsCapabilities`,
+ * `getWmsMap`, `getWmsFeatureInfo`, `getWmsLegend`); this class is the
+ * typed surface consumers reach through `Source.protocol("wms")`.
+ *
+ * @module
+ */
+
+import type { HonuaClient } from "./client.js";
+import { HonuaCapabilityNotSupportedError } from "./errors.js";
+import type { WmsCapabilities, WmsCapabilityLayer, WmsCapabilityStyle } from "./wms-capabilities.js";
+import { findWmsLayer } from "./wms-capabilities.js";
+import type {
+  HonuaWmsFeatureInfoResponse,
+  HonuaWmsImageResponse,
+  WmsFeatureInfoRequest,
+  WmsLegendRequest,
+  WmsMapRequest,
+} from "./wms-types.js";
+
+export interface HonuaWmsOptions {
+  client: HonuaClient;
+  serviceId: string;
+}
+
+export interface HonuaWmsLayerOptions extends HonuaWmsOptions {
+  /** WMS LAYER name (single layer; multi-layer renders use the parent handle). */
+  layerName: string;
+  /** Default STYLE for renders / feature-info on this layer. */
+  defaultStyleId?: string;
+}
+
+/**
+ * Service-level WMS handle. Use `layer(name)` to bind a single LAYER and
+ * style; for multi-layer composites (`LAYERS=a,b,c`) call `map()` /
+ * `featureInfo()` directly on this handle.
+ */
+export class HonuaWms {
+  public readonly client: HonuaClient;
+  public readonly serviceId: string;
+
+  public constructor(options: HonuaWmsOptions) {
+    this.client = options.client;
+    this.serviceId = options.serviceId;
+  }
+
+  /** Bind a single named layer for layer-scoped requests. */
+  public layer(name: string, defaultStyleId?: string): HonuaWmsLayer {
+    const opts: HonuaWmsLayerOptions = {
+      client: this.client,
+      serviceId: this.serviceId,
+      layerName: name,
+    };
+    if (defaultStyleId !== undefined) opts.defaultStyleId = defaultStyleId;
+    return new HonuaWmsLayer(opts);
+  }
+
+  /** Fetch and parse the service `GetCapabilities` document. */
+  public async capabilities(options?: { signal?: AbortSignal }): Promise<WmsCapabilities> {
+    return this.client.getWmsCapabilities({
+      serviceId: this.serviceId,
+      ...(options?.signal ? { signal: options.signal } : {}),
+    });
+  }
+
+  /** Render a `GetMap` request across one or more advertised layers. */
+  public async map(request: WmsMapRequest): Promise<HonuaWmsImageResponse> {
+    return this.client.getWmsMap({ serviceId: this.serviceId, ...request });
+  }
+
+  /** Issue a `GetFeatureInfo` against one or more advertised layers. */
+  public async featureInfo<T = Record<string, unknown>>(
+    request: WmsFeatureInfoRequest,
+  ): Promise<HonuaWmsFeatureInfoResponse<T>> {
+    return this.client.getWmsFeatureInfo<T>({ serviceId: this.serviceId, ...request });
+  }
+
+  /**
+   * Fetch a `GetLegendGraphic` image. Throws
+   * `HonuaCapabilityNotSupportedError` when the service `Capabilities`
+   * does not advertise `<GetLegendGraphic>` so callers can branch
+   * deterministically on advertised support.
+   */
+  public async legend(
+    request: WmsLegendRequest,
+    options?: { capabilities?: WmsCapabilities },
+  ): Promise<HonuaWmsImageResponse> {
+    if (options?.capabilities && !options.capabilities.request.getLegendGraphic) {
+      throw new HonuaCapabilityNotSupportedError("legend", "wms", this.serviceId);
+    }
+    return this.client.getWmsLegend({ serviceId: this.serviceId, ...request });
+  }
+}
+
+/**
+ * Bound layer handle. Drops `layers` / `styles` from per-call requests
+ * and pre-fills the LAYER name. `featureInfo()` carries the same `i`,
+ * `j`, and `bbox` envelope as the service-level handle.
+ */
+export class HonuaWmsLayer {
+  public readonly client: HonuaClient;
+  public readonly serviceId: string;
+  public readonly layerName: string;
+  public readonly defaultStyleId: string | undefined;
+
+  public constructor(options: HonuaWmsLayerOptions) {
+    this.client = options.client;
+    this.serviceId = options.serviceId;
+    this.layerName = options.layerName;
+    this.defaultStyleId = options.defaultStyleId;
+  }
+
+  /** Fetch the parent service's `GetCapabilities`. */
+  public async capabilities(options?: { signal?: AbortSignal }): Promise<WmsCapabilities> {
+    return this.client.getWmsCapabilities({
+      serviceId: this.serviceId,
+      ...(options?.signal ? { signal: options.signal } : {}),
+    });
+  }
+
+  /** Find this layer in a parsed Capabilities document. */
+  public describe(capabilities: WmsCapabilities): WmsCapabilityLayer | undefined {
+    return findWmsLayer(capabilities, this.layerName);
+  }
+
+  /** Enumerate the styles advertised on this layer. */
+  public stylesIn(capabilities: WmsCapabilities): readonly WmsCapabilityStyle[] {
+    return this.describe(capabilities)?.styles ?? [];
+  }
+
+  public async map(
+    request: Omit<WmsMapRequest, "layers" | "styles"> & {
+      style?: string;
+    },
+  ): Promise<HonuaWmsImageResponse> {
+    const { style, ...rest } = request;
+    const styleId = style ?? this.defaultStyleId;
+    return this.client.getWmsMap({
+      serviceId: this.serviceId,
+      layers: [this.layerName],
+      ...(styleId !== undefined ? { styles: [styleId] } : {}),
+      ...rest,
+    });
+  }
+
+  public async featureInfo<T = Record<string, unknown>>(
+    request: Omit<WmsFeatureInfoRequest, "layers" | "queryLayers" | "styles"> & {
+      style?: string;
+    },
+  ): Promise<HonuaWmsFeatureInfoResponse<T>> {
+    const { style, ...rest } = request;
+    const styleId = style ?? this.defaultStyleId;
+    return this.client.getWmsFeatureInfo<T>({
+      serviceId: this.serviceId,
+      layers: [this.layerName],
+      queryLayers: [this.layerName],
+      ...(styleId !== undefined ? { styles: [styleId] } : {}),
+      ...rest,
+    });
+  }
+
+  public async legend(
+    request: Omit<WmsLegendRequest, "layer" | "style"> & { style?: string } = {},
+    options?: { capabilities?: WmsCapabilities },
+  ): Promise<HonuaWmsImageResponse> {
+    if (options?.capabilities && !options.capabilities.request.getLegendGraphic) {
+      throw new HonuaCapabilityNotSupportedError("legend", "wms", this.serviceId);
+    }
+    const { style, ...rest } = request;
+    const styleId = style ?? this.defaultStyleId;
+    return this.client.getWmsLegend({
+      serviceId: this.serviceId,
+      layer: this.layerName,
+      ...(styleId !== undefined ? { style: styleId } : {}),
+      ...rest,
+    });
+  }
+}
+
+export function createHonuaWms(client: HonuaClient, serviceId: string): HonuaWms {
+  return new HonuaWms({ client, serviceId });
+}

--- a/src/core/wms.ts
+++ b/src/core/wms.ts
@@ -43,6 +43,7 @@ export interface HonuaWmsLayerOptions extends HonuaWmsOptions {
 export class HonuaWms {
   public readonly client: HonuaClient;
   public readonly serviceId: string;
+  private capabilitiesPromise: Promise<WmsCapabilities> | undefined;
 
   public constructor(options: HonuaWmsOptions) {
     this.client = options.client;
@@ -81,19 +82,34 @@ export class HonuaWms {
   }
 
   /**
-   * Fetch a `GetLegendGraphic` image. Throws
-   * `HonuaCapabilityNotSupportedError` when the service `Capabilities`
-   * does not advertise `<GetLegendGraphic>` so callers can branch
-   * deterministically on advertised support.
+   * Fetch a `GetLegendGraphic` image. Always gates on parsed Capabilities:
+   * when the caller does not pre-supply `options.capabilities`, the handle
+   * lazily loads them once via `getWmsCapabilities` and caches the
+   * promise on the instance so repeat calls reuse the same fetch. Throws
+   * `HonuaCapabilityNotSupportedError("legend", "wms", serviceId)` when
+   * the service does not advertise `<GetLegendGraphic>`.
    */
   public async legend(
     request: WmsLegendRequest,
     options?: { capabilities?: WmsCapabilities },
   ): Promise<HonuaWmsImageResponse> {
-    if (options?.capabilities && !options.capabilities.request.getLegendGraphic) {
+    const caps = options?.capabilities ?? (await this.loadCachedCapabilities());
+    if (!caps.request.getLegendGraphic) {
       throw new HonuaCapabilityNotSupportedError("legend", "wms", this.serviceId);
     }
     return this.client.getWmsLegend({ serviceId: this.serviceId, ...request });
+  }
+
+  private async loadCachedCapabilities(): Promise<WmsCapabilities> {
+    if (!this.capabilitiesPromise) {
+      this.capabilitiesPromise = this.capabilities().catch((error) => {
+        // Drop the cached promise on failure so the next call retries
+        // instead of permanently surfacing the same error.
+        this.capabilitiesPromise = undefined;
+        throw error;
+      });
+    }
+    return this.capabilitiesPromise;
   }
 }
 
@@ -107,6 +123,7 @@ export class HonuaWmsLayer {
   public readonly serviceId: string;
   public readonly layerName: string;
   public readonly defaultStyleId: string | undefined;
+  private capabilitiesPromise: Promise<WmsCapabilities> | undefined;
 
   public constructor(options: HonuaWmsLayerOptions) {
     this.client = options.client;
@@ -164,11 +181,20 @@ export class HonuaWmsLayer {
     });
   }
 
+  /**
+   * Fetch a `GetLegendGraphic` image scoped to the bound layer + style.
+   * Mirrors `HonuaWms.legend`'s gating: when `options.capabilities` is
+   * not supplied, the handle lazily loads them once via
+   * `getWmsCapabilities` and caches the promise. Throws
+   * `HonuaCapabilityNotSupportedError("legend", "wms", serviceId)` when
+   * the service does not advertise `<GetLegendGraphic>`.
+   */
   public async legend(
     request: Omit<WmsLegendRequest, "layer" | "style"> & { style?: string } = {},
     options?: { capabilities?: WmsCapabilities },
   ): Promise<HonuaWmsImageResponse> {
-    if (options?.capabilities && !options.capabilities.request.getLegendGraphic) {
+    const caps = options?.capabilities ?? (await this.loadCachedCapabilities());
+    if (!caps.request.getLegendGraphic) {
       throw new HonuaCapabilityNotSupportedError("legend", "wms", this.serviceId);
     }
     const { style, ...rest } = request;
@@ -179,6 +205,16 @@ export class HonuaWmsLayer {
       ...(styleId !== undefined ? { style: styleId } : {}),
       ...rest,
     });
+  }
+
+  private async loadCachedCapabilities(): Promise<WmsCapabilities> {
+    if (!this.capabilitiesPromise) {
+      this.capabilitiesPromise = this.capabilities().catch((error) => {
+        this.capabilitiesPromise = undefined;
+        throw error;
+      });
+    }
+    return this.capabilitiesPromise;
   }
 }
 

--- a/src/core/wmts-capabilities.ts
+++ b/src/core/wmts-capabilities.ts
@@ -1,0 +1,469 @@
+/**
+ * WMTS 1.0.0 Capabilities parser. Hand-rolled, narrow-scope walker over
+ * the `Capabilities` document advertised by honua-server (single
+ * advertised TileMatrixSet today: `WebMercatorQuad`). Yields a typed
+ * `WmtsCapabilities` shape so the SDK can route through the canonical
+ * `Source` surface without leaking XML.
+ *
+ * @module
+ */
+
+/**
+ * Top-level WMTS Capabilities surface.
+ */
+export interface WmtsCapabilities {
+  /** Protocol version. honua-server advertises `1.0.0`. */
+  version: string;
+  service: WmtsCapabilitiesService;
+  layers: ReadonlyArray<WmtsCapabilityLayer>;
+  tileMatrixSets: ReadonlyArray<WmtsCapabilityTileMatrixSet>;
+}
+
+export interface WmtsCapabilitiesService {
+  title?: string;
+  abstract?: string;
+}
+
+export interface WmtsCapabilityLayer {
+  identifier: string;
+  title?: string;
+  abstract?: string;
+  formats: readonly string[];
+  styles: ReadonlyArray<WmtsCapabilityStyle>;
+  /** TileMatrixSet identifiers the layer supports. */
+  tileMatrixSetIds: readonly string[];
+  /** RESTful tile templates (xlink:href) advertised by `ResourceURL@resourceType="tile"`. */
+  resourceTemplates: ReadonlyArray<WmtsCapabilityResourceUrl>;
+  /** RESTful FeatureInfo templates advertised by `ResourceURL@resourceType="FeatureInfo"`. */
+  featureInfoTemplates: ReadonlyArray<WmtsCapabilityResourceUrl>;
+  /** Geographic bounding box (WGS84) when advertised. */
+  bbox?: { west: number; south: number; east: number; north: number };
+}
+
+export interface WmtsCapabilityStyle {
+  identifier: string;
+  title?: string;
+  isDefault: boolean;
+  legendUrl?: string;
+}
+
+export interface WmtsCapabilityResourceUrl {
+  format: string;
+  template: string;
+}
+
+export interface WmtsCapabilityTileMatrixSet {
+  identifier: string;
+  /** CRS supportedCRS or wellKnownScaleSet href when advertised. */
+  supportedCrs?: string;
+  wellKnownScaleSet?: string;
+  matrices: ReadonlyArray<WmtsCapabilityTileMatrix>;
+}
+
+export interface WmtsCapabilityTileMatrix {
+  identifier: string;
+  scaleDenominator: number;
+  matrixWidth: number;
+  matrixHeight: number;
+  tileWidth: number;
+  tileHeight: number;
+  topLeftCorner: readonly [number, number];
+}
+
+export class HonuaWmtsCapabilitiesParseError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "HonuaWmtsCapabilitiesParseError";
+  }
+}
+
+/**
+ * Parse a `Capabilities` text body for WMTS 1.0 into the typed
+ * `WmtsCapabilities` shape.
+ */
+export function parseWmtsCapabilities(xml: string): WmtsCapabilities {
+  if (typeof xml !== "string" || xml.length === 0) {
+    throw new HonuaWmtsCapabilitiesParseError("WMTS Capabilities body is empty");
+  }
+  const root = findElement(xml, 0, "Capabilities");
+  if (!root) {
+    throw new HonuaWmtsCapabilitiesParseError("missing <Capabilities> root element");
+  }
+  const version = readAttribute(root.openTag, "version") ?? "1.0.0";
+  const service = parseServiceMetadata(root.inner);
+  const contents = findElement(root.inner, 0, "Contents");
+  const layers = contents ? collectLayers(contents.inner) : [];
+  const tileMatrixSets = contents ? collectTileMatrixSets(contents.inner) : [];
+  return { version, service, layers, tileMatrixSets };
+}
+
+function parseServiceMetadata(xml: string): WmtsCapabilitiesService {
+  const node = findElement(xml, 0, "ows:ServiceIdentification") ?? findElement(xml, 0, "ServiceIdentification");
+  if (!node) return {};
+  const out: WmtsCapabilitiesService = {};
+  const title = readTextElement(node.inner, "ows:Title") ?? readTextElement(node.inner, "Title");
+  if (title !== undefined) out.title = title;
+  const abstract = readTextElement(node.inner, "ows:Abstract") ?? readTextElement(node.inner, "Abstract");
+  if (abstract !== undefined) out.abstract = abstract;
+  return out;
+}
+
+function collectLayers(contentsInner: string): WmtsCapabilityLayer[] {
+  const out: WmtsCapabilityLayer[] = [];
+  let cursor = 0;
+  while (cursor < contentsInner.length) {
+    const node = findElement(contentsInner, cursor, "Layer");
+    if (!node) break;
+    const identifier = readTextElement(node.inner, "Identifier") ?? readTextElement(node.inner, "ows:Identifier") ?? "";
+    if (identifier.length > 0) {
+      const title = readTextElement(node.inner, "Title") ?? readTextElement(node.inner, "ows:Title");
+      const abstract = readTextElement(node.inner, "Abstract") ?? readTextElement(node.inner, "ows:Abstract");
+      const formats = collectChildText(node.inner, "Format");
+      const styles = collectStyles(node.inner);
+      const tileMatrixSetIds = collectTileMatrixSetLinks(node.inner);
+      const resources = collectResources(node.inner, "tile");
+      const featureInfoResources = collectResources(node.inner, "FeatureInfo");
+      const bbox = readWgs84BoundingBox(node.inner);
+      const layer: WmtsCapabilityLayer = {
+        identifier,
+        formats,
+        styles,
+        tileMatrixSetIds,
+        resourceTemplates: resources,
+        featureInfoTemplates: featureInfoResources,
+      };
+      if (title !== undefined) layer.title = title;
+      if (abstract !== undefined) layer.abstract = abstract;
+      if (bbox !== undefined) layer.bbox = bbox;
+      out.push(layer);
+    }
+    cursor = node.endIndex;
+  }
+  return out;
+}
+
+function collectStyles(layerInner: string): WmtsCapabilityStyle[] {
+  const out: WmtsCapabilityStyle[] = [];
+  let cursor = 0;
+  while (cursor < layerInner.length) {
+    const node = findElement(layerInner, cursor, "Style");
+    if (!node) break;
+    const identifier = readTextElement(node.inner, "Identifier") ?? readTextElement(node.inner, "ows:Identifier") ?? "";
+    if (identifier.length > 0) {
+      const title = readTextElement(node.inner, "Title") ?? readTextElement(node.inner, "ows:Title");
+      const isDefault = readAttribute(node.openTag, "isDefault") === "true";
+      const legend = findElement(node.inner, 0, "LegendURL");
+      const legendUrl = legend ? readAttribute(legend.openTag, "xlink:href") : undefined;
+      const style: WmtsCapabilityStyle = { identifier, isDefault };
+      if (title !== undefined) style.title = title;
+      if (legendUrl !== undefined) style.legendUrl = legendUrl;
+      out.push(style);
+    }
+    cursor = node.endIndex;
+  }
+  return out;
+}
+
+function collectTileMatrixSetLinks(layerInner: string): readonly string[] {
+  const out: string[] = [];
+  let cursor = 0;
+  while (cursor < layerInner.length) {
+    const node = findElement(layerInner, cursor, "TileMatrixSetLink");
+    if (!node) break;
+    const tms = readTextElement(node.inner, "TileMatrixSet") ?? readTextElement(node.inner, "ows:TileMatrixSet");
+    if (tms !== undefined && tms.length > 0) out.push(tms);
+    cursor = node.endIndex;
+  }
+  return out;
+}
+
+function collectResources(layerInner: string, resourceType: string): WmtsCapabilityResourceUrl[] {
+  const out: WmtsCapabilityResourceUrl[] = [];
+  let cursor = 0;
+  while (cursor < layerInner.length) {
+    const node = findElement(layerInner, cursor, "ResourceURL");
+    if (!node) break;
+    const type = readAttribute(node.openTag, "resourceType");
+    if (type === resourceType) {
+      const format = readAttribute(node.openTag, "format") ?? "";
+      const template = readAttribute(node.openTag, "template") ?? "";
+      if (template.length > 0) {
+        out.push({ format, template });
+      }
+    }
+    cursor = node.endIndex;
+  }
+  return out;
+}
+
+function readWgs84BoundingBox(
+  layerInner: string,
+): { west: number; south: number; east: number; north: number } | undefined {
+  const node = findElement(layerInner, 0, "WGS84BoundingBox") ?? findElement(layerInner, 0, "ows:WGS84BoundingBox");
+  if (!node) return undefined;
+  const lower = readTextElement(node.inner, "LowerCorner") ?? readTextElement(node.inner, "ows:LowerCorner") ?? "";
+  const upper = readTextElement(node.inner, "UpperCorner") ?? readTextElement(node.inner, "ows:UpperCorner") ?? "";
+  const lowerParts = lower.trim().split(/\s+/).map(Number);
+  const upperParts = upper.trim().split(/\s+/).map(Number);
+  if (
+    lowerParts.length !== 2 ||
+    upperParts.length !== 2 ||
+    !Number.isFinite(lowerParts[0]) ||
+    !Number.isFinite(lowerParts[1]) ||
+    !Number.isFinite(upperParts[0]) ||
+    !Number.isFinite(upperParts[1])
+  ) {
+    return undefined;
+  }
+  return {
+    west: lowerParts[0]!,
+    south: lowerParts[1]!,
+    east: upperParts[0]!,
+    north: upperParts[1]!,
+  };
+}
+
+function collectTileMatrixSets(contentsInner: string): WmtsCapabilityTileMatrixSet[] {
+  const out: WmtsCapabilityTileMatrixSet[] = [];
+  let cursor = 0;
+  while (cursor < contentsInner.length) {
+    const node = findElement(contentsInner, cursor, "TileMatrixSet");
+    if (!node) break;
+    const identifier = readTextElement(node.inner, "Identifier") ?? readTextElement(node.inner, "ows:Identifier");
+    // Skip the per-layer `TileMatrixSet` reference inside `TileMatrixSetLink`
+    // (those carry only an identifier and no nested `TileMatrix` children).
+    const matrices = collectTileMatrices(node.inner);
+    if (identifier !== undefined && identifier.length > 0 && matrices.length > 0) {
+      const supportedCrs =
+        readTextElement(node.inner, "SupportedCRS") ?? readTextElement(node.inner, "ows:SupportedCRS");
+      const wellKnown =
+        readTextElement(node.inner, "WellKnownScaleSet") ?? readTextElement(node.inner, "ows:WellKnownScaleSet");
+      const tms: WmtsCapabilityTileMatrixSet = {
+        identifier,
+        matrices,
+      };
+      if (supportedCrs !== undefined) tms.supportedCrs = supportedCrs;
+      if (wellKnown !== undefined) tms.wellKnownScaleSet = wellKnown;
+      out.push(tms);
+    }
+    cursor = node.endIndex;
+  }
+  return out;
+}
+
+function collectTileMatrices(tmsInner: string): WmtsCapabilityTileMatrix[] {
+  const out: WmtsCapabilityTileMatrix[] = [];
+  let cursor = 0;
+  while (cursor < tmsInner.length) {
+    const node = findElement(tmsInner, cursor, "TileMatrix");
+    if (!node) break;
+    const identifier = readTextElement(node.inner, "Identifier") ?? readTextElement(node.inner, "ows:Identifier") ?? "";
+    const scale = Number.parseFloat(readTextElement(node.inner, "ScaleDenominator") ?? "");
+    const topLeft = (readTextElement(node.inner, "TopLeftCorner") ?? "").trim().split(/\s+/).map(Number);
+    const tileWidth = Number.parseFloat(readTextElement(node.inner, "TileWidth") ?? "");
+    const tileHeight = Number.parseFloat(readTextElement(node.inner, "TileHeight") ?? "");
+    const matrixWidth = Number.parseFloat(readTextElement(node.inner, "MatrixWidth") ?? "");
+    const matrixHeight = Number.parseFloat(readTextElement(node.inner, "MatrixHeight") ?? "");
+    if (
+      identifier.length > 0 &&
+      Number.isFinite(scale) &&
+      Number.isFinite(tileWidth) &&
+      Number.isFinite(tileHeight) &&
+      Number.isFinite(matrixWidth) &&
+      Number.isFinite(matrixHeight) &&
+      topLeft.length === 2 &&
+      Number.isFinite(topLeft[0]) &&
+      Number.isFinite(topLeft[1])
+    ) {
+      out.push({
+        identifier,
+        scaleDenominator: scale,
+        tileWidth,
+        tileHeight,
+        matrixWidth,
+        matrixHeight,
+        topLeftCorner: [topLeft[0]!, topLeft[1]!],
+      });
+    }
+    cursor = node.endIndex;
+  }
+  return out;
+}
+
+function collectChildText(inner: string, tag: string): readonly string[] {
+  const out: string[] = [];
+  let cursor = 0;
+  while (cursor < inner.length) {
+    const node = findElement(inner, cursor, tag);
+    if (!node) break;
+    const text = decodeXmlText(node.inner.trim());
+    if (text.length > 0) out.push(text);
+    cursor = node.endIndex;
+  }
+  return out;
+}
+
+// ── Tiny named-element walker (shared logic with wms-capabilities.ts) ──
+
+interface FoundElement {
+  openTag: string;
+  inner: string;
+  endIndex: number;
+}
+
+function findElement(xml: string, from: number, tag: string): FoundElement | undefined {
+  let i = from;
+  while (i < xml.length) {
+    if (xml[i] !== "<") {
+      i += 1;
+      continue;
+    }
+    const next = xml[i + 1];
+    if (next === "!" && xml.startsWith("<!--", i)) {
+      const end = xml.indexOf("-->", i + 4);
+      if (end < 0) return undefined;
+      i = end + 3;
+      continue;
+    }
+    if (next === "!" && xml.startsWith("<![CDATA[", i)) {
+      const end = xml.indexOf("]]>", i + 9);
+      if (end < 0) return undefined;
+      i = end + 3;
+      continue;
+    }
+    if (next === "?" || next === "!") {
+      const end = xml.indexOf(">", i);
+      if (end < 0) return undefined;
+      i = end + 1;
+      continue;
+    }
+    const isClosing = next === "/";
+    const nameStart = isClosing ? i + 2 : i + 1;
+    const matchesTag = xml.startsWith(tag, nameStart) && isTagBoundary(xml.charCodeAt(nameStart + tag.length));
+    if (!matchesTag) {
+      const close = xml.indexOf(">", i);
+      if (close < 0) return undefined;
+      i = close + 1;
+      continue;
+    }
+    const close = xml.indexOf(">", i);
+    if (close < 0) return undefined;
+    const openTag = xml.slice(i, close + 1);
+    const selfClosing = !isClosing && xml.charCodeAt(close - 1) === 47;
+    if (selfClosing) return { openTag, inner: "", endIndex: close + 1 };
+    if (isClosing) {
+      i = close + 1;
+      continue;
+    }
+    let depth = 1;
+    let cursor = close + 1;
+    while (cursor < xml.length && depth > 0) {
+      const angle = xml.indexOf("<", cursor);
+      if (angle < 0) break;
+      const next2 = xml[angle + 1];
+      if (next2 === "!" && xml.startsWith("<!--", angle)) {
+        const end = xml.indexOf("-->", angle + 4);
+        if (end < 0) return undefined;
+        cursor = end + 3;
+        continue;
+      }
+      if (next2 === "!" && xml.startsWith("<![CDATA[", angle)) {
+        const end = xml.indexOf("]]>", angle + 9);
+        if (end < 0) return undefined;
+        cursor = end + 3;
+        continue;
+      }
+      const isCloser = next2 === "/";
+      const inspectStart = isCloser ? angle + 2 : angle + 1;
+      const matchesSame = xml.startsWith(tag, inspectStart) && isTagBoundary(xml.charCodeAt(inspectStart + tag.length));
+      const angleClose = xml.indexOf(">", angle);
+      if (angleClose < 0) return undefined;
+      if (matchesSame) {
+        if (isCloser) {
+          depth -= 1;
+          if (depth === 0) {
+            return {
+              openTag,
+              inner: xml.slice(close + 1, angle),
+              endIndex: angleClose + 1,
+            };
+          }
+        } else {
+          const innerSelfClose = xml.charCodeAt(angleClose - 1) === 47;
+          if (!innerSelfClose) depth += 1;
+        }
+      }
+      cursor = angleClose + 1;
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
+function isTagBoundary(code: number): boolean {
+  return code === 32 || code === 9 || code === 10 || code === 13 || code === 47 || code === 62;
+}
+
+function readAttribute(openTag: string, name: string): string | undefined {
+  const idx = findAttributeIndex(openTag, name);
+  if (idx < 0) return undefined;
+  const after = openTag.slice(idx + name.length);
+  const eq = after.indexOf("=");
+  if (eq < 0) return undefined;
+  let cursor = eq + 1;
+  while (cursor < after.length && /\s/.test(after[cursor]!)) cursor += 1;
+  const quote = after[cursor];
+  if (quote !== '"' && quote !== "'") return undefined;
+  const end = after.indexOf(quote, cursor + 1);
+  if (end < 0) return undefined;
+  return decodeXmlText(after.slice(cursor + 1, end));
+}
+
+function findAttributeIndex(openTag: string, name: string): number {
+  let i = 0;
+  while (i < openTag.length) {
+    const found = openTag.indexOf(name, i);
+    if (found < 0) return -1;
+    const before = openTag.charCodeAt(found - 1);
+    const isBoundaryStart = found === 0 || before === 32 || before === 9 || before === 10 || before === 13;
+    const after = openTag.charCodeAt(found + name.length);
+    const isBoundaryEnd = after === 61 || after === 32 || after === 9 || after === 10 || after === 13;
+    if (isBoundaryStart && isBoundaryEnd) {
+      return found;
+    }
+    i = found + 1;
+  }
+  return -1;
+}
+
+function readTextElement(xml: string, tag: string): string | undefined {
+  const node = findElement(xml, 0, tag);
+  if (!node) return undefined;
+  return decodeXmlText(node.inner.trim());
+}
+
+function decodeXmlText(text: string): string {
+  if (text.indexOf("&") < 0 && text.indexOf("<![CDATA[") < 0) return text;
+  return text
+    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, "$1")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&#(\d+);/g, (_match, dec: string) => String.fromCodePoint(Number(dec)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_match, hex: string) => String.fromCodePoint(Number.parseInt(hex, 16)));
+}
+
+/** Find a layer by identifier in a parsed `WmtsCapabilities`. */
+export function findWmtsLayer(capabilities: WmtsCapabilities, identifier: string): WmtsCapabilityLayer | undefined {
+  return capabilities.layers.find((l) => l.identifier === identifier);
+}
+
+/** Find a tile-matrix-set by identifier. */
+export function findWmtsTileMatrixSet(
+  capabilities: WmtsCapabilities,
+  identifier: string,
+): WmtsCapabilityTileMatrixSet | undefined {
+  return capabilities.tileMatrixSets.find((t) => t.identifier === identifier);
+}

--- a/src/core/wmts.ts
+++ b/src/core/wmts.ts
@@ -1,0 +1,232 @@
+/**
+ * First-party WMTS 1.0.0 adapter. `HonuaWmts` is the service-level
+ * handle returned by `client.wmts(serviceId)`; `HonuaWmtsLayer` is a
+ * single-layer projection that pre-fills LAYER and (optionally) STYLE;
+ * `HonuaWmtsTileset` adds a TileMatrixSet binding so per-call requests
+ * shrink to `{tileMatrix, tileRow, tileCol}`.
+ *
+ * The wire path lives on `HonuaClient` (`getWmtsCapabilities`,
+ * `fetchWmtsTile`, `getWmtsFeatureInfo`).
+ *
+ * @module
+ */
+
+import type { HonuaClient } from "./client.js";
+import type { WmtsCapabilities, WmtsCapabilityLayer, WmtsCapabilityTileMatrixSet } from "./wmts-capabilities.js";
+import { findWmtsLayer, findWmtsTileMatrixSet } from "./wmts-capabilities.js";
+import type {
+  HonuaWmtsFeatureInfoResponse,
+  HonuaWmtsTileResponse,
+  WmtsFeatureInfoRequest,
+  WmtsTileRequest,
+} from "./wms-types.js";
+
+export interface HonuaWmtsOptions {
+  client: HonuaClient;
+  serviceId: string;
+}
+
+export interface HonuaWmtsLayerOptions extends HonuaWmtsOptions {
+  layerName: string;
+  defaultStyleId?: string;
+  defaultTileMatrixSetId?: string;
+}
+
+export interface HonuaWmtsTilesetOptions extends HonuaWmtsOptions {
+  layerName: string;
+  styleId: string;
+  tileMatrixSetId: string;
+}
+
+export class HonuaWmts {
+  public readonly client: HonuaClient;
+  public readonly serviceId: string;
+
+  public constructor(options: HonuaWmtsOptions) {
+    this.client = options.client;
+    this.serviceId = options.serviceId;
+  }
+
+  /** Bind a single LAYER + optional STYLE / TileMatrixSet defaults. */
+  public layer(name: string, options?: { styleId?: string; tileMatrixSetId?: string }): HonuaWmtsLayer {
+    const opts: HonuaWmtsLayerOptions = {
+      client: this.client,
+      serviceId: this.serviceId,
+      layerName: name,
+    };
+    if (options?.styleId !== undefined) opts.defaultStyleId = options.styleId;
+    if (options?.tileMatrixSetId !== undefined) opts.defaultTileMatrixSetId = options.tileMatrixSetId;
+    return new HonuaWmtsLayer(opts);
+  }
+
+  public tileset(layerName: string, styleId: string, tileMatrixSetId: string): HonuaWmtsTileset {
+    return new HonuaWmtsTileset({
+      client: this.client,
+      serviceId: this.serviceId,
+      layerName,
+      styleId,
+      tileMatrixSetId,
+    });
+  }
+
+  public async capabilities(options?: { signal?: AbortSignal }): Promise<WmtsCapabilities> {
+    return this.client.getWmtsCapabilities({
+      serviceId: this.serviceId,
+      ...(options?.signal ? { signal: options.signal } : {}),
+    });
+  }
+
+  public async tile(request: WmtsTileRequest): Promise<HonuaWmtsTileResponse> {
+    return this.client.fetchWmtsTile({ serviceId: this.serviceId, ...request });
+  }
+
+  public async featureInfo<T = Record<string, unknown>>(
+    request: WmtsFeatureInfoRequest,
+  ): Promise<HonuaWmtsFeatureInfoResponse<T>> {
+    return this.client.getWmtsFeatureInfo<T>({ serviceId: this.serviceId, ...request });
+  }
+}
+
+export class HonuaWmtsLayer {
+  public readonly client: HonuaClient;
+  public readonly serviceId: string;
+  public readonly layerName: string;
+  public readonly defaultStyleId: string | undefined;
+  public readonly defaultTileMatrixSetId: string | undefined;
+
+  public constructor(options: HonuaWmtsLayerOptions) {
+    this.client = options.client;
+    this.serviceId = options.serviceId;
+    this.layerName = options.layerName;
+    this.defaultStyleId = options.defaultStyleId;
+    this.defaultTileMatrixSetId = options.defaultTileMatrixSetId;
+  }
+
+  public describe(capabilities: WmtsCapabilities): WmtsCapabilityLayer | undefined {
+    return findWmtsLayer(capabilities, this.layerName);
+  }
+
+  public tileset(styleId?: string, tileMatrixSetId?: string): HonuaWmtsTileset {
+    const style = styleId ?? this.defaultStyleId ?? "default";
+    const tms = tileMatrixSetId ?? this.defaultTileMatrixSetId ?? "WebMercatorQuad";
+    return new HonuaWmtsTileset({
+      client: this.client,
+      serviceId: this.serviceId,
+      layerName: this.layerName,
+      styleId: style,
+      tileMatrixSetId: tms,
+    });
+  }
+
+  public async tile(
+    request: Omit<WmtsTileRequest, "layer" | "style" | "tileMatrixSet"> & {
+      style?: string;
+      tileMatrixSet?: string;
+    },
+  ): Promise<HonuaWmtsTileResponse> {
+    return this.client.fetchWmtsTile({
+      serviceId: this.serviceId,
+      layer: this.layerName,
+      style: request.style ?? this.defaultStyleId,
+      tileMatrixSet: request.tileMatrixSet ?? this.defaultTileMatrixSetId,
+      tileMatrix: request.tileMatrix,
+      tileRow: request.tileRow,
+      tileCol: request.tileCol,
+      ...(request.format !== undefined ? { format: request.format } : {}),
+      ...(request.mode !== undefined ? { mode: request.mode } : {}),
+      ...(request.signal !== undefined ? { signal: request.signal } : {}),
+      ...(request.extraParams !== undefined ? { extraParams: request.extraParams } : {}),
+    });
+  }
+
+  public async featureInfo<T = Record<string, unknown>>(
+    request: Omit<WmtsFeatureInfoRequest, "layer" | "style" | "tileMatrixSet"> & {
+      style?: string;
+      tileMatrixSet?: string;
+    },
+  ): Promise<HonuaWmtsFeatureInfoResponse<T>> {
+    return this.client.getWmtsFeatureInfo<T>({
+      serviceId: this.serviceId,
+      layer: this.layerName,
+      style: request.style ?? this.defaultStyleId,
+      tileMatrixSet: request.tileMatrixSet ?? this.defaultTileMatrixSetId,
+      tileMatrix: request.tileMatrix,
+      tileRow: request.tileRow,
+      tileCol: request.tileCol,
+      i: request.i,
+      j: request.j,
+      ...(request.format !== undefined ? { format: request.format } : {}),
+      ...(request.infoFormat !== undefined ? { infoFormat: request.infoFormat } : {}),
+      ...(request.mode !== undefined ? { mode: request.mode } : {}),
+      ...(request.signal !== undefined ? { signal: request.signal } : {}),
+      ...(request.extraParams !== undefined ? { extraParams: request.extraParams } : {}),
+    });
+  }
+}
+
+/**
+ * Tileset handle bound to (layer × style × tileMatrixSet). The runtime
+ * binding for MapLibre's `raster` source spec is keyed off this shape.
+ */
+export class HonuaWmtsTileset {
+  public readonly client: HonuaClient;
+  public readonly serviceId: string;
+  public readonly layerName: string;
+  public readonly styleId: string;
+  public readonly tileMatrixSetId: string;
+
+  public constructor(options: HonuaWmtsTilesetOptions) {
+    this.client = options.client;
+    this.serviceId = options.serviceId;
+    this.layerName = options.layerName;
+    this.styleId = options.styleId;
+    this.tileMatrixSetId = options.tileMatrixSetId;
+  }
+
+  public describe(capabilities: WmtsCapabilities): WmtsCapabilityTileMatrixSet | undefined {
+    return findWmtsTileMatrixSet(capabilities, this.tileMatrixSetId);
+  }
+
+  public async tile(
+    request: Omit<WmtsTileRequest, "layer" | "style" | "tileMatrixSet">,
+  ): Promise<HonuaWmtsTileResponse> {
+    return this.client.fetchWmtsTile({
+      serviceId: this.serviceId,
+      layer: this.layerName,
+      style: this.styleId,
+      tileMatrixSet: this.tileMatrixSetId,
+      tileMatrix: request.tileMatrix,
+      tileRow: request.tileRow,
+      tileCol: request.tileCol,
+      ...(request.format !== undefined ? { format: request.format } : {}),
+      ...(request.mode !== undefined ? { mode: request.mode } : {}),
+      ...(request.signal !== undefined ? { signal: request.signal } : {}),
+      ...(request.extraParams !== undefined ? { extraParams: request.extraParams } : {}),
+    });
+  }
+
+  public async featureInfo<T = Record<string, unknown>>(
+    request: Omit<WmtsFeatureInfoRequest, "layer" | "style" | "tileMatrixSet">,
+  ): Promise<HonuaWmtsFeatureInfoResponse<T>> {
+    return this.client.getWmtsFeatureInfo<T>({
+      serviceId: this.serviceId,
+      layer: this.layerName,
+      style: this.styleId,
+      tileMatrixSet: this.tileMatrixSetId,
+      tileMatrix: request.tileMatrix,
+      tileRow: request.tileRow,
+      tileCol: request.tileCol,
+      i: request.i,
+      j: request.j,
+      ...(request.format !== undefined ? { format: request.format } : {}),
+      ...(request.infoFormat !== undefined ? { infoFormat: request.infoFormat } : {}),
+      ...(request.mode !== undefined ? { mode: request.mode } : {}),
+      ...(request.signal !== undefined ? { signal: request.signal } : {}),
+      ...(request.extraParams !== undefined ? { extraParams: request.extraParams } : {}),
+    });
+  }
+}
+
+export function createHonuaWmts(client: HonuaClient, serviceId: string): HonuaWmts {
+  return new HonuaWmts({ client, serviceId });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,8 @@ export {
   isFeatureServiceSource,
   isMapServiceSource,
   isOgcFeaturesSource,
+  isWmsSource,
+  isWmtsSource,
   parseOgcFeaturesUrl,
   validateHonuaStyle,
   createSources,
@@ -38,6 +40,8 @@ export type {
   HonuaFeatureServiceSourceSpecification,
   HonuaMapServiceSourceSpecification,
   HonuaOgcFeaturesSourceSpecification,
+  HonuaWmsSourceSpecification,
+  HonuaWmtsSourceSpecification,
   HonuaSourceSpecification,
   HonuaLayerSpecification,
   HonuaStyleSpecification,
@@ -848,6 +852,70 @@ export type {
   HonuaOgcMapsOptions,
 } from "./core/ogc-maps.js";
 export {
+  createHonuaWms,
+  HonuaWms,
+  HonuaWmsLayer,
+} from "./core/wms.js";
+export type {
+  HonuaWmsLayerOptions,
+  HonuaWmsOptions,
+} from "./core/wms.js";
+export {
+  createHonuaWmts,
+  HonuaWmts,
+  HonuaWmtsLayer,
+  HonuaWmtsTileset,
+} from "./core/wmts.js";
+export type {
+  HonuaWmtsLayerOptions,
+  HonuaWmtsOptions,
+  HonuaWmtsTilesetOptions,
+} from "./core/wmts.js";
+export {
+  HonuaWmsCapabilitiesParseError,
+  findWmsLayer,
+  iterateWmsLayers,
+  parseWmsCapabilities,
+} from "./core/wms-capabilities.js";
+export type {
+  WmsCapabilities,
+  WmsCapabilitiesFormats,
+  WmsCapabilitiesRequestSupport,
+  WmsCapabilitiesService,
+  WmsCapabilityBoundingBox,
+  WmsCapabilityDimension,
+  WmsCapabilityLayer,
+  WmsCapabilityStyle,
+} from "./core/wms-capabilities.js";
+export {
+  HonuaWmtsCapabilitiesParseError,
+  findWmtsLayer,
+  findWmtsTileMatrixSet,
+  parseWmtsCapabilities,
+} from "./core/wmts-capabilities.js";
+export type {
+  WmtsCapabilities,
+  WmtsCapabilitiesService,
+  WmtsCapabilityLayer,
+  WmtsCapabilityResourceUrl,
+  WmtsCapabilityStyle,
+  WmtsCapabilityTileMatrix,
+  WmtsCapabilityTileMatrixSet,
+} from "./core/wmts-capabilities.js";
+export type {
+  HonuaWmsFeatureInfoResponse,
+  HonuaWmsImageResponse,
+  HonuaWmtsFeatureInfoResponse,
+  HonuaWmtsTileResponse,
+  WmsCrs,
+  WmsFeatureInfoRequest,
+  WmsLegendRequest,
+  WmsMapRequest,
+  WmtsFeatureInfoRequest,
+  WmtsTileMode,
+  WmtsTileRequest,
+} from "./core/wms-types.js";
+export {
   createHonuaOgcProcesses,
   HonuaJobFailedError,
   HonuaOgcProcessJobRun,
@@ -1068,6 +1136,8 @@ export {
   ogcMapsSource,
   ogcTilesSource,
   stacSearchSource,
+  wmsSource,
+  wmtsSource,
 } from "./contract/index.js";
 export type {
   AdapterFor,

--- a/src/map/honua-map.ts
+++ b/src/map/honua-map.ts
@@ -19,15 +19,13 @@ import {
   type HonuaOgcFeatureCollection,
   HonuaOgcFeatures,
 } from "../core/surfaces.js";
-import { HonuaWms, HonuaWmsLayer } from "../core/wms.js";
-import { HonuaWmts, type HonuaWmtsLayer, HonuaWmtsTileset } from "../core/wmts.js";
+import type { HonuaWms, HonuaWmsLayer } from "../core/wms.js";
+import type { HonuaWmts, HonuaWmtsLayer, HonuaWmtsTileset } from "../core/wmts.js";
 import { parseFeatureLayerUrl, parseMapServiceUrl } from "../esri-compat/url.js";
 import type {
   HonuaLayerSpecification,
   HonuaSourceSpecification,
   HonuaStyleSpecification,
-  HonuaWmsSourceSpecification,
-  HonuaWmtsSourceSpecification,
 } from "../style/specification.js";
 import {
   isFeatureServiceSource,
@@ -38,6 +36,7 @@ import {
   isWmtsSource,
   parseOgcFeaturesUrl,
 } from "../style/specification.js";
+import { resolveWmsSpec, resolveWmtsSpec } from "../style/wms-wmts-resolvers.js";
 
 // ── Types ─────────────────────────────────────────────────────
 
@@ -408,61 +407,4 @@ export class HonuaMap {
       listener(event);
     }
   }
-}
-
-const WMS_URL_RE = /\/(?:rest\/services\/([^/?#]+)\/MapServer\/(?:WMS|WMTS)|ogc\/services\/([^/?#]+)\/(?:wms|wmts))/i;
-
-function parseWmsServiceIdFromUrl(url: string): string | undefined {
-  const match = WMS_URL_RE.exec(url);
-  if (!match) return undefined;
-  const id = match[1] ?? match[2];
-  if (!id) return undefined;
-  try {
-    return decodeURIComponent(id);
-  } catch {
-    return id;
-  }
-}
-
-function resolveWmsSpec(client: HonuaClient, spec: HonuaWmsSourceSpecification): HonuaWms | HonuaWmsLayer {
-  const serviceId = spec.serviceId ?? parseWmsServiceIdFromUrl(spec.url);
-  if (!serviceId) {
-    throw new Error("HonuaMap: honua-wms source requires either serviceId or a URL containing the service id");
-  }
-  const root = new HonuaWms({ client, serviceId });
-  if (typeof spec.layers === "string" && spec.layers.length > 0) {
-    const opts: { client: HonuaClient; serviceId: string; layerName: string; defaultStyleId?: string } = {
-      client,
-      serviceId,
-      layerName: spec.layers,
-    };
-    if (typeof spec.styles === "string" && spec.styles.length > 0) {
-      opts.defaultStyleId = spec.styles;
-    }
-    return new HonuaWmsLayer(opts);
-  }
-  return root;
-}
-
-function resolveWmtsSpec(
-  client: HonuaClient,
-  spec: HonuaWmtsSourceSpecification,
-): HonuaWmts | HonuaWmtsLayer | HonuaWmtsTileset {
-  const serviceId = spec.serviceId ?? parseWmsServiceIdFromUrl(spec.url);
-  if (!serviceId) {
-    throw new Error("HonuaMap: honua-wmts source requires either serviceId or a URL containing the service id");
-  }
-  const root = new HonuaWmts({ client, serviceId });
-  if (typeof spec.layer === "string" && spec.layer.length > 0) {
-    const style = spec.style ?? "default";
-    const tms = spec.tileMatrixSet ?? "WebMercatorQuad";
-    return new HonuaWmtsTileset({
-      client,
-      serviceId,
-      layerName: spec.layer,
-      styleId: style,
-      tileMatrixSetId: tms,
-    });
-  }
-  return root;
 }

--- a/src/map/honua-map.ts
+++ b/src/map/honua-map.ts
@@ -19,24 +19,39 @@ import {
   type HonuaOgcFeatureCollection,
   HonuaOgcFeatures,
 } from "../core/surfaces.js";
+import { HonuaWms, HonuaWmsLayer } from "../core/wms.js";
+import { HonuaWmts, type HonuaWmtsLayer, HonuaWmtsTileset } from "../core/wmts.js";
 import { parseFeatureLayerUrl, parseMapServiceUrl } from "../esri-compat/url.js";
 import type {
   HonuaLayerSpecification,
   HonuaSourceSpecification,
   HonuaStyleSpecification,
+  HonuaWmsSourceSpecification,
+  HonuaWmtsSourceSpecification,
 } from "../style/specification.js";
 import {
   isFeatureServiceSource,
   isHonuaSource,
   isMapServiceSource,
   isOgcFeaturesSource,
+  isWmsSource,
+  isWmtsSource,
   parseOgcFeaturesUrl,
 } from "../style/specification.js";
 
 // ── Types ─────────────────────────────────────────────────────
 
 /** A resolved Honua source: either an SDK surface instance or `null` for native MapLibre sources. */
-export type ResolvedMapSource = HonuaFeatureLayer | HonuaMapService | HonuaOgcFeatureCollection | null;
+export type ResolvedMapSource =
+  | HonuaFeatureLayer
+  | HonuaMapService
+  | HonuaOgcFeatureCollection
+  | HonuaWms
+  | HonuaWmsLayer
+  | HonuaWmts
+  | HonuaWmtsLayer
+  | HonuaWmtsTileset
+  | null;
 
 /** Options for constructing a {@link HonuaMap}. */
 export interface HonuaMapOptions {
@@ -379,6 +394,12 @@ export class HonuaMap {
       const collectionId = spec.collectionId ?? parsed.collectionId ?? "";
       return ogcRoot.collection(collectionId);
     }
+    if (isWmsSource(spec)) {
+      return resolveWmsSpec(this.#client, spec);
+    }
+    if (isWmtsSource(spec)) {
+      return resolveWmtsSpec(this.#client, spec);
+    }
     return null;
   }
 
@@ -387,4 +408,61 @@ export class HonuaMap {
       listener(event);
     }
   }
+}
+
+const WMS_URL_RE = /\/(?:rest\/services\/([^/?#]+)\/MapServer\/(?:WMS|WMTS)|ogc\/services\/([^/?#]+)\/(?:wms|wmts))/i;
+
+function parseWmsServiceIdFromUrl(url: string): string | undefined {
+  const match = WMS_URL_RE.exec(url);
+  if (!match) return undefined;
+  const id = match[1] ?? match[2];
+  if (!id) return undefined;
+  try {
+    return decodeURIComponent(id);
+  } catch {
+    return id;
+  }
+}
+
+function resolveWmsSpec(client: HonuaClient, spec: HonuaWmsSourceSpecification): HonuaWms | HonuaWmsLayer {
+  const serviceId = spec.serviceId ?? parseWmsServiceIdFromUrl(spec.url);
+  if (!serviceId) {
+    throw new Error("HonuaMap: honua-wms source requires either serviceId or a URL containing the service id");
+  }
+  const root = new HonuaWms({ client, serviceId });
+  if (typeof spec.layers === "string" && spec.layers.length > 0) {
+    const opts: { client: HonuaClient; serviceId: string; layerName: string; defaultStyleId?: string } = {
+      client,
+      serviceId,
+      layerName: spec.layers,
+    };
+    if (typeof spec.styles === "string" && spec.styles.length > 0) {
+      opts.defaultStyleId = spec.styles;
+    }
+    return new HonuaWmsLayer(opts);
+  }
+  return root;
+}
+
+function resolveWmtsSpec(
+  client: HonuaClient,
+  spec: HonuaWmtsSourceSpecification,
+): HonuaWmts | HonuaWmtsLayer | HonuaWmtsTileset {
+  const serviceId = spec.serviceId ?? parseWmsServiceIdFromUrl(spec.url);
+  if (!serviceId) {
+    throw new Error("HonuaMap: honua-wmts source requires either serviceId or a URL containing the service id");
+  }
+  const root = new HonuaWmts({ client, serviceId });
+  if (typeof spec.layer === "string" && spec.layer.length > 0) {
+    const style = spec.style ?? "default";
+    const tms = spec.tileMatrixSet ?? "WebMercatorQuad";
+    return new HonuaWmtsTileset({
+      client,
+      serviceId,
+      layerName: spec.layer,
+      styleId: style,
+      tileMatrixSetId: tms,
+    });
+  }
+  return root;
 }

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -75,7 +75,12 @@ export type {
 export { applyStyleRefs, applyTheme, composeStyle } from "./style-compose.js";
 export type { StyleComposeOptions, StyleRefResolver, ThemeResolver } from "./style-compose.js";
 
-export { projectSourceBindings, toHonuaSourceSpec } from "./source-bridge.js";
+export {
+  buildWmsRasterSourceSpec,
+  buildWmtsRasterSourceSpec,
+  projectSourceBindings,
+  toHonuaSourceSpec,
+} from "./source-bridge.js";
 export type { NativeMapLibreSourceEntry, SourceBridgeProjection } from "./source-bridge.js";
 
 export { diffPackages } from "./diff.js";

--- a/src/runtime/map-package.ts
+++ b/src/runtime/map-package.ts
@@ -36,6 +36,7 @@ export type HonuaMapPackageProtocol =
   | "ogc_tiles"
   | "wfs"
   | "wms"
+  | "wmts"
   | "odata"
   | "vector_tile"
   | "raster_tile"

--- a/src/runtime/source-bridge.ts
+++ b/src/runtime/source-bridge.ts
@@ -204,13 +204,14 @@ export function buildWmsRasterSourceSpec(
   params.set("LAYERS", layers);
   params.set("STYLES", styles);
   params.set("CRS", "EPSG:3857");
-  params.set("WIDTH", String(tileSize));
-  params.set("HEIGHT", String(tileSize));
   params.set("FORMAT", format);
   params.set("TRANSPARENT", String(transparent).toUpperCase());
   // MapLibre substitutes these placeholders at fetch-time. They are
   // intentionally appended verbatim (no encoding) so MapLibre's
-  // template parser sees the literal `{bbox-epsg3857}` token.
+  // template parser sees the literal tokens. WIDTH and HEIGHT are
+  // emitted only as placeholders — duplicating them as fixed params
+  // would produce ambiguous query keys that honua-server's
+  // TryGetRequiredQueryValue / int.TryParse pair rejects.
   const baseUrl = `${url}?${params.toString()}&BBOX={bbox-epsg3857}&WIDTH={width}&HEIGHT={height}`;
   const out: { type: "raster"; tiles: string[]; tileSize: number; attribution?: string } = {
     type: "raster",

--- a/src/runtime/source-bridge.ts
+++ b/src/runtime/source-bridge.ts
@@ -26,6 +26,7 @@ import {
   type SourceDescriptor,
   type SourceLocator,
 } from "../contract/index.js";
+import { wmtsExtensionForFormat } from "../core/wms-types.js";
 import { HonuaMapPackageError } from "./errors.js";
 import type { HonuaMapPackageLocator, HonuaMapPackageProtocol, HonuaMapPackageSourceBinding } from "./map-package.js";
 
@@ -242,7 +243,7 @@ export function buildWmtsRasterSourceSpec(
   const url = requireLocatorUrl(descriptor);
   const tileSize = options.tileSize ?? 256;
   const format = options.format ?? "image/png";
-  const ext = format.toLowerCase().includes("jpeg") || format.toLowerCase().includes("jpg") ? "jpeg" : "png";
+  const ext = wmtsExtensionForFormat(format);
   const layer = descriptor.locator.typeName ?? "";
   const style = descriptor.locator.styleId ?? "default";
   const tms = descriptor.locator.tileMatrixSetId ?? "WebMercatorQuad";

--- a/src/runtime/source-bridge.ts
+++ b/src/runtime/source-bridge.ts
@@ -27,11 +27,7 @@ import {
   type SourceLocator,
 } from "../contract/index.js";
 import { HonuaMapPackageError } from "./errors.js";
-import type {
-  HonuaMapPackageLocator,
-  HonuaMapPackageProtocol,
-  HonuaMapPackageSourceBinding,
-} from "./map-package.js";
+import type { HonuaMapPackageLocator, HonuaMapPackageProtocol, HonuaMapPackageSourceBinding } from "./map-package.js";
 
 /** One MapLibre-native source entry derived from a binding. */
 export interface NativeMapLibreSourceEntry {
@@ -113,7 +109,10 @@ export function projectSourceBindings(
  * Build the Honua custom-source spec (to be inserted into `style.sources`)
  * for a protocol-backed descriptor.
  */
-export function toHonuaSourceSpec(descriptor: SourceDescriptor, filter?: string): { type: string; [key: string]: unknown } {
+export function toHonuaSourceSpec(
+  descriptor: SourceDescriptor,
+  filter?: string,
+): { type: string; [key: string]: unknown } {
   switch (descriptor.protocol) {
     case "geoservices-feature-service": {
       const url = requireLocatorUrl(descriptor);
@@ -144,6 +143,33 @@ export function toHonuaSourceSpec(descriptor: SourceDescriptor, filter?: string)
         ...(descriptor.attribution ? { attribution: descriptor.attribution } : {}),
       };
     }
+    case "wms": {
+      const url = requireLocatorUrl(descriptor);
+      const out: { type: string; [key: string]: unknown } = {
+        type: "honua-wms",
+        url,
+      };
+      if (descriptor.locator.serviceId !== undefined) out.serviceId = descriptor.locator.serviceId;
+      if (descriptor.locator.typeName !== undefined) out.layers = descriptor.locator.typeName;
+      if (descriptor.locator.styleId !== undefined) out.styles = descriptor.locator.styleId;
+      if (descriptor.attribution !== undefined) out.attribution = descriptor.attribution;
+      return out;
+    }
+    case "wmts": {
+      const url = requireLocatorUrl(descriptor);
+      const out: { type: string; [key: string]: unknown } = {
+        type: "honua-wmts",
+        url,
+      };
+      if (descriptor.locator.serviceId !== undefined) out.serviceId = descriptor.locator.serviceId;
+      if (descriptor.locator.typeName !== undefined) out.layer = descriptor.locator.typeName;
+      if (descriptor.locator.styleId !== undefined) out.style = descriptor.locator.styleId;
+      if (descriptor.locator.tileMatrixSetId !== undefined) {
+        out.tileMatrixSet = descriptor.locator.tileMatrixSetId;
+      }
+      if (descriptor.attribution !== undefined) out.attribution = descriptor.attribution;
+      return out;
+    }
     default:
       return {
         type: `honua-${descriptor.protocol}`,
@@ -152,6 +178,92 @@ export function toHonuaSourceSpec(descriptor: SourceDescriptor, filter?: string)
         ...(descriptor.attribution ? { attribution: descriptor.attribution } : {}),
       };
   }
+}
+
+/**
+ * Build a MapLibre `raster` source spec for a WMS descriptor. The
+ * `tiles` template uses MapLibre's runtime substitution placeholders
+ * (`{bbox-epsg3857}`, `{width}`, `{height}`) so each tile request is a
+ * pre-baked KVP URL — consumers do not have to hand-assemble GetMap
+ * URLs themselves.
+ */
+export function buildWmsRasterSourceSpec(
+  descriptor: SourceDescriptor,
+  options: { tileSize?: number; format?: string; transparent?: boolean } = {},
+): { type: "raster"; tiles: string[]; tileSize: number; attribution?: string } {
+  const url = requireLocatorUrl(descriptor);
+  const tileSize = options.tileSize ?? 256;
+  const format = options.format ?? "image/png";
+  const transparent = options.transparent ?? true;
+  const layers = descriptor.locator.typeName ?? "";
+  const styles = descriptor.locator.styleId ?? "";
+  const params = new URLSearchParams();
+  params.set("SERVICE", "WMS");
+  params.set("VERSION", "1.3.0");
+  params.set("REQUEST", "GetMap");
+  params.set("LAYERS", layers);
+  params.set("STYLES", styles);
+  params.set("CRS", "EPSG:3857");
+  params.set("WIDTH", String(tileSize));
+  params.set("HEIGHT", String(tileSize));
+  params.set("FORMAT", format);
+  params.set("TRANSPARENT", String(transparent).toUpperCase());
+  // MapLibre substitutes these placeholders at fetch-time. They are
+  // intentionally appended verbatim (no encoding) so MapLibre's
+  // template parser sees the literal `{bbox-epsg3857}` token.
+  const baseUrl = `${url}?${params.toString()}&BBOX={bbox-epsg3857}&WIDTH={width}&HEIGHT={height}`;
+  const out: { type: "raster"; tiles: string[]; tileSize: number; attribution?: string } = {
+    type: "raster",
+    tiles: [baseUrl],
+    tileSize,
+  };
+  if (descriptor.attribution) out.attribution = descriptor.attribution;
+  return out;
+}
+
+/**
+ * Build a MapLibre `raster` source spec for a WMTS descriptor using the
+ * RESTful tile route. The template expands `{z}/{y}/{x}` at runtime
+ * (MapLibre's standard tile placeholders).
+ */
+export function buildWmtsRasterSourceSpec(
+  descriptor: SourceDescriptor,
+  options: { tileSize?: number; format?: string; minzoom?: number; maxzoom?: number } = {},
+): {
+  type: "raster";
+  tiles: string[];
+  tileSize: number;
+  scheme?: string;
+  minzoom?: number;
+  maxzoom?: number;
+  attribution?: string;
+} {
+  const url = requireLocatorUrl(descriptor);
+  const tileSize = options.tileSize ?? 256;
+  const format = options.format ?? "image/png";
+  const ext = format.toLowerCase().includes("jpeg") || format.toLowerCase().includes("jpg") ? "jpeg" : "png";
+  const layer = descriptor.locator.typeName ?? "";
+  const style = descriptor.locator.styleId ?? "default";
+  const tms = descriptor.locator.tileMatrixSetId ?? "WebMercatorQuad";
+  const tileTemplate = `${url}/${encodeURIComponent(layer)}/${encodeURIComponent(style)}/${encodeURIComponent(tms)}/{z}/{y}/{x}.${ext}`;
+  const out: {
+    type: "raster";
+    tiles: string[];
+    tileSize: number;
+    scheme?: string;
+    minzoom?: number;
+    maxzoom?: number;
+    attribution?: string;
+  } = {
+    type: "raster",
+    tiles: [tileTemplate],
+    tileSize,
+    scheme: "xyz",
+  };
+  if (options.minzoom !== undefined) out.minzoom = options.minzoom;
+  if (options.maxzoom !== undefined) out.maxzoom = options.maxzoom;
+  if (descriptor.attribution) out.attribution = descriptor.attribution;
+  return out;
 }
 
 function toSdkProtocol(protocol: HonuaMapPackageProtocol): Protocol | undefined {
@@ -166,6 +278,8 @@ function toSdkProtocol(protocol: HonuaMapPackageProtocol): Protocol | undefined 
       return "wfs";
     case "wms":
       return "wms";
+    case "wmts":
+      return "wmts";
     case "odata":
       return "odata";
     default:
@@ -216,10 +330,11 @@ function toSourceLocator(
   }
 
   if (typeof loc.url !== "string" || loc.url.length === 0) {
-    throw new HonuaMapPackageError(
-      `SourceBinding "${binding.sourceId}" is missing locator.url`,
-      { packageId, stage: "source-bind", detail: { sourceId: binding.sourceId, protocol: binding.protocol } },
-    );
+    throw new HonuaMapPackageError(`SourceBinding "${binding.sourceId}" is missing locator.url`, {
+      packageId,
+      stage: "source-bind",
+      detail: { sourceId: binding.sourceId, protocol: binding.protocol },
+    });
   }
 
   const locator: SourceLocator = { url: loc.url };
@@ -229,6 +344,12 @@ function toSourceLocator(
   if (loc.collectionId !== undefined) locator.collectionId = loc.collectionId;
   if (loc.typeName !== undefined) locator.typeName = loc.typeName;
   if (loc.entitySet !== undefined) locator.entitySet = loc.entitySet;
+  if (typeof (loc as { styleId?: unknown }).styleId === "string") {
+    locator.styleId = (loc as { styleId: string }).styleId;
+  }
+  if (typeof (loc as { tileMatrixSetId?: unknown }).tileMatrixSetId === "string") {
+    locator.tileMatrixSetId = (loc as { tileMatrixSetId: string }).tileMatrixSetId;
+  }
 
   // Backfill protocol-specific fields from the URL when the server ships
   // only `locator.url`. The built-in GeoServices and OGC adapters require
@@ -248,6 +369,11 @@ function toSourceLocator(
     if (locator.collectionId === undefined) {
       const parsedCollectionId = parseOgcCollectionId(loc.url);
       if (parsedCollectionId !== undefined) locator.collectionId = parsedCollectionId;
+    }
+  } else if (sdkProtocol === "wms" || sdkProtocol === "wmts") {
+    if (locator.serviceId === undefined) {
+      const parsedServiceId = parseWmsServiceId(loc.url);
+      if (parsedServiceId !== undefined) locator.serviceId = parsedServiceId;
     }
   }
   return locator;
@@ -304,13 +430,28 @@ function parseOgcCollectionId(url: string): string | undefined {
   }
 }
 
+const WMS_SERVICE_URL_RE =
+  /\/(?:rest\/services\/([^/?#]+)\/MapServer\/(?:WMS|WMTS)|ogc\/services\/([^/?#]+)\/(?:wms|wmts))/i;
+
+function parseWmsServiceId(url: string): string | undefined {
+  const match = WMS_SERVICE_URL_RE.exec(url);
+  if (!match) return undefined;
+  const id = match[1] ?? match[2];
+  if (!id) return undefined;
+  try {
+    return decodeURIComponent(id);
+  } catch {
+    return id;
+  }
+}
+
 function requireLocatorUrl(descriptor: SourceDescriptor): string {
   const url = descriptor.locator.url;
   if (typeof url !== "string" || url.length === 0) {
-    throw new HonuaMapPackageError(
-      `descriptor for "${descriptor.id}" is missing locator.url`,
-      { stage: "source-bind", detail: { sourceId: descriptor.id, protocol: descriptor.protocol } },
-    );
+    throw new HonuaMapPackageError(`descriptor for "${descriptor.id}" is missing locator.url`, {
+      stage: "source-bind",
+      detail: { sourceId: descriptor.id, protocol: descriptor.protocol },
+    });
   }
   return url;
 }

--- a/src/style/factory.ts
+++ b/src/style/factory.ts
@@ -12,17 +12,30 @@ import {
   type HonuaOgcFeatureCollection,
   HonuaOgcFeatures,
 } from "../core/surfaces.js";
+import type { HonuaWms, HonuaWmsLayer } from "../core/wms.js";
+import type { HonuaWmts, HonuaWmtsTileset } from "../core/wmts.js";
 import { parseFeatureLayerUrl, parseMapServiceUrl } from "../esri-compat/url.js";
 import type { HonuaStyleSpecification } from "./specification.js";
 import {
   isFeatureServiceSource,
   isMapServiceSource,
   isOgcFeaturesSource,
+  isWmsSource,
+  isWmtsSource,
   parseOgcFeaturesUrl,
 } from "./specification.js";
+import { resolveWmsSpec, resolveWmtsSpec } from "./wms-wmts-resolvers.js";
 
 /** A resolved Honua source: either a surface instance or `null` for non-Honua (MapLibre-native) sources. */
-export type ResolvedSource = HonuaFeatureLayer | HonuaMapService | HonuaOgcFeatureCollection | null;
+export type ResolvedSource =
+  | HonuaFeatureLayer
+  | HonuaMapService
+  | HonuaOgcFeatureCollection
+  | HonuaWms
+  | HonuaWmsLayer
+  | HonuaWmts
+  | HonuaWmtsTileset
+  | null;
 
 /**
  * Create Honua SDK surface instances for each source in a style.
@@ -67,6 +80,10 @@ export function createSources(client: HonuaClient, style: HonuaStyleSpecificatio
       const ogcRoot = new HonuaOgcFeatures({ client });
       const collectionId = spec.collectionId ?? parsed.collectionId ?? "";
       result.set(name, ogcRoot.collection(collectionId));
+    } else if (isWmsSource(spec)) {
+      result.set(name, resolveWmsSpec(client, spec));
+    } else if (isWmtsSource(spec)) {
+      result.set(name, resolveWmtsSpec(client, spec));
     } else {
       result.set(name, null);
     }

--- a/src/style/index.ts
+++ b/src/style/index.ts
@@ -3,6 +3,8 @@ export {
   isFeatureServiceSource,
   isMapServiceSource,
   isOgcFeaturesSource,
+  isWmsSource,
+  isWmtsSource,
   parseOgcFeaturesUrl,
   validateHonuaStyle,
 } from "./specification.js";
@@ -11,6 +13,8 @@ export type {
   HonuaFeatureServiceSourceSpecification,
   HonuaMapServiceSourceSpecification,
   HonuaOgcFeaturesSourceSpecification,
+  HonuaWmsSourceSpecification,
+  HonuaWmtsSourceSpecification,
   HonuaSourceSpecification,
   HonuaLayerSpecification,
   HonuaStyleSpecification,

--- a/src/style/specification.ts
+++ b/src/style/specification.ts
@@ -76,11 +76,53 @@ export interface HonuaOgcFeaturesSourceSpecification extends HonuaSourceBase {
   limit?: number;
 }
 
+/**
+ * A source backed by a first-party WMS 1.3.0 service.
+ *
+ * URL format: `https://host/rest/services/{serviceId}/MapServer/WMS`.
+ */
+export interface HonuaWmsSourceSpecification extends HonuaSourceBase {
+  type: "honua-wms";
+  /** Service identifier, when not parseable from the URL. */
+  serviceId?: string;
+  /** Comma-separated layer names (the WMS `LAYERS=` value). */
+  layers?: string;
+  /** Comma-separated style names (the WMS `STYLES=` value). */
+  styles?: string;
+  /** Image MIME type. Defaults to `image/png`. */
+  format?: string;
+  /** Whether the rendered image should be transparent. */
+  transparent?: boolean;
+  /** CRS code. Defaults to `EPSG:3857`. */
+  crs?: string;
+}
+
+/**
+ * A source backed by a first-party WMTS 1.0.0 service.
+ *
+ * URL format: `https://host/rest/services/{serviceId}/MapServer/WMTS`.
+ */
+export interface HonuaWmtsSourceSpecification extends HonuaSourceBase {
+  type: "honua-wmts";
+  /** Service identifier, when not parseable from the URL. */
+  serviceId?: string;
+  /** Layer identifier. */
+  layer?: string;
+  /** Style identifier. Defaults to `default`. */
+  style?: string;
+  /** TileMatrixSet identifier. Defaults to `WebMercatorQuad`. */
+  tileMatrixSet?: string;
+  /** Image MIME type. Defaults to `image/png`. */
+  format?: string;
+}
+
 /** Union of all Honua custom source types. */
 export type HonuaSourceSpecification =
   | HonuaFeatureServiceSourceSpecification
   | HonuaMapServiceSourceSpecification
-  | HonuaOgcFeaturesSourceSpecification;
+  | HonuaOgcFeaturesSourceSpecification
+  | HonuaWmsSourceSpecification
+  | HonuaWmtsSourceSpecification;
 
 // ── Minimal layer type (MapLibre-compatible) ─────────────────
 
@@ -141,6 +183,16 @@ export function isMapServiceSource(source: { type: string }): source is HonuaMap
 /** Test whether a source is a `honua-ogc-features`. */
 export function isOgcFeaturesSource(source: { type: string }): source is HonuaOgcFeaturesSourceSpecification {
   return source.type === "honua-ogc-features";
+}
+
+/** Test whether a source is a `honua-wms`. */
+export function isWmsSource(source: { type: string }): source is HonuaWmsSourceSpecification {
+  return source.type === "honua-wms";
+}
+
+/** Test whether a source is a `honua-wmts`. */
+export function isWmtsSource(source: { type: string }): source is HonuaWmtsSourceSpecification {
+  return source.type === "honua-wmts";
 }
 
 // ── URL parsing ──────────────────────────────────────────────

--- a/src/style/wms-wmts-resolvers.ts
+++ b/src/style/wms-wmts-resolvers.ts
@@ -9,7 +9,7 @@
  */
 
 import type { HonuaClient } from "../core/client.js";
-import { HonuaWms, HonuaWmsLayer } from "../core/wms.js";
+import { HonuaWms, HonuaWmsLayer, parseWmsLayerNames } from "../core/wms.js";
 import { HonuaWmts, HonuaWmtsTileset } from "../core/wmts.js";
 import type { HonuaWmsSourceSpecification, HonuaWmtsSourceSpecification } from "./specification.js";
 
@@ -42,9 +42,12 @@ export function parseWmsServiceIdFromUrl(url: string): string | undefined {
 
 /**
  * Resolve a `honua-wms` source spec to a runtime handle. Returns the
- * layer-bound `HonuaWmsLayer` when the spec pins a single LAYER (and
- * optional STYLE); otherwise returns the service-level `HonuaWms`
- * handle for multi-layer composites.
+ * layer-bound `HonuaWmsLayer` only when `spec.layers` parses to exactly
+ * one non-empty layer token, because `HonuaWmsLayer` is a single-layer
+ * handle (its `describe()` resolves one `<Layer>` from the parsed
+ * Capabilities). Multi-layer composites (`LAYERS=a,b`) and
+ * empty / missing values stay on the service-level `HonuaWms` handle so
+ * `map()` / `featureInfo()` can still target the composite.
  */
 export function resolveWmsSpec(client: HonuaClient, spec: HonuaWmsSourceSpecification): HonuaWms | HonuaWmsLayer {
   const serviceId = spec.serviceId ?? parseWmsServiceIdFromUrl(spec.url);
@@ -52,11 +55,12 @@ export function resolveWmsSpec(client: HonuaClient, spec: HonuaWmsSourceSpecific
     throw new Error("honua-wms source requires either serviceId or a URL containing the service id");
   }
   const root = new HonuaWms({ client, serviceId });
-  if (typeof spec.layers === "string" && spec.layers.length > 0) {
+  const parsedLayers = parseWmsLayerNames(spec.layers);
+  if (parsedLayers.length === 1) {
     const opts: { client: HonuaClient; serviceId: string; layerName: string; defaultStyleId?: string } = {
       client,
       serviceId,
-      layerName: spec.layers,
+      layerName: parsedLayers[0]!,
     };
     if (typeof spec.styles === "string" && spec.styles.length > 0) {
       opts.defaultStyleId = spec.styles;

--- a/src/style/wms-wmts-resolvers.ts
+++ b/src/style/wms-wmts-resolvers.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared resolvers that turn a `HonuaWmsSourceSpecification` /
+ * `HonuaWmtsSourceSpecification` into a runtime SDK handle. Used by both
+ * `src/style/factory.ts` (`createSources`) and `src/map/honua-map.ts`
+ * (`HonuaMap.getSource`) so the URL-parsing and handle-selection rules
+ * stay identical between the two surfaces.
+ *
+ * @module
+ */
+
+import type { HonuaClient } from "../core/client.js";
+import { HonuaWms, HonuaWmsLayer } from "../core/wms.js";
+import { HonuaWmts, HonuaWmtsTileset } from "../core/wmts.js";
+import type { HonuaWmsSourceSpecification, HonuaWmtsSourceSpecification } from "./specification.js";
+
+/**
+ * Match the canonical Esri MapServer WMS/WMTS endpoint shape
+ * (`/rest/services/<name>/MapServer/{WMS|WMTS}`) and the OGC web-map
+ * shape (`/ogc/services/<name>/{wms|wmts}`) so we can lift the service
+ * id out of the URL when the spec did not carry it explicitly.
+ */
+const HONUA_WMS_WMTS_URL_RE =
+  /\/(?:rest\/services\/([^/?#]+)\/MapServer\/(?:WMS|WMTS)|ogc\/services\/([^/?#]+)\/(?:wms|wmts))/i;
+
+/**
+ * Extract the service id from a WMS/WMTS endpoint URL. Returns
+ * `undefined` if the URL does not match a known service shape so the
+ * caller can fall back to the spec's explicit `serviceId` (or surface a
+ * typed error).
+ */
+export function parseWmsServiceIdFromUrl(url: string): string | undefined {
+  const match = HONUA_WMS_WMTS_URL_RE.exec(url);
+  if (!match) return undefined;
+  const id = match[1] ?? match[2];
+  if (!id) return undefined;
+  try {
+    return decodeURIComponent(id);
+  } catch {
+    return id;
+  }
+}
+
+/**
+ * Resolve a `honua-wms` source spec to a runtime handle. Returns the
+ * layer-bound `HonuaWmsLayer` when the spec pins a single LAYER (and
+ * optional STYLE); otherwise returns the service-level `HonuaWms`
+ * handle for multi-layer composites.
+ */
+export function resolveWmsSpec(client: HonuaClient, spec: HonuaWmsSourceSpecification): HonuaWms | HonuaWmsLayer {
+  const serviceId = spec.serviceId ?? parseWmsServiceIdFromUrl(spec.url);
+  if (!serviceId) {
+    throw new Error("honua-wms source requires either serviceId or a URL containing the service id");
+  }
+  const root = new HonuaWms({ client, serviceId });
+  if (typeof spec.layers === "string" && spec.layers.length > 0) {
+    const opts: { client: HonuaClient; serviceId: string; layerName: string; defaultStyleId?: string } = {
+      client,
+      serviceId,
+      layerName: spec.layers,
+    };
+    if (typeof spec.styles === "string" && spec.styles.length > 0) {
+      opts.defaultStyleId = spec.styles;
+    }
+    return new HonuaWmsLayer(opts);
+  }
+  return root;
+}
+
+/**
+ * Resolve a `honua-wmts` source spec to a runtime handle. Returns the
+ * (layer × style × TileMatrixSet) `HonuaWmtsTileset` when the spec
+ * pins a single layer; otherwise returns the service-level `HonuaWmts`
+ * handle.
+ */
+export function resolveWmtsSpec(client: HonuaClient, spec: HonuaWmtsSourceSpecification): HonuaWmts | HonuaWmtsTileset {
+  const serviceId = spec.serviceId ?? parseWmsServiceIdFromUrl(spec.url);
+  if (!serviceId) {
+    throw new Error("honua-wmts source requires either serviceId or a URL containing the service id");
+  }
+  const root = new HonuaWmts({ client, serviceId });
+  if (typeof spec.layer === "string" && spec.layer.length > 0) {
+    const style = spec.style ?? "default";
+    const tms = spec.tileMatrixSet ?? "WebMercatorQuad";
+    return new HonuaWmtsTileset({
+      client,
+      serviceId,
+      layerName: spec.layer,
+      styleId: style,
+      tileMatrixSetId: tms,
+    });
+  }
+  return root;
+}

--- a/test/contract/conformance.test.ts
+++ b/test/contract/conformance.test.ts
@@ -145,7 +145,7 @@ const harnesses: Harness[] = [
 ];
 
 describe("contract / Protocol enum", () => {
-  it("includes all canonical protocols (five GeoServices service types, OGC Features/Tiles/Maps, STAC, WFS/WMS/OData, MapLibre-native)", () => {
+  it("includes all canonical protocols (five GeoServices service types, OGC Features/Tiles/Maps, STAC, WFS/WMS/WMTS/OData, MapLibre-native)", () => {
     expect(PROTOCOLS).toEqual([
       "geoservices-feature-service",
       "geoservices-map-service",
@@ -158,6 +158,7 @@ describe("contract / Protocol enum", () => {
       "stac",
       "wfs",
       "wms",
+      "wmts",
       "odata",
       "maplibre-vector",
       "maplibre-raster",

--- a/test/contract/wms.test.ts
+++ b/test/contract/wms.test.ts
@@ -8,10 +8,10 @@
 
 import { describe, expect, it } from "vitest";
 
-import { PROTOCOL_DEFAULT_CAPABILITIES, createDataset, type SourceDescriptor } from "../../src/contract/index.js";
+import { PROTOCOL_DEFAULT_CAPABILITIES, type SourceDescriptor, createDataset } from "../../src/contract/index.js";
 import { HonuaCapabilityNotSupportedError } from "../../src/core/errors.js";
-import { HonuaWms, HonuaWmsLayer } from "../../src/core/wms.js";
 import { point } from "../../src/core/spatial-filter.js";
+import { HonuaWms, HonuaWmsLayer } from "../../src/core/wms.js";
 import { buildWmsRasterSourceSpec } from "../../src/runtime/source-bridge.js";
 
 import { jsonResponse, makeMockClient } from "./shared.js";
@@ -329,6 +329,34 @@ describe("wms / Source adapter", () => {
     expect(source.protocol("wms-layer")).toBeInstanceOf(HonuaWmsLayer);
   });
 
+  it("does not register the wms-layer adapter when locator.typeName is a multi-layer composite", () => {
+    // HonuaWmsLayer.describe() resolves a single <Layer> by name from
+    // the parsed Capabilities, so binding it to "a,b" would silently
+    // mis-route describe() / stylesIn() / legend(). Multi-layer queries
+    // still work through the service-level wms handle.
+    const client = makeMockClient({ routes: [] });
+    const dataset = createDataset({
+      id: "imagery",
+      client,
+      skipCompatibilityCheck: true,
+      sources: [
+        {
+          id: "composite",
+          protocol: "wms",
+          locator: {
+            url: "https://mock.honua.test/rest/services/imagery/MapServer/WMS",
+            serviceId: "imagery",
+            typeName: "parcels,roads",
+          },
+          capabilities: PROTOCOL_DEFAULT_CAPABILITIES.wms,
+        } satisfies SourceDescriptor,
+      ],
+    });
+    const source = dataset.source("composite")!;
+    expect(source.protocol("wms")).toBeInstanceOf(HonuaWms);
+    expect(source.protocol("wms-layer")).toBeUndefined();
+  });
+
   it("translates a point spatialFilter into a 1x1 GetFeatureInfo and decodes the JSON response", async () => {
     let observed: URLSearchParams | undefined;
     const client = makeMockClient({
@@ -410,10 +438,9 @@ describe("wms / Source adapter", () => {
       ],
     });
     const source = dataset.source("parcels")!;
-    // EPSG:4326 lat/lon point. outSr is the output SR (3857 here)
-    // and must not be mistaken for the input CRS.
+    // EPSG:4326 lat/lon point. The wire CRS comes from the geometry's
+    // spatialReference, not from Query.outSr.
     await source.query({
-      outSr: 3857,
       spatialFilter: point(38, -122, { wkid: 4326 }),
     });
     expect(observed?.get("CRS")).toBe("EPSG:4326");
@@ -552,6 +579,11 @@ describe("wms / Source adapter", () => {
       /pagination\.offset/,
     );
     await expect(source.query({ spatialFilter: filter, returnGeometry: false })).rejects.toThrow(/returnGeometry/);
+    // Query.outSr must fail fast — honua-server's WMS GetFeatureInfo
+    // projects the response in the request CRS itself and has no
+    // separate output-SR knob. Silently dropping outSr would let a
+    // mixed-source caller think they got reprojected results.
+    await expect(source.query({ spatialFilter: filter, outSr: 3857 })).rejects.toThrow(/Query\.outSr/);
   });
 });
 

--- a/test/contract/wms.test.ts
+++ b/test/contract/wms.test.ts
@@ -245,8 +245,91 @@ describe("wms / Source adapter", () => {
     expect(observed?.get("J")).toBe("0");
     expect(observed?.get("INFO_FORMAT")).toBe("application/json");
     expect(observed?.get("QUERY_LAYERS")).toBe("parcels");
+    // WGS84 lon/lat point with no explicit spatial reference defaults
+    // to CRS:84 (lon, lat axis order) per WMS 1.3.0; outSr is the
+    // output SR and must not leak into the input CRS.
+    expect(observed?.get("CRS")).toBe("CRS:84");
     expect(result.features).toHaveLength(1);
     expect(result.features[0]?.attributes.OBJECTID).toBe(7);
+  });
+
+  it("derives the WMS CRS from the spatial filter geometry's spatialReference", async () => {
+    let observed: URLSearchParams | undefined;
+    const client = makeMockClient({
+      routes: [
+        [
+          "MapServer/WMS",
+          (url) => {
+            observed = url.searchParams;
+            return jsonResponse({ type: "FeatureInfoResponse", features: [] });
+          },
+        ],
+      ],
+    });
+    const dataset = createDataset({
+      id: "imagery",
+      client,
+      skipCompatibilityCheck: true,
+      sources: [
+        {
+          id: "parcels",
+          protocol: "wms",
+          locator: {
+            url: "https://mock.honua.test/rest/services/imagery/MapServer/WMS",
+            serviceId: "imagery",
+            typeName: "parcels",
+          },
+          capabilities: PROTOCOL_DEFAULT_CAPABILITIES.wms,
+        } satisfies SourceDescriptor,
+      ],
+    });
+    const source = dataset.source("parcels")!;
+    // EPSG:4326 lat/lon point. outSr is the output SR (3857 here)
+    // and must not be mistaken for the input CRS.
+    await source.query({
+      outSr: 3857,
+      spatialFilter: point(38, -122, { wkid: 4326 }),
+    });
+    expect(observed?.get("CRS")).toBe("EPSG:4326");
+    expect(observed?.get("WIDTH")).toBe("1");
+    expect(observed?.get("HEIGHT")).toBe("1");
+  });
+
+  it("prefers latestWkid over wkid when both are present on the spatial reference", async () => {
+    let observed: URLSearchParams | undefined;
+    const client = makeMockClient({
+      routes: [
+        [
+          "MapServer/WMS",
+          (url) => {
+            observed = url.searchParams;
+            return jsonResponse({ type: "FeatureInfoResponse", features: [] });
+          },
+        ],
+      ],
+    });
+    const dataset = createDataset({
+      id: "imagery",
+      client,
+      skipCompatibilityCheck: true,
+      sources: [
+        {
+          id: "parcels",
+          protocol: "wms",
+          locator: {
+            url: "https://mock.honua.test/rest/services/imagery/MapServer/WMS",
+            serviceId: "imagery",
+            typeName: "parcels",
+          },
+          capabilities: PROTOCOL_DEFAULT_CAPABILITIES.wms,
+        } satisfies SourceDescriptor,
+      ],
+    });
+    const source = dataset.source("parcels")!;
+    await source.query({
+      spatialFilter: point(-13624000, 4567000, { wkid: 102100, latestWkid: 3857 }),
+    });
+    expect(observed?.get("CRS")).toBe("EPSG:3857");
   });
 
   it("rejects non-point spatialFilter envelopes through Source.query()", async () => {
@@ -333,5 +416,14 @@ describe("wms / MapLibre binding", () => {
     expect(url).toContain("BBOX={bbox-epsg3857}");
     expect(url).toContain("WIDTH={width}");
     expect(url).toContain("HEIGHT={height}");
+    // Honua Server's WMS handler reads WIDTH / HEIGHT through
+    // `TryGetRequiredQueryValue` + `int.TryParse`, so the same key
+    // must appear exactly once. Counting the occurrences keeps a
+    // future regression that re-introduces a fixed `WIDTH=256` from
+    // silently breaking GetMap dispatch.
+    const widthOccurrences = url.match(/[?&]WIDTH=/g) ?? [];
+    const heightOccurrences = url.match(/[?&]HEIGHT=/g) ?? [];
+    expect(widthOccurrences).toHaveLength(1);
+    expect(heightOccurrences).toHaveLength(1);
   });
 });

--- a/test/contract/wms.test.ts
+++ b/test/contract/wms.test.ts
@@ -515,6 +515,44 @@ describe("wms / Source adapter", () => {
     await expect(source.queryObjectIds()).rejects.toThrow(HonuaCapabilityNotSupportedError);
     await expect(source.applyEdits({ adds: [] })).rejects.toThrow(HonuaCapabilityNotSupportedError);
   });
+
+  it("rejects unsupported Query fields on Source.query() instead of silently dropping them", async () => {
+    // GetFeatureInfo only consumes (i, j) plus the rendered envelope; rejecting
+    // the other Query fields up front prevents callers from receiving an
+    // unfiltered or differently-shaped result that looks like a silent data bug.
+    const client = makeMockClient({ routes: [] });
+    const dataset = createDataset({
+      id: "imagery",
+      client,
+      skipCompatibilityCheck: true,
+      sources: [
+        {
+          id: "parcels",
+          protocol: "wms",
+          locator: {
+            url: "https://mock.honua.test/rest/services/imagery/MapServer/WMS",
+            serviceId: "imagery",
+            typeName: "parcels",
+          },
+          capabilities: PROTOCOL_DEFAULT_CAPABILITIES.wms,
+        } satisfies SourceDescriptor,
+      ],
+    });
+    const source = dataset.source("parcels")!;
+    const filter = point(-13624000, 4567000);
+    await expect(
+      source.query({ spatialFilter: filter, aggregation: { metrics: [{ fn: "count", field: "*" }] } }),
+    ).rejects.toThrow(HonuaCapabilityNotSupportedError);
+    await expect(source.query({ spatialFilter: filter, where: "STATE = 'CA'" })).rejects.toThrow(/Query\.where/);
+    await expect(source.query({ spatialFilter: filter, outFields: ["NAME"] })).rejects.toThrow(/Query\.outFields/);
+    await expect(
+      source.query({ spatialFilter: filter, orderBy: [{ field: "OBJECTID", direction: "asc" }] }),
+    ).rejects.toThrow(/Query\.orderBy/);
+    await expect(source.query({ spatialFilter: filter, pagination: { offset: 50 } })).rejects.toThrow(
+      /pagination\.offset/,
+    );
+    await expect(source.query({ spatialFilter: filter, returnGeometry: false })).rejects.toThrow(/returnGeometry/);
+  });
 });
 
 describe("wms / MapLibre binding", () => {

--- a/test/contract/wms.test.ts
+++ b/test/contract/wms.test.ts
@@ -175,6 +175,132 @@ describe("wms / wire", () => {
   });
 });
 
+describe("wms / legend gating", () => {
+  // Capabilities fixture that *does* advertise GetLegendGraphic, so the
+  // gated path lets the request through.
+  const LEGEND_CAPABILITIES = `<?xml version="1.0" encoding="UTF-8"?>
+<WMS_Capabilities version="1.3.0">
+  <Service><Title>Honua WMS</Title></Service>
+  <Capability>
+    <Request>
+      <GetMap><Format>image/png</Format></GetMap>
+      <GetLegendGraphic><Format>image/png</Format></GetLegendGraphic>
+    </Request>
+    <Layer queryable="1"><Name>parcels</Name><Style><Name>default</Name></Style></Layer>
+  </Capability>
+</WMS_Capabilities>`;
+
+  it("HonuaWms.legend throws when caller-supplied capabilities omit GetLegendGraphic", async () => {
+    const client = makeMockClient({
+      routes: [["MapServer/WMS", () => xmlResponse(WMS_CAPABILITIES_FIXTURE)]],
+    });
+    const wms = new HonuaWms({ client, serviceId: "imagery" });
+    const caps = await wms.capabilities();
+    await expect(wms.legend({ layer: "parcels" }, { capabilities: caps })).rejects.toThrow(
+      HonuaCapabilityNotSupportedError,
+    );
+  });
+
+  it("HonuaWms.legend lazy-loads capabilities and throws when the server does not advertise GetLegendGraphic", async () => {
+    let capabilitiesFetches = 0;
+    let legendFetches = 0;
+    const client = makeMockClient({
+      routes: [
+        [
+          "MapServer/WMS",
+          (url) => {
+            const request = url.searchParams.get("REQUEST");
+            if (request === "GetLegendGraphic") {
+              legendFetches += 1;
+              return pngResponse();
+            }
+            capabilitiesFetches += 1;
+            return xmlResponse(WMS_CAPABILITIES_FIXTURE);
+          },
+        ],
+      ],
+    });
+    const wms = new HonuaWms({ client, serviceId: "imagery" });
+    await expect(wms.legend({ layer: "parcels" })).rejects.toThrow(HonuaCapabilityNotSupportedError);
+    // A second call reuses the cached capabilities promise — no second
+    // GetCapabilities round-trip.
+    await expect(wms.legend({ layer: "parcels" })).rejects.toThrow(HonuaCapabilityNotSupportedError);
+    expect(capabilitiesFetches).toBe(1);
+    expect(legendFetches).toBe(0);
+  });
+
+  it("HonuaWms.legend forwards the request when capabilities advertise GetLegendGraphic", async () => {
+    let observed: URLSearchParams | undefined;
+    const client = makeMockClient({
+      routes: [
+        [
+          "MapServer/WMS",
+          (url) => {
+            const request = url.searchParams.get("REQUEST");
+            if (request === "GetLegendGraphic") {
+              observed = url.searchParams;
+              return pngResponse();
+            }
+            return xmlResponse(LEGEND_CAPABILITIES);
+          },
+        ],
+      ],
+    });
+    const wms = new HonuaWms({ client, serviceId: "imagery" });
+    await wms.legend({ layer: "parcels", style: "default" });
+    expect(observed?.get("REQUEST")).toBe("GetLegendGraphic");
+    expect(observed?.get("LAYER")).toBe("parcels");
+    expect(observed?.get("STYLE")).toBe("default");
+  });
+
+  it("HonuaWmsLayer.legend lazy-loads capabilities and throws when GetLegendGraphic is missing", async () => {
+    let capabilitiesFetches = 0;
+    const client = makeMockClient({
+      routes: [
+        [
+          "MapServer/WMS",
+          (url) => {
+            const request = url.searchParams.get("REQUEST");
+            if (request === "GetLegendGraphic") return pngResponse();
+            capabilitiesFetches += 1;
+            return xmlResponse(WMS_CAPABILITIES_FIXTURE);
+          },
+        ],
+      ],
+    });
+    const layer = new HonuaWmsLayer({ client, serviceId: "imagery", layerName: "parcels" });
+    await expect(layer.legend()).rejects.toThrow(HonuaCapabilityNotSupportedError);
+    await expect(layer.legend()).rejects.toThrow(HonuaCapabilityNotSupportedError);
+    expect(capabilitiesFetches).toBe(1);
+  });
+
+  it("HonuaWms.legend retries the capabilities fetch after a transient failure", async () => {
+    let capabilitiesFetches = 0;
+    const client = makeMockClient({
+      routes: [
+        [
+          "MapServer/WMS",
+          (url) => {
+            const request = url.searchParams.get("REQUEST");
+            if (request === "GetLegendGraphic") return pngResponse();
+            capabilitiesFetches += 1;
+            if (capabilitiesFetches === 1) {
+              return new Response("transient", { status: 503 });
+            }
+            return xmlResponse(LEGEND_CAPABILITIES);
+          },
+        ],
+      ],
+    });
+    const wms = new HonuaWms({ client, serviceId: "imagery" });
+    await expect(wms.legend({ layer: "parcels" })).rejects.not.toThrow(HonuaCapabilityNotSupportedError);
+    // The first call's failed cache entry must be cleared so the second
+    // call retries the capabilities fetch (and then succeeds).
+    await wms.legend({ layer: "parcels" });
+    expect(capabilitiesFetches).toBeGreaterThanOrEqual(2);
+  });
+});
+
 describe("wms / Source adapter", () => {
   it("registers under the canonical Source surface and exposes the wms-layer adapter", () => {
     const client = makeMockClient({ routes: [] });

--- a/test/contract/wms.test.ts
+++ b/test/contract/wms.test.ts
@@ -1,0 +1,337 @@
+/**
+ * WMS 1.3 wire + Source-adapter conformance. Exercises the
+ * `GetCapabilities` parse, `GetMap` KVP serialization (including CRS
+ * axis-order swap on `EPSG:4326`), `GetFeatureInfo` JSON decode through
+ * `Source.query()`, and the `HonuaCapabilityNotSupportedError` paths
+ * for non-point queries / aggregates / streams.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { PROTOCOL_DEFAULT_CAPABILITIES, createDataset, type SourceDescriptor } from "../../src/contract/index.js";
+import { HonuaCapabilityNotSupportedError } from "../../src/core/errors.js";
+import { HonuaWms, HonuaWmsLayer } from "../../src/core/wms.js";
+import { point } from "../../src/core/spatial-filter.js";
+import { buildWmsRasterSourceSpec } from "../../src/runtime/source-bridge.js";
+
+import { jsonResponse, makeMockClient } from "./shared.js";
+
+const WMS_CAPABILITIES_FIXTURE = `<?xml version="1.0" encoding="UTF-8"?>
+<WMS_Capabilities version="1.3.0" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <Service><Title>Honua Test WMS</Title></Service>
+  <Capability>
+    <Request>
+      <GetMap><Format>image/png</Format></GetMap>
+      <GetFeatureInfo><Format>application/json</Format></GetFeatureInfo>
+    </Request>
+    <Layer queryable="1">
+      <Name>parcels</Name>
+      <Title>Parcels</Title>
+      <CRS>EPSG:3857</CRS>
+      <CRS>EPSG:4326</CRS>
+      <BoundingBox CRS="EPSG:3857" minx="-20037508" miny="-20037508" maxx="20037508" maxy="20037508"/>
+      <Style><Name>default</Name></Style>
+    </Layer>
+  </Capability>
+</WMS_Capabilities>`;
+
+function pngResponse(): Response {
+  return new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]), {
+    status: 200,
+    headers: { "Content-Type": "image/png" },
+  });
+}
+
+function xmlResponse(body: string): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "text/xml; charset=utf-8" },
+  });
+}
+
+describe("wms / wire", () => {
+  it("parses GetCapabilities into the typed envelope", async () => {
+    const client = makeMockClient({
+      routes: [["MapServer/WMS", () => xmlResponse(WMS_CAPABILITIES_FIXTURE)]],
+    });
+    const caps = await client.wms("imagery").capabilities();
+    expect(caps.version).toBe("1.3.0");
+    expect(caps.layers).toHaveLength(1);
+    expect(caps.layers[0]?.name).toBe("parcels");
+    expect(caps.formats.map).toContain("image/png");
+    expect(caps.request.getFeatureInfo).toBe(true);
+    expect(caps.request.getLegendGraphic).toBe(false);
+  });
+
+  it("serializes GetMap with default CRS=EPSG:3857 and unswapped bbox", async () => {
+    let observed: URLSearchParams | undefined;
+    const client = makeMockClient({
+      routes: [
+        [
+          "MapServer/WMS",
+          (url) => {
+            observed = url.searchParams;
+            return pngResponse();
+          },
+        ],
+      ],
+    });
+    await client.wms("imagery").map({
+      layers: ["parcels"],
+      styles: ["default"],
+      bbox: [-13540000, 4540000, -13530000, 4550000],
+      width: 256,
+      height: 256,
+    });
+    expect(observed?.get("REQUEST")).toBe("GetMap");
+    expect(observed?.get("CRS")).toBe("EPSG:3857");
+    expect(observed?.get("BBOX")).toBe("-13540000,4540000,-13530000,4550000");
+    expect(observed?.get("LAYERS")).toBe("parcels");
+    expect(observed?.get("STYLES")).toBe("default");
+    expect(observed?.get("WIDTH")).toBe("256");
+    expect(observed?.get("FORMAT")).toBe("image/png");
+    expect(observed?.get("TRANSPARENT")).toBe("TRUE");
+  });
+
+  it("swaps bbox axis order on EPSG:4326 per WMS 1.3 §6.7.3.2", async () => {
+    let observed: URLSearchParams | undefined;
+    const client = makeMockClient({
+      routes: [
+        [
+          "MapServer/WMS",
+          (url) => {
+            observed = url.searchParams;
+            return pngResponse();
+          },
+        ],
+      ],
+    });
+    await client.wms("imagery").map({
+      layers: ["parcels"],
+      crs: "EPSG:4326",
+      bbox: [-122, 37, -120, 38], // canonical [minx, miny, maxx, maxy] in lon/lat
+      width: 256,
+      height: 256,
+    });
+    // EPSG:4326 axes are (lat, lon); the wire bbox flips to lat-first.
+    expect(observed?.get("BBOX")).toBe("37,-122,38,-120");
+    expect(observed?.get("CRS")).toBe("EPSG:4326");
+  });
+
+  it("decodes GetFeatureInfo JSON into the canonical typed feature shape", async () => {
+    const client = makeMockClient({
+      routes: [
+        [
+          "MapServer/WMS",
+          (url) => {
+            if (url.searchParams.get("REQUEST") === "GetFeatureInfo") {
+              return jsonResponse({
+                type: "FeatureInfoResponse",
+                features: [{ layer: "parcels", attributes: { OBJECTID: 42, name: "lot-42" } }],
+              });
+            }
+            return pngResponse();
+          },
+        ],
+      ],
+    });
+    const response = await client.wms("imagery").featureInfo({
+      layers: ["parcels"],
+      queryLayers: ["parcels"],
+      bbox: [-122, 37, -120, 38],
+      width: 256,
+      height: 256,
+      i: 128,
+      j: 128,
+    });
+    expect(response.contentType).toContain("application/json");
+    expect(response.features).toHaveLength(1);
+    expect(response.features?.[0]?.attributes).toEqual({ OBJECTID: 42, name: "lot-42" });
+  });
+
+  it("forwards TIME / ELEVATION dimensions through to the wire", async () => {
+    let observed: URLSearchParams | undefined;
+    const client = makeMockClient({
+      routes: [
+        [
+          "MapServer/WMS",
+          (url) => {
+            observed = url.searchParams;
+            return pngResponse();
+          },
+        ],
+      ],
+    });
+    await client.wms("imagery").map({
+      layers: ["parcels"],
+      bbox: [-122, 37, -120, 38],
+      width: 256,
+      height: 256,
+      time: "2026-01-01T00:00:00Z",
+      elevation: "100",
+    });
+    expect(observed?.get("TIME")).toBe("2026-01-01T00:00:00Z");
+    expect(observed?.get("ELEVATION")).toBe("100");
+  });
+});
+
+describe("wms / Source adapter", () => {
+  it("registers under the canonical Source surface and exposes the wms-layer adapter", () => {
+    const client = makeMockClient({ routes: [] });
+    const dataset = createDataset({
+      id: "imagery",
+      client,
+      skipCompatibilityCheck: true,
+      sources: [
+        {
+          id: "parcels",
+          protocol: "wms",
+          locator: {
+            url: "https://mock.honua.test/rest/services/imagery/MapServer/WMS",
+            serviceId: "imagery",
+            typeName: "parcels",
+            styleId: "default",
+          },
+          capabilities: PROTOCOL_DEFAULT_CAPABILITIES.wms,
+        } satisfies SourceDescriptor,
+      ],
+    });
+    const source = dataset.source("parcels")!;
+    expect(source.capabilities.has("render")).toBe(true);
+    expect(source.capabilities.has("query")).toBe(true);
+    expect(source.protocol("wms")).toBeInstanceOf(HonuaWms);
+    expect(source.protocol("wms-layer")).toBeInstanceOf(HonuaWmsLayer);
+  });
+
+  it("translates a point spatialFilter into a 1x1 GetFeatureInfo and decodes the JSON response", async () => {
+    let observed: URLSearchParams | undefined;
+    const client = makeMockClient({
+      routes: [
+        [
+          "MapServer/WMS",
+          (url) => {
+            observed = url.searchParams;
+            return jsonResponse({
+              type: "FeatureInfoResponse",
+              features: [{ layer: "parcels", attributes: { OBJECTID: 7, name: "lot-7" } }],
+            });
+          },
+        ],
+      ],
+    });
+    const dataset = createDataset({
+      id: "imagery",
+      client,
+      skipCompatibilityCheck: true,
+      sources: [
+        {
+          id: "parcels",
+          protocol: "wms",
+          locator: {
+            url: "https://mock.honua.test/rest/services/imagery/MapServer/WMS",
+            serviceId: "imagery",
+            typeName: "parcels",
+          },
+          capabilities: PROTOCOL_DEFAULT_CAPABILITIES.wms,
+        } satisfies SourceDescriptor,
+      ],
+    });
+    const source = dataset.source<{ OBJECTID: number; name: string }>("parcels")!;
+    const result = await source.query({ spatialFilter: point(-122, 38) });
+    expect(observed?.get("REQUEST")).toBe("GetFeatureInfo");
+    expect(observed?.get("WIDTH")).toBe("1");
+    expect(observed?.get("HEIGHT")).toBe("1");
+    expect(observed?.get("I")).toBe("0");
+    expect(observed?.get("J")).toBe("0");
+    expect(observed?.get("INFO_FORMAT")).toBe("application/json");
+    expect(observed?.get("QUERY_LAYERS")).toBe("parcels");
+    expect(result.features).toHaveLength(1);
+    expect(result.features[0]?.attributes.OBJECTID).toBe(7);
+  });
+
+  it("rejects non-point spatialFilter envelopes through Source.query()", async () => {
+    const client = makeMockClient({ routes: [] });
+    const dataset = createDataset({
+      id: "imagery",
+      client,
+      skipCompatibilityCheck: true,
+      sources: [
+        {
+          id: "parcels",
+          protocol: "wms",
+          locator: {
+            url: "https://mock.honua.test/rest/services/imagery/MapServer/WMS",
+            serviceId: "imagery",
+            typeName: "parcels",
+          },
+          capabilities: PROTOCOL_DEFAULT_CAPABILITIES.wms,
+        } satisfies SourceDescriptor,
+      ],
+    });
+    const source = dataset.source("parcels")!;
+    await expect(
+      source.query({
+        spatialFilter: {
+          geometryType: "esriGeometryEnvelope",
+          geometry: { xmin: -122, ymin: 37, xmax: -120, ymax: 38 },
+        },
+      }),
+    ).rejects.toThrow(HonuaCapabilityNotSupportedError);
+  });
+
+  it("throws HonuaCapabilityNotSupportedError on aggregates / extent / stream / edits", async () => {
+    const client = makeMockClient({ routes: [] });
+    const dataset = createDataset({
+      id: "imagery",
+      client,
+      skipCompatibilityCheck: true,
+      sources: [
+        {
+          id: "parcels",
+          protocol: "wms",
+          locator: {
+            url: "https://mock.honua.test/rest/services/imagery/MapServer/WMS",
+            serviceId: "imagery",
+            typeName: "parcels",
+          },
+          capabilities: PROTOCOL_DEFAULT_CAPABILITIES.wms,
+        } satisfies SourceDescriptor,
+      ],
+    });
+    const source = dataset.source("parcels")!;
+    await expect(source.queryExtent()).rejects.toThrow(HonuaCapabilityNotSupportedError);
+    await expect(source.queryAggregate({ aggregation: { metrics: [{ fn: "count", field: "*" }] } })).rejects.toThrow(
+      HonuaCapabilityNotSupportedError,
+    );
+    await expect(source.queryObjectIds()).rejects.toThrow(HonuaCapabilityNotSupportedError);
+    await expect(source.applyEdits({ adds: [] })).rejects.toThrow(HonuaCapabilityNotSupportedError);
+  });
+});
+
+describe("wms / MapLibre binding", () => {
+  it("emits a raster source spec with the MapLibre runtime placeholders", () => {
+    const spec = buildWmsRasterSourceSpec({
+      id: "parcels",
+      protocol: "wms",
+      locator: {
+        url: "https://mock.honua.test/rest/services/imagery/MapServer/WMS",
+        serviceId: "imagery",
+        typeName: "parcels",
+        styleId: "default",
+      },
+      capabilities: PROTOCOL_DEFAULT_CAPABILITIES.wms,
+      attribution: "© Honua",
+    });
+    expect(spec.type).toBe("raster");
+    expect(spec.tileSize).toBe(256);
+    expect(spec.attribution).toBe("© Honua");
+    const url = spec.tiles[0]!;
+    expect(url).toContain("REQUEST=GetMap");
+    expect(url).toContain("LAYERS=parcels");
+    expect(url).toContain("STYLES=default");
+    expect(url).toContain("CRS=EPSG%3A3857");
+    expect(url).toContain("BBOX={bbox-epsg3857}");
+    expect(url).toContain("WIDTH={width}");
+    expect(url).toContain("HEIGHT={height}");
+  });
+});

--- a/test/contract/wmts.test.ts
+++ b/test/contract/wmts.test.ts
@@ -155,6 +155,67 @@ describe("wmts / wire", () => {
     expect(observedPath).toContain("/imagery/default/WebMercatorQuad/3/2/1/64/128.json");
     expect(response.features?.[0]?.attributes.px).toBeCloseTo(0.42);
   });
+
+  it("appends extraParams to the RESTful tile URL while preserving the path", async () => {
+    let observedPath = "";
+    let observed: URLSearchParams | undefined;
+    const client = makeMockClient({
+      routes: [
+        [
+          /MapServer\/WMTS\/imagery\/default\/WebMercatorQuad\/5\/9\/12\.png/,
+          (url) => {
+            observedPath = url.pathname;
+            observed = url.searchParams;
+            return pngResponse();
+          },
+        ],
+      ],
+    });
+    await client.wmts("imagery").tile({
+      layer: "imagery",
+      tileMatrix: 5,
+      tileRow: 9,
+      tileCol: 12,
+      // Path-encoded keys (LAYER / TILEMATRIX / etc.) must be dropped
+      // by the SDK so honua-server's RESTful router never sees the
+      // value twice. `time` and `apiKey` are pass-through query
+      // parameters that the server preserves before dispatch.
+      extraParams: { time: "2026-04-01", apiKey: "secret-token", LAYER: "ignored" },
+    });
+    expect(observedPath).toContain("/imagery/default/WebMercatorQuad/5/9/12.png");
+    expect(observed?.get("time")).toBe("2026-04-01");
+    expect(observed?.get("apiKey")).toBe("secret-token");
+    expect(observed?.has("LAYER")).toBe(false);
+  });
+
+  it("appends extraParams to the RESTful GetFeatureInfo URL", async () => {
+    let observedPath = "";
+    let observed: URLSearchParams | undefined;
+    const client = makeMockClient({
+      routes: [
+        [
+          /MapServer\/WMTS\/imagery\/default\/WebMercatorQuad\/3\/2\/1\/64\/128\.json/,
+          (url) => {
+            observedPath = url.pathname;
+            observed = url.searchParams;
+            return jsonResponse({ type: "FeatureInfoResponse", features: [] });
+          },
+        ],
+      ],
+    });
+    await client.wmts("imagery").featureInfo({
+      layer: "imagery",
+      tileMatrix: 3,
+      tileRow: 2,
+      tileCol: 1,
+      i: 128,
+      j: 64,
+      extraParams: { time: "2026-04-01", INFOFORMAT: "ignored" },
+    });
+    expect(observedPath).toContain("/imagery/default/WebMercatorQuad/3/2/1/64/128.json");
+    expect(observed?.get("time")).toBe("2026-04-01");
+    expect(observed?.has("INFOFORMAT")).toBe(false);
+  });
 });
 
 describe("wmts / Source adapter", () => {

--- a/test/contract/wmts.test.ts
+++ b/test/contract/wmts.test.ts
@@ -1,0 +1,254 @@
+/**
+ * WMTS 1.0 wire + Source-adapter conformance. Exercises the
+ * `GetCapabilities` parse, the RESTful and KVP `GetTile` routes, the
+ * `Source.protocol("wmts" | "wmts-layer" | "wmts-tileset")` escape
+ * hatches, and the MapLibre `raster` source spec emitter.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { PROTOCOL_DEFAULT_CAPABILITIES, createDataset, type SourceDescriptor } from "../../src/contract/index.js";
+import { HonuaCapabilityNotSupportedError } from "../../src/core/errors.js";
+import { HonuaWmts, HonuaWmtsLayer, HonuaWmtsTileset } from "../../src/core/wmts.js";
+import { buildWmtsRasterSourceSpec } from "../../src/runtime/source-bridge.js";
+
+import { jsonResponse, makeMockClient } from "./shared.js";
+
+const WMTS_CAPABILITIES_FIXTURE = `<?xml version="1.0" encoding="UTF-8"?>
+<Capabilities version="1.0.0"
+  xmlns="http://www.opengis.net/wmts/1.0"
+  xmlns:ows="http://www.opengis.net/ows/1.1"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <ows:ServiceIdentification><ows:Title>Honua Test WMTS</ows:Title></ows:ServiceIdentification>
+  <Contents>
+    <Layer>
+      <ows:Title>Imagery</ows:Title>
+      <ows:Identifier>imagery</ows:Identifier>
+      <Style isDefault="true"><ows:Identifier>default</ows:Identifier></Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink><TileMatrixSet>WebMercatorQuad</TileMatrixSet></TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile"
+        template="https://example.com/wmts/imagery/default/WebMercatorQuad/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+    </Layer>
+    <TileMatrixSet>
+      <ows:Identifier>WebMercatorQuad</ows:Identifier>
+      <ows:SupportedCRS>urn:ogc:def:crs:EPSG::3857</ows:SupportedCRS>
+      <TileMatrix>
+        <ows:Identifier>0</ows:Identifier>
+        <ScaleDenominator>559082264.0287178</ScaleDenominator>
+        <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1</MatrixWidth>
+        <MatrixHeight>1</MatrixHeight>
+      </TileMatrix>
+    </TileMatrixSet>
+  </Contents>
+</Capabilities>`;
+
+function pngResponse(): Response {
+  return new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+    status: 200,
+    headers: { "Content-Type": "image/png" },
+  });
+}
+
+describe("wmts / wire", () => {
+  it("parses GetCapabilities into the typed envelope", async () => {
+    const client = makeMockClient({
+      routes: [
+        [
+          "MapServer/WMTS?",
+          () =>
+            new Response(WMTS_CAPABILITIES_FIXTURE, {
+              status: 200,
+              headers: { "Content-Type": "text/xml" },
+            }),
+        ],
+      ],
+    });
+    const caps = await client.wmts("imagery").capabilities();
+    expect(caps.layers[0]?.identifier).toBe("imagery");
+    expect(caps.tileMatrixSets[0]?.identifier).toBe("WebMercatorQuad");
+  });
+
+  it("fetches tiles through the RESTful path by default", async () => {
+    let observedPath = "";
+    const client = makeMockClient({
+      routes: [
+        [
+          /MapServer\/WMTS\/imagery\/default\/WebMercatorQuad\/5\/9\/12\.png/,
+          (url) => {
+            observedPath = url.pathname;
+            return pngResponse();
+          },
+        ],
+      ],
+    });
+    const result = await client.wmts("imagery").tile({
+      layer: "imagery",
+      tileMatrix: 5,
+      tileRow: 9,
+      tileCol: 12,
+    });
+    expect(result.contentType).toBe("image/png");
+    expect(observedPath).toContain("/imagery/default/WebMercatorQuad/5/9/12.png");
+  });
+
+  it("falls back to KVP routing when mode=kvp", async () => {
+    let observed: URLSearchParams | undefined;
+    let observedPath = "";
+    const client = makeMockClient({
+      routes: [
+        [
+          "MapServer/WMTS",
+          (url) => {
+            observed = url.searchParams;
+            observedPath = url.pathname;
+            return pngResponse();
+          },
+        ],
+      ],
+    });
+    await client.wmts("imagery").tile({
+      layer: "imagery",
+      tileMatrix: 5,
+      tileRow: 9,
+      tileCol: 12,
+      mode: "kvp",
+    });
+    expect(observed?.get("REQUEST")).toBe("GetTile");
+    expect(observed?.get("LAYER")).toBe("imagery");
+    expect(observed?.get("STYLE")).toBe("default");
+    expect(observed?.get("TILEMATRIXSET")).toBe("WebMercatorQuad");
+    expect(observed?.get("TILEMATRIX")).toBe("5");
+    expect(observed?.get("TILEROW")).toBe("9");
+    expect(observed?.get("TILECOL")).toBe("12");
+    expect(observedPath).toBe("/rest/services/imagery/MapServer/WMTS");
+  });
+
+  it("decodes WMTS GetFeatureInfo JSON through the RESTful route", async () => {
+    let observedPath = "";
+    const client = makeMockClient({
+      routes: [
+        [
+          /MapServer\/WMTS\/imagery\/default\/WebMercatorQuad\/3\/2\/1\/64\/128\.json/,
+          (url) => {
+            observedPath = url.pathname;
+            return jsonResponse({
+              type: "FeatureInfoResponse",
+              features: [{ layer: "imagery", attributes: { px: 0.42 } }],
+            });
+          },
+        ],
+      ],
+    });
+    const response = await client.wmts("imagery").featureInfo<{ px: number }>({
+      layer: "imagery",
+      tileMatrix: 3,
+      tileRow: 2,
+      tileCol: 1,
+      i: 128,
+      j: 64,
+    });
+    // RESTful FeatureInfo segments are `.../{TileMatrix}/{TileRow}/{TileCol}/{J}/{I}.{ext}`.
+    expect(observedPath).toContain("/imagery/default/WebMercatorQuad/3/2/1/64/128.json");
+    expect(response.features?.[0]?.attributes.px).toBeCloseTo(0.42);
+  });
+});
+
+describe("wmts / Source adapter", () => {
+  it("registers as a render-only Source with the wmts adapters wired", () => {
+    const client = makeMockClient({ routes: [] });
+    const dataset = createDataset({
+      id: "imagery",
+      client,
+      skipCompatibilityCheck: true,
+      sources: [
+        {
+          id: "imagery-tiles",
+          protocol: "wmts",
+          locator: {
+            url: "https://mock.honua.test/rest/services/imagery/MapServer/WMTS",
+            serviceId: "imagery",
+            typeName: "imagery",
+            styleId: "default",
+            tileMatrixSetId: "WebMercatorQuad",
+          },
+          capabilities: PROTOCOL_DEFAULT_CAPABILITIES.wmts,
+        } satisfies SourceDescriptor,
+      ],
+    });
+    const source = dataset.source("imagery-tiles")!;
+    expect(source.capabilities.has("render")).toBe(true);
+    expect(source.capabilities.has("tiles")).toBe(true);
+    expect(source.protocol("wmts")).toBeInstanceOf(HonuaWmts);
+    expect(source.protocol("wmts-layer")).toBeInstanceOf(HonuaWmtsLayer);
+    expect(source.protocol("wmts-tileset")).toBeInstanceOf(HonuaWmtsTileset);
+  });
+
+  it("Source.query() throws because WMTS GetFeatureInfo is keyed on tile pixels", async () => {
+    const client = makeMockClient({ routes: [] });
+    const dataset = createDataset({
+      id: "imagery",
+      client,
+      skipCompatibilityCheck: true,
+      sources: [
+        {
+          id: "imagery-tiles",
+          protocol: "wmts",
+          locator: {
+            url: "https://mock.honua.test/rest/services/imagery/MapServer/WMTS",
+            serviceId: "imagery",
+            typeName: "imagery",
+          },
+          capabilities: PROTOCOL_DEFAULT_CAPABILITIES.wmts,
+        } satisfies SourceDescriptor,
+      ],
+    });
+    const source = dataset.source("imagery-tiles")!;
+    await expect(source.query({ where: "1=1" })).rejects.toThrow(HonuaCapabilityNotSupportedError);
+    await expect(source.queryExtent()).rejects.toThrow(HonuaCapabilityNotSupportedError);
+  });
+
+  it("rejects descriptors missing serviceId", () => {
+    const client = makeMockClient({ routes: [] });
+    expect(() =>
+      createDataset({
+        id: "imagery",
+        client,
+        skipCompatibilityCheck: true,
+        sources: [
+          {
+            id: "imagery-tiles",
+            protocol: "wmts",
+            locator: { url: "https://mock/" },
+            capabilities: PROTOCOL_DEFAULT_CAPABILITIES.wmts,
+          } satisfies SourceDescriptor,
+        ],
+      }).source("imagery-tiles"),
+    ).toThrow(/locator\.serviceId/);
+  });
+});
+
+describe("wmts / MapLibre binding", () => {
+  it("emits a raster source spec using the RESTful tile template", () => {
+    const spec = buildWmtsRasterSourceSpec({
+      id: "imagery-tiles",
+      protocol: "wmts",
+      locator: {
+        url: "https://mock.honua.test/rest/services/imagery/MapServer/WMTS",
+        serviceId: "imagery",
+        typeName: "imagery",
+        styleId: "default",
+        tileMatrixSetId: "WebMercatorQuad",
+      },
+      capabilities: PROTOCOL_DEFAULT_CAPABILITIES.wmts,
+    });
+    expect(spec.type).toBe("raster");
+    expect(spec.scheme).toBe("xyz");
+    expect(spec.tiles[0]).toBe(
+      "https://mock.honua.test/rest/services/imagery/MapServer/WMTS/imagery/default/WebMercatorQuad/{z}/{y}/{x}.png",
+    );
+  });
+});

--- a/test/contract/wmts.test.ts
+++ b/test/contract/wmts.test.ts
@@ -312,4 +312,33 @@ describe("wmts / MapLibre binding", () => {
       "https://mock.honua.test/rest/services/imagery/MapServer/WMTS/imagery/default/WebMercatorQuad/{z}/{y}/{x}.png",
     );
   });
+
+  // Regression: format-to-extension mapping must agree with the WMTS wire
+  // client's `wmtsExtensionForFormat`. Earlier, the runtime helper had a
+  // bespoke jpeg/png-only branch that emitted `.png` for `image/webp` while
+  // the client tile path emitted `.webp`, so MapLibre tiles diverged from
+  // the same logical service.
+  it("uses the shared WMTS format-to-extension mapping (image/webp → .webp)", () => {
+    const descriptor: SourceDescriptor = {
+      id: "imagery-tiles",
+      protocol: "wmts",
+      locator: {
+        url: "https://mock.honua.test/rest/services/imagery/MapServer/WMTS",
+        serviceId: "imagery",
+        typeName: "imagery",
+        styleId: "default",
+        tileMatrixSetId: "WebMercatorQuad",
+      },
+      capabilities: PROTOCOL_DEFAULT_CAPABILITIES.wmts,
+    };
+    expect(buildWmtsRasterSourceSpec(descriptor, { format: "image/webp" }).tiles[0]).toBe(
+      "https://mock.honua.test/rest/services/imagery/MapServer/WMTS/imagery/default/WebMercatorQuad/{z}/{y}/{x}.webp",
+    );
+    expect(buildWmtsRasterSourceSpec(descriptor, { format: "image/jpeg" }).tiles[0]).toBe(
+      "https://mock.honua.test/rest/services/imagery/MapServer/WMTS/imagery/default/WebMercatorQuad/{z}/{y}/{x}.jpeg",
+    );
+    expect(buildWmtsRasterSourceSpec(descriptor, { format: "image/avif" }).tiles[0]).toBe(
+      "https://mock.honua.test/rest/services/imagery/MapServer/WMTS/imagery/default/WebMercatorQuad/{z}/{y}/{x}.png",
+    );
+  });
 });

--- a/test/entrypoints.test.ts
+++ b/test/entrypoints.test.ts
@@ -245,11 +245,11 @@ describe("entrypoint modules", () => {
   });
 
   it("exposes the canonical contract entrypoint", () => {
-    // Fifteen canonical protocols: five GeoServices service types
+    // Sixteen canonical protocols: five GeoServices service types
     // (FeatureServer, MapServer, ImageServer, Geometry, GP), OGC API
-    // Features / Tiles / Maps, STAC, WFS / WMS / OData, and three
+    // Features / Tiles / Maps, STAC, WFS / WMS / WMTS / OData, and three
     // MapLibre-native sources.
-    expect(PROTOCOLS).toHaveLength(15);
+    expect(PROTOCOLS).toHaveLength(16);
     expect(CAPABILITIES.length).toBeGreaterThan(0);
     expect(Object.keys(PROTOCOL_DEFAULT_CAPABILITIES)).toEqual([...PROTOCOLS]);
     expect(capabilities).toBeTypeOf("function");

--- a/test/error-hierarchy.test.ts
+++ b/test/error-hierarchy.test.ts
@@ -9,6 +9,8 @@ import {
   HonuaHttpError,
   HonuaNetworkError,
   HonuaTimeoutError,
+  HonuaWmsCapabilitiesParseError,
+  HonuaWmtsCapabilitiesParseError,
   isHonuaError,
 } from "../src/index.js";
 
@@ -136,8 +138,26 @@ describe("Error hierarchy", () => {
     });
   });
 
+  describe("HonuaWmsCapabilitiesParseError", () => {
+    it("carries the parser message and is an Error", () => {
+      const err = new HonuaWmsCapabilitiesParseError("missing <WMS_Capabilities> root element");
+      expect(err.name).toBe("HonuaWmsCapabilitiesParseError");
+      expect(err.message).toContain("WMS_Capabilities");
+      expect(err).toBeInstanceOf(Error);
+    });
+  });
+
+  describe("HonuaWmtsCapabilitiesParseError", () => {
+    it("carries the parser message and is an Error", () => {
+      const err = new HonuaWmtsCapabilitiesParseError("missing <Capabilities> root element");
+      expect(err.name).toBe("HonuaWmtsCapabilitiesParseError");
+      expect(err.message).toContain("Capabilities");
+      expect(err).toBeInstanceOf(Error);
+    });
+  });
+
   describe("isHonuaError", () => {
-    it("returns true for all 7 error types", () => {
+    it("returns true for all SDK error types", () => {
       expect(isHonuaError(new HonuaHttpError(404, "not found", null))).toBe(true);
       expect(isHonuaError(new HonuaTimeoutError(1000))).toBe(true);
       expect(isHonuaError(new HonuaNetworkError("fail", null))).toBe(true);
@@ -145,6 +165,8 @@ describe("Error hierarchy", () => {
       expect(isHonuaError(new HonuaGrpcError(2, "unknown"))).toBe(true);
       expect(isHonuaError(new HonuaCapabilityNotSupportedError("query", "wfs"))).toBe(true);
       expect(isHonuaError(new HonuaExplorationContextError("disposed", "ctx"))).toBe(true);
+      expect(isHonuaError(new HonuaWmsCapabilitiesParseError("missing root"))).toBe(true);
+      expect(isHonuaError(new HonuaWmtsCapabilitiesParseError("missing root"))).toBe(true);
     });
 
     it("returns false for plain Error and non-Error values", () => {

--- a/test/style.test.ts
+++ b/test/style.test.ts
@@ -1,15 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { HonuaOgcFeatureCollection } from "../src/core/surfaces.js";
 import {
-  isHonuaSource,
-  isFeatureServiceSource,
-  isMapServiceSource,
-  isOgcFeaturesSource,
-  parseFeatureLayerUrl,
-  parseMapServiceUrl,
-  parseOgcFeaturesUrl,
-  validateHonuaStyle,
-  createSources,
   HonuaClient,
   HonuaFeatureLayer,
   HonuaMapService,
@@ -17,8 +9,16 @@ import {
   HonuaWmsLayer,
   HonuaWmts,
   HonuaWmtsTileset,
+  createSources,
+  isFeatureServiceSource,
+  isHonuaSource,
+  isMapServiceSource,
+  isOgcFeaturesSource,
+  parseFeatureLayerUrl,
+  parseMapServiceUrl,
+  parseOgcFeaturesUrl,
+  validateHonuaStyle,
 } from "../src/index.js";
-import { HonuaOgcFeatureCollection } from "../src/core/surfaces.js";
 import type { HonuaStyleSpecification } from "../src/index.js";
 
 describe("Type guards", () => {
@@ -315,6 +315,49 @@ describe("createSources", () => {
     expect((handle as HonuaWmsLayer).serviceId).toBe("imagery");
     expect((handle as HonuaWmsLayer).layerName).toBe("parcels");
     expect((handle as HonuaWmsLayer).defaultStyleId).toBe("default");
+  });
+
+  it("trims whitespace around a single LAYER token before binding HonuaWmsLayer", () => {
+    const style: HonuaStyleSpecification = {
+      version: 8,
+      sources: {
+        parcels: {
+          type: "honua-wms",
+          url: "https://gis.example.com/rest/services/imagery/MapServer/WMS",
+          layers: "  parcels  ",
+        },
+      },
+      layers: [],
+    };
+    const sources = createSources(client, style);
+    const handle = sources.get("parcels");
+    expect(handle).toBeInstanceOf(HonuaWmsLayer);
+    expect((handle as HonuaWmsLayer).layerName).toBe("parcels");
+  });
+
+  it("returns service-level HonuaWms for multi-layer LAYERS=a,b composites", () => {
+    // HonuaWmsLayer is a single-layer handle (its describe() resolves
+    // exactly one <Layer>); registering it for a comma-separated
+    // composite would silently mis-route describe() / stylesIn() /
+    // legend() to a layer name that does not exist on the wire. The
+    // service-level handle keeps map() / featureInfo() targeting the
+    // composite verbatim.
+    const style: HonuaStyleSpecification = {
+      version: 8,
+      sources: {
+        composite: {
+          type: "honua-wms",
+          url: "https://gis.example.com/rest/services/imagery/MapServer/WMS",
+          layers: "parcels, roads",
+        },
+      },
+      layers: [],
+    };
+    const sources = createSources(client, style);
+    const handle = sources.get("composite");
+    expect(handle).toBeInstanceOf(HonuaWms);
+    expect(handle).not.toBeInstanceOf(HonuaWmsLayer);
+    expect((handle as HonuaWms).serviceId).toBe("imagery");
   });
 
   it("creates HonuaWmts (service-level) for honua-wmts sources without a layer", () => {

--- a/test/style.test.ts
+++ b/test/style.test.ts
@@ -13,6 +13,10 @@ import {
   HonuaClient,
   HonuaFeatureLayer,
   HonuaMapService,
+  HonuaWms,
+  HonuaWmsLayer,
+  HonuaWmts,
+  HonuaWmtsTileset,
 } from "../src/index.js";
 import { HonuaOgcFeatureCollection } from "../src/core/surfaces.js";
 import type { HonuaStyleSpecification } from "../src/index.js";
@@ -273,6 +277,84 @@ describe("createSources", () => {
     expect(
       (sources.get("data") as HonuaOgcFeatureCollection).collectionId,
     ).toBe("new-name");
+  });
+
+  it("creates HonuaWms (service-level) for honua-wms sources without LAYERS", () => {
+    const style: HonuaStyleSpecification = {
+      version: 8,
+      sources: {
+        imagery: {
+          type: "honua-wms",
+          url: "https://gis.example.com/rest/services/imagery/MapServer/WMS",
+        },
+      },
+      layers: [],
+    };
+    const sources = createSources(client, style);
+    const handle = sources.get("imagery");
+    expect(handle).toBeInstanceOf(HonuaWms);
+    expect((handle as HonuaWms).serviceId).toBe("imagery");
+  });
+
+  it("creates HonuaWmsLayer when honua-wms binds a single LAYER (and STYLE)", () => {
+    const style: HonuaStyleSpecification = {
+      version: 8,
+      sources: {
+        parcels: {
+          type: "honua-wms",
+          url: "https://gis.example.com/rest/services/imagery/MapServer/WMS",
+          layers: "parcels",
+          styles: "default",
+        },
+      },
+      layers: [],
+    };
+    const sources = createSources(client, style);
+    const handle = sources.get("parcels");
+    expect(handle).toBeInstanceOf(HonuaWmsLayer);
+    expect((handle as HonuaWmsLayer).serviceId).toBe("imagery");
+    expect((handle as HonuaWmsLayer).layerName).toBe("parcels");
+    expect((handle as HonuaWmsLayer).defaultStyleId).toBe("default");
+  });
+
+  it("creates HonuaWmts (service-level) for honua-wmts sources without a layer", () => {
+    const style: HonuaStyleSpecification = {
+      version: 8,
+      sources: {
+        tiles: {
+          type: "honua-wmts",
+          url: "https://gis.example.com/rest/services/imagery/MapServer/WMTS",
+        },
+      },
+      layers: [],
+    };
+    const sources = createSources(client, style);
+    const handle = sources.get("tiles");
+    expect(handle).toBeInstanceOf(HonuaWmts);
+    expect((handle as HonuaWmts).serviceId).toBe("imagery");
+  });
+
+  it("creates HonuaWmtsTileset when honua-wmts pins a layer + style + TileMatrixSet", () => {
+    const style: HonuaStyleSpecification = {
+      version: 8,
+      sources: {
+        tiles: {
+          type: "honua-wmts",
+          url: "https://gis.example.com/rest/services/imagery/MapServer/WMTS",
+          layer: "imagery",
+          style: "default",
+          tileMatrixSet: "WebMercatorQuad",
+        },
+      },
+      layers: [],
+    };
+    const sources = createSources(client, style);
+    const handle = sources.get("tiles");
+    expect(handle).toBeInstanceOf(HonuaWmtsTileset);
+    expect((handle as HonuaWmtsTileset).serviceId).toBe("imagery");
+    expect((handle as HonuaWmtsTileset).layerName).toBe("imagery");
+    expect((handle as HonuaWmtsTileset).styleId).toBe("default");
+    expect((handle as HonuaWmtsTileset).tileMatrixSetId).toBe("WebMercatorQuad");
   });
 
   it("returns null for non-Honua sources", () => {

--- a/test/wms-capabilities.test.ts
+++ b/test/wms-capabilities.test.ts
@@ -165,6 +165,53 @@ describe("parseWmsCapabilities", () => {
     expect(caps.service.title).toBeUndefined();
   });
 
+  it("does not leak descendant Layer metadata into the parent or siblings", () => {
+    // Unnamed group layer with two named children. Child `a` advertises a
+    // `red` style and a `EPSG:32612` CRS; child `b` advertises neither.
+    // Without the direct-child guard, the unnamed parent inherits `a`'s
+    // Name / Style / CRS by scanning into the descendant subtree, then
+    // `mergeAncestors` propagates the leaked style and CRS down to sibling
+    // `b`. This regression test pins both layers' local fields.
+    const xml = `<?xml version="1.0"?>
+<WMS_Capabilities version="1.3.0">
+  <Capability>
+    <Request><GetMap><Format>image/png</Format></GetMap></Request>
+    <Layer>
+      <Title>Unnamed group</Title>
+      <Layer queryable="1">
+        <Name>a</Name>
+        <Title>A</Title>
+        <CRS>EPSG:32612</CRS>
+        <Style><Name>red</Name></Style>
+      </Layer>
+      <Layer queryable="1">
+        <Name>b</Name>
+        <Title>B</Title>
+      </Layer>
+    </Layer>
+  </Capability>
+</WMS_Capabilities>`;
+    const caps = parseWmsCapabilities(xml);
+    const named = [...iterateWmsLayers(caps)];
+    expect(named.map((l) => l.name).sort()).toEqual(["a", "b"]);
+
+    const a = findWmsLayer(caps, "a");
+    const b = findWmsLayer(caps, "b");
+    expect(a?.styles.map((s) => s.name)).toEqual(["red"]);
+    expect(a?.crs).toContain("EPSG:32612");
+
+    // The sibling must NOT inherit `a`'s style or CRS.
+    expect(b?.styles).toEqual([]);
+    expect(b?.crs).not.toContain("EPSG:32612");
+
+    // The unnamed group must not synthesize a name from its child.
+    const root = caps.layers[0];
+    expect(root?.name).toBe("");
+    expect(root?.title).toBe("Unnamed group");
+    expect(root?.styles).toEqual([]);
+    expect(root?.crs).toEqual([]);
+  });
+
   it("decodes XML entities in element text", () => {
     const xml = `<?xml version="1.0"?>
 <WMS_Capabilities version="1.3.0">

--- a/test/wms-capabilities.test.ts
+++ b/test/wms-capabilities.test.ts
@@ -1,0 +1,276 @@
+/**
+ * WMS / WMTS Capabilities parser unit tests. Exercises the
+ * named-element walker against representative honua-server fixtures
+ * (single layer, nested layers with inherited CRS / bbox, WMTS RESTful
+ * tile templates, missing optional nodes).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  HonuaWmsCapabilitiesParseError,
+  findWmsLayer,
+  iterateWmsLayers,
+  parseWmsCapabilities,
+} from "../src/core/wms-capabilities.js";
+import {
+  HonuaWmtsCapabilitiesParseError,
+  findWmtsTileMatrixSet,
+  parseWmtsCapabilities,
+} from "../src/core/wmts-capabilities.js";
+
+const BASIC_WMS_CAPABILITIES = `<?xml version="1.0" encoding="UTF-8"?>
+<WMS_Capabilities version="1.3.0" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <Service>
+    <Name>WMS</Name>
+    <Title>Honua Test Service</Title>
+    <Abstract>Imagery + parcels for conformance fixtures.</Abstract>
+  </Service>
+  <Capability>
+    <Request>
+      <GetCapabilities>
+        <Format>text/xml</Format>
+      </GetCapabilities>
+      <GetMap>
+        <Format>image/png</Format>
+        <Format>image/jpeg</Format>
+      </GetMap>
+      <GetFeatureInfo>
+        <Format>application/json</Format>
+        <Format>text/plain</Format>
+      </GetFeatureInfo>
+    </Request>
+    <Layer>
+      <Name>root</Name>
+      <Title>Root group</Title>
+      <CRS>EPSG:4326</CRS>
+      <CRS>EPSG:3857</CRS>
+      <CRS>CRS:84</CRS>
+      <EX_GeographicBoundingBox>
+        <westBoundLongitude>-180</westBoundLongitude>
+        <eastBoundLongitude>180</eastBoundLongitude>
+        <southBoundLatitude>-85</southBoundLatitude>
+        <northBoundLatitude>85</northBoundLatitude>
+      </EX_GeographicBoundingBox>
+      <BoundingBox CRS="EPSG:3857" minx="-20037508" miny="-20037508" maxx="20037508" maxy="20037508"/>
+      <Layer queryable="1">
+        <Name>parcels</Name>
+        <Title>Parcels</Title>
+        <Style>
+          <Name>default</Name>
+          <Title>Default</Title>
+          <LegendURL width="100" height="50">
+            <Format>image/png</Format>
+            <OnlineResource xlink:href="https://example.com/legend.png"/>
+          </LegendURL>
+        </Style>
+        <Style>
+          <Name>highlighted</Name>
+          <Title>Highlighted</Title>
+        </Style>
+        <Dimension name="time" units="ISO8601" default="2026-01-01T00:00:00Z">
+          2025-01-01T00:00:00Z,2026-01-01T00:00:00Z
+        </Dimension>
+      </Layer>
+      <Layer>
+        <Name>imagery</Name>
+        <Title>Imagery</Title>
+      </Layer>
+    </Layer>
+  </Capability>
+</WMS_Capabilities>`;
+
+describe("parseWmsCapabilities", () => {
+  it("rejects missing root element", () => {
+    expect(() => parseWmsCapabilities("<NotCapabilities/>")).toThrow(HonuaWmsCapabilitiesParseError);
+  });
+
+  it("rejects empty input", () => {
+    expect(() => parseWmsCapabilities("")).toThrow(HonuaWmsCapabilitiesParseError);
+  });
+
+  it("extracts version, service metadata, and request support flags", () => {
+    const caps = parseWmsCapabilities(BASIC_WMS_CAPABILITIES);
+    expect(caps.version).toBe("1.3.0");
+    expect(caps.service.title).toBe("Honua Test Service");
+    expect(caps.service.abstract).toContain("conformance fixtures");
+    expect(caps.request.getFeatureInfo).toBe(true);
+    // honua-server does not advertise GetLegendGraphic; the fixture
+    // mirrors that gap so the parser flag is exercised.
+    expect(caps.request.getLegendGraphic).toBe(false);
+  });
+
+  it("collects request-format lists per request type", () => {
+    const caps = parseWmsCapabilities(BASIC_WMS_CAPABILITIES);
+    expect(caps.formats.map).toContain("image/png");
+    expect(caps.formats.map).toContain("image/jpeg");
+    expect(caps.formats.featureInfo).toContain("application/json");
+    expect(caps.formats.legend.length).toBe(0);
+  });
+
+  it("inherits CRS, bbox, and queryable from ancestor layers", () => {
+    const caps = parseWmsCapabilities(BASIC_WMS_CAPABILITIES);
+    const parcels = findWmsLayer(caps, "parcels");
+    expect(parcels).toBeDefined();
+    expect(parcels?.crs).toEqual(expect.arrayContaining(["EPSG:4326", "EPSG:3857", "CRS:84"]));
+    expect(parcels?.bbox.find((bb) => bb.crs === "EPSG:3857")).toBeDefined();
+    // EX_GeographicBoundingBox synthesizes a CRS:84 entry.
+    expect(parcels?.bbox.find((bb) => bb.crs === "CRS:84")).toBeDefined();
+    expect(parcels?.queryable).toBe(true);
+  });
+
+  it("emits styles with optional legend URLs and titles", () => {
+    const caps = parseWmsCapabilities(BASIC_WMS_CAPABILITIES);
+    const parcels = findWmsLayer(caps, "parcels");
+    expect(parcels?.styles).toHaveLength(2);
+    expect(parcels?.styles[0]?.name).toBe("default");
+    expect(parcels?.styles[0]?.legendUrl).toBe("https://example.com/legend.png");
+    expect(parcels?.styles[1]?.legendUrl).toBeUndefined();
+  });
+
+  it("extracts dimensions with units, default, and discrete values", () => {
+    const caps = parseWmsCapabilities(BASIC_WMS_CAPABILITIES);
+    const parcels = findWmsLayer(caps, "parcels");
+    expect(parcels?.dimensions).toHaveLength(1);
+    const time = parcels?.dimensions[0];
+    expect(time?.name).toBe("time");
+    expect(time?.units).toBe("ISO8601");
+    expect(time?.default).toBe("2026-01-01T00:00:00Z");
+    expect(time?.values).toEqual(["2025-01-01T00:00:00Z", "2026-01-01T00:00:00Z"]);
+  });
+
+  it("iterates named layers including children and skips container layers without a name", () => {
+    const xml = BASIC_WMS_CAPABILITIES.replace("<Name>root</Name>", "");
+    const caps = parseWmsCapabilities(xml);
+    const names = [...iterateWmsLayers(caps)].map((l) => l.name);
+    expect(names).toEqual(expect.arrayContaining(["parcels", "imagery"]));
+    expect(names).not.toContain("");
+  });
+
+  it("tolerates missing optional nodes (Title / Abstract / styles)", () => {
+    const minimal = `<?xml version="1.0"?>
+<WMS_Capabilities version="1.3.0">
+  <Capability>
+    <Request><GetMap><Format>image/png</Format></GetMap></Request>
+    <Layer>
+      <Name>only</Name>
+    </Layer>
+  </Capability>
+</WMS_Capabilities>`;
+    const caps = parseWmsCapabilities(minimal);
+    const layer = findWmsLayer(caps, "only");
+    expect(layer).toBeDefined();
+    expect(layer?.styles).toHaveLength(0);
+    expect(layer?.dimensions).toHaveLength(0);
+    expect(caps.service.title).toBeUndefined();
+  });
+
+  it("decodes XML entities in element text", () => {
+    const xml = `<?xml version="1.0"?>
+<WMS_Capabilities version="1.3.0">
+  <Service><Title>Honua &amp; Co</Title></Service>
+  <Capability>
+    <Request><GetMap><Format>image/png</Format></GetMap></Request>
+    <Layer><Name>x</Name></Layer>
+  </Capability>
+</WMS_Capabilities>`;
+    const caps = parseWmsCapabilities(xml);
+    expect(caps.service.title).toBe("Honua & Co");
+  });
+});
+
+const BASIC_WMTS_CAPABILITIES = `<?xml version="1.0" encoding="UTF-8"?>
+<Capabilities version="1.0.0"
+  xmlns="http://www.opengis.net/wmts/1.0"
+  xmlns:ows="http://www.opengis.net/ows/1.1"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <ows:ServiceIdentification>
+    <ows:Title>Honua Test WMTS</ows:Title>
+    <ows:Abstract>Single-layer fixture.</ows:Abstract>
+  </ows:ServiceIdentification>
+  <Contents>
+    <Layer>
+      <ows:Title>Imagery</ows:Title>
+      <ows:Identifier>imagery</ows:Identifier>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180 -85</ows:LowerCorner>
+        <ows:UpperCorner>180 85</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <Style isDefault="true">
+        <ows:Title>Default</ows:Title>
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WebMercatorQuad</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile"
+        template="https://example.com/wmts/imagery/default/WebMercatorQuad/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+      <ResourceURL format="application/json" resourceType="FeatureInfo"
+        template="https://example.com/wmts/imagery/default/WebMercatorQuad/{TileMatrix}/{TileRow}/{TileCol}/{J}/{I}.json"/>
+    </Layer>
+    <TileMatrixSet>
+      <ows:Identifier>WebMercatorQuad</ows:Identifier>
+      <ows:SupportedCRS>urn:ogc:def:crs:EPSG::3857</ows:SupportedCRS>
+      <WellKnownScaleSet>urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible</WellKnownScaleSet>
+      <TileMatrix>
+        <ows:Identifier>0</ows:Identifier>
+        <ScaleDenominator>559082264.0287178</ScaleDenominator>
+        <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1</MatrixWidth>
+        <MatrixHeight>1</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>1</ows:Identifier>
+        <ScaleDenominator>279541132.0143589</ScaleDenominator>
+        <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>2</MatrixWidth>
+        <MatrixHeight>2</MatrixHeight>
+      </TileMatrix>
+    </TileMatrixSet>
+  </Contents>
+</Capabilities>`;
+
+describe("parseWmtsCapabilities", () => {
+  it("rejects empty / missing root", () => {
+    expect(() => parseWmtsCapabilities("")).toThrow(HonuaWmtsCapabilitiesParseError);
+    expect(() => parseWmtsCapabilities("<NotCapabilities/>")).toThrow(HonuaWmtsCapabilitiesParseError);
+  });
+
+  it("collects layer metadata, formats, styles, and TMS links", () => {
+    const caps = parseWmtsCapabilities(BASIC_WMTS_CAPABILITIES);
+    expect(caps.version).toBe("1.0.0");
+    expect(caps.service.title).toBe("Honua Test WMTS");
+    expect(caps.layers).toHaveLength(1);
+    const layer = caps.layers[0]!;
+    expect(layer.identifier).toBe("imagery");
+    expect(layer.formats).toContain("image/png");
+    expect(layer.styles[0]?.identifier).toBe("default");
+    expect(layer.styles[0]?.isDefault).toBe(true);
+    expect(layer.tileMatrixSetIds).toEqual(["WebMercatorQuad"]);
+    expect(layer.bbox).toEqual({ west: -180, south: -85, east: 180, north: 85 });
+  });
+
+  it("captures RESTful tile and FeatureInfo templates", () => {
+    const caps = parseWmtsCapabilities(BASIC_WMTS_CAPABILITIES);
+    const layer = caps.layers[0]!;
+    expect(layer.resourceTemplates[0]?.format).toBe("image/png");
+    expect(layer.resourceTemplates[0]?.template).toContain("/{TileMatrix}/{TileRow}/{TileCol}.png");
+    expect(layer.featureInfoTemplates[0]?.format).toBe("application/json");
+    expect(layer.featureInfoTemplates[0]?.template).toContain("/{J}/{I}.json");
+  });
+
+  it("decodes the WebMercatorQuad TMS with all matrices", () => {
+    const caps = parseWmtsCapabilities(BASIC_WMTS_CAPABILITIES);
+    const tms = findWmtsTileMatrixSet(caps, "WebMercatorQuad");
+    expect(tms).toBeDefined();
+    expect(tms?.matrices).toHaveLength(2);
+    expect(tms?.matrices[0]?.tileWidth).toBe(256);
+    expect(tms?.matrices[1]?.matrixWidth).toBe(2);
+    expect(tms?.supportedCrs).toBe("urn:ogc:def:crs:EPSG::3857");
+  });
+});


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #28
## Summary

First-party WMS client on the shared JS client contract
## Changes Made

- First-party WMS client on the shared JS client contract
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally
## Additional Context

Decisions:
Centralized WMS layer token parsing in `parseWmsLayerNames` to keep contract and style resolver behavior aligned. Used existing typed `Error` behavior for unsupported WMS query fields, matching nearby guard patterns.

Follow-ons:
Optional only: the standalone narrative `docs/wms-adapter.md` remains deferred; the current review findings are documented in existing protocol docs.

Code kaizen:
Skipped by kaizen policy.
