### PR TITLE
feat: Operator-native component architecture on the shared JS client and MapPackage runtime (#29)

### DIFF
--- a/docs/operator-components.md
+++ b/docs/operator-components.md
@@ -1,0 +1,51 @@
+# Operator Components
+
+The operator module exposes framework-neutral controllers and a workspace
+orchestrator under `@honua/sdk-js/operator`. Hosts can render the surfaces in
+React, Web Components, plain DOM, or native shells while reusing the same state
+and transport contract.
+
+```ts
+import { OperatorWorkspace } from "@honua/sdk-js/operator";
+import { HonuaClient } from "@honua/sdk-js";
+
+const workspace = new OperatorWorkspace({
+  client: operatorClient,
+  mapFactory: () => ({ map }),
+  mapLoadOptions: {
+    client: new HonuaClient({ baseUrl: "https://api.example.test" }),
+    skipCompatibilityCheck: false,
+  },
+});
+
+workspace.on((event) => {
+  switch (event.kind) {
+    case "clarification-needed":
+      renderClarificationForm(event.intent);
+      break;
+    case "plan-loaded":
+      renderPlanReview(event.plan);
+      break;
+    case "map-loaded":
+      showMapPreview(event.pkg);
+      break;
+    case "approval-required":
+      renderApprovalGate(event.decision);
+      break;
+  }
+});
+```
+
+The workspace composes six controller surfaces:
+
+- `ChatController` streams a freeform user request into a drafted operator intent.
+- `ClarificationController` submits typed clarification answers back through the shared client.
+- `PlanReviewController` loads, revises, and accepts server-produced plans without mutating steps locally.
+- `ExecutionController` adapts the shared `IJobRun` contract and emits every progress and terminal transition.
+- `MapWorkspaceController` loads result `MapPackage` objects through the runtime instead of owning MapLibre source/style logic.
+- `BuilderWorkspaceController` exposes app package preview handles for host-owned sandbox rendering.
+- `ApprovalController` surfaces server-rendered policy decisions and never upgrades deferred or denied outcomes locally.
+
+The public extension points are controller subscriptions, workspace events,
+theme tokens, and message catalogs. The module intentionally does not expose
+feature editing or client-side policy override affordances.

--- a/package.json
+++ b/package.json
@@ -62,6 +62,26 @@
     "./runtime": {
       "types": "./dist/src/runtime/index.d.ts",
       "default": "./dist/src/runtime/index.js"
+    },
+    "./operator": {
+      "types": "./dist/src/operator/index.d.ts",
+      "default": "./dist/src/operator/index.js"
+    },
+    "./operator/controllers": {
+      "types": "./dist/src/operator/controllers/index.d.ts",
+      "default": "./dist/src/operator/controllers/index.js"
+    },
+    "./operator/workspace": {
+      "types": "./dist/src/operator/workspace/index.d.ts",
+      "default": "./dist/src/operator/workspace/index.js"
+    },
+    "./operator/theming": {
+      "types": "./dist/src/operator/theming/index.d.ts",
+      "default": "./dist/src/operator/theming/index.js"
+    },
+    "./operator/i18n": {
+      "types": "./dist/src/operator/i18n/index.d.ts",
+      "default": "./dist/src/operator/i18n/index.js"
     }
   },
   "scripts": {

--- a/src/operator/client.ts
+++ b/src/operator/client.ts
@@ -1,0 +1,78 @@
+/**
+ * `OperatorClient` — consumer-facing transport interface every operator
+ * controller depends on. Authored in this module so controllers and
+ * tests are not blocked on a downstream `HonuaClient` extension; the
+ * shipping `HonuaClient` is expected to implement this interface
+ * (mirroring how `#21` shipped runtime code against an interface its
+ * server counterpart later filled in).
+ *
+ * The interface names operator methods only — wire framing
+ * (HTTP/MCP/gRPC) is the implementer's choice.
+ *
+ * @module
+ */
+
+import type { IJobRun } from "../contract/index.js";
+import type { HonuaMapPackage } from "../runtime/index.js";
+import type {
+  AnalysisIntent,
+  AnalysisPlan,
+  AppPackage,
+  ApprovalDecision,
+  BuilderIntent,
+  BuilderPlan,
+  ClarificationAnswer,
+  DeploymentPlan,
+  ExecutionResult,
+  PublishingPlan,
+} from "./workspace/types.js";
+
+export interface ChatChunk {
+  readonly turnId: string;
+  readonly delta: string;
+  readonly done: boolean;
+  readonly intentDraft?: AnalysisIntent | BuilderIntent;
+}
+
+/**
+ * Minimal operator transport surface. The full interface is consumed by
+ * the controllers in `src/operator/controllers/`.
+ */
+export interface OperatorClientApi {
+  chat(text: string, signal?: AbortSignal): AsyncIterable<ChatChunk>;
+  clarify(
+    intentId: string,
+    answers: ReadonlyArray<ClarificationAnswer>,
+    signal?: AbortSignal,
+  ): Promise<AnalysisIntent | BuilderIntent>;
+  getPlan(
+    intentId: string,
+    signal?: AbortSignal,
+  ): Promise<AnalysisPlan | PublishingPlan | BuilderPlan | DeploymentPlan>;
+  submitPlan(
+    plan: AnalysisPlan | PublishingPlan | BuilderPlan | DeploymentPlan,
+    signal?: AbortSignal,
+  ): Promise<IJobRun<ExecutionResult>>;
+  refineMap(intentId: string, prompt: string, signal?: AbortSignal): Promise<HonuaMapPackage>;
+  refineApp(intentId: string, prompt: string, signal?: AbortSignal): Promise<AppPackage>;
+  getApproval(operationId: string, signal?: AbortSignal): Promise<ApprovalDecision>;
+  confirmApproval(operationId: string, signal?: AbortSignal): Promise<ApprovalDecision>;
+}
+
+/**
+ * `HonuaClient` (or any caller-supplied client) must expose the operator
+ * methods on a stable `operator` namespace. The operator surface is
+ * isolated so that pre-operator embedders pay no cost and adapter
+ * extensions do not collide with operator method names.
+ */
+export interface OperatorClient {
+  readonly operator: OperatorClientApi;
+}
+
+/**
+ * The fixed output key the server places the single execution result
+ * under in `JobResult<ExecutionResult>.outputs`. Naming the key in one
+ * place lets controllers read it without spreading wire-shape knowledge.
+ * If the server contract renames the key, only this constant changes.
+ */
+export const OPERATOR_EXECUTION_OUTPUT_KEY = "result";

--- a/src/operator/client.ts
+++ b/src/operator/client.ts
@@ -49,6 +49,17 @@ export interface OperatorClientApi {
     intentId: string,
     signal?: AbortSignal,
   ): Promise<AnalysisPlan | PublishingPlan | BuilderPlan | DeploymentPlan>;
+  /**
+   * Request a revised plan from the server. `notes` carries the
+   * embedder's revision request (e.g. "use vector tiles instead") and
+   * is forwarded as part of the wire request, not just observed in
+   * telemetry.
+   */
+  revisePlan(
+    intentId: string,
+    notes: string | undefined,
+    signal?: AbortSignal,
+  ): Promise<AnalysisPlan | PublishingPlan | BuilderPlan | DeploymentPlan>;
   submitPlan(
     plan: AnalysisPlan | PublishingPlan | BuilderPlan | DeploymentPlan,
     signal?: AbortSignal,

--- a/src/operator/controllers/approval.ts
+++ b/src/operator/controllers/approval.ts
@@ -76,10 +76,13 @@ export class ApprovalController {
       this.#bag.emit({ kind: "loaded", decision });
       return decision;
     } catch (error) {
-      const wrapped = new HonuaOperatorApprovalError("approval load failed", {
-        cause: error,
-        detail: { operationId },
-      });
+      const wrapped =
+        error instanceof HonuaOperatorApprovalError
+          ? error
+          : new HonuaOperatorApprovalError("approval load failed", {
+              cause: error,
+              detail: { operationId },
+            });
       if (gen === this.#generation) {
         this.#bag.emit({ kind: "error", error: wrapped });
       }
@@ -121,10 +124,13 @@ export class ApprovalController {
       this.#bag.emit({ kind: "confirmed", decision: next });
       return next;
     } catch (error) {
-      const wrapped = new HonuaOperatorApprovalError("approval confirm failed", {
-        cause: error,
-        detail: { operationId },
-      });
+      const wrapped =
+        error instanceof HonuaOperatorApprovalError
+          ? error
+          : new HonuaOperatorApprovalError("approval confirm failed", {
+              cause: error,
+              detail: { operationId },
+            });
       if (gen === this.#generation) {
         this.#bag.emit({ kind: "error", error: wrapped });
       }

--- a/src/operator/controllers/approval.ts
+++ b/src/operator/controllers/approval.ts
@@ -36,6 +36,11 @@ export class ApprovalController {
   readonly #bag = new ListenerBag<ApprovalEvent>();
   readonly #seenAudit = new Set<string>();
   #decision: ApprovalDecision | undefined;
+  // Bumped on every load() / confirm() entry so a slow approval call
+  // for operation A cannot resolve after the controller has moved on
+  // to operation B and emit a stale `loaded` / `confirmed` for A. The
+  // captured value is checked at resolution time; mismatch ⇒ drop.
+  #generation = 0;
 
   public constructor(options: ApprovalControllerOptions) {
     this.#client = options.client;
@@ -51,6 +56,7 @@ export class ApprovalController {
   }
 
   public async load(operationId: string, signal?: AbortSignal): Promise<ApprovalDecision> {
+    const gen = ++this.#generation;
     try {
       const decision = await withTelemetrySpan(
         this.#telemetry,
@@ -59,6 +65,12 @@ export class ApprovalController {
         () => this.#client.operator.getApproval(operationId, signal),
         { operationId },
       );
+      if (gen !== this.#generation) {
+        // Superseded by a newer load()/confirm(); drop without
+        // committing or emitting so a stale operationId does not
+        // overwrite the active decision.
+        return decision;
+      }
       this.#decision = decision;
       this.#fanOutAudit(decision);
       this.#bag.emit({ kind: "loaded", decision });
@@ -68,7 +80,9 @@ export class ApprovalController {
         cause: error,
         detail: { operationId },
       });
-      this.#bag.emit({ kind: "error", error: wrapped });
+      if (gen === this.#generation) {
+        this.#bag.emit({ kind: "error", error: wrapped });
+      }
       throw wrapped;
     }
   }
@@ -90,6 +104,7 @@ export class ApprovalController {
         detail: { operationId, state: this.#decision.state },
       });
     }
+    const gen = ++this.#generation;
     try {
       const next = await withTelemetrySpan(
         this.#telemetry,
@@ -98,6 +113,9 @@ export class ApprovalController {
         () => this.#client.operator.confirmApproval(operationId, signal),
         { operationId },
       );
+      if (gen !== this.#generation) {
+        return next;
+      }
       this.#decision = next;
       this.#fanOutAudit(next);
       this.#bag.emit({ kind: "confirmed", decision: next });
@@ -107,7 +125,9 @@ export class ApprovalController {
         cause: error,
         detail: { operationId },
       });
-      this.#bag.emit({ kind: "error", error: wrapped });
+      if (gen === this.#generation) {
+        this.#bag.emit({ kind: "error", error: wrapped });
+      }
       throw wrapped;
     }
   }

--- a/src/operator/controllers/approval.ts
+++ b/src/operator/controllers/approval.ts
@@ -1,0 +1,130 @@
+/**
+ * `ApprovalController` — loads the policy decision for an in-flight
+ * operation and exposes a single `confirm()` action when the gate is
+ * `pending`. The controller never short-circuits a deferred outcome
+ * to "approved"; it surfaces the server's verbatim decision.
+ *
+ * Audit entries returned with each decision are forwarded to the
+ * `OperatorTelemetry.after` hook as `approval-audit` events so partner
+ * observability stacks see the same evidence the server records. The
+ * server remains the canonical audit-of-record — client telemetry is
+ * observability, not evidence.
+ *
+ * @module
+ */
+
+import type { OperatorClient } from "../client.js";
+import { HonuaOperatorApprovalError } from "../errors.js";
+import type { OperatorTelemetry } from "../telemetry.js";
+import type { ApprovalAuditEntry, ApprovalDecision } from "../workspace/types.js";
+import { ListenerBag, type Unsubscribe, emitTelemetryEvent, withTelemetrySpan } from "./base.js";
+
+export type ApprovalEvent =
+  | { kind: "loaded"; decision: ApprovalDecision }
+  | { kind: "confirmed"; decision: ApprovalDecision }
+  | { kind: "audit"; entry: ApprovalAuditEntry; decision: ApprovalDecision }
+  | { kind: "error"; error: HonuaOperatorApprovalError };
+
+export interface ApprovalControllerOptions {
+  client: OperatorClient;
+  telemetry?: OperatorTelemetry;
+}
+
+export class ApprovalController {
+  readonly #client: OperatorClient;
+  readonly #telemetry: OperatorTelemetry | undefined;
+  readonly #bag = new ListenerBag<ApprovalEvent>();
+  readonly #seenAudit = new Set<string>();
+  #decision: ApprovalDecision | undefined;
+
+  public constructor(options: ApprovalControllerOptions) {
+    this.#client = options.client;
+    this.#telemetry = options.telemetry;
+  }
+
+  public get decision(): ApprovalDecision | undefined {
+    return this.#decision;
+  }
+
+  public on(listener: (event: ApprovalEvent) => void): Unsubscribe {
+    return this.#bag.on(listener);
+  }
+
+  public async load(operationId: string, signal?: AbortSignal): Promise<ApprovalDecision> {
+    try {
+      const decision = await withTelemetrySpan(
+        this.#telemetry,
+        "approval-load",
+        undefined,
+        () => this.#client.operator.getApproval(operationId, signal),
+        { operationId },
+      );
+      this.#decision = decision;
+      this.#fanOutAudit(decision);
+      this.#bag.emit({ kind: "loaded", decision });
+      return decision;
+    } catch (error) {
+      const wrapped = new HonuaOperatorApprovalError("approval load failed", {
+        cause: error,
+        detail: { operationId },
+      });
+      this.#bag.emit({ kind: "error", error: wrapped });
+      throw wrapped;
+    }
+  }
+
+  /**
+   * Confirm a `pending` approval. The controller refuses to invoke the
+   * server when the loaded decision is in any other state — preventing
+   * a UI from re-confirming an already granted/denied/deferred outcome.
+   * Returns the server's outcome unchanged.
+   */
+  public async confirm(operationId: string, signal?: AbortSignal): Promise<ApprovalDecision> {
+    if (!this.#decision || this.#decision.operationId !== operationId) {
+      throw new HonuaOperatorApprovalError("confirm requires a loaded decision for the same operation", {
+        detail: { operationId, decisionOperationId: this.#decision?.operationId },
+      });
+    }
+    if (this.#decision.state !== "pending") {
+      throw new HonuaOperatorApprovalError(`cannot confirm an approval in state "${this.#decision.state}"`, {
+        detail: { operationId, state: this.#decision.state },
+      });
+    }
+    try {
+      const next = await withTelemetrySpan(
+        this.#telemetry,
+        "approval-confirm",
+        undefined,
+        () => this.#client.operator.confirmApproval(operationId, signal),
+        { operationId },
+      );
+      this.#decision = next;
+      this.#fanOutAudit(next);
+      this.#bag.emit({ kind: "confirmed", decision: next });
+      return next;
+    } catch (error) {
+      const wrapped = new HonuaOperatorApprovalError("approval confirm failed", {
+        cause: error,
+        detail: { operationId },
+      });
+      this.#bag.emit({ kind: "error", error: wrapped });
+      throw wrapped;
+    }
+  }
+
+  #fanOutAudit(decision: ApprovalDecision): void {
+    for (const entry of decision.audit) {
+      const key = `${decision.operationId}|${entry.at}|${entry.actor}|${entry.action}`;
+      if (this.#seenAudit.has(key)) continue;
+      this.#seenAudit.add(key);
+      emitTelemetryEvent(this.#telemetry, "approval-audit", undefined, {
+        operationId: decision.operationId,
+        actor: entry.actor,
+        action: entry.action,
+        reason: entry.reason,
+        at: entry.at,
+      });
+      this.#bag.emit({ kind: "audit", entry, decision });
+    }
+  }
+}

--- a/src/operator/controllers/base.ts
+++ b/src/operator/controllers/base.ts
@@ -1,0 +1,73 @@
+/**
+ * Tiny shared subscribe/notify helper for operator controllers. Mirrors
+ * the listener-set pattern used by `HonuaMapRuntime` and
+ * `ExplorationContext` so a single embedder hook style works everywhere.
+ *
+ * @module
+ */
+
+import type { OperatorTelemetry, OperatorTelemetryKind, OperatorTelemetrySpan } from "../telemetry.js";
+
+export type Unsubscribe = () => void;
+
+export class ListenerBag<E> {
+  readonly #listeners = new Set<(event: E) => void>();
+
+  public on(listener: (event: E) => void): Unsubscribe {
+    this.#listeners.add(listener);
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  }
+
+  public emit(event: E): void {
+    for (const listener of [...this.#listeners]) listener(event);
+  }
+
+  public clear(): void {
+    this.#listeners.clear();
+  }
+
+  public get size(): number {
+    return this.#listeners.size;
+  }
+}
+
+/**
+ * Run an async operation with telemetry spans wrapped around it. Mirrors
+ * the before/after/error semantics of `HonuaRuntimeTelemetry`.
+ */
+export async function withTelemetrySpan<T>(
+  telemetry: OperatorTelemetry | undefined,
+  kind: OperatorTelemetryKind,
+  intentId: string | undefined,
+  fn: () => Promise<T>,
+  detail?: Record<string, unknown>,
+): Promise<T> {
+  const span: OperatorTelemetrySpan = { kind, intentId, startedAt: Date.now(), detail };
+  telemetry?.before?.(span);
+  try {
+    const result = await fn();
+    const finishedAt = Date.now();
+    telemetry?.after?.({ ...span, finishedAt, durationMs: finishedAt - span.startedAt });
+    return result;
+  } catch (error) {
+    const finishedAt = Date.now();
+    telemetry?.error?.({ ...span, finishedAt, durationMs: finishedAt - span.startedAt, error });
+    throw error;
+  }
+}
+
+/**
+ * Telemetry counterpart for synchronous events that have no
+ * before/after wrap (e.g. an audit-record fan-out).
+ */
+export function emitTelemetryEvent(
+  telemetry: OperatorTelemetry | undefined,
+  kind: OperatorTelemetryKind,
+  intentId: string | undefined,
+  detail?: Record<string, unknown>,
+): void {
+  const startedAt = Date.now();
+  telemetry?.after?.({ kind, intentId, startedAt, finishedAt: startedAt, durationMs: 0, detail });
+}

--- a/src/operator/controllers/builder-workspace.ts
+++ b/src/operator/controllers/builder-workspace.ts
@@ -51,6 +51,11 @@ export class BuilderWorkspaceController {
   #pkg: AppPackage | undefined;
   #boundMap: HonuaMapPackage | undefined;
   #activeIntentId: string | undefined;
+  // Same generation pattern as the other controllers: bumped on
+  // every loadPackage()/refine()/dispose(), captured by each
+  // operation, and consulted at resolution time so an older
+  // refineApp() cannot overwrite a newer package.
+  #opGeneration = 0;
 
   public constructor(options: BuilderWorkspaceControllerOptions) {
     this.#client = options.client;
@@ -71,11 +76,13 @@ export class BuilderWorkspaceController {
   }
 
   public async loadPackage(pkg: AppPackage): Promise<void> {
+    const gen = ++this.#opGeneration;
     return withTelemetrySpan(
       this.#telemetry,
       "app-load",
       this.#activeIntentId,
       async () => {
+        if (gen !== this.#opGeneration) return;
         this.#pkg = pkg;
         this.#bag.emit({ kind: "package-loaded", pkg });
       },
@@ -104,6 +111,7 @@ export class BuilderWorkspaceController {
       throw new HonuaOperatorAppError("refine requires bindIntent before invocation");
     }
     const intentId = this.#activeIntentId;
+    const gen = ++this.#opGeneration;
     return withTelemetrySpan(
       this.#telemetry,
       "app-refine",
@@ -111,6 +119,7 @@ export class BuilderWorkspaceController {
       async () => {
         try {
           const next = await this.#client.operator.refineApp(intentId, prompt, signal);
+          if (gen !== this.#opGeneration) return next;
           this.#pkg = next;
           this.#bag.emit({ kind: "package-refined", pkg: next });
           return next;
@@ -120,7 +129,9 @@ export class BuilderWorkspaceController {
             cause: error,
             detail: { prompt },
           });
-          this.#bag.emit({ kind: "error", error: wrapped });
+          if (gen === this.#opGeneration) {
+            this.#bag.emit({ kind: "error", error: wrapped });
+          }
           throw wrapped;
         }
       },
@@ -129,6 +140,7 @@ export class BuilderWorkspaceController {
   }
 
   public dispose(): void {
+    this.#opGeneration += 1;
     this.#pkg = undefined;
     this.#boundMap = undefined;
     this.#activeIntentId = undefined;

--- a/src/operator/controllers/builder-workspace.ts
+++ b/src/operator/controllers/builder-workspace.ts
@@ -1,0 +1,137 @@
+/**
+ * `BuilderWorkspaceController` — mirrors `MapWorkspaceController` for an
+ * `AppPackage`. The controller does not execute the app; it surfaces a
+ * `PreviewHandle` carrying the bundle URL the embedder mounts inside an
+ * `<iframe sandbox>`.
+ *
+ * @module
+ */
+
+import type { HonuaMapPackage } from "../../runtime/index.js";
+import type { OperatorClient } from "../client.js";
+import { HonuaOperatorAppError } from "../errors.js";
+import type { OperatorTelemetry } from "../telemetry.js";
+import type { AppPackage, ArtifactRef } from "../workspace/types.js";
+import { ListenerBag, type Unsubscribe, withTelemetrySpan } from "./base.js";
+
+export interface PreviewHandle {
+  readonly url: string | undefined;
+  readonly assets: ReadonlyArray<ArtifactRef>;
+  readonly mapPackage: HonuaMapPackage | undefined;
+}
+
+export type BuilderWorkspaceEvent =
+  | { kind: "package-loaded"; pkg: AppPackage }
+  | { kind: "package-refined"; pkg: AppPackage }
+  | { kind: "map-bound"; pkg: HonuaMapPackage }
+  | { kind: "error"; error: HonuaOperatorAppError };
+
+export interface BuilderWorkspaceControllerOptions {
+  client: OperatorClient;
+  telemetry?: OperatorTelemetry;
+  /**
+   * Optional adapter that picks the entry-point URL out of an
+   * `AppPackage`. Defaults to the first asset whose `kind === "app-package"`,
+   * falling back to the first asset with a `url`.
+   */
+  resolveEntryUrl?: (pkg: AppPackage) => string | undefined;
+}
+
+const defaultEntryUrl = (pkg: AppPackage): string | undefined => {
+  const appAsset = pkg.assets.find((asset) => asset.kind === "app-package" && asset.url);
+  if (appAsset?.url) return appAsset.url;
+  return pkg.assets.find((asset) => asset.url)?.url;
+};
+
+export class BuilderWorkspaceController {
+  readonly #client: OperatorClient;
+  readonly #telemetry: OperatorTelemetry | undefined;
+  readonly #resolveEntryUrl: (pkg: AppPackage) => string | undefined;
+  readonly #bag = new ListenerBag<BuilderWorkspaceEvent>();
+  #pkg: AppPackage | undefined;
+  #boundMap: HonuaMapPackage | undefined;
+  #activeIntentId: string | undefined;
+
+  public constructor(options: BuilderWorkspaceControllerOptions) {
+    this.#client = options.client;
+    this.#telemetry = options.telemetry;
+    this.#resolveEntryUrl = options.resolveEntryUrl ?? defaultEntryUrl;
+  }
+
+  public get appPackage(): AppPackage | undefined {
+    return this.#pkg;
+  }
+
+  public on(listener: (event: BuilderWorkspaceEvent) => void): Unsubscribe {
+    return this.#bag.on(listener);
+  }
+
+  public bindIntent(intentId: string): void {
+    this.#activeIntentId = intentId;
+  }
+
+  public async loadPackage(pkg: AppPackage): Promise<void> {
+    return withTelemetrySpan(
+      this.#telemetry,
+      "app-load",
+      this.#activeIntentId,
+      async () => {
+        this.#pkg = pkg;
+        this.#bag.emit({ kind: "package-loaded", pkg });
+      },
+      { appPackageId: pkg.id },
+    );
+  }
+
+  public bindMapPackage(pkg: HonuaMapPackage): void {
+    this.#boundMap = pkg;
+    this.#bag.emit({ kind: "map-bound", pkg });
+  }
+
+  public preview(): PreviewHandle {
+    if (!this.#pkg) {
+      throw new HonuaOperatorAppError("preview called before loadPackage");
+    }
+    return {
+      url: this.#resolveEntryUrl(this.#pkg),
+      assets: this.#pkg.assets,
+      mapPackage: this.#boundMap,
+    };
+  }
+
+  public async refine(prompt: string, signal?: AbortSignal): Promise<AppPackage> {
+    if (!this.#activeIntentId) {
+      throw new HonuaOperatorAppError("refine requires bindIntent before invocation");
+    }
+    const intentId = this.#activeIntentId;
+    return withTelemetrySpan(
+      this.#telemetry,
+      "app-refine",
+      intentId,
+      async () => {
+        try {
+          const next = await this.#client.operator.refineApp(intentId, prompt, signal);
+          this.#pkg = next;
+          this.#bag.emit({ kind: "package-refined", pkg: next });
+          return next;
+        } catch (error) {
+          const wrapped = new HonuaOperatorAppError("app refine failed", {
+            intentId,
+            cause: error,
+            detail: { prompt },
+          });
+          this.#bag.emit({ kind: "error", error: wrapped });
+          throw wrapped;
+        }
+      },
+      { prompt },
+    );
+  }
+
+  public dispose(): void {
+    this.#pkg = undefined;
+    this.#boundMap = undefined;
+    this.#activeIntentId = undefined;
+    this.#bag.clear();
+  }
+}

--- a/src/operator/controllers/builder-workspace.ts
+++ b/src/operator/controllers/builder-workspace.ts
@@ -77,6 +77,12 @@ export class BuilderWorkspaceController {
 
   public async loadPackage(pkg: AppPackage): Promise<void> {
     const gen = ++this.#opGeneration;
+    // Clear the prior map binding eagerly so the next preview() call
+    // never returns a previous execution's map. The workspace re-binds
+    // the map within the same execution-success handler when the new
+    // result actually carries one; an app-only result therefore
+    // produces a preview with no `mapPackage`.
+    this.#boundMap = undefined;
     return withTelemetrySpan(
       this.#telemetry,
       "app-load",

--- a/src/operator/controllers/chat.ts
+++ b/src/operator/controllers/chat.ts
@@ -1,0 +1,179 @@
+/**
+ * `ChatController` — turn ledger and intent-draft pump for the freeform
+ * request surface. The controller owns no streaming token assembly logic
+ * beyond accumulating `ChatChunk.delta` strings; the transport (an
+ * `AsyncIterable<ChatChunk>` from the `OperatorClient`) is responsible
+ * for chunking.
+ *
+ * @module
+ */
+
+import type { ChatChunk, OperatorClient } from "../client.js";
+import { HonuaOperatorIntentError } from "../errors.js";
+import type { OperatorTelemetry } from "../telemetry.js";
+import type { AnalysisIntent, BuilderIntent, ConversationTurn, TurnRole } from "../workspace/types.js";
+import { ListenerBag, type Unsubscribe, withTelemetrySpan } from "./base.js";
+
+export type ChatEvent =
+  | { kind: "turn-updated"; turn: ConversationTurn }
+  | { kind: "intent-drafted"; intent: AnalysisIntent | BuilderIntent }
+  | { kind: "error"; error: HonuaOperatorIntentError };
+
+export type DecorateTurn = (turn: ConversationTurn) => ConversationTurn;
+
+export interface ChatControllerOptions {
+  client: OperatorClient;
+  telemetry?: OperatorTelemetry;
+  /**
+   * Pure transformation applied to a turn snapshot before the
+   * `turn-updated` event fires. Cannot mutate controller state.
+   */
+  decorate?: DecorateTurn;
+  /** Fixture seam for deterministic ids in tests. */
+  generateTurnId?: () => string;
+  /** Fixture seam for deterministic timestamps in tests. */
+  now?: () => number;
+}
+
+let chatTurnCounter = 0;
+
+function defaultTurnId(): string {
+  chatTurnCounter += 1;
+  return `turn-${Date.now().toString(36)}-${chatTurnCounter.toString(36)}`;
+}
+
+export class ChatController {
+  readonly #client: OperatorClient;
+  readonly #telemetry: OperatorTelemetry | undefined;
+  readonly #decorate: DecorateTurn | undefined;
+  readonly #generateTurnId: () => string;
+  readonly #now: () => number;
+  readonly #bag = new ListenerBag<ChatEvent>();
+  readonly #turns: ConversationTurn[] = [];
+  #abortController: AbortController | undefined;
+
+  public constructor(options: ChatControllerOptions) {
+    this.#client = options.client;
+    this.#telemetry = options.telemetry;
+    this.#decorate = options.decorate;
+    this.#generateTurnId = options.generateTurnId ?? defaultTurnId;
+    this.#now = options.now ?? (() => Date.now());
+  }
+
+  public get turns(): ReadonlyArray<ConversationTurn> {
+    return this.#turns;
+  }
+
+  public on(listener: (event: ChatEvent) => void): Unsubscribe {
+    return this.#bag.on(listener);
+  }
+
+  public abort(): void {
+    this.#abortController?.abort();
+    this.#abortController = undefined;
+  }
+
+  /**
+   * Send a freeform user message and stream the agent reply. Resolves
+   * with the final agent turn (intent draft inlined) when the stream
+   * completes; rejects with `HonuaOperatorIntentError` on transport
+   * failure.
+   */
+  public async send(text: string): Promise<ConversationTurn> {
+    const userTurn = this.#appendTurn({ role: "user", content: text });
+    const agentTurnId = this.#generateTurnId();
+    const startedAt = this.#now();
+    const agentIndex =
+      this.#turns.push({
+        turnId: agentTurnId,
+        role: "agent",
+        content: "",
+        startedAt,
+      }) - 1;
+    this.#emitTurnUpdated(this.#turns[agentIndex]!);
+
+    this.#abortController = new AbortController();
+    const signal = this.#abortController.signal;
+
+    try {
+      return await withTelemetrySpan(
+        this.#telemetry,
+        "chat-turn",
+        undefined,
+        async () => {
+          let intentDraft: AnalysisIntent | BuilderIntent | undefined;
+          let accumulated = "";
+          let lastChunk: ChatChunk | undefined;
+
+          for await (const chunk of this.#client.operator.chat(text, signal)) {
+            lastChunk = chunk;
+            accumulated += chunk.delta;
+            if (chunk.intentDraft) intentDraft = chunk.intentDraft;
+            const updated: ConversationTurn = {
+              turnId: agentTurnId,
+              role: "agent",
+              content: accumulated,
+              startedAt,
+              ...(chunk.done ? { finishedAt: this.#now() } : {}),
+              ...(intentDraft ? { intentDraft } : {}),
+            };
+            this.#turns[agentIndex] = updated;
+            this.#emitTurnUpdated(updated);
+            if (chunk.done) break;
+          }
+
+          if (!lastChunk?.done) {
+            // Stream ended without an explicit terminal chunk — close
+            // the turn so consumers always observe a `finishedAt`.
+            const closed: ConversationTurn = {
+              ...this.#turns[agentIndex]!,
+              finishedAt: this.#now(),
+            };
+            this.#turns[agentIndex] = closed;
+            this.#emitTurnUpdated(closed);
+          }
+          if (intentDraft) {
+            this.#bag.emit({ kind: "intent-drafted", intent: intentDraft });
+          }
+          // Touch userTurn so the variable is observed even when no
+          // intermediate observer reads it (silences strict-unused).
+          void userTurn;
+          return this.#turns[agentIndex]!;
+        },
+        { turnId: agentTurnId },
+      );
+    } catch (error) {
+      const wrapped =
+        error instanceof HonuaOperatorIntentError
+          ? error
+          : new HonuaOperatorIntentError("chat send failed", { cause: error, detail: { turnId: agentTurnId } });
+      this.#bag.emit({ kind: "error", error: wrapped });
+      throw wrapped;
+    } finally {
+      this.#abortController = undefined;
+    }
+  }
+
+  /** Append a system message (e.g. an embedder-supplied notice). */
+  public appendSystem(content: string): ConversationTurn {
+    return this.#appendTurn({ role: "system", content });
+  }
+
+  #appendTurn(input: { role: TurnRole; content: string }): ConversationTurn {
+    const turn: ConversationTurn = {
+      turnId: this.#generateTurnId(),
+      role: input.role,
+      content: input.content,
+      startedAt: this.#now(),
+      finishedAt: this.#now(),
+    };
+    this.#turns.push(turn);
+    this.#emitTurnUpdated(turn);
+    return turn;
+  }
+
+  #emitTurnUpdated(turn: ConversationTurn): void {
+    const decorated = this.#decorate ? this.#decorate(turn) : turn;
+    this.#bag.emit({ kind: "turn-updated", turn: decorated });
+  }
+}

--- a/src/operator/controllers/chat.ts
+++ b/src/operator/controllers/chat.ts
@@ -78,8 +78,16 @@ export class ChatController {
    * with the final agent turn (intent draft inlined) when the stream
    * completes; rejects with `HonuaOperatorIntentError` on transport
    * failure.
+   *
+   * If a previous send is still in flight, it is aborted before this
+   * one starts. The active controller identity is the per-send token —
+   * stream updates, `intent-drafted`, and `error` emissions are gated
+   * on it so a slow earlier stream cannot drive workspace state back
+   * to a stale intent after a newer send has taken over.
    */
   public async send(text: string): Promise<ConversationTurn> {
+    this.#abortController?.abort();
+
     const userTurn = this.#appendTurn({ role: "user", content: text });
     const agentTurnId = this.#generateTurnId();
     const startedAt = this.#now();
@@ -92,8 +100,10 @@ export class ChatController {
       }) - 1;
     this.#emitTurnUpdated(this.#turns[agentIndex]!);
 
-    this.#abortController = new AbortController();
-    const signal = this.#abortController.signal;
+    const controller = new AbortController();
+    this.#abortController = controller;
+    const signal = controller.signal;
+    const isCurrent = (): boolean => this.#abortController === controller;
 
     try {
       return await withTelemetrySpan(
@@ -106,6 +116,7 @@ export class ChatController {
           let lastChunk: ChatChunk | undefined;
 
           for await (const chunk of this.#client.operator.chat(text, signal)) {
+            if (!isCurrent()) return this.#turns[agentIndex]!;
             lastChunk = chunk;
             accumulated += chunk.delta;
             if (chunk.intentDraft) intentDraft = chunk.intentDraft;
@@ -121,6 +132,8 @@ export class ChatController {
             this.#emitTurnUpdated(updated);
             if (chunk.done) break;
           }
+
+          if (!isCurrent()) return this.#turns[agentIndex]!;
 
           if (!lastChunk?.done) {
             // Stream ended without an explicit terminal chunk — close
@@ -147,10 +160,15 @@ export class ChatController {
         error instanceof HonuaOperatorIntentError
           ? error
           : new HonuaOperatorIntentError("chat send failed", { cause: error, detail: { turnId: agentTurnId } });
-      this.#bag.emit({ kind: "error", error: wrapped });
+      // Only emit on the bag if this send still owns the surface; a
+      // superseded send is expected to throw (its consumer awaits the
+      // returned promise) but should not pollute the event stream.
+      if (isCurrent()) {
+        this.#bag.emit({ kind: "error", error: wrapped });
+      }
       throw wrapped;
     } finally {
-      this.#abortController = undefined;
+      if (isCurrent()) this.#abortController = undefined;
     }
   }
 

--- a/src/operator/controllers/clarification.ts
+++ b/src/operator/controllers/clarification.ts
@@ -63,6 +63,11 @@ export class ClarificationController {
 
   public load(intent: AnalysisIntent | BuilderIntent): void {
     this.#generation += 1;
+    // Reset the submitting flag here too: a load() that supersedes a
+    // pending submit() leaves the in-flight call unable to clear it
+    // (its `finally` is generation-gated), so without this the
+    // observable `state.submitting` would stay true forever.
+    this.#submitting = false;
     this.#intent = intent;
     this.#answers.clear();
     this.#bag.emit({ kind: "loaded", intent });

--- a/src/operator/controllers/clarification.ts
+++ b/src/operator/controllers/clarification.ts
@@ -37,6 +37,11 @@ export class ClarificationController {
   #intent: AnalysisIntent | BuilderIntent | undefined;
   #answers = new Map<string, string>();
   #submitting = false;
+  // Bumped on every load() and submit(); an in-flight submit checks
+  // this on resolution so a slow clarify() response cannot revive a
+  // superseded intent after the host has already moved on to a newer
+  // one. Generation > captured generation ⇒ drop the result silently.
+  #generation = 0;
 
   public constructor(options: ClarificationControllerOptions) {
     this.#client = options.client;
@@ -57,6 +62,7 @@ export class ClarificationController {
   }
 
   public load(intent: AnalysisIntent | BuilderIntent): void {
+    this.#generation += 1;
     this.#intent = intent;
     this.#answers.clear();
     this.#bag.emit({ kind: "loaded", intent });
@@ -102,6 +108,7 @@ export class ClarificationController {
       fieldId,
       value,
     }));
+    const gen = ++this.#generation;
     this.#submitting = true;
     try {
       const revised = await withTelemetrySpan(
@@ -111,6 +118,13 @@ export class ClarificationController {
         () => this.#client.operator.clarify(intent.id, answers, signal),
         { fieldCount: answers.length },
       );
+      if (gen !== this.#generation) {
+        // A newer load()/submit() superseded this submission while it
+        // was in flight. Drop the response without committing or
+        // emitting so the workspace cannot be driven back to a stale
+        // intent.
+        return revised;
+      }
       this.#intent = revised;
       this.#answers.clear();
       this.#bag.emit({ kind: "submitted", intent: revised });
@@ -123,10 +137,12 @@ export class ClarificationController {
               intentId: intent.id,
               cause: error,
             });
-      this.#bag.emit({ kind: "error", error: wrapped });
+      if (gen === this.#generation) {
+        this.#bag.emit({ kind: "error", error: wrapped });
+      }
       throw wrapped;
     } finally {
-      this.#submitting = false;
+      if (gen === this.#generation) this.#submitting = false;
     }
   }
 }

--- a/src/operator/controllers/clarification.ts
+++ b/src/operator/controllers/clarification.ts
@@ -1,0 +1,132 @@
+/**
+ * `ClarificationController` — typed form derived from
+ * `intent.clarifications[]`. Submission is a pass-through to
+ * `OperatorClient.operator.clarify` and yields a fresh intent revision.
+ *
+ * @module
+ */
+
+import type { OperatorClient } from "../client.js";
+import { HonuaOperatorIntentError } from "../errors.js";
+import type { OperatorTelemetry } from "../telemetry.js";
+import type { AnalysisIntent, BuilderIntent, ClarificationAnswer, ClarificationField } from "../workspace/types.js";
+import { ListenerBag, type Unsubscribe, withTelemetrySpan } from "./base.js";
+
+export interface ClarificationState {
+  readonly intent: AnalysisIntent | BuilderIntent | undefined;
+  readonly fields: ReadonlyArray<ClarificationField>;
+  readonly answers: ReadonlyMap<string, string>;
+  readonly submitting: boolean;
+}
+
+export type ClarificationEvent =
+  | { kind: "loaded"; intent: AnalysisIntent | BuilderIntent }
+  | { kind: "answer-changed"; fieldId: string; value: string }
+  | { kind: "submitted"; intent: AnalysisIntent | BuilderIntent }
+  | { kind: "error"; error: HonuaOperatorIntentError };
+
+export interface ClarificationControllerOptions {
+  client: OperatorClient;
+  telemetry?: OperatorTelemetry;
+}
+
+export class ClarificationController {
+  readonly #client: OperatorClient;
+  readonly #telemetry: OperatorTelemetry | undefined;
+  readonly #bag = new ListenerBag<ClarificationEvent>();
+  #intent: AnalysisIntent | BuilderIntent | undefined;
+  #answers = new Map<string, string>();
+  #submitting = false;
+
+  public constructor(options: ClarificationControllerOptions) {
+    this.#client = options.client;
+    this.#telemetry = options.telemetry;
+  }
+
+  public get state(): ClarificationState {
+    return {
+      intent: this.#intent,
+      fields: this.#intent?.clarifications ?? [],
+      answers: new Map(this.#answers),
+      submitting: this.#submitting,
+    };
+  }
+
+  public on(listener: (event: ClarificationEvent) => void): Unsubscribe {
+    return this.#bag.on(listener);
+  }
+
+  public load(intent: AnalysisIntent | BuilderIntent): void {
+    this.#intent = intent;
+    this.#answers.clear();
+    this.#bag.emit({ kind: "loaded", intent });
+  }
+
+  public setAnswer(fieldId: string, value: string): void {
+    if (!this.#intent) {
+      throw new HonuaOperatorIntentError("setAnswer called before clarification load");
+    }
+    const exists = this.#intent.clarifications?.some((field) => field.id === fieldId);
+    if (!exists) {
+      throw new HonuaOperatorIntentError(`unknown clarification field "${fieldId}"`, {
+        intentId: this.#intent.id,
+        detail: { fieldId },
+      });
+    }
+    this.#answers.set(fieldId, value);
+    this.#bag.emit({ kind: "answer-changed", fieldId, value });
+  }
+
+  /**
+   * Submit the current answers and resolve with the revised intent.
+   * Missing required answers reject with `HonuaOperatorIntentError`
+   * before any network call so the controller never depends on the
+   * server for required-field validation.
+   */
+  public async submit(signal?: AbortSignal): Promise<AnalysisIntent | BuilderIntent> {
+    if (!this.#intent) {
+      throw new HonuaOperatorIntentError("submit called before clarification load");
+    }
+    const intent = this.#intent;
+    const missing: string[] = [];
+    for (const field of intent.clarifications ?? []) {
+      if (field.required && !(this.#answers.get(field.id) ?? "").trim()) missing.push(field.id);
+    }
+    if (missing.length > 0) {
+      throw new HonuaOperatorIntentError("missing required clarification answers", {
+        intentId: intent.id,
+        detail: { missing },
+      });
+    }
+    const answers: ClarificationAnswer[] = [...this.#answers.entries()].map(([fieldId, value]) => ({
+      fieldId,
+      value,
+    }));
+    this.#submitting = true;
+    try {
+      const revised = await withTelemetrySpan(
+        this.#telemetry,
+        "clarify",
+        intent.id,
+        () => this.#client.operator.clarify(intent.id, answers, signal),
+        { fieldCount: answers.length },
+      );
+      this.#intent = revised;
+      this.#answers.clear();
+      this.#bag.emit({ kind: "submitted", intent: revised });
+      return revised;
+    } catch (error) {
+      const wrapped =
+        error instanceof HonuaOperatorIntentError
+          ? error
+          : new HonuaOperatorIntentError("clarification submit failed", {
+              intentId: intent.id,
+              cause: error,
+            });
+      this.#bag.emit({ kind: "error", error: wrapped });
+      throw wrapped;
+    } finally {
+      this.#submitting = false;
+    }
+  }
+}

--- a/src/operator/controllers/execution.ts
+++ b/src/operator/controllers/execution.ts
@@ -40,6 +40,12 @@ export class ExecutionController {
   #unsubscribe: (() => void) | undefined;
   #activePlan: OperatorPlan | undefined;
   #lastSnapshot: JobSnapshot<ExecutionResult> | undefined;
+  // Per-start abort controller. dispose() aborts it so the in-flight
+  // submitPlan() can short-circuit; the start path also uses identity
+  // comparison (this.#startAbort === captured) to detect the case
+  // where submitPlan resolved despite the abort and a newer start
+  // already took ownership.
+  #startAbort: AbortController | undefined;
 
   public constructor(options: ExecutionControllerOptions) {
     this.#client = options.client;
@@ -61,16 +67,26 @@ export class ExecutionController {
   /**
    * Submit a plan and start watching the resulting job. Resolves with
    * the live `IJobRun` once the watch subscription is active.
+   *
+   * Concurrent calls supersede each other: the second call disposes
+   * the first (which aborts its in-flight `submitPlan`); if the older
+   * `submitPlan` still resolves, the result is cancelled and the
+   * promise rejects so the older caller does not see a started event
+   * for a run that is no longer authoritative.
    */
   public async start(plan: OperatorPlan, signal?: AbortSignal): Promise<IJobRun<ExecutionResult>> {
     this.dispose();
+    const startAbort = new AbortController();
+    this.#startAbort = startAbort;
+    const linkedSignal = linkSignals(signal, startAbort);
+
     let run: IJobRun<ExecutionResult>;
     try {
       run = await withTelemetrySpan(
         this.#telemetry,
         "execution-start",
         plan.intentId,
-        () => this.#client.operator.submitPlan(plan, signal),
+        () => this.#client.operator.submitPlan(plan, linkedSignal),
         { planId: plan.id, planKind: plan.kind },
       );
     } catch (error) {
@@ -78,14 +94,37 @@ export class ExecutionController {
         intentId: plan.intentId,
         detail: { planId: plan.id, planKind: plan.kind },
       });
-      this.#bag.emit({ kind: "error", error: wrapped });
+      // Suppress the error event when this start was superseded — the
+      // newer start owns the surface and a stale error would mislead
+      // observers about the current execution.
+      if (this.#startAbort === startAbort) {
+        this.#bag.emit({ kind: "error", error: wrapped });
+      }
       throw wrapped;
     }
+
+    if (this.#startAbort !== startAbort) {
+      // A newer start took ownership while we were awaiting submitPlan.
+      // Cancel this run silently and reject so the original caller is
+      // not handed a stale IJobRun.
+      void run.cancel().catch(() => {});
+      throw new HonuaOperatorExecutionError("execution superseded by a newer start", {
+        intentId: plan.intentId,
+        executionId: run.id,
+        failureKind: "Cancelled",
+      });
+    }
+
     this.#activeRun = run;
     this.#activePlan = plan;
     this.#bag.emit({ kind: "started", executionId: run.id });
 
     this.#unsubscribe = run.watch((snapshot) => {
+      // Stale-watch guard: an older watch subscription can fire after
+      // dispose() if the underlying adapter has already buffered the
+      // snapshot. `#activeRun !== run` means we are no longer the
+      // authoritative run; drop without emitting.
+      if (this.#activeRun !== run) return;
       this.#lastSnapshot = snapshot;
       if (snapshot.progress) {
         this.#bag.emit({ kind: "progress", executionId: run.id, progress: snapshot.progress });
@@ -131,6 +170,8 @@ export class ExecutionController {
   }
 
   public dispose(): void {
+    this.#startAbort?.abort();
+    this.#startAbort = undefined;
     this.#unsubscribe?.();
     this.#unsubscribe = undefined;
     this.#activeRun = undefined;
@@ -231,4 +272,19 @@ function wrapExecutionError(
     failureKind: "ExecutionFailed",
     cause: error,
   });
+}
+
+/**
+ * Returns an `AbortSignal` that fires when either the externally-supplied
+ * caller signal aborts or the per-start internal controller is aborted by
+ * `dispose()`. Lets `submitPlan` be cancelled by either source.
+ */
+function linkSignals(external: AbortSignal | undefined, internal: AbortController): AbortSignal {
+  if (!external) return internal.signal;
+  if (external.aborted) {
+    internal.abort();
+    return internal.signal;
+  }
+  external.addEventListener("abort", () => internal.abort(), { once: true });
+  return internal.signal;
 }

--- a/src/operator/controllers/execution.ts
+++ b/src/operator/controllers/execution.ts
@@ -1,0 +1,181 @@
+/**
+ * `ExecutionController` — thin adapter on `IJobRun<ExecutionResult>`.
+ * Subscribes to `watch()`, surfaces snapshot transitions on a controller
+ * event stream, and routes the terminal payload onto the workspace.
+ *
+ * @module
+ */
+
+import {
+  type IJobRun,
+  type JobError,
+  type JobProgress,
+  type JobSnapshot,
+  isJobTerminal,
+} from "../../contract/index.js";
+import { OPERATOR_EXECUTION_OUTPUT_KEY, type OperatorClient } from "../client.js";
+import { HonuaOperatorExecutionError, type HonuaOperatorExecutionFailureKind } from "../errors.js";
+import type { OperatorTelemetry } from "../telemetry.js";
+import type { ExecutionResult, OperatorPlan } from "../workspace/types.js";
+import { ListenerBag, type Unsubscribe, withTelemetrySpan } from "./base.js";
+
+export type ExecutionEvent =
+  | { kind: "started"; executionId: string }
+  | { kind: "progress"; executionId: string; progress: JobProgress }
+  | { kind: "successful"; executionId: string; result: ExecutionResult }
+  | { kind: "failed"; executionId: string; error: HonuaOperatorExecutionError }
+  | { kind: "dismissed"; executionId: string };
+
+export interface ExecutionControllerOptions {
+  client: OperatorClient;
+  telemetry?: OperatorTelemetry;
+}
+
+export class ExecutionController {
+  readonly #client: OperatorClient;
+  readonly #telemetry: OperatorTelemetry | undefined;
+  readonly #bag = new ListenerBag<ExecutionEvent>();
+  #activeRun: IJobRun<ExecutionResult> | undefined;
+  #unsubscribe: (() => void) | undefined;
+  #activePlan: OperatorPlan | undefined;
+  #lastSnapshot: JobSnapshot<ExecutionResult> | undefined;
+
+  public constructor(options: ExecutionControllerOptions) {
+    this.#client = options.client;
+    this.#telemetry = options.telemetry;
+  }
+
+  public get run(): IJobRun<ExecutionResult> | undefined {
+    return this.#activeRun;
+  }
+
+  public get snapshot(): JobSnapshot<ExecutionResult> | undefined {
+    return this.#lastSnapshot;
+  }
+
+  public on(listener: (event: ExecutionEvent) => void): Unsubscribe {
+    return this.#bag.on(listener);
+  }
+
+  /**
+   * Submit a plan and start watching the resulting job. Resolves with
+   * the live `IJobRun` once the watch subscription is active.
+   */
+  public async start(plan: OperatorPlan, signal?: AbortSignal): Promise<IJobRun<ExecutionResult>> {
+    this.dispose();
+    const run = await withTelemetrySpan(
+      this.#telemetry,
+      "execution-start",
+      plan.intentId,
+      () => this.#client.operator.submitPlan(plan, signal),
+      { planId: plan.id, planKind: plan.kind },
+    );
+    this.#activeRun = run;
+    this.#activePlan = plan;
+    this.#bag.emit({ kind: "started", executionId: run.id });
+
+    this.#unsubscribe = run.watch((snapshot) => {
+      this.#lastSnapshot = snapshot;
+      if (snapshot.progress) {
+        this.#bag.emit({ kind: "progress", executionId: run.id, progress: snapshot.progress });
+      }
+      if (!isJobTerminal(snapshot.status)) return;
+      this.#emitTerminal(run.id, snapshot);
+    });
+    return run;
+  }
+
+  public async cancel(): Promise<void> {
+    if (!this.#activeRun) return;
+    await this.#activeRun.cancel();
+  }
+
+  public dispose(): void {
+    this.#unsubscribe?.();
+    this.#unsubscribe = undefined;
+    this.#activeRun = undefined;
+    this.#activePlan = undefined;
+    this.#lastSnapshot = undefined;
+  }
+
+  #emitTerminal(executionId: string, snapshot: JobSnapshot<ExecutionResult>): void {
+    const intentId = this.#activePlan?.intentId;
+    const startedAt = Date.now();
+    const detail = { executionId, status: snapshot.status };
+    if (snapshot.status === "successful") {
+      const result = snapshot.result?.outputs?.[OPERATOR_EXECUTION_OUTPUT_KEY];
+      if (!result) {
+        const error = new HonuaOperatorExecutionError("execution succeeded but no result was returned", {
+          intentId,
+          executionId,
+          failureKind: "OutputBindingFailed",
+        });
+        this.#bag.emit({ kind: "failed", executionId, error });
+        this.#telemetry?.error?.({
+          kind: "execution-terminal",
+          intentId,
+          startedAt,
+          finishedAt: startedAt,
+          durationMs: 0,
+          detail,
+          error,
+        });
+        return;
+      }
+      this.#bag.emit({ kind: "successful", executionId, result });
+      this.#telemetry?.after?.({
+        kind: "execution-terminal",
+        intentId,
+        startedAt,
+        finishedAt: startedAt,
+        durationMs: 0,
+        detail: { ...detail, resultKind: result.kind },
+      });
+      return;
+    }
+    if (snapshot.status === "dismissed") {
+      this.#bag.emit({ kind: "dismissed", executionId });
+      this.#telemetry?.after?.({
+        kind: "execution-terminal",
+        intentId,
+        startedAt,
+        finishedAt: startedAt,
+        durationMs: 0,
+        detail,
+      });
+      return;
+    }
+    const wrapped = jobErrorToExecutionError(snapshot.error, executionId, intentId);
+    this.#bag.emit({ kind: "failed", executionId, error: wrapped });
+    this.#telemetry?.error?.({
+      kind: "execution-terminal",
+      intentId,
+      startedAt,
+      finishedAt: startedAt,
+      durationMs: 0,
+      detail,
+      error: wrapped,
+    });
+  }
+}
+
+function jobErrorToExecutionError(
+  jobError: JobError | undefined,
+  executionId: string,
+  intentId: string | undefined,
+): HonuaOperatorExecutionError {
+  if (!jobError) {
+    return new HonuaOperatorExecutionError("execution failed", {
+      intentId,
+      executionId,
+      failureKind: "ExecutionFailed",
+    });
+  }
+  const failureKind: HonuaOperatorExecutionFailureKind = jobError.code as HonuaOperatorExecutionFailureKind;
+  return new HonuaOperatorExecutionError(jobError.message, {
+    intentId,
+    executionId,
+    failureKind,
+    detail: jobError.details ? { details: jobError.details } : undefined,
+  });
+}

--- a/src/operator/controllers/execution.ts
+++ b/src/operator/controllers/execution.ts
@@ -24,7 +24,8 @@ export type ExecutionEvent =
   | { kind: "progress"; executionId: string; progress: JobProgress }
   | { kind: "successful"; executionId: string; result: ExecutionResult }
   | { kind: "failed"; executionId: string; error: HonuaOperatorExecutionError }
-  | { kind: "dismissed"; executionId: string };
+  | { kind: "dismissed"; executionId: string }
+  | { kind: "error"; error: HonuaOperatorExecutionError };
 
 export interface ExecutionControllerOptions {
   client: OperatorClient;
@@ -63,13 +64,23 @@ export class ExecutionController {
    */
   public async start(plan: OperatorPlan, signal?: AbortSignal): Promise<IJobRun<ExecutionResult>> {
     this.dispose();
-    const run = await withTelemetrySpan(
-      this.#telemetry,
-      "execution-start",
-      plan.intentId,
-      () => this.#client.operator.submitPlan(plan, signal),
-      { planId: plan.id, planKind: plan.kind },
-    );
+    let run: IJobRun<ExecutionResult>;
+    try {
+      run = await withTelemetrySpan(
+        this.#telemetry,
+        "execution-start",
+        plan.intentId,
+        () => this.#client.operator.submitPlan(plan, signal),
+        { planId: plan.id, planKind: plan.kind },
+      );
+    } catch (error) {
+      const wrapped = wrapExecutionError(error, "plan submission failed", {
+        intentId: plan.intentId,
+        detail: { planId: plan.id, planKind: plan.kind },
+      });
+      this.#bag.emit({ kind: "error", error: wrapped });
+      throw wrapped;
+    }
     this.#activeRun = run;
     this.#activePlan = plan;
     this.#bag.emit({ kind: "started", executionId: run.id });
@@ -82,12 +93,41 @@ export class ExecutionController {
       if (!isJobTerminal(snapshot.status)) return;
       this.#emitTerminal(run.id, snapshot);
     });
+
+    // The shared `IJobRun` contract permits passive `watch()` implementations
+    // (the OGC adapter only registers listeners; polling is driven by
+    // `results()`). Kick off the polling path so snapshots actually flow.
+    // `results()` rejects with `HonuaJobFailedError` on failed/dismissed
+    // terminals — those are already surfaced by the watcher above, so we
+    // suppress them when the watcher already observed a terminal snapshot.
+    // Any other rejection (poll-side network failure that prevents reaching
+    // a terminal state) routes through the error event surface.
+    void run.results().catch((error: unknown) => {
+      if (this.#activeRun !== run) return;
+      if (this.#lastSnapshot && isJobTerminal(this.#lastSnapshot.status)) return;
+      const wrapped = wrapExecutionError(error, "execution polling failed", {
+        intentId: plan.intentId,
+        executionId: run.id,
+      });
+      this.#bag.emit({ kind: "error", error: wrapped });
+    });
     return run;
   }
 
   public async cancel(): Promise<void> {
     if (!this.#activeRun) return;
-    await this.#activeRun.cancel();
+    const run = this.#activeRun;
+    try {
+      await run.cancel();
+    } catch (error) {
+      if (this.#activeRun !== run) return;
+      const wrapped = wrapExecutionError(error, "execution cancel failed", {
+        intentId: this.#activePlan?.intentId,
+        executionId: run.id,
+      });
+      this.#bag.emit({ kind: "error", error: wrapped });
+      throw wrapped;
+    }
   }
 
   public dispose(): void {
@@ -177,5 +217,18 @@ function jobErrorToExecutionError(
     executionId,
     failureKind,
     detail: jobError.details ? { details: jobError.details } : undefined,
+  });
+}
+
+function wrapExecutionError(
+  error: unknown,
+  fallbackMessage: string,
+  context: { intentId?: string; executionId?: string; detail?: Record<string, unknown> },
+): HonuaOperatorExecutionError {
+  if (error instanceof HonuaOperatorExecutionError) return error;
+  return new HonuaOperatorExecutionError(fallbackMessage, {
+    ...context,
+    failureKind: "ExecutionFailed",
+    cause: error,
   });
 }

--- a/src/operator/controllers/execution.ts
+++ b/src/operator/controllers/execution.ts
@@ -11,6 +11,7 @@ import {
   type JobError,
   type JobProgress,
   type JobSnapshot,
+  type JobStatus,
   isJobTerminal,
 } from "../../contract/index.js";
 import { OPERATOR_EXECUTION_OUTPUT_KEY, type OperatorClient } from "../client.js";
@@ -125,11 +126,16 @@ export class ExecutionController {
       // snapshot. `#activeRun !== run` means we are no longer the
       // authoritative run; drop without emitting.
       if (this.#activeRun !== run) return;
+      // Double-emit guard: cancel() may have already synthesized a
+      // terminal snapshot for the same run. Detect via the prior
+      // #lastSnapshot's status before overwriting it.
+      const alreadyTerminal = this.#lastSnapshot !== undefined && isJobTerminal(this.#lastSnapshot.status);
       this.#lastSnapshot = snapshot;
       if (snapshot.progress) {
         this.#bag.emit({ kind: "progress", executionId: run.id, progress: snapshot.progress });
       }
       if (!isJobTerminal(snapshot.status)) return;
+      if (alreadyTerminal) return;
       this.#emitTerminal(run.id, snapshot);
     });
 
@@ -156,8 +162,9 @@ export class ExecutionController {
   public async cancel(): Promise<void> {
     if (!this.#activeRun) return;
     const run = this.#activeRun;
+    let status: JobStatus;
     try {
-      await run.cancel();
+      status = await run.cancel();
     } catch (error) {
       if (this.#activeRun !== run) return;
       const wrapped = wrapExecutionError(error, "execution cancel failed", {
@@ -167,6 +174,32 @@ export class ExecutionController {
       this.#bag.emit({ kind: "error", error: wrapped });
       throw wrapped;
     }
+    if (this.#activeRun !== run) return;
+    if (!isJobTerminal(status)) return;
+    // The IJobRun contract does not require watch() to fire during
+    // cancellation, so a conforming adapter can dismiss the run
+    // without ever delivering a terminal snapshot. Synthesize one when
+    // the watcher has not already produced a terminal. The watcher's
+    // double-emit guard handles the converse race (watcher fires after
+    // we synthesize).
+    if (this.#lastSnapshot !== undefined && isJobTerminal(this.#lastSnapshot.status)) return;
+    let snapshot: JobSnapshot<ExecutionResult> = { status };
+    if (status !== "dismissed") {
+      // The server may have raced cancel to a successful/failed
+      // terminal. poll() carries the authoritative payload; fall back
+      // to the bare status if poll fails so #emitTerminal still routes
+      // to a terminal event rather than silently dropping it.
+      try {
+        const polled = await run.poll();
+        if (this.#activeRun !== run) return;
+        snapshot = polled;
+      } catch {
+        // Best-effort poll; emit the bare status snapshot.
+      }
+    }
+    if (this.#lastSnapshot !== undefined && isJobTerminal(this.#lastSnapshot.status)) return;
+    this.#lastSnapshot = snapshot;
+    this.#emitTerminal(run.id, snapshot);
   }
 
   public dispose(): void {

--- a/src/operator/controllers/index.ts
+++ b/src/operator/controllers/index.ts
@@ -1,0 +1,38 @@
+export { ApprovalController } from "./approval.js";
+export type { ApprovalControllerOptions, ApprovalEvent } from "./approval.js";
+
+export { BuilderWorkspaceController } from "./builder-workspace.js";
+export type {
+  BuilderWorkspaceControllerOptions,
+  BuilderWorkspaceEvent,
+  PreviewHandle,
+} from "./builder-workspace.js";
+
+export { ChatController } from "./chat.js";
+export type { ChatControllerOptions, ChatEvent, DecorateTurn } from "./chat.js";
+
+export { ClarificationController } from "./clarification.js";
+export type {
+  ClarificationControllerOptions,
+  ClarificationEvent,
+  ClarificationState,
+} from "./clarification.js";
+
+export { ExecutionController } from "./execution.js";
+export type { ExecutionControllerOptions, ExecutionEvent } from "./execution.js";
+
+export { MapWorkspaceController } from "./map-workspace.js";
+export type {
+  MapFactory,
+  MapFactoryResult,
+  MapWorkspaceControllerOptions,
+  MapWorkspaceEvent,
+} from "./map-workspace.js";
+
+export { PlanReviewController } from "./plan-review.js";
+export type {
+  DecorateStep,
+  PlanReviewControllerOptions,
+  PlanReviewEvent,
+  PlanRevisionRequest,
+} from "./plan-review.js";

--- a/src/operator/controllers/map-workspace.ts
+++ b/src/operator/controllers/map-workspace.ts
@@ -173,6 +173,15 @@ export class MapWorkspaceController {
             // Superseded; the newer load owns teardown. Don't re-tear or emit.
             throw error;
           }
+          // `#disposeMap` is only assigned after `loadMapPackage`
+          // succeeds, so a factory that returned a host map followed
+          // by a `loadMapPackage` failure leaves the map orphaned.
+          // Dispose the locally-captured factoryResult / runtime here
+          // before #tearDown runs (it will be a no-op for those).
+          if (runtime !== undefined) disposeRuntime(runtime);
+          if (factoryResult !== undefined && this.#disposeMap === undefined) {
+            disposeFactoryResult(factoryResult);
+          }
           this.#tearDown();
           const wrapped =
             error instanceof HonuaOperatorMapError

--- a/src/operator/controllers/map-workspace.ts
+++ b/src/operator/controllers/map-workspace.ts
@@ -1,0 +1,256 @@
+/**
+ * `MapWorkspaceController` — orchestrates the `HonuaMapRuntime` and the
+ * `ExplorationContext` for a single result `MapPackage`. The controller
+ * owns no MapLibre source/style code of its own — every map mutation
+ * delegates to the runtime from `src/runtime/`.
+ *
+ * @module
+ */
+
+import {
+  type ExplorationContext,
+  type LinkedViewPresetName,
+  type ViewHandle,
+  createExplorationContext,
+} from "../../exploration/index.js";
+import {
+  type HonuaMapPackage,
+  type HonuaMapPackagePopupBinding,
+  type HonuaMapRuntime,
+  type LegendEntry,
+  type LoadMapPackageOptions,
+  type MaplibreMap,
+  type SetViewStateInput,
+  loadMapPackage,
+} from "../../runtime/index.js";
+import type { OperatorClient } from "../client.js";
+import { HonuaOperatorMapError } from "../errors.js";
+import type { OperatorTelemetry } from "../telemetry.js";
+import { ListenerBag, type Unsubscribe, withTelemetrySpan } from "./base.js";
+
+export type MapWorkspaceEvent =
+  | { kind: "package-loaded"; pkg: HonuaMapPackage }
+  | { kind: "package-refined"; pkg: HonuaMapPackage }
+  | { kind: "package-disposed" }
+  | { kind: "error"; error: HonuaOperatorMapError };
+
+/**
+ * Caller-supplied factory that builds the host MapLibre map and returns
+ * a teardown handle. The host owns the `MaplibreMap` lifecycle.
+ */
+export type MapFactory = () => MapFactoryResult | Promise<MapFactoryResult>;
+
+export interface MapFactoryResult {
+  map: MaplibreMap;
+  dispose?: () => void;
+}
+
+export interface MapWorkspaceControllerOptions {
+  client: OperatorClient;
+  mapFactory: MapFactory;
+  /** Linked-view preset for the embedded `ExplorationContext`. Default `"mapDriven"`. */
+  explorationPreset?: LinkedViewPresetName;
+  telemetry?: OperatorTelemetry;
+  /**
+   * Pass-through options handed to `loadMapPackage`. The controller
+   * never instantiates a `HonuaClient` itself — the host wires the
+   * runtime client through this hook.
+   */
+  loadOptions?: Omit<LoadMapPackageOptions, "telemetry">;
+}
+
+const MAP_VIEW_BINDING_ID = "map-primary";
+
+export class MapWorkspaceController {
+  readonly #client: OperatorClient;
+  readonly #mapFactory: MapFactory;
+  readonly #preset: LinkedViewPresetName;
+  readonly #telemetry: OperatorTelemetry | undefined;
+  readonly #loadOptions: Omit<LoadMapPackageOptions, "telemetry"> | undefined;
+  readonly #bag = new ListenerBag<MapWorkspaceEvent>();
+
+  #runtime: HonuaMapRuntime | undefined;
+  #context: ExplorationContext | undefined;
+  #viewHandle: ViewHandle | undefined;
+  #disposeMap: (() => void) | undefined;
+  #activeIntentId: string | undefined;
+
+  public constructor(options: MapWorkspaceControllerOptions) {
+    this.#client = options.client;
+    this.#mapFactory = options.mapFactory;
+    this.#preset = options.explorationPreset ?? "mapDriven";
+    this.#telemetry = options.telemetry;
+    this.#loadOptions = options.loadOptions;
+  }
+
+  public get runtime(): HonuaMapRuntime | undefined {
+    return this.#runtime;
+  }
+
+  public get exploration(): ExplorationContext | undefined {
+    return this.#context;
+  }
+
+  public on(listener: (event: MapWorkspaceEvent) => void): Unsubscribe {
+    return this.#bag.on(listener);
+  }
+
+  /**
+   * Bind the controller to an intent so that subsequent `refine()` calls
+   * have an intent id to attach to the server request. Idempotent.
+   */
+  public bindIntent(intentId: string): void {
+    this.#activeIntentId = intentId;
+  }
+
+  /**
+   * Load a `MapPackage` into a fresh runtime + exploration context.
+   * Tears down any previously loaded package; safe to call repeatedly.
+   */
+  public async loadPackage(pkg: HonuaMapPackage): Promise<HonuaMapRuntime> {
+    this.#tearDown();
+
+    if (!this.#loadOptions) {
+      throw new HonuaOperatorMapError("loadPackage requires loadOptions on the controller", {
+        detail: { mapPackageId: pkg.mapPackageId },
+      });
+    }
+
+    return withTelemetrySpan(
+      this.#telemetry,
+      "map-load",
+      this.#activeIntentId,
+      async () => {
+        const factoryResult = await this.#mapFactory();
+        this.#disposeMap = factoryResult.dispose;
+        try {
+          const runtime = await loadMapPackage(pkg, factoryResult.map, {
+            ...this.#loadOptions!,
+          });
+          this.#runtime = runtime;
+          this.#context = createExplorationContext({
+            datasetId: pkg.mapPackageId,
+            sourceIds: pkg.sourceBindings.map((binding) => binding.sourceId),
+            preset: this.#preset,
+          });
+          this.#viewHandle = this.#context.bind({ id: MAP_VIEW_BINDING_ID, role: "map" });
+          this.#bag.emit({ kind: "package-loaded", pkg });
+          return runtime;
+        } catch (error) {
+          this.#tearDown();
+          const wrapped =
+            error instanceof HonuaOperatorMapError
+              ? error
+              : new HonuaOperatorMapError("map package load failed", {
+                  cause: error,
+                  detail: { mapPackageId: pkg.mapPackageId },
+                });
+          this.#bag.emit({ kind: "error", error: wrapped });
+          throw wrapped;
+        }
+      },
+      { mapPackageId: pkg.mapPackageId },
+    );
+  }
+
+  /**
+   * Natural-language refinement. The server returns an updated
+   * `MapPackage`; the runtime's diff path applies it incrementally.
+   * Source-binding failures inside the runtime are forwarded via
+   * `runtime.reportSourceError(...)` rather than thrown.
+   */
+  public async refine(prompt: string, signal?: AbortSignal): Promise<HonuaMapPackage> {
+    if (!this.#runtime) {
+      throw new HonuaOperatorMapError("refine called before loadPackage");
+    }
+    if (!this.#activeIntentId) {
+      throw new HonuaOperatorMapError("refine requires bindIntent before invocation");
+    }
+    const intentId = this.#activeIntentId;
+    return withTelemetrySpan(
+      this.#telemetry,
+      "map-refine",
+      intentId,
+      async () => {
+        try {
+          const next = await this.#client.operator.refineMap(intentId, prompt, signal);
+          await this.#runtime!.updatePackage(next);
+          this.#bag.emit({ kind: "package-refined", pkg: next });
+          return next;
+        } catch (error) {
+          const wrapped = new HonuaOperatorMapError("map refine failed", {
+            intentId,
+            cause: error,
+            detail: { prompt },
+          });
+          this.#bag.emit({ kind: "error", error: wrapped });
+          // Forward any per-source recoveries to the runtime so
+          // listeners on the runtime see the failure on the same
+          // channel as native source events.
+          this.#runtime?.reportSourceError("__refine__", error);
+          throw wrapped;
+        }
+      },
+      { prompt },
+    );
+  }
+
+  // ── Thin re-exports of HonuaMapRuntime ops ───────────────────
+
+  public setLayerVisibility(layerId: string, visible: boolean): void {
+    this.#assertRuntime().setLayerVisibility(layerId, visible);
+  }
+
+  public bindPopup(layerId: string, binding?: HonuaMapPackagePopupBinding): { remove(): void } {
+    return this.#assertRuntime().bindPopup(layerId, binding);
+  }
+
+  public setViewState(view: SetViewStateInput): void {
+    this.#assertRuntime().setViewState(view);
+  }
+
+  public getLegend(): LegendEntry[] {
+    return this.#assertRuntime().getLegend();
+  }
+
+  public dispose(): void {
+    this.#tearDown();
+    this.#bag.clear();
+  }
+
+  #assertRuntime(): HonuaMapRuntime {
+    if (!this.#runtime) {
+      throw new HonuaOperatorMapError("operation requires a loaded MapPackage");
+    }
+    return this.#runtime;
+  }
+
+  #tearDown(): void {
+    if (this.#viewHandle) {
+      this.#viewHandle.unbind();
+      this.#viewHandle = undefined;
+    }
+    if (this.#context) {
+      this.#context.dispose();
+      this.#context = undefined;
+    }
+    if (this.#runtime) {
+      try {
+        this.#runtime.dispose();
+      } catch {
+        // dispose is best-effort during teardown; map errors do not
+        // re-surface here because the controller already returned.
+      }
+      this.#runtime = undefined;
+      this.#bag.emit({ kind: "package-disposed" });
+    }
+    if (this.#disposeMap) {
+      try {
+        this.#disposeMap();
+      } catch {
+        // ignore — host-owned teardown.
+      }
+      this.#disposeMap = undefined;
+    }
+  }
+}

--- a/src/operator/controllers/map-workspace.ts
+++ b/src/operator/controllers/map-workspace.ts
@@ -121,9 +121,14 @@ export class MapWorkspaceController {
       "map-load",
       this.#activeIntentId,
       async () => {
-        const factoryResult = await this.#mapFactory();
-        this.#disposeMap = factoryResult.dispose;
         try {
+          // The host-supplied factory can reject before any runtime
+          // setup happens (e.g. WebGL unavailable). Keep its failure
+          // inside the wrapper so embedders see a typed
+          // HonuaOperatorMapError on the workspace event stream
+          // instead of a raw factory rejection.
+          const factoryResult = await this.#mapFactory();
+          this.#disposeMap = factoryResult.dispose;
           const runtime = await loadMapPackage(pkg, factoryResult.map, {
             ...this.#loadOptions!,
           });

--- a/src/operator/controllers/map-workspace.ts
+++ b/src/operator/controllers/map-workspace.ts
@@ -74,6 +74,12 @@ export class MapWorkspaceController {
   #viewHandle: ViewHandle | undefined;
   #disposeMap: (() => void) | undefined;
   #activeIntentId: string | undefined;
+  // Bumped on every loadPackage() / refine() / dispose() entry. The
+  // operation captures it before awaiting and only commits state when
+  // the captured value still matches at resolution time. Parallel
+  // loads or refinements thereby cannot let an older `MapPackage`
+  // overwrite a newer one.
+  #opGeneration = 0;
 
   public constructor(options: MapWorkspaceControllerOptions) {
     this.#client = options.client;
@@ -106,32 +112,53 @@ export class MapWorkspaceController {
   /**
    * Load a `MapPackage` into a fresh runtime + exploration context.
    * Tears down any previously loaded package; safe to call repeatedly.
+   *
+   * Concurrent loads supersede each other via `#opGeneration`: an
+   * older load whose factory or `loadMapPackage` is still pending when
+   * a newer load arrives discards its locally-built runtime/context
+   * instead of overwriting the newer state.
    */
   public async loadPackage(pkg: HonuaMapPackage): Promise<HonuaMapRuntime> {
-    this.#tearDown();
-
     if (!this.#loadOptions) {
       throw new HonuaOperatorMapError("loadPackage requires loadOptions on the controller", {
         detail: { mapPackageId: pkg.mapPackageId },
       });
     }
 
+    this.#tearDown();
+    const gen = ++this.#opGeneration;
+
     return withTelemetrySpan(
       this.#telemetry,
       "map-load",
       this.#activeIntentId,
       async () => {
+        let factoryResult: MapFactoryResult | undefined;
+        let runtime: HonuaMapRuntime | undefined;
         try {
           // The host-supplied factory can reject before any runtime
           // setup happens (e.g. WebGL unavailable). Keep its failure
           // inside the wrapper so embedders see a typed
           // HonuaOperatorMapError on the workspace event stream
           // instead of a raw factory rejection.
-          const factoryResult = await this.#mapFactory();
-          this.#disposeMap = factoryResult.dispose;
-          const runtime = await loadMapPackage(pkg, factoryResult.map, {
+          factoryResult = await this.#mapFactory();
+          if (gen !== this.#opGeneration) {
+            disposeFactoryResult(factoryResult);
+            throw new HonuaOperatorMapError("map load superseded by newer load", {
+              detail: { mapPackageId: pkg.mapPackageId },
+            });
+          }
+          runtime = await loadMapPackage(pkg, factoryResult.map, {
             ...this.#loadOptions!,
           });
+          if (gen !== this.#opGeneration) {
+            disposeRuntime(runtime);
+            disposeFactoryResult(factoryResult);
+            throw new HonuaOperatorMapError("map load superseded by newer load", {
+              detail: { mapPackageId: pkg.mapPackageId },
+            });
+          }
+          this.#disposeMap = factoryResult.dispose;
           this.#runtime = runtime;
           this.#context = createExplorationContext({
             datasetId: pkg.mapPackageId,
@@ -142,6 +169,10 @@ export class MapWorkspaceController {
           this.#bag.emit({ kind: "package-loaded", pkg });
           return runtime;
         } catch (error) {
+          if (gen !== this.#opGeneration) {
+            // Superseded; the newer load owns teardown. Don't re-tear or emit.
+            throw error;
+          }
           this.#tearDown();
           const wrapped =
             error instanceof HonuaOperatorMapError
@@ -172,6 +203,8 @@ export class MapWorkspaceController {
       throw new HonuaOperatorMapError("refine requires bindIntent before invocation");
     }
     const intentId = this.#activeIntentId;
+    const ownRuntime = this.#runtime;
+    const gen = ++this.#opGeneration;
     return withTelemetrySpan(
       this.#telemetry,
       "map-refine",
@@ -179,11 +212,24 @@ export class MapWorkspaceController {
       async () => {
         try {
           const next = await this.#client.operator.refineMap(intentId, prompt, signal);
-          await this.#runtime!.updatePackage(next);
+          if (gen !== this.#opGeneration || this.#runtime !== ownRuntime) {
+            // Superseded by a newer load/refine, or the runtime was
+            // torn down while we awaited. Skip the apply so we never
+            // mutate a stale or replaced runtime.
+            return next;
+          }
+          await ownRuntime.updatePackage(next);
+          if (gen !== this.#opGeneration || this.#runtime !== ownRuntime) {
+            return next;
+          }
           this.#syncExplorationContext(next);
           this.#bag.emit({ kind: "package-refined", pkg: next });
           return next;
         } catch (error) {
+          if (gen !== this.#opGeneration || this.#runtime !== ownRuntime) {
+            // Superseded; let the newer op own error reporting.
+            throw error;
+          }
           const wrapped = new HonuaOperatorMapError("map refine failed", {
             intentId,
             cause: error,
@@ -193,7 +239,7 @@ export class MapWorkspaceController {
           // Forward any per-source recoveries to the runtime so
           // listeners on the runtime see the failure on the same
           // channel as native source events.
-          this.#runtime?.reportSourceError("__refine__", error);
+          ownRuntime.reportSourceError("__refine__", error);
           throw wrapped;
         }
       },
@@ -220,6 +266,7 @@ export class MapWorkspaceController {
   }
 
   public dispose(): void {
+    this.#opGeneration += 1;
     this.#tearDown();
     this.#bag.clear();
   }
@@ -299,4 +346,20 @@ function sameSourceIds(a: ReadonlyArray<string>, b: ReadonlyArray<string>): bool
     if (a[i] !== b[i]) return false;
   }
   return true;
+}
+
+function disposeFactoryResult(factoryResult: MapFactoryResult): void {
+  try {
+    factoryResult.dispose?.();
+  } catch {
+    // ignore — host-owned teardown.
+  }
+}
+
+function disposeRuntime(runtime: HonuaMapRuntime): void {
+  try {
+    runtime.dispose();
+  } catch {
+    // dispose is best-effort during supersession cleanup.
+  }
 }

--- a/src/operator/controllers/map-workspace.ts
+++ b/src/operator/controllers/map-workspace.ts
@@ -175,6 +175,7 @@ export class MapWorkspaceController {
         try {
           const next = await this.#client.operator.refineMap(intentId, prompt, signal);
           await this.#runtime!.updatePackage(next);
+          this.#syncExplorationContext(next);
           this.#bag.emit({ kind: "package-refined", pkg: next });
           return next;
         } catch (error) {
@@ -225,6 +226,38 @@ export class MapWorkspaceController {
     return this.#runtime;
   }
 
+  /**
+   * `ExplorationContext` exposes immutable `datasetId` / `sourceIds`,
+   * so a refined package that changes either leaves linked views bound
+   * to stale metadata. Rebuild the context (and the primary view
+   * binding) on those transitions; otherwise leave it intact so
+   * subscribers retain their current state.
+   */
+  #syncExplorationContext(pkg: HonuaMapPackage): void {
+    const nextSourceIds = pkg.sourceBindings.map((binding) => binding.sourceId);
+    if (
+      this.#context &&
+      this.#context.datasetId === pkg.mapPackageId &&
+      sameSourceIds(this.#context.sourceIds, nextSourceIds)
+    ) {
+      return;
+    }
+    if (this.#viewHandle) {
+      this.#viewHandle.unbind();
+      this.#viewHandle = undefined;
+    }
+    if (this.#context) {
+      this.#context.dispose();
+      this.#context = undefined;
+    }
+    this.#context = createExplorationContext({
+      datasetId: pkg.mapPackageId,
+      sourceIds: nextSourceIds,
+      preset: this.#preset,
+    });
+    this.#viewHandle = this.#context.bind({ id: MAP_VIEW_BINDING_ID, role: "map" });
+  }
+
   #tearDown(): void {
     if (this.#viewHandle) {
       this.#viewHandle.unbind();
@@ -253,4 +286,12 @@ export class MapWorkspaceController {
       this.#disposeMap = undefined;
     }
   }
+}
+
+function sameSourceIds(a: ReadonlyArray<string>, b: ReadonlyArray<string>): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
 }

--- a/src/operator/controllers/plan-review.ts
+++ b/src/operator/controllers/plan-review.ts
@@ -1,0 +1,151 @@
+/**
+ * `PlanReviewController` — exposes a server-produced plan, lets the
+ * embedder accept or revise it, and emits lifecycle events the workspace
+ * relays to embedders.
+ *
+ * Plan revisions are pass-through to the server; the controller never
+ * mutates plan steps locally.
+ *
+ * @module
+ */
+
+import type { OperatorClient } from "../client.js";
+import { HonuaOperatorPlanError } from "../errors.js";
+import type { OperatorTelemetry } from "../telemetry.js";
+import type {
+  AnalysisPlan,
+  BuilderPlan,
+  DeploymentPlan,
+  OperatorPlan,
+  PlanStep,
+  PublishingPlan,
+} from "../workspace/types.js";
+import { ListenerBag, type Unsubscribe, withTelemetrySpan } from "./base.js";
+
+export type PlanRevisionRequest = {
+  readonly intentId: string;
+  readonly notes?: string;
+};
+
+export type PlanReviewEvent =
+  | { kind: "plan-loaded"; plan: OperatorPlan }
+  | { kind: "plan-accepted"; plan: OperatorPlan }
+  | { kind: "plan-revising"; plan: OperatorPlan }
+  | { kind: "plan-revised"; plan: OperatorPlan }
+  | { kind: "error"; error: HonuaOperatorPlanError };
+
+export type DecorateStep = (step: PlanStep) => PlanStep;
+
+export interface PlanReviewControllerOptions {
+  client: OperatorClient;
+  telemetry?: OperatorTelemetry;
+  /** Pure transformation applied to plan steps before they are emitted. */
+  decorateStep?: DecorateStep;
+}
+
+export class PlanReviewController {
+  readonly #client: OperatorClient;
+  readonly #telemetry: OperatorTelemetry | undefined;
+  readonly #decorateStep: DecorateStep | undefined;
+  readonly #bag = new ListenerBag<PlanReviewEvent>();
+  #plan: OperatorPlan | undefined;
+
+  public constructor(options: PlanReviewControllerOptions) {
+    this.#client = options.client;
+    this.#telemetry = options.telemetry;
+    this.#decorateStep = options.decorateStep;
+  }
+
+  public get plan(): OperatorPlan | undefined {
+    return this.#plan ? this.#decoratedPlan(this.#plan) : undefined;
+  }
+
+  public on(listener: (event: PlanReviewEvent) => void): Unsubscribe {
+    return this.#bag.on(listener);
+  }
+
+  /**
+   * Load the plan attached to an intent. Wraps transport errors in
+   * `HonuaOperatorPlanError` and emits an `error` event.
+   */
+  public async load(intentId: string, signal?: AbortSignal): Promise<OperatorPlan> {
+    try {
+      const plan = await withTelemetrySpan(this.#telemetry, "plan-load", intentId, () =>
+        this.#client.operator.getPlan(intentId, signal),
+      );
+      this.#plan = plan;
+      const decorated = this.#decoratedPlan(plan);
+      this.#bag.emit({ kind: "plan-loaded", plan: decorated });
+      return decorated;
+    } catch (error) {
+      const wrapped =
+        error instanceof HonuaOperatorPlanError
+          ? error
+          : new HonuaOperatorPlanError("plan load failed", { intentId, cause: error });
+      this.#bag.emit({ kind: "error", error: wrapped });
+      throw wrapped;
+    }
+  }
+
+  /**
+   * Accept the loaded plan. The controller does not start execution —
+   * the workspace handles the hand-off to `ExecutionController`.
+   */
+  public accept(): OperatorPlan {
+    if (!this.#plan) {
+      throw new HonuaOperatorPlanError("acceptPlan called before plan load");
+    }
+    const decorated = this.#decoratedPlan(this.#plan);
+    this.#bag.emit({ kind: "plan-accepted", plan: decorated });
+    return decorated;
+  }
+
+  /**
+   * Ask the server for a revised plan. Pass-through wrapper around
+   * `OperatorClient.getPlan` with the intent id; revision payload (notes,
+   * etc.) is server-side. The controller never mutates step shape locally.
+   */
+  public async revise(request: PlanRevisionRequest, signal?: AbortSignal): Promise<OperatorPlan> {
+    if (this.#plan) {
+      this.#bag.emit({ kind: "plan-revising", plan: this.#decoratedPlan(this.#plan) });
+    }
+    try {
+      const next = await withTelemetrySpan(
+        this.#telemetry,
+        "plan-load",
+        request.intentId,
+        () => this.#client.operator.getPlan(request.intentId, signal),
+        { revision: true, notes: request.notes },
+      );
+      this.#plan = next;
+      const decorated = this.#decoratedPlan(next);
+      this.#bag.emit({ kind: "plan-revised", plan: decorated });
+      return decorated;
+    } catch (error) {
+      const wrapped =
+        error instanceof HonuaOperatorPlanError
+          ? error
+          : new HonuaOperatorPlanError("plan revision failed", {
+              intentId: request.intentId,
+              cause: error,
+            });
+      this.#bag.emit({ kind: "error", error: wrapped });
+      throw wrapped;
+    }
+  }
+
+  #decoratedPlan(plan: OperatorPlan): OperatorPlan {
+    if (!this.#decorateStep) return plan;
+    const steps = plan.steps.map((step) => this.#decorateStep!(step));
+    switch (plan.kind) {
+      case "analysis":
+        return { ...plan, steps } satisfies AnalysisPlan;
+      case "publishing":
+        return { ...plan, steps } satisfies PublishingPlan;
+      case "builder":
+        return { ...plan, steps } satisfies BuilderPlan;
+      case "deployment":
+        return { ...plan, steps } satisfies DeploymentPlan;
+    }
+  }
+}

--- a/src/operator/controllers/plan-review.ts
+++ b/src/operator/controllers/plan-review.ts
@@ -101,9 +101,10 @@ export class PlanReviewController {
   }
 
   /**
-   * Ask the server for a revised plan. Pass-through wrapper around
-   * `OperatorClient.getPlan` with the intent id; revision payload (notes,
-   * etc.) is server-side. The controller never mutates step shape locally.
+   * Ask the server for a revised plan. The controller forwards the
+   * embedder's revision notes through `OperatorClient.revisePlan` so
+   * the server can act on them, instead of just observing them in
+   * telemetry. The controller never mutates step shape locally.
    */
   public async revise(request: PlanRevisionRequest, signal?: AbortSignal): Promise<OperatorPlan> {
     if (this.#plan) {
@@ -114,7 +115,7 @@ export class PlanReviewController {
         this.#telemetry,
         "plan-load",
         request.intentId,
-        () => this.#client.operator.getPlan(request.intentId, signal),
+        () => this.#client.operator.revisePlan(request.intentId, request.notes, signal),
         { revision: true, notes: request.notes },
       );
       this.#plan = next;

--- a/src/operator/controllers/plan-review.ts
+++ b/src/operator/controllers/plan-review.ts
@@ -49,6 +49,12 @@ export class PlanReviewController {
   readonly #decorateStep: DecorateStep | undefined;
   readonly #bag = new ListenerBag<PlanReviewEvent>();
   #plan: OperatorPlan | undefined;
+  // Bumped on every load() / revise() entry. When `getPlan` /
+  // `revisePlan` resolves out of order (older intent's plan arrives
+  // after a newer intent has already triggered a load), the older
+  // resolution finds gen !== captured and is dropped without
+  // committing or emitting — accept() never executes a stale plan.
+  #generation = 0;
 
   public constructor(options: PlanReviewControllerOptions) {
     this.#client = options.client;
@@ -69,12 +75,17 @@ export class PlanReviewController {
    * `HonuaOperatorPlanError` and emits an `error` event.
    */
   public async load(intentId: string, signal?: AbortSignal): Promise<OperatorPlan> {
+    const gen = ++this.#generation;
     try {
       const plan = await withTelemetrySpan(this.#telemetry, "plan-load", intentId, () =>
         this.#client.operator.getPlan(intentId, signal),
       );
-      this.#plan = plan;
       const decorated = this.#decoratedPlan(plan);
+      if (gen !== this.#generation) {
+        // Superseded by a newer load()/revise(); don't commit or emit.
+        return decorated;
+      }
+      this.#plan = plan;
       this.#bag.emit({ kind: "plan-loaded", plan: decorated });
       return decorated;
     } catch (error) {
@@ -82,7 +93,9 @@ export class PlanReviewController {
         error instanceof HonuaOperatorPlanError
           ? error
           : new HonuaOperatorPlanError("plan load failed", { intentId, cause: error });
-      this.#bag.emit({ kind: "error", error: wrapped });
+      if (gen === this.#generation) {
+        this.#bag.emit({ kind: "error", error: wrapped });
+      }
       throw wrapped;
     }
   }
@@ -110,6 +123,7 @@ export class PlanReviewController {
     if (this.#plan) {
       this.#bag.emit({ kind: "plan-revising", plan: this.#decoratedPlan(this.#plan) });
     }
+    const gen = ++this.#generation;
     try {
       const next = await withTelemetrySpan(
         this.#telemetry,
@@ -118,8 +132,11 @@ export class PlanReviewController {
         () => this.#client.operator.revisePlan(request.intentId, request.notes, signal),
         { revision: true, notes: request.notes },
       );
-      this.#plan = next;
       const decorated = this.#decoratedPlan(next);
+      if (gen !== this.#generation) {
+        return decorated;
+      }
+      this.#plan = next;
       this.#bag.emit({ kind: "plan-revised", plan: decorated });
       return decorated;
     } catch (error) {
@@ -130,7 +147,9 @@ export class PlanReviewController {
               intentId: request.intentId,
               cause: error,
             });
-      this.#bag.emit({ kind: "error", error: wrapped });
+      if (gen === this.#generation) {
+        this.#bag.emit({ kind: "error", error: wrapped });
+      }
       throw wrapped;
     }
   }

--- a/src/operator/errors.ts
+++ b/src/operator/errors.ts
@@ -1,0 +1,124 @@
+/**
+ * Operator-stage errors. Mirrors the discriminated-union pattern from
+ * `src/core/errors.ts`: each concrete class extends `Error` directly,
+ * the `HonuaOperatorError` type is the union of those classes, and
+ * `isHonuaOperatorError()` is the narrowing type guard.
+ *
+ * The set is independent of `HonuaError` in `src/core/errors.ts`; the
+ * two coexist so that adapter-level failures and operator-level failures
+ * can be discriminated separately.
+ *
+ * @module
+ */
+
+export type HonuaOperatorErrorStage = "intent" | "plan" | "execution" | "approval" | "map" | "app";
+
+/**
+ * Failure-kind taxonomy aligned with `AI_OPERATOR_CONTRACT`. Server
+ * responses with a structured failure kind populate the controller's
+ * error verbatim; unknown values are preserved as strings.
+ */
+export type HonuaOperatorExecutionFailureKind =
+  | "ValidationFailed"
+  | "AuthorizationDenied"
+  | "UnknownDataset"
+  | "UnknownProcess"
+  | "ExecutionFailed"
+  | "Timeout"
+  | "Cancelled"
+  | "OutputBindingFailed"
+  | (string & { readonly __brand?: never });
+
+interface OperatorErrorContext {
+  intentId?: string;
+  planId?: string;
+  executionId?: string;
+  detail?: Record<string, unknown>;
+  cause?: unknown;
+}
+
+abstract class HonuaOperatorErrorBase extends Error {
+  public readonly stage: HonuaOperatorErrorStage;
+  public readonly intentId: string | undefined;
+  public readonly planId: string | undefined;
+  public readonly executionId: string | undefined;
+  public readonly detail: Record<string, unknown> | undefined;
+  public override readonly cause: unknown;
+
+  protected constructor(stage: HonuaOperatorErrorStage, message: string, context: OperatorErrorContext = {}) {
+    super(message);
+    this.stage = stage;
+    this.intentId = context.intentId;
+    this.planId = context.planId;
+    this.executionId = context.executionId;
+    this.detail = context.detail;
+    this.cause = context.cause;
+  }
+}
+
+export class HonuaOperatorIntentError extends HonuaOperatorErrorBase {
+  public constructor(message: string, context: OperatorErrorContext = {}) {
+    super("intent", message, context);
+    this.name = "HonuaOperatorIntentError";
+  }
+}
+
+export class HonuaOperatorPlanError extends HonuaOperatorErrorBase {
+  public constructor(message: string, context: OperatorErrorContext = {}) {
+    super("plan", message, context);
+    this.name = "HonuaOperatorPlanError";
+  }
+}
+
+export class HonuaOperatorExecutionError extends HonuaOperatorErrorBase {
+  public readonly failureKind: HonuaOperatorExecutionFailureKind | undefined;
+
+  public constructor(
+    message: string,
+    context: OperatorErrorContext & { failureKind?: HonuaOperatorExecutionFailureKind } = {},
+  ) {
+    super("execution", message, context);
+    this.name = "HonuaOperatorExecutionError";
+    this.failureKind = context.failureKind;
+  }
+}
+
+export class HonuaOperatorApprovalError extends HonuaOperatorErrorBase {
+  public constructor(message: string, context: OperatorErrorContext = {}) {
+    super("approval", message, context);
+    this.name = "HonuaOperatorApprovalError";
+  }
+}
+
+export class HonuaOperatorMapError extends HonuaOperatorErrorBase {
+  public constructor(message: string, context: OperatorErrorContext = {}) {
+    super("map", message, context);
+    this.name = "HonuaOperatorMapError";
+  }
+}
+
+export class HonuaOperatorAppError extends HonuaOperatorErrorBase {
+  public constructor(message: string, context: OperatorErrorContext = {}) {
+    super("app", message, context);
+    this.name = "HonuaOperatorAppError";
+  }
+}
+
+export type HonuaOperatorError =
+  | HonuaOperatorIntentError
+  | HonuaOperatorPlanError
+  | HonuaOperatorExecutionError
+  | HonuaOperatorApprovalError
+  | HonuaOperatorMapError
+  | HonuaOperatorAppError;
+
+export function isHonuaOperatorError(error: unknown): error is HonuaOperatorError {
+  return (
+    error instanceof HonuaOperatorIntentError ||
+    error instanceof HonuaOperatorPlanError ||
+    error instanceof HonuaOperatorExecutionError ||
+    error instanceof HonuaOperatorApprovalError ||
+    error instanceof HonuaOperatorMapError ||
+    error instanceof HonuaOperatorAppError
+  );
+}

--- a/src/operator/i18n/index.ts
+++ b/src/operator/i18n/index.ts
@@ -1,0 +1,2 @@
+export { DEFAULT_MESSAGES, resolveMessage } from "./messages.js";
+export type { MessageCatalog, MessageId } from "./messages.js";

--- a/src/operator/i18n/messages.ts
+++ b/src/operator/i18n/messages.ts
@@ -52,7 +52,7 @@ export const DEFAULT_MESSAGES: Readonly<Record<MessageId, string>> = {
   "plan.accept": "Run plan",
   "plan.revise": "Revise plan",
   "plan.requiresApproval": "Requires approval",
-  "plan.estimatedCost": "Estimated cost: ${amount}",
+  "plan.estimatedCost": "Estimated cost: {amount}",
   "execution.idle": "Waiting to start.",
   "execution.accepted": "Queued.",
   "execution.running": "Running… {percent}%",

--- a/src/operator/i18n/messages.ts
+++ b/src/operator/i18n/messages.ts
@@ -1,0 +1,92 @@
+/**
+ * `MessageCatalog` — flat `id → string` map with ICU-lite placeholder
+ * substitution (`{name}`). The catalog is the only place reference
+ * components read user-facing strings from; embedders ship alternates
+ * by passing a different catalog.
+ *
+ * @module
+ */
+
+export type MessageId =
+  | "chat.placeholder"
+  | "chat.send"
+  | "chat.empty"
+  | "clarification.title"
+  | "clarification.submit"
+  | "clarification.required"
+  | "plan.title"
+  | "plan.empty"
+  | "plan.accept"
+  | "plan.revise"
+  | "plan.requiresApproval"
+  | "plan.estimatedCost"
+  | "execution.idle"
+  | "execution.accepted"
+  | "execution.running"
+  | "execution.successful"
+  | "execution.failed"
+  | "execution.dismissed"
+  | "map.empty"
+  | "map.refine"
+  | "builder.empty"
+  | "builder.refine"
+  | "approval.notRequired"
+  | "approval.pending"
+  | "approval.granted"
+  | "approval.deferred"
+  | "approval.denied"
+  | "approval.confirm"
+  | "approval.audit";
+
+export type MessageCatalog = Partial<Record<MessageId, string>>;
+
+export const DEFAULT_MESSAGES: Readonly<Record<MessageId, string>> = {
+  "chat.placeholder": "Describe what you'd like to do…",
+  "chat.send": "Send",
+  "chat.empty": "No messages yet.",
+  "clarification.title": "We need a few more details",
+  "clarification.submit": "Continue",
+  "clarification.required": "Required",
+  "plan.title": "Proposed plan",
+  "plan.empty": "No plan loaded.",
+  "plan.accept": "Run plan",
+  "plan.revise": "Revise plan",
+  "plan.requiresApproval": "Requires approval",
+  "plan.estimatedCost": "Estimated cost: ${amount}",
+  "execution.idle": "Waiting to start.",
+  "execution.accepted": "Queued.",
+  "execution.running": "Running… {percent}%",
+  "execution.successful": "Completed.",
+  "execution.failed": "Failed: {message}",
+  "execution.dismissed": "Cancelled.",
+  "map.empty": "No map output yet.",
+  "map.refine": "Refine map",
+  "builder.empty": "No app preview yet.",
+  "builder.refine": "Refine app",
+  "approval.notRequired": "No approval required.",
+  "approval.pending": "Approval pending.",
+  "approval.granted": "Approved.",
+  "approval.deferred": "Approval deferred.",
+  "approval.denied": "Denied: {reason}",
+  "approval.confirm": "Approve",
+  "approval.audit": "Audit",
+};
+
+/**
+ * Resolve a message id to a string with ICU-lite `{placeholder}`
+ * substitution. Falls back to `DEFAULT_MESSAGES` when an id is not
+ * present in the supplied catalog. Unknown placeholders survive
+ * unrendered so missing data is visible rather than silently empty.
+ */
+export function resolveMessage(
+  catalog: MessageCatalog | undefined,
+  id: MessageId,
+  values?: Readonly<Record<string, string | number>>,
+): string {
+  const template = catalog?.[id] ?? DEFAULT_MESSAGES[id];
+  if (!values) return template;
+  return template.replace(/\{(\w+)\}/g, (match, key) => {
+    const v = values[key];
+    return v === undefined ? match : String(v);
+  });
+}

--- a/src/operator/index.ts
+++ b/src/operator/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Operator-native component architecture. Exposes framework-neutral
+ * controllers and workspace orchestration for chat, clarification, plan
+ * review, execution, map/app preview, and approval surfaces.
+ *
+ * @module
+ */
+
+export { OPERATOR_EXECUTION_OUTPUT_KEY } from "./client.js";
+export type { ChatChunk, OperatorClient, OperatorClientApi } from "./client.js";
+
+export {
+  HonuaOperatorApprovalError,
+  HonuaOperatorAppError,
+  HonuaOperatorExecutionError,
+  HonuaOperatorIntentError,
+  HonuaOperatorMapError,
+  HonuaOperatorPlanError,
+  isHonuaOperatorError,
+} from "./errors.js";
+export type {
+  HonuaOperatorError,
+  HonuaOperatorErrorStage,
+  HonuaOperatorExecutionFailureKind,
+} from "./errors.js";
+
+export type {
+  OperatorTelemetry,
+  OperatorTelemetryKind,
+  OperatorTelemetrySpan,
+  OperatorTelemetrySpanResult,
+} from "./telemetry.js";
+
+export * from "./controllers/index.js";
+export * from "./workspace/index.js";
+export * from "./theming/index.js";
+export * from "./i18n/index.js";

--- a/src/operator/telemetry.ts
+++ b/src/operator/telemetry.ts
@@ -1,0 +1,43 @@
+/**
+ * Operator-stage telemetry. Mirrors the before/after/error collector
+ * shape in `HonuaRuntimeTelemetry` (`src/runtime/runtime.ts`) so that an
+ * embedder wiring one observer can feed both surfaces without inventing
+ * a parallel pipeline.
+ *
+ * @module
+ */
+
+export type OperatorTelemetryKind =
+  | "chat-turn"
+  | "intent-draft"
+  | "clarify"
+  | "plan-load"
+  | "plan-accept"
+  | "execution-start"
+  | "execution-terminal"
+  | "map-load"
+  | "map-refine"
+  | "app-load"
+  | "app-refine"
+  | "approval-load"
+  | "approval-confirm"
+  | "approval-audit";
+
+export interface OperatorTelemetrySpan {
+  kind: OperatorTelemetryKind;
+  intentId: string | undefined;
+  startedAt: number;
+  detail?: Record<string, unknown>;
+}
+
+export interface OperatorTelemetrySpanResult extends OperatorTelemetrySpan {
+  finishedAt: number;
+  durationMs: number;
+  error?: unknown;
+}
+
+export interface OperatorTelemetry {
+  before?: (span: OperatorTelemetrySpan) => void;
+  after?: (span: OperatorTelemetrySpanResult) => void;
+  error?: (span: OperatorTelemetrySpanResult) => void;
+}

--- a/src/operator/theming/index.ts
+++ b/src/operator/theming/index.ts
@@ -1,0 +1,8 @@
+export { createThemeProvider } from "./provider.js";
+export type { ThemeProvider, ThemeTargetElement } from "./provider.js";
+export {
+  DEFAULT_OPERATOR_TOKENS,
+  OPERATOR_TOKEN_IDS,
+  tokenIdToCssVariable,
+} from "./tokens.js";
+export type { OperatorThemeTokens, OperatorTokenId } from "./tokens.js";

--- a/src/operator/theming/provider.ts
+++ b/src/operator/theming/provider.ts
@@ -1,0 +1,48 @@
+/**
+ * `ThemeProvider` writes operator tokens onto a host element as CSS
+ * custom properties. The provider is the only place reference components
+ * read tokens from; embedders that want to rebrand swap the provider or
+ * pass overrides instead of forking components.
+ *
+ * @module
+ */
+
+import {
+  DEFAULT_OPERATOR_TOKENS,
+  type OperatorThemeTokens,
+  type OperatorTokenId,
+  tokenIdToCssVariable,
+} from "./tokens.js";
+
+/**
+ * Minimal element duck-type — anything with `style.setProperty` works.
+ * Avoids requiring `HTMLElement` so the provider is testable without a
+ * DOM.
+ */
+export interface ThemeTargetElement {
+  style: { setProperty(name: string, value: string): void };
+}
+
+export interface ThemeProvider {
+  /** Returns the merged tokens, defaults filled in for unspecified ids. */
+  resolved(): Readonly<Record<OperatorTokenId, string | number>>;
+  /** Apply the merged tokens onto a host element as CSS custom properties. */
+  apply(target: ThemeTargetElement): void;
+}
+
+export function createThemeProvider(overrides?: OperatorThemeTokens): ThemeProvider {
+  const merged: Record<OperatorTokenId, string | number> = { ...DEFAULT_OPERATOR_TOKENS };
+  if (overrides) {
+    for (const [id, value] of Object.entries(overrides) as ReadonlyArray<[OperatorTokenId, string | number]>) {
+      if (value !== undefined) merged[id] = value;
+    }
+  }
+  return {
+    resolved: () => merged,
+    apply(target: ThemeTargetElement): void {
+      for (const [id, value] of Object.entries(merged) as ReadonlyArray<[OperatorTokenId, string | number]>) {
+        target.style.setProperty(tokenIdToCssVariable(id), String(value));
+      }
+    },
+  };
+}

--- a/src/operator/theming/tokens.ts
+++ b/src/operator/theming/tokens.ts
@@ -1,0 +1,72 @@
+/**
+ * Operator theming tokens. Flat name-keyed map matching the
+ * `HonuaMapPackageThemeSpec` shape from `src/runtime/map-package.ts` so
+ * one theme can drive both the map runtime and the surrounding operator
+ * components.
+ *
+ * @module
+ */
+
+/**
+ * Canonical token identifiers used by the reference Web Components. New
+ * surfaces add token ids here; reference components MUST reference these
+ * names rather than ad-hoc strings.
+ */
+export const OPERATOR_TOKEN_IDS = [
+  "color.surface",
+  "color.surface-muted",
+  "color.surface-elevated",
+  "color.text",
+  "color.text-muted",
+  "color.accent",
+  "color.danger",
+  "color.warning",
+  "color.success",
+  "color.border",
+  "space.xs",
+  "space.sm",
+  "space.md",
+  "space.lg",
+  "radius.sm",
+  "radius.md",
+  "font.body",
+  "font.mono",
+] as const;
+
+export type OperatorTokenId = (typeof OPERATOR_TOKEN_IDS)[number];
+
+export type OperatorThemeTokens = Partial<Record<OperatorTokenId, string | number>>;
+
+/**
+ * Neutral defaults used by reference components when the embedder has
+ * not supplied a theme.
+ */
+export const DEFAULT_OPERATOR_TOKENS: Readonly<Record<OperatorTokenId, string>> = {
+  "color.surface": "#ffffff",
+  "color.surface-muted": "#f5f5f7",
+  "color.surface-elevated": "#ffffff",
+  "color.text": "#1a1a1a",
+  "color.text-muted": "#5a5a5a",
+  "color.accent": "#1f6feb",
+  "color.danger": "#cf222e",
+  "color.warning": "#9a6700",
+  "color.success": "#1a7f37",
+  "color.border": "#d0d7de",
+  "space.xs": "4px",
+  "space.sm": "8px",
+  "space.md": "16px",
+  "space.lg": "24px",
+  "radius.sm": "4px",
+  "radius.md": "8px",
+  "font.body": "system-ui, -apple-system, Segoe UI, sans-serif",
+  "font.mono": "ui-monospace, SFMono-Regular, monospace",
+};
+
+/**
+ * Convert a token id like `color.accent` to its CSS custom property name
+ * `--operator-color-accent`. Lower-case, dot replaced with hyphen, no
+ * other transforms.
+ */
+export function tokenIdToCssVariable(id: string): string {
+  return `--operator-${id.replace(/\./g, "-")}`;
+}

--- a/src/operator/workspace/events.ts
+++ b/src/operator/workspace/events.ts
@@ -1,0 +1,44 @@
+/**
+ * `WorkspaceEvent` — typed event union the `OperatorWorkspace` emits as
+ * the cross-surface state machine advances. Embedders subscribe via
+ * `OperatorWorkspace.on()` to hook intermediate transitions without
+ * subclassing controllers.
+ *
+ * @module
+ */
+
+import type { HonuaMapPackage } from "../../runtime/index.js";
+import type { HonuaOperatorError } from "../errors.js";
+import type {
+  AnalysisIntent,
+  AnalysisPlan,
+  AppPackage,
+  ApprovalDecision,
+  BuilderIntent,
+  BuilderPlan,
+  ConversationTurn,
+  DeploymentPlan,
+  ExecutionResult,
+  PublishingPlan,
+} from "./types.js";
+
+export type WorkspaceEvent =
+  | { kind: "turn-updated"; turn: ConversationTurn }
+  | { kind: "intent-drafted"; intent: AnalysisIntent | BuilderIntent }
+  | { kind: "clarification-needed"; intent: AnalysisIntent | BuilderIntent }
+  | { kind: "clarification-answered"; intent: AnalysisIntent | BuilderIntent }
+  | { kind: "plan-loaded"; plan: AnalysisPlan | PublishingPlan | BuilderPlan | DeploymentPlan }
+  | { kind: "plan-accepted"; plan: AnalysisPlan | PublishingPlan | BuilderPlan | DeploymentPlan }
+  | { kind: "execution-started"; executionId: string }
+  | { kind: "execution-progress"; executionId: string; percent?: number; message?: string }
+  | { kind: "execution-terminal"; executionId: string; result: ExecutionResult }
+  | { kind: "map-loaded"; pkg: HonuaMapPackage }
+  | { kind: "map-refined"; pkg: HonuaMapPackage }
+  | { kind: "app-loaded"; pkg: AppPackage }
+  | { kind: "app-refined"; pkg: AppPackage }
+  | { kind: "approval-required"; decision: ApprovalDecision }
+  | { kind: "approval-resolved"; decision: ApprovalDecision }
+  | { kind: "error"; error: HonuaOperatorError; recoverable: boolean };
+
+export type WorkspaceEventListener = (event: WorkspaceEvent) => void;
+export type Unsubscribe = () => void;

--- a/src/operator/workspace/events.ts
+++ b/src/operator/workspace/events.ts
@@ -32,6 +32,7 @@ export type WorkspaceEvent =
   | { kind: "execution-started"; executionId: string }
   | { kind: "execution-progress"; executionId: string; percent?: number; message?: string }
   | { kind: "execution-terminal"; executionId: string; result: ExecutionResult }
+  | { kind: "execution-dismissed"; executionId: string }
   | { kind: "map-loaded"; pkg: HonuaMapPackage }
   | { kind: "map-refined"; pkg: HonuaMapPackage }
   | { kind: "app-loaded"; pkg: AppPackage }

--- a/src/operator/workspace/index.ts
+++ b/src/operator/workspace/index.ts
@@ -1,0 +1,32 @@
+export { OperatorWorkspace } from "./workspace.js";
+export type { OperatorWorkspaceOptions } from "./workspace.js";
+export type {
+  Unsubscribe,
+  WorkspaceEvent,
+  WorkspaceEventListener,
+} from "./events.js";
+export type {
+  AnalysisIntent,
+  AnalysisPlan,
+  AppPackage,
+  ApprovalAuditEntry,
+  ApprovalDecision,
+  ApprovalState,
+  ArtifactRef,
+  BuilderIntent,
+  BuilderPlan,
+  ClarificationAnswer,
+  ClarificationField,
+  ClarificationFieldOption,
+  ClarificationFieldType,
+  ConversationTurn,
+  DeploymentPlan,
+  ExecutionResult,
+  ExecutionResultKind,
+  OperatorIntent,
+  OperatorPlan,
+  PlanStep,
+  ProvenanceRecord,
+  PublishingPlan,
+  TurnRole,
+} from "./types.js";

--- a/src/operator/workspace/types.ts
+++ b/src/operator/workspace/types.ts
@@ -1,0 +1,179 @@
+/**
+ * Operator workspace types — typed mirrors of the server-owned operator
+ * domain (intents, plans, execution results, approval decisions). The
+ * shapes follow the mirror-not-duplicate posture used by
+ * `src/runtime/map-package.ts`: structurally typed, additive fields
+ * preserved through round-trip, no parallel validation logic.
+ *
+ * `AppPackage` is forward-declared as a stub until the canonical server
+ * shape is delivered alongside the `HonuaClient` operator transport.
+ *
+ * @module
+ */
+
+import type { HonuaMapPackage } from "../../runtime/index.js";
+
+// ── Conversation ─────────────────────────────────────────────
+
+export type TurnRole = "user" | "agent" | "system";
+
+export interface ConversationTurn {
+  readonly turnId: string;
+  readonly role: TurnRole;
+  readonly content: string;
+  readonly startedAt: number;
+  readonly finishedAt?: number;
+  readonly intentDraft?: AnalysisIntent | BuilderIntent;
+}
+
+// ── Clarification ────────────────────────────────────────────
+
+export type ClarificationFieldType = "text" | "select" | "dataset-ref" | "expression";
+
+export interface ClarificationFieldOption {
+  readonly value: string;
+  readonly label: string;
+}
+
+export interface ClarificationField {
+  readonly id: string;
+  readonly label: string;
+  readonly type: ClarificationFieldType;
+  readonly options?: ReadonlyArray<ClarificationFieldOption>;
+  readonly required: boolean;
+}
+
+export interface ClarificationAnswer {
+  readonly fieldId: string;
+  readonly value: string;
+}
+
+// ── Intents ──────────────────────────────────────────────────
+
+export interface AnalysisIntent {
+  readonly id: string;
+  readonly kind: "analysis";
+  readonly request: string;
+  readonly assumptionPolicy?: "strict" | "permissive";
+  readonly clarifications?: ReadonlyArray<ClarificationField>;
+  readonly [extra: string]: unknown;
+}
+
+export interface BuilderIntent {
+  readonly id: string;
+  readonly kind: "builder";
+  readonly request: string;
+  readonly clarifications?: ReadonlyArray<ClarificationField>;
+  readonly [extra: string]: unknown;
+}
+
+export type OperatorIntent = AnalysisIntent | BuilderIntent;
+
+// ── Plans ────────────────────────────────────────────────────
+
+export interface PlanStep {
+  readonly id: string;
+  readonly kind: string;
+  readonly label: string;
+  readonly inputs?: ReadonlyArray<string>;
+  readonly outputs?: ReadonlyArray<string>;
+  readonly requiresApproval?: boolean;
+  readonly estimatedCostUsd?: number;
+  readonly [extra: string]: unknown;
+}
+
+export interface AnalysisPlan {
+  readonly id: string;
+  readonly intentId: string;
+  readonly kind: "analysis";
+  readonly steps: ReadonlyArray<PlanStep>;
+  readonly [extra: string]: unknown;
+}
+
+export interface PublishingPlan {
+  readonly id: string;
+  readonly intentId: string;
+  readonly kind: "publishing";
+  readonly steps: ReadonlyArray<PlanStep>;
+  readonly [extra: string]: unknown;
+}
+
+export interface BuilderPlan {
+  readonly id: string;
+  readonly intentId: string;
+  readonly kind: "builder";
+  readonly steps: ReadonlyArray<PlanStep>;
+  readonly [extra: string]: unknown;
+}
+
+export interface DeploymentPlan {
+  readonly id: string;
+  readonly intentId: string;
+  readonly kind: "deployment";
+  readonly steps: ReadonlyArray<PlanStep>;
+  readonly [extra: string]: unknown;
+}
+
+export type OperatorPlan = AnalysisPlan | PublishingPlan | BuilderPlan | DeploymentPlan;
+
+// ── Execution ────────────────────────────────────────────────
+
+export interface ArtifactRef {
+  readonly id: string;
+  readonly kind: "map-package" | "app-package" | "file" | "artifact";
+  readonly url?: string;
+  readonly [extra: string]: unknown;
+}
+
+/**
+ * Forward-declared stub. The canonical server shape replaces this when
+ * the `HonuaClient` operator transport ticket lands. Until then in-repo
+ * fixtures drive `BuilderWorkspaceController` and its tests.
+ */
+export interface AppPackage {
+  readonly id: string;
+  readonly version: string;
+  readonly assets: ReadonlyArray<ArtifactRef>;
+  readonly metadata?: unknown;
+  readonly [extra: string]: unknown;
+}
+
+export interface ProvenanceRecord {
+  readonly step: string;
+  readonly tool?: string;
+  readonly startedAt: number;
+  readonly finishedAt?: number;
+  readonly [extra: string]: unknown;
+}
+
+export type ExecutionResultKind = "analysis" | "publishing" | "builder" | "deployment";
+
+export interface ExecutionResult {
+  readonly kind: ExecutionResultKind;
+  readonly summary?: string;
+  readonly mapPackage?: HonuaMapPackage;
+  readonly appPackage?: AppPackage;
+  readonly artifacts?: ReadonlyArray<ArtifactRef>;
+  readonly provenance?: ReadonlyArray<ProvenanceRecord>;
+  readonly [extra: string]: unknown;
+}
+
+// ── Approval ─────────────────────────────────────────────────
+
+export type ApprovalState = "not-required" | "pending" | "granted" | "deferred" | "denied";
+
+export interface ApprovalAuditEntry {
+  readonly at: number;
+  readonly actor: string;
+  readonly action: string;
+  readonly reason?: string;
+}
+
+export interface ApprovalDecision {
+  readonly operationId: string;
+  readonly state: ApprovalState;
+  readonly scope: string;
+  readonly reasons: ReadonlyArray<string>;
+  readonly requiredRoles: ReadonlyArray<string>;
+  readonly audit: ReadonlyArray<ApprovalAuditEntry>;
+}

--- a/src/operator/workspace/types.ts
+++ b/src/operator/workspace/types.ts
@@ -1,9 +1,43 @@
 /**
- * Operator workspace types — typed mirrors of the server-owned operator
- * domain (intents, plans, execution results, approval decisions). The
- * shapes follow the mirror-not-duplicate posture used by
+ * Operator workspace types — UI view models the operator controllers
+ * and reference components consume. They are not the wire DTOs the
+ * server emits; the canonical operator contract
+ * (`honua-server/docs/archive/developer/AI_OPERATOR_CONTRACT.md`,
+ * §AnalysisIntent, §ClarificationRequest, §ClarificationResponse,
+ * §AnalysisPlan, §ExecutionJob) names different fields and uses
+ * different shapes for the same semantic objects.
+ *
+ * The split is deliberate: controllers want form-friendly clarification
+ * fields and a flat plan-step shape that the plan-review UI can
+ * decorate, while the wire contract carries `planId`/`stepId`,
+ * `dependsOn` adjacency, string-keyed `inputs` maps, and reason-coded
+ * clarification questions. The `OperatorClient` implementation is
+ * responsible for the bidirectional adapter at the transport boundary
+ * (HTTP / MCP / gRPC); controllers in this module deliberately know
+ * nothing about the wire framing.
+ *
+ * Adapter mapping responsibilities, by SDK type:
+ *
+ * - {@link ClarificationField} ↔ server `ClarificationQuestion`
+ *   (`id` ↔ `questionId`, `label` ↔ `prompt`, `type` ↔ `kind`).
+ * - {@link ClarificationAnswer} ↔ entries in the server's
+ *   `ClarificationResponse.answers` map (`fieldId` is the
+ *   `questionId`; `value` becomes a single-element string array on the
+ *   wire — multi-select callers send the controller multiple
+ *   `ClarificationAnswer` entries with the same `fieldId`).
+ * - {@link PlanStep} ↔ server `PlanStep` (`id` ↔ `stepId`, `inputs`
+ *   string array ↔ string-keyed `inputs` map, `outputs` string array
+ *   ↔ server `outputs` artifact-kind enum, `dependsOn` is collapsed
+ *   into the steps the controller orders).
+ * - {@link AnalysisPlan} / {@link PublishingPlan} / {@link BuilderPlan} /
+ *   {@link DeploymentPlan} ↔ server `AnalysisPlan` (`id` ↔ `planId`).
+ *   Server-side `warnings[]` is preserved on the open `[extra: string]`
+ *   index signature instead of being modelled at this layer.
+ *
+ * Shapes follow the mirror-not-duplicate posture used by
  * `src/runtime/map-package.ts`: structurally typed, additive fields
- * preserved through round-trip, no parallel validation logic.
+ * preserved through the open `[extra: string]: unknown` index signature,
+ * no parallel validation logic.
  *
  * `AppPackage` is forward-declared as a stub until the canonical server
  * shape is delivered alongside the `HonuaClient` operator transport.

--- a/src/operator/workspace/workspace.ts
+++ b/src/operator/workspace/workspace.ts
@@ -1,0 +1,321 @@
+/**
+ * `OperatorWorkspace` — cross-surface orchestrator. Wires controllers
+ * for chat, clarification, plan review, execution, map and builder
+ * workspaces, and approval into a single typed event stream that
+ * embedders can subscribe to.
+ *
+ * Individual controllers stay independently usable; the workspace is
+ * the orchestrator, not a gatekeeper.
+ *
+ * @module
+ */
+
+import type { LinkedViewPresetName } from "../../exploration/index.js";
+import type { LoadMapPackageOptions } from "../../runtime/index.js";
+import type { OperatorClient } from "../client.js";
+import { ApprovalController } from "../controllers/approval.js";
+import { ListenerBag } from "../controllers/base.js";
+import { BuilderWorkspaceController } from "../controllers/builder-workspace.js";
+import { ChatController } from "../controllers/chat.js";
+import { ClarificationController } from "../controllers/clarification.js";
+import { ExecutionController } from "../controllers/execution.js";
+import { type MapFactory, MapWorkspaceController } from "../controllers/map-workspace.js";
+import { PlanReviewController } from "../controllers/plan-review.js";
+import { HonuaOperatorIntentError, HonuaOperatorPlanError, isHonuaOperatorError } from "../errors.js";
+import type { MessageCatalog } from "../i18n/messages.js";
+import type { OperatorTelemetry } from "../telemetry.js";
+import { type ThemeProvider, createThemeProvider } from "../theming/provider.js";
+import type { OperatorThemeTokens } from "../theming/tokens.js";
+import type { Unsubscribe, WorkspaceEvent } from "./events.js";
+
+export interface OperatorWorkspaceOptions {
+  client: OperatorClient;
+  /** Optional MapLibre map factory; required if the host plans to load map packages. */
+  mapFactory?: MapFactory;
+  /** Map-runtime options for `loadMapPackage`. */
+  mapLoadOptions?: Omit<LoadMapPackageOptions, "telemetry">;
+  /** Linked-view preset for the embedded `ExplorationContext`. Defaults to `"mapDriven"`. */
+  explorationPreset?: LinkedViewPresetName;
+  theme?: ThemeProvider | OperatorThemeTokens;
+  messages?: MessageCatalog;
+  telemetry?: OperatorTelemetry;
+}
+
+export class OperatorWorkspace {
+  public readonly chat: ChatController;
+  public readonly clarification: ClarificationController;
+  public readonly planReview: PlanReviewController;
+  public readonly execution: ExecutionController;
+  public readonly map: MapWorkspaceController | undefined;
+  public readonly builder: BuilderWorkspaceController;
+  public readonly approval: ApprovalController;
+  public readonly theme: ThemeProvider;
+  public readonly messages: MessageCatalog | undefined;
+
+  readonly #telemetry: OperatorTelemetry | undefined;
+  readonly #bag = new ListenerBag<WorkspaceEvent>();
+  readonly #unsubscribers: Array<() => void> = [];
+  #activeIntentId: string | undefined;
+  #activeOperationId: string | undefined;
+
+  public constructor(options: OperatorWorkspaceOptions) {
+    const { client, telemetry } = options;
+    this.#telemetry = telemetry;
+    this.theme =
+      options.theme && typeof (options.theme as ThemeProvider).apply === "function"
+        ? (options.theme as ThemeProvider)
+        : createThemeProvider(options.theme as OperatorThemeTokens | undefined);
+    this.messages = options.messages;
+
+    this.chat = new ChatController({ client, telemetry });
+    this.clarification = new ClarificationController({ client, telemetry });
+    this.planReview = new PlanReviewController({ client, telemetry });
+    this.execution = new ExecutionController({ client, telemetry });
+    this.builder = new BuilderWorkspaceController({ client, telemetry });
+    this.approval = new ApprovalController({ client, telemetry });
+    this.map = options.mapFactory
+      ? new MapWorkspaceController({
+          client,
+          mapFactory: options.mapFactory,
+          explorationPreset: options.explorationPreset,
+          telemetry,
+          ...(options.mapLoadOptions ? { loadOptions: options.mapLoadOptions } : {}),
+        })
+      : undefined;
+
+    this.#wireChat();
+    this.#wireClarification();
+    this.#wirePlanReview();
+    this.#wireExecution();
+    this.#wireMap();
+    this.#wireBuilder();
+    this.#wireApproval();
+  }
+
+  public on(listener: (event: WorkspaceEvent) => void): Unsubscribe {
+    return this.#bag.on(listener);
+  }
+
+  public dispose(): void {
+    for (const off of this.#unsubscribers.splice(0)) off();
+    this.execution.dispose();
+    this.map?.dispose();
+    this.builder.dispose();
+    this.#bag.clear();
+  }
+
+  // ── Wiring ──────────────────────────────────────────────────
+
+  #wireChat(): void {
+    this.#unsubscribers.push(
+      this.chat.on((event) => {
+        switch (event.kind) {
+          case "turn-updated":
+            this.#bag.emit({ kind: "turn-updated", turn: event.turn });
+            break;
+          case "intent-drafted":
+            this.#activeIntentId = event.intent.id;
+            this.map?.bindIntent(event.intent.id);
+            this.builder.bindIntent(event.intent.id);
+            this.#bag.emit({ kind: "intent-drafted", intent: event.intent });
+            if (event.intent.clarifications && event.intent.clarifications.length > 0) {
+              this.clarification.load(event.intent);
+              this.#bag.emit({ kind: "clarification-needed", intent: event.intent });
+            }
+            break;
+          case "error":
+            this.#emitError(event.error);
+            break;
+        }
+      }),
+    );
+  }
+
+  #wireClarification(): void {
+    this.#unsubscribers.push(
+      this.clarification.on((event) => {
+        switch (event.kind) {
+          case "submitted":
+            this.#activeIntentId = event.intent.id;
+            this.map?.bindIntent(event.intent.id);
+            this.builder.bindIntent(event.intent.id);
+            this.#bag.emit({ kind: "clarification-answered", intent: event.intent });
+            if (event.intent.clarifications && event.intent.clarifications.length > 0) {
+              this.#bag.emit({ kind: "clarification-needed", intent: event.intent });
+            }
+            break;
+          case "error":
+            this.#emitError(event.error);
+            break;
+          case "loaded":
+          case "answer-changed":
+            // Intermediate signals — embedder reads through controller.
+            break;
+        }
+      }),
+    );
+  }
+
+  #wirePlanReview(): void {
+    this.#unsubscribers.push(
+      this.planReview.on((event) => {
+        switch (event.kind) {
+          case "plan-loaded":
+          case "plan-revised":
+            this.#bag.emit({ kind: "plan-loaded", plan: event.plan });
+            break;
+          case "plan-accepted":
+            this.#bag.emit({ kind: "plan-accepted", plan: event.plan });
+            break;
+          case "plan-revising":
+            // Intermediate; embedder watches the controller event stream.
+            break;
+          case "error":
+            this.#emitError(event.error);
+            break;
+        }
+      }),
+    );
+  }
+
+  #wireExecution(): void {
+    this.#unsubscribers.push(
+      this.execution.on((event) => {
+        switch (event.kind) {
+          case "started":
+            this.#activeOperationId = event.executionId;
+            this.#bag.emit({ kind: "execution-started", executionId: event.executionId });
+            break;
+          case "progress":
+            this.#bag.emit({
+              kind: "execution-progress",
+              executionId: event.executionId,
+              ...(event.progress.percent !== undefined ? { percent: event.progress.percent } : {}),
+              ...(event.progress.message !== undefined ? { message: event.progress.message } : {}),
+            });
+            break;
+          case "successful": {
+            this.#bag.emit({ kind: "execution-terminal", executionId: event.executionId, result: event.result });
+            const { result } = event;
+            if (result.mapPackage && this.map) {
+              void this.map.loadPackage(result.mapPackage).catch((error: unknown) => {
+                if (isHonuaOperatorError(error)) this.#emitError(error);
+              });
+            }
+            if (result.appPackage) {
+              void this.builder.loadPackage(result.appPackage).catch((error: unknown) => {
+                if (isHonuaOperatorError(error)) this.#emitError(error);
+              });
+              if (result.mapPackage) this.builder.bindMapPackage(result.mapPackage);
+            }
+            break;
+          }
+          case "failed":
+            this.#emitError(event.error);
+            break;
+          case "dismissed":
+            // Surfaced through controller event stream; workspace stays
+            // silent because `execution-terminal` already fired with the
+            // result in flight when dismissed mid-run.
+            break;
+        }
+      }),
+    );
+  }
+
+  #wireMap(): void {
+    if (!this.map) return;
+    this.#unsubscribers.push(
+      this.map.on((event) => {
+        switch (event.kind) {
+          case "package-loaded":
+            this.#bag.emit({ kind: "map-loaded", pkg: event.pkg });
+            break;
+          case "package-refined":
+            this.#bag.emit({ kind: "map-refined", pkg: event.pkg });
+            break;
+          case "error":
+            this.#emitError(event.error);
+            break;
+          case "package-disposed":
+            break;
+        }
+      }),
+    );
+  }
+
+  #wireBuilder(): void {
+    this.#unsubscribers.push(
+      this.builder.on((event) => {
+        switch (event.kind) {
+          case "package-loaded":
+            this.#bag.emit({ kind: "app-loaded", pkg: event.pkg });
+            break;
+          case "package-refined":
+            this.#bag.emit({ kind: "app-refined", pkg: event.pkg });
+            break;
+          case "map-bound":
+            // Internal hand-off; not a top-level workspace event.
+            break;
+          case "error":
+            this.#emitError(event.error);
+            break;
+        }
+      }),
+    );
+  }
+
+  #wireApproval(): void {
+    this.#unsubscribers.push(
+      this.approval.on((event) => {
+        switch (event.kind) {
+          case "loaded":
+            if (event.decision.state === "pending") {
+              this.#bag.emit({ kind: "approval-required", decision: event.decision });
+            } else {
+              this.#bag.emit({ kind: "approval-resolved", decision: event.decision });
+            }
+            break;
+          case "confirmed":
+            this.#bag.emit({ kind: "approval-resolved", decision: event.decision });
+            break;
+          case "audit":
+            // Audit fan-out happens through telemetry.
+            break;
+          case "error":
+            this.#emitError(event.error);
+            break;
+        }
+      }),
+    );
+  }
+
+  #emitError(error: unknown): void {
+    if (isHonuaOperatorError(error)) {
+      this.#bag.emit({ kind: "error", error, recoverable: this.#isRecoverable(error) });
+      return;
+    }
+    // Defensive: anything that is not a known operator error gets
+    // wrapped as an intent-stage error so embedders never see a raw
+    // `unknown` on the workspace event stream.
+    const wrapped = new HonuaOperatorIntentError("workspace observed an unrecognized error", { cause: error });
+    this.#bag.emit({ kind: "error", error: wrapped, recoverable: false });
+  }
+
+  #isRecoverable(error: unknown): boolean {
+    if (error instanceof HonuaOperatorIntentError) return true;
+    if (error instanceof HonuaOperatorPlanError) return true;
+    return false;
+  }
+
+  /** Read-only accessor used by host code that needs the active context. */
+  public get activeIntentId(): string | undefined {
+    return this.#activeIntentId;
+  }
+
+  public get activeOperationId(): string | undefined {
+    return this.#activeOperationId;
+  }
+}
+
+export type { Unsubscribe, WorkspaceEvent } from "./events.js";

--- a/src/operator/workspace/workspace.ts
+++ b/src/operator/workspace/workspace.ts
@@ -27,6 +27,7 @@ import type { OperatorTelemetry } from "../telemetry.js";
 import { type ThemeProvider, createThemeProvider } from "../theming/provider.js";
 import type { OperatorThemeTokens } from "../theming/tokens.js";
 import type { Unsubscribe, WorkspaceEvent } from "./events.js";
+import type { OperatorPlan } from "./types.js";
 
 export interface OperatorWorkspaceOptions {
   client: OperatorClient;
@@ -121,6 +122,8 @@ export class OperatorWorkspace {
             if (event.intent.clarifications && event.intent.clarifications.length > 0) {
               this.clarification.load(event.intent);
               this.#bag.emit({ kind: "clarification-needed", intent: event.intent });
+            } else {
+              this.#advanceToPlan(event.intent.id);
             }
             break;
           case "error":
@@ -142,6 +145,8 @@ export class OperatorWorkspace {
             this.#bag.emit({ kind: "clarification-answered", intent: event.intent });
             if (event.intent.clarifications && event.intent.clarifications.length > 0) {
               this.#bag.emit({ kind: "clarification-needed", intent: event.intent });
+            } else {
+              this.#advanceToPlan(event.intent.id);
             }
             break;
           case "error":
@@ -166,6 +171,7 @@ export class OperatorWorkspace {
             break;
           case "plan-accepted":
             this.#bag.emit({ kind: "plan-accepted", plan: event.plan });
+            this.#advanceToExecution(event.plan);
             break;
           case "plan-revising":
             // Intermediate; embedder watches the controller event stream.
@@ -216,9 +222,27 @@ export class OperatorWorkspace {
           case "dismissed":
             this.#bag.emit({ kind: "execution-dismissed", executionId: event.executionId });
             break;
+          case "error":
+            this.#emitError(event.error);
+            break;
         }
       }),
     );
+  }
+
+  // Cross-surface hand-offs. The workspace orchestrates the documented
+  // state machine — chat/clarification → plan-load → execution-start —
+  // so embedders observe a single event stream rather than wiring each
+  // controller transition by hand. Async failures surface through the
+  // controllers' own `error` events, which `#wirePlanReview` /
+  // `#wireExecution` route to `#emitError`; the trailing `.catch` here
+  // only suppresses the unhandled-rejection warning.
+  #advanceToPlan(intentId: string): void {
+    void this.planReview.load(intentId).catch(() => {});
+  }
+
+  #advanceToExecution(plan: OperatorPlan): void {
+    void this.execution.start(plan).catch(() => {});
   }
 
   #wireMap(): void {

--- a/src/operator/workspace/workspace.ts
+++ b/src/operator/workspace/workspace.ts
@@ -319,6 +319,15 @@ export class OperatorWorkspace {
       this.approval.on((event) => {
         switch (event.kind) {
           case "loaded":
+            // Defence-in-depth: ApprovalController already drops stale
+            // resolutions, but a host that drives approval.load
+            // directly could still queue a decision whose operation is
+            // no longer active. The filter only fires when an active
+            // operation is set, so hosts exercising approval without
+            // an execution still see the events.
+            if (this.#activeOperationId !== undefined && event.decision.operationId !== this.#activeOperationId) {
+              break;
+            }
             if (event.decision.state === "pending") {
               this.#bag.emit({ kind: "approval-required", decision: event.decision });
             } else {
@@ -326,6 +335,9 @@ export class OperatorWorkspace {
             }
             break;
           case "confirmed":
+            if (this.#activeOperationId !== undefined && event.decision.operationId !== this.#activeOperationId) {
+              break;
+            }
             this.#bag.emit({ kind: "approval-resolved", decision: event.decision });
             break;
           case "audit":

--- a/src/operator/workspace/workspace.ts
+++ b/src/operator/workspace/workspace.ts
@@ -167,9 +167,22 @@ export class OperatorWorkspace {
         switch (event.kind) {
           case "plan-loaded":
           case "plan-revised":
+            // Defence-in-depth: PlanReviewController already drops
+            // stale resolutions via its generation token, but a host
+            // that drives planReview.load directly could still queue a
+            // plan whose intent is no longer the active one. The
+            // filter only fires when an active intent is set; hosts
+            // that exercise plan-review without going through the
+            // chat/clarification flow still see the events.
+            if (this.#activeIntentId !== undefined && event.plan.intentId !== this.#activeIntentId) {
+              break;
+            }
             this.#bag.emit({ kind: "plan-loaded", plan: event.plan });
             break;
           case "plan-accepted":
+            if (this.#activeIntentId !== undefined && event.plan.intentId !== this.#activeIntentId) {
+              break;
+            }
             this.#bag.emit({ kind: "plan-accepted", plan: event.plan });
             this.#advanceToExecution(event.plan);
             break;
@@ -201,19 +214,29 @@ export class OperatorWorkspace {
             });
             break;
           case "successful": {
-            this.#bag.emit({ kind: "execution-terminal", executionId: event.executionId, result: event.result });
+            // Bind the result load to the executionId that produced
+            // it. If a newer execution takes ownership before this
+            // load finishes, the .catch suppresses the stale error and
+            // the controller-level generation token prevents the stale
+            // package from clobbering newer state.
+            const executionId = event.executionId;
+            if (executionId !== this.#activeOperationId) break;
+            this.#bag.emit({ kind: "execution-terminal", executionId, result: event.result });
             const { result } = event;
             if (result.mapPackage && this.map) {
               // Map / app loadPackage always rejects with a typed
               // operator error after wrapping; route any rejection
               // through `#emitError` (which wraps unknowns) so a host
-              // factory failure cannot disappear from the event stream.
+              // factory failure cannot disappear from the event stream
+              // — but only when the execution is still active.
               void this.map.loadPackage(result.mapPackage).catch((error: unknown) => {
+                if (executionId !== this.#activeOperationId) return;
                 this.#emitError(error);
               });
             }
             if (result.appPackage) {
               void this.builder.loadPackage(result.appPackage).catch((error: unknown) => {
+                if (executionId !== this.#activeOperationId) return;
                 this.#emitError(error);
               });
               if (result.mapPackage) this.builder.bindMapPackage(result.mapPackage);

--- a/src/operator/workspace/workspace.ts
+++ b/src/operator/workspace/workspace.ts
@@ -214,9 +214,7 @@ export class OperatorWorkspace {
             this.#emitError(event.error);
             break;
           case "dismissed":
-            // Surfaced through controller event stream; workspace stays
-            // silent because `execution-terminal` already fired with the
-            // result in flight when dismissed mid-run.
+            this.#bag.emit({ kind: "execution-dismissed", executionId: event.executionId });
             break;
         }
       }),

--- a/src/operator/workspace/workspace.ts
+++ b/src/operator/workspace/workspace.ts
@@ -204,13 +204,17 @@ export class OperatorWorkspace {
             this.#bag.emit({ kind: "execution-terminal", executionId: event.executionId, result: event.result });
             const { result } = event;
             if (result.mapPackage && this.map) {
+              // Map / app loadPackage always rejects with a typed
+              // operator error after wrapping; route any rejection
+              // through `#emitError` (which wraps unknowns) so a host
+              // factory failure cannot disappear from the event stream.
               void this.map.loadPackage(result.mapPackage).catch((error: unknown) => {
-                if (isHonuaOperatorError(error)) this.#emitError(error);
+                this.#emitError(error);
               });
             }
             if (result.appPackage) {
               void this.builder.loadPackage(result.appPackage).catch((error: unknown) => {
-                if (isHonuaOperatorError(error)) this.#emitError(error);
+                this.#emitError(error);
               });
               if (result.mapPackage) this.builder.bindMapPackage(result.mapPackage);
             }

--- a/src/operator/workspace/workspace.ts
+++ b/src/operator/workspace/workspace.ts
@@ -98,6 +98,11 @@ export class OperatorWorkspace {
   }
 
   public dispose(): void {
+    // Abort any in-flight chat stream first so its for-await loop
+    // exits before we tear down listeners. Without this a slow chat
+    // network request could keep mutating chat state after the
+    // workspace has been disposed.
+    this.chat.abort();
     for (const off of this.#unsubscribers.splice(0)) off();
     this.execution.dispose();
     this.map?.dispose();

--- a/test/operator/operator-workspace.test.ts
+++ b/test/operator/operator-workspace.test.ts
@@ -231,6 +231,9 @@ function makeOperatorClient(): OperatorClient {
       async getPlan(intentId) {
         return makePlan(intentId);
       },
+      async revisePlan(intentId) {
+        return makePlan(intentId);
+      },
       async submitPlan() {
         return new FakeJobRun(result);
       },
@@ -313,6 +316,9 @@ function makeDismissingClient(): OperatorClient {
         return intent;
       },
       async getPlan(intentId) {
+        return makePlan(intentId);
+      },
+      async revisePlan(intentId) {
         return makePlan(intentId);
       },
       async submitPlan() {
@@ -485,6 +491,181 @@ describe("OperatorWorkspace", () => {
 
     workspace.dispose();
   });
+
+  it("forwards plan revision notes through OperatorClient.revisePlan", async () => {
+    const captured: Array<{ intentId: string; notes: string | undefined }> = [];
+    const client: OperatorClient = {
+      operator: {
+        async *chat(): AsyncIterable<ChatChunk> {
+          yield { turnId: "agent-1", delta: "ok", done: true };
+        },
+        async clarify() {
+          return makeIntent(false);
+        },
+        async getPlan(intentId) {
+          return makePlan(intentId);
+        },
+        async revisePlan(intentId, notes) {
+          captured.push({ intentId, notes });
+          return { ...makePlan(intentId), id: "plan-revised" };
+        },
+        async submitPlan() {
+          return new FakeJobRun({ kind: "analysis" });
+        },
+        async refineMap() {
+          return makeMapPackage();
+        },
+        async refineApp() {
+          return makeAppPackage();
+        },
+        async getApproval() {
+          return makeDecision("pending");
+        },
+        async confirmApproval() {
+          return makeDecision("granted");
+        },
+      },
+    };
+    const workspace = new OperatorWorkspace({ client });
+
+    await workspace.planReview.load("intent-rev");
+    await workspace.planReview.revise({ intentId: "intent-rev", notes: "use vector tiles" });
+
+    expect(captured).toEqual([{ intentId: "intent-rev", notes: "use vector tiles" }]);
+    expect(workspace.planReview.plan?.id).toBe("plan-revised");
+
+    workspace.dispose();
+  });
+
+  it("surfaces map factory failures as HonuaOperatorMapError on the workspace error stream", async () => {
+    const factoryFailure = new Error("WebGL unavailable");
+    const events: WorkspaceEvent[] = [];
+    const workspace = new OperatorWorkspace({
+      client: makeOperatorClient(),
+      mapFactory: () => {
+        throw factoryFailure;
+      },
+      mapLoadOptions: {
+        client: new HonuaClient({
+          baseUrl: "https://honua.example.test",
+          fetchFn: async () => new Response("not used", { status: 200 }),
+        }),
+        skipCompatibilityCheck: true,
+      },
+    });
+    workspace.on((event) => events.push(event));
+
+    workspace.map?.bindIntent("intent-factory");
+    await expect(workspace.map!.loadPackage(makeMapPackage())).rejects.toMatchObject({
+      name: "HonuaOperatorMapError",
+      cause: factoryFailure,
+    });
+
+    workspace.dispose();
+  });
+
+  it("propagates host map factory failures through the workspace event stream when execution loads a map", async () => {
+    const factoryFailure = new Error("factory boom");
+    const events: WorkspaceEvent[] = [];
+    const workspace = new OperatorWorkspace({
+      client: makeOperatorClient(),
+      mapFactory: () => {
+        throw factoryFailure;
+      },
+      mapLoadOptions: {
+        client: new HonuaClient({
+          baseUrl: "https://honua.example.test",
+          fetchFn: async () => new Response("not used", { status: 200 }),
+        }),
+        skipCompatibilityCheck: true,
+      },
+    });
+    workspace.on((event) => events.push(event));
+
+    await workspace.chat.send("draft");
+    workspace.clarification.setAnswer("area", "Honolulu");
+    await workspace.clarification.submit();
+    await waitForEvent(events, "plan-loaded");
+    workspace.planReview.accept();
+    await waitForEvent(events, "execution-terminal");
+    await waitForEvent(events, "error");
+
+    const errorEvent = events.find((event) => event.kind === "error");
+    if (errorEvent?.kind !== "error") throw new Error("expected error event");
+    expect(errorEvent.error.name).toBe("HonuaOperatorMapError");
+    expect(errorEvent.error.cause).toBe(factoryFailure);
+
+    workspace.dispose();
+  });
+
+  it("does not let an in-flight chat send overwrite a newer send's intent", async () => {
+    let resolveSlow!: () => void;
+    const slowGate = new Promise<void>((resolve) => {
+      resolveSlow = resolve;
+    });
+    const slowIntent: AnalysisIntent = { ...makeIntent(false), id: "intent-slow" };
+    const fastIntent: AnalysisIntent = { ...makeIntent(false), id: "intent-fast" };
+    let sendIndex = 0;
+
+    const client: OperatorClient = {
+      operator: {
+        async *chat(): AsyncIterable<ChatChunk> {
+          sendIndex += 1;
+          const ownIndex = sendIndex;
+          if (ownIndex === 1) {
+            await slowGate;
+            yield { turnId: "agent-slow", delta: "slow", done: true, intentDraft: slowIntent };
+          } else {
+            yield { turnId: "agent-fast", delta: "fast", done: true, intentDraft: fastIntent };
+          }
+        },
+        async clarify() {
+          return fastIntent;
+        },
+        async getPlan(intentId) {
+          return makePlan(intentId);
+        },
+        async revisePlan(intentId) {
+          return makePlan(intentId);
+        },
+        async submitPlan() {
+          return new FakeJobRun({ kind: "analysis" });
+        },
+        async refineMap() {
+          return makeMapPackage();
+        },
+        async refineApp() {
+          return makeAppPackage();
+        },
+        async getApproval() {
+          return makeDecision("pending");
+        },
+        async confirmApproval() {
+          return makeDecision("granted");
+        },
+      },
+    };
+
+    const events: WorkspaceEvent[] = [];
+    const workspace = new OperatorWorkspace({ client });
+    workspace.on((event) => events.push(event));
+
+    const slow = workspace.chat.send("first").catch(() => undefined);
+    const fast = workspace.chat.send("second");
+
+    await fast;
+    resolveSlow();
+    await slow;
+    await flushMicrotasks();
+
+    const intentEvents = events.filter((event) => event.kind === "intent-drafted");
+    expect(intentEvents).toHaveLength(1);
+    if (intentEvents[0]?.kind !== "intent-drafted") throw new Error("expected intent-drafted");
+    expect(intentEvents[0].intent.id).toBe("intent-fast");
+    expect(workspace.activeIntentId).toBe("intent-fast");
+
+    workspace.dispose();
+  });
 });
 
 class PassiveJobRun implements IJobRun<ExecutionResult> {
@@ -545,6 +726,9 @@ function makeClientWithRun(run: IJobRun<ExecutionResult>): OperatorClient {
       async getPlan(intentId) {
         return makePlan(intentId);
       },
+      async revisePlan(intentId) {
+        return makePlan(intentId);
+      },
       async submitPlan() {
         return run;
       },
@@ -576,6 +760,9 @@ function makeFailingSubmitClient(failure: Error): OperatorClient {
       async getPlan(intentId) {
         return makePlan(intentId);
       },
+      async revisePlan(intentId) {
+        return makePlan(intentId);
+      },
       async submitPlan() {
         throw failure;
       },
@@ -605,6 +792,9 @@ function makeRefiningClient(refined: HonuaMapPackage): OperatorClient {
         return makeIntent(false);
       },
       async getPlan(intentId) {
+        return makePlan(intentId);
+      },
+      async revisePlan(intentId) {
         return makePlan(intentId);
       },
       async submitPlan() {

--- a/test/operator/operator-workspace.test.ts
+++ b/test/operator/operator-workspace.test.ts
@@ -254,6 +254,73 @@ async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
 }
 
+class DismissingJobRun implements IJobRun<ExecutionResult> {
+  public readonly id = "op-dismiss";
+  public readonly type = "operator-plan";
+  public status: JobStatus = "accepted";
+  public progress: JobProgress | undefined;
+
+  public async poll(): Promise<JobSnapshot<ExecutionResult>> {
+    return { status: this.status, progress: this.progress };
+  }
+
+  public watch(listener: JobSnapshotListener<ExecutionResult>): () => void {
+    let active = true;
+    queueMicrotask(() => {
+      if (!active) return;
+      this.status = "running";
+      listener({ status: this.status });
+      if (!active) return;
+      this.status = "dismissed";
+      listener({ status: this.status });
+    });
+    return () => {
+      active = false;
+    };
+  }
+
+  public async results(): Promise<{ outputs: Record<string, ExecutionResult> }> {
+    return { outputs: {} };
+  }
+
+  public async cancel(): Promise<JobStatus> {
+    this.status = "dismissed";
+    return this.status;
+  }
+}
+
+function makeDismissingClient(): OperatorClient {
+  const intent = makeIntent(false);
+  return {
+    operator: {
+      async *chat(): AsyncIterable<ChatChunk> {
+        yield { turnId: "agent-1", delta: "ok", done: true, intentDraft: intent };
+      },
+      async clarify() {
+        return intent;
+      },
+      async getPlan(intentId) {
+        return makePlan(intentId);
+      },
+      async submitPlan() {
+        return new DismissingJobRun();
+      },
+      async refineMap() {
+        return makeMapPackage();
+      },
+      async refineApp() {
+        return makeAppPackage();
+      },
+      async getApproval() {
+        return makeDecision("pending");
+      },
+      async confirmApproval() {
+        return makeDecision("granted");
+      },
+    },
+  };
+}
+
 describe("OperatorWorkspace", () => {
   it("assembles the operator flow from composable controllers and package runtime primitives", async () => {
     const map = makeMockMap();
@@ -306,6 +373,23 @@ describe("OperatorWorkspace", () => {
         "approval-resolved",
       ]),
     );
+
+    workspace.dispose();
+  });
+
+  it("emits execution-dismissed on the workspace event stream when a run is cancelled", async () => {
+    const events: WorkspaceEvent[] = [];
+    const workspace = new OperatorWorkspace({ client: makeDismissingClient() });
+    workspace.on((event) => events.push(event));
+
+    const plan = makePlan("intent-2");
+    await workspace.execution.start(plan);
+    await flushMicrotasks();
+
+    const dismissed = events.find((event) => event.kind === "execution-dismissed");
+    expect(dismissed).toBeDefined();
+    expect(dismissed?.kind === "execution-dismissed" && dismissed.executionId).toBe("op-dismiss");
+    expect(events.some((event) => event.kind === "execution-terminal")).toBe(false);
 
     workspace.dispose();
   });

--- a/test/operator/operator-workspace.test.ts
+++ b/test/operator/operator-workspace.test.ts
@@ -666,6 +666,277 @@ describe("OperatorWorkspace", () => {
 
     workspace.dispose();
   });
+
+  it("does not let a slow clarification submit revive a superseded intent", async () => {
+    let releaseSlow!: (intent: AnalysisIntent) => void;
+    const slowClarify = new Promise<AnalysisIntent>((resolve) => {
+      releaseSlow = resolve;
+    });
+    const intentA: AnalysisIntent = {
+      id: "intent-A",
+      kind: "analysis",
+      request: "first",
+      clarifications: [{ id: "area", label: "Area", type: "text", required: true }],
+    };
+    const intentB: AnalysisIntent = {
+      id: "intent-B",
+      kind: "analysis",
+      request: "second",
+      clarifications: [],
+    };
+    const revivedA: AnalysisIntent = { ...intentA, clarifications: [] };
+
+    const client: OperatorClient = {
+      operator: {
+        async *chat(): AsyncIterable<ChatChunk> {
+          yield { turnId: "agent-1", delta: "ok", done: true };
+        },
+        async clarify() {
+          return slowClarify;
+        },
+        async getPlan(intentId) {
+          return makePlan(intentId);
+        },
+        async revisePlan(intentId) {
+          return makePlan(intentId);
+        },
+        async submitPlan() {
+          return new FakeJobRun({ kind: "analysis" });
+        },
+        async refineMap() {
+          return makeMapPackage();
+        },
+        async refineApp() {
+          return makeAppPackage();
+        },
+        async getApproval() {
+          return makeDecision("pending");
+        },
+        async confirmApproval() {
+          return makeDecision("granted");
+        },
+      },
+    };
+
+    const events: WorkspaceEvent[] = [];
+    const workspace = new OperatorWorkspace({ client });
+    workspace.on((event) => events.push(event));
+
+    workspace.clarification.load(intentA);
+    workspace.clarification.setAnswer("area", "Honolulu");
+    const submission = workspace.clarification.submit();
+    workspace.clarification.load(intentB);
+    releaseSlow(revivedA);
+    await submission;
+    await flushMicrotasks();
+
+    expect(workspace.clarification.state.intent?.id).toBe("intent-B");
+    expect(events.some((event) => event.kind === "clarification-answered")).toBe(false);
+
+    workspace.dispose();
+  });
+
+  it("drops out-of-order plan loads so accept executes the latest intent's plan", async () => {
+    const planA: AnalysisPlan = { ...makePlan("intent-A"), id: "plan-A" };
+    const planB: AnalysisPlan = { ...makePlan("intent-B"), id: "plan-B" };
+    let releaseA!: () => void;
+    const aGate = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+
+    const client: OperatorClient = {
+      operator: {
+        async *chat(): AsyncIterable<ChatChunk> {
+          yield { turnId: "agent-1", delta: "ok", done: true };
+        },
+        async clarify() {
+          return makeIntent(false);
+        },
+        async getPlan(intentId) {
+          if (intentId === "intent-A") {
+            await aGate;
+            return planA;
+          }
+          return planB;
+        },
+        async revisePlan(intentId) {
+          return makePlan(intentId);
+        },
+        async submitPlan() {
+          return new FakeJobRun({ kind: "analysis" });
+        },
+        async refineMap() {
+          return makeMapPackage();
+        },
+        async refineApp() {
+          return makeAppPackage();
+        },
+        async getApproval() {
+          return makeDecision("pending");
+        },
+        async confirmApproval() {
+          return makeDecision("granted");
+        },
+      },
+    };
+
+    const events: WorkspaceEvent[] = [];
+    const workspace = new OperatorWorkspace({ client });
+    workspace.on((event) => events.push(event));
+
+    const slowLoad = workspace.planReview.load("intent-A").catch(() => undefined);
+    const fastLoad = workspace.planReview.load("intent-B");
+    const fastResult = await fastLoad;
+    expect(fastResult.id).toBe("plan-B");
+    expect(workspace.planReview.plan?.id).toBe("plan-B");
+
+    releaseA();
+    await slowLoad;
+    await flushMicrotasks();
+
+    expect(workspace.planReview.plan?.id).toBe("plan-B");
+    const planLoadedEvents = events.filter((event) => event.kind === "plan-loaded");
+    expect(planLoadedEvents).toHaveLength(1);
+    if (planLoadedEvents[0]?.kind !== "plan-loaded") throw new Error("expected plan-loaded");
+    expect(planLoadedEvents[0].plan.id).toBe("plan-B");
+
+    workspace.dispose();
+  });
+
+  it("cancels an older submitPlan that resolves after a newer start has taken ownership", async () => {
+    let releaseSlow!: (run: IJobRun<ExecutionResult>) => void;
+    const slowSubmit = new Promise<IJobRun<ExecutionResult>>((resolve) => {
+      releaseSlow = resolve;
+    });
+    const slowResult: ExecutionResult = { kind: "analysis", summary: "slow" };
+    const fastResult: ExecutionResult = { kind: "analysis", summary: "fast" };
+    const slowRun = new FakeJobRun(slowResult);
+    let cancelCalls = 0;
+    const originalCancel = slowRun.cancel.bind(slowRun);
+    slowRun.cancel = async () => {
+      cancelCalls += 1;
+      return originalCancel();
+    };
+
+    let submitCount = 0;
+    const client: OperatorClient = {
+      operator: {
+        async *chat(): AsyncIterable<ChatChunk> {
+          yield { turnId: "agent-1", delta: "ok", done: true };
+        },
+        async clarify() {
+          return makeIntent(false);
+        },
+        async getPlan(intentId) {
+          return makePlan(intentId);
+        },
+        async revisePlan(intentId) {
+          return makePlan(intentId);
+        },
+        async submitPlan() {
+          submitCount += 1;
+          if (submitCount === 1) return slowSubmit;
+          return new FakeJobRun(fastResult);
+        },
+        async refineMap() {
+          return makeMapPackage();
+        },
+        async refineApp() {
+          return makeAppPackage();
+        },
+        async getApproval() {
+          return makeDecision("pending");
+        },
+        async confirmApproval() {
+          return makeDecision("granted");
+        },
+      },
+    };
+
+    const workspace = new OperatorWorkspace({ client });
+
+    const slowStart = workspace.execution.start(makePlan("intent-slow")).catch((error: unknown) => error);
+    const fastStart = workspace.execution.start(makePlan("intent-fast"));
+    const fastRun = await fastStart;
+    expect(fastRun.id).toBe("op-1");
+    expect(workspace.execution.run).toBe(fastRun);
+
+    releaseSlow(slowRun);
+    const slowOutcome = await slowStart;
+    expect(slowOutcome).toBeInstanceOf(HonuaOperatorExecutionError);
+    expect(workspace.execution.run).toBe(fastRun);
+    expect(cancelCalls).toBe(1);
+
+    workspace.dispose();
+  });
+
+  it("does not let a slow map loadPackage overwrite a newer load's runtime", async () => {
+    const mapA = makeMockMap();
+    const mapB = makeMockMap();
+    const pkgA: HonuaMapPackage = { ...makeMapPackage(), mapPackageId: "pkg-A" };
+    const pkgB: HonuaMapPackage = {
+      mapPackageId: "pkg-B",
+      format: HONUA_MAP_PACKAGE_FORMAT_V1,
+      sourceBindings: [
+        {
+          sourceId: "vector",
+          protocol: "raster_tile",
+          locator: { url: "https://tiles.example.test/v2/{z}/{x}/{y}.png" },
+        },
+      ],
+      mapSpec: {
+        version: 8,
+        sources: {},
+        layers: [{ id: "vector", type: "raster", source: "vector" }],
+      },
+      initialView: { center: [-157.85, 21.3], zoom: 9 },
+    };
+    let releaseA!: () => void;
+    const aGate = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+    let factoryCall = 0;
+    const events: WorkspaceEvent[] = [];
+    const workspace = new OperatorWorkspace({
+      client: makeOperatorClient(),
+      mapFactory: async () => {
+        factoryCall += 1;
+        if (factoryCall === 1) {
+          await aGate;
+          return { map: mapA };
+        }
+        return { map: mapB };
+      },
+      mapLoadOptions: {
+        client: new HonuaClient({
+          baseUrl: "https://honua.example.test",
+          fetchFn: async () => new Response("not used", { status: 200 }),
+        }),
+        skipCompatibilityCheck: true,
+      },
+    });
+    workspace.on((event) => events.push(event));
+    workspace.map?.bindIntent("intent-1");
+
+    const slow = workspace.map!.loadPackage(pkgA).catch((error: unknown) => error);
+    const fast = workspace.map!.loadPackage(pkgB);
+    const fastRuntime = await fast;
+    expect(workspace.map?.exploration?.datasetId).toBe("pkg-B");
+    expect(workspace.map?.runtime).toBe(fastRuntime);
+
+    releaseA();
+    await slow;
+    await flushMicrotasks();
+
+    expect(workspace.map?.exploration?.datasetId).toBe("pkg-B");
+    expect(workspace.map?.runtime).toBe(fastRuntime);
+    const mapLoadedEvents = events.filter((event) => event.kind === "map-loaded");
+    expect(mapLoadedEvents).toHaveLength(1);
+    if (mapLoadedEvents[0]?.kind !== "map-loaded") throw new Error("expected map-loaded");
+    expect(mapLoadedEvents[0].pkg.mapPackageId).toBe("pkg-B");
+
+    workspace.dispose();
+  });
 });
 
 class PassiveJobRun implements IJobRun<ExecutionResult> {

--- a/test/operator/operator-workspace.test.ts
+++ b/test/operator/operator-workspace.test.ts
@@ -937,6 +937,187 @@ describe("OperatorWorkspace", () => {
 
     workspace.dispose();
   });
+
+  it("does not let a slow approval load overwrite the active decision", async () => {
+    let releaseA!: (decision: ApprovalDecision) => void;
+    const aGate = new Promise<ApprovalDecision>((resolve) => {
+      releaseA = resolve;
+    });
+    const decisionA: ApprovalDecision = {
+      operationId: "op-A",
+      state: "denied",
+      scope: "publish-map",
+      reasons: ["policy denied"],
+      requiredRoles: ["operator-admin"],
+      audit: [{ at: 1, actor: "policy", action: "denied" }],
+    };
+    const decisionB: ApprovalDecision = {
+      operationId: "op-B",
+      state: "pending",
+      scope: "publish-map",
+      reasons: [],
+      requiredRoles: ["operator-admin"],
+      audit: [{ at: 2, actor: "policy", action: "pending" }],
+    };
+
+    const client: OperatorClient = {
+      operator: {
+        async *chat(): AsyncIterable<ChatChunk> {
+          yield { turnId: "agent-1", delta: "ok", done: true };
+        },
+        async clarify() {
+          return makeIntent(false);
+        },
+        async getPlan(intentId) {
+          return makePlan(intentId);
+        },
+        async revisePlan(intentId) {
+          return makePlan(intentId);
+        },
+        async submitPlan() {
+          return new FakeJobRun({ kind: "analysis" });
+        },
+        async refineMap() {
+          return makeMapPackage();
+        },
+        async refineApp() {
+          return makeAppPackage();
+        },
+        async getApproval(operationId) {
+          if (operationId === "op-A") return aGate;
+          return decisionB;
+        },
+        async confirmApproval() {
+          return decisionB;
+        },
+      },
+    };
+
+    const events: WorkspaceEvent[] = [];
+    const workspace = new OperatorWorkspace({ client });
+    workspace.on((event) => events.push(event));
+
+    const slowLoad = workspace.approval.load("op-A").catch(() => undefined);
+    const fast = await workspace.approval.load("op-B");
+    expect(fast.operationId).toBe("op-B");
+    expect(workspace.approval.decision?.operationId).toBe("op-B");
+
+    releaseA(decisionA);
+    await slowLoad;
+    await flushMicrotasks();
+
+    expect(workspace.approval.decision?.operationId).toBe("op-B");
+    const approvalEvents = events.filter(
+      (event) => event.kind === "approval-required" || event.kind === "approval-resolved",
+    );
+    for (const event of approvalEvents) {
+      if (event.kind !== "approval-required" && event.kind !== "approval-resolved") {
+        throw new Error("unexpected approval event kind");
+      }
+      expect(event.decision.operationId).toBe("op-B");
+    }
+
+    workspace.dispose();
+  });
+
+  it("clears the bound map when an app-only execution result is loaded", async () => {
+    const map = makeMockMap();
+    const firstResult: ExecutionResult = {
+      kind: "analysis",
+      summary: "first",
+      mapPackage: makeMapPackage(),
+      appPackage: makeAppPackage(),
+    };
+    const secondAppPkg: AppPackage = { ...makeAppPackage(), id: "app-2" };
+    const secondResult: ExecutionResult = {
+      kind: "analysis",
+      summary: "second (app-only)",
+      appPackage: secondAppPkg,
+    };
+    const firstRun = new FakeJobRun(firstResult);
+    const secondRun = new FakeJobRun(secondResult);
+    let runIndex = 0;
+    const client: OperatorClient = {
+      operator: {
+        async *chat(): AsyncIterable<ChatChunk> {
+          yield { turnId: "agent-1", delta: "ok", done: true };
+        },
+        async clarify() {
+          return makeIntent(false);
+        },
+        async getPlan(intentId) {
+          return makePlan(intentId);
+        },
+        async revisePlan(intentId) {
+          return makePlan(intentId);
+        },
+        async submitPlan() {
+          runIndex += 1;
+          return runIndex === 1 ? firstRun : secondRun;
+        },
+        async refineMap() {
+          return makeMapPackage();
+        },
+        async refineApp() {
+          return makeAppPackage();
+        },
+        async getApproval() {
+          return makeDecision("pending");
+        },
+        async confirmApproval() {
+          return makeDecision("granted");
+        },
+      },
+    };
+    const events: WorkspaceEvent[] = [];
+    const workspace = new OperatorWorkspace({
+      client,
+      mapFactory: () => ({ map }),
+      mapLoadOptions: {
+        client: new HonuaClient({
+          baseUrl: "https://honua.example.test",
+          fetchFn: async () => new Response("not used", { status: 200 }),
+        }),
+        skipCompatibilityCheck: true,
+      },
+    });
+    workspace.on((event) => events.push(event));
+    workspace.builder.bindIntent("intent-1");
+    workspace.map?.bindIntent("intent-1");
+
+    await workspace.execution.start(makePlan("intent-1"));
+    await waitForEvent(events, "execution-terminal");
+    await flushMicrotasks();
+    expect(workspace.builder.preview().mapPackage?.mapPackageId).toBe("operator-map");
+
+    await workspace.execution.start(makePlan("intent-1"));
+    await waitForEvent(events.slice(events.findIndex((event) => event.kind === "app-loaded") + 1), "app-loaded");
+    await flushMicrotasks();
+    expect(workspace.builder.appPackage?.id).toBe("app-2");
+    expect(workspace.builder.preview().mapPackage).toBeUndefined();
+
+    workspace.dispose();
+  });
+
+  it("emits execution-dismissed when a passive run reports dismissed only via cancel()", async () => {
+    const passiveRun = new SilentDismissJobRun();
+    const events: WorkspaceEvent[] = [];
+    const workspace = new OperatorWorkspace({ client: makeClientWithRun(passiveRun) });
+    workspace.on((event) => events.push(event));
+
+    await workspace.execution.start(makePlan("intent-passive"));
+    await flushMicrotasks();
+
+    await workspace.execution.cancel();
+    await flushMicrotasks();
+
+    const dismissedEvents = events.filter((event) => event.kind === "execution-dismissed");
+    expect(dismissedEvents).toHaveLength(1);
+    if (dismissedEvents[0]?.kind !== "execution-dismissed") throw new Error("expected execution-dismissed");
+    expect(workspace.execution.snapshot?.status).toBe("dismissed");
+
+    workspace.dispose();
+  });
 });
 
 class PassiveJobRun implements IJobRun<ExecutionResult> {
@@ -977,6 +1158,41 @@ class PassiveJobRun implements IJobRun<ExecutionResult> {
       listener({ status: this.status, result: { outputs } });
     }
     return { outputs };
+  }
+
+  public async cancel(): Promise<JobStatus> {
+    this.status = "dismissed";
+    return this.status;
+  }
+}
+
+// Models a conforming `IJobRun` that satisfies the contract minimum:
+// `cancel()` flips status to "dismissed" but `watch()` listeners are
+// never invoked. Lets the cancel-terminal test prove the controller
+// surfaces the dismissed event without relying on watcher delivery.
+class SilentDismissJobRun implements IJobRun<ExecutionResult> {
+  public readonly id = "op-silent-dismiss";
+  public readonly type = "operator-plan";
+  public status: JobStatus = "accepted";
+  public progress: JobProgress | undefined;
+
+  public async poll(): Promise<JobSnapshot<ExecutionResult>> {
+    return { status: this.status, progress: this.progress };
+  }
+
+  public watch(): () => void {
+    // Conforming-but-passive: never delivers a snapshot.
+    return () => {};
+  }
+
+  public async results(): Promise<{ outputs: Record<string, ExecutionResult> }> {
+    // Hold open until cancel() flips us terminal so results() never
+    // resolves on its own; the test drives termination via cancel().
+    await new Promise<void>(() => {
+      // Resolves only when the surrounding test disposes; the unresolved
+      // promise keeps the polling path quiet during the cancel window.
+    });
+    return { outputs: {} };
   }
 
   public async cancel(): Promise<JobStatus> {

--- a/test/operator/operator-workspace.test.ts
+++ b/test/operator/operator-workspace.test.ts
@@ -22,6 +22,10 @@ import {
   OperatorWorkspace,
   type WorkspaceEvent,
 } from "@honua/sdk-js/operator";
+// Subpath import — also acts as a regression for the Vitest alias
+// resolving `@honua/sdk-js/operator/i18n` to a file that exists
+// rather than `src/operator/index.ts/i18n`.
+import { DEFAULT_MESSAGES, resolveMessage } from "@honua/sdk-js/operator/i18n";
 import { HONUA_MAP_PACKAGE_FORMAT_V1, type HonuaMapPackage, type MaplibreMap } from "@honua/sdk-js/runtime";
 
 interface MockCall {
@@ -1160,6 +1164,48 @@ describe("OperatorWorkspace", () => {
     await expect(workspace.approval.load("op-typed")).rejects.toBe(typedError);
 
     workspace.dispose();
+  });
+
+  it("disposes the host map when loadMapPackage rejects after the factory has built it", async () => {
+    const map = makeMockMap();
+    // Sabotage setStyle so loadMapPackage rejects after the factory
+    // already returned a host map. Without the leak fix the
+    // factory's dispose() would never run.
+    map.setStyle = () => {
+      throw new Error("style apply failed");
+    };
+    let factoryDisposed = 0;
+    const workspace = new OperatorWorkspace({
+      client: makeOperatorClient(),
+      mapFactory: () => ({
+        map,
+        dispose: () => {
+          factoryDisposed += 1;
+        },
+      }),
+      mapLoadOptions: {
+        client: new HonuaClient({
+          baseUrl: "https://honua.example.test",
+          fetchFn: async () => new Response("not used", { status: 200 }),
+        }),
+        skipCompatibilityCheck: true,
+      },
+    });
+    workspace.map?.bindIntent("intent-leak");
+
+    await expect(workspace.map!.loadPackage(makeMapPackage())).rejects.toMatchObject({
+      name: "HonuaOperatorMapError",
+    });
+    expect(factoryDisposed).toBe(1);
+
+    workspace.dispose();
+    // dispose() must not double-dispose the already-released factory.
+    expect(factoryDisposed).toBe(1);
+  });
+
+  it("substitutes the {amount} placeholder in plan.estimatedCost", () => {
+    expect(resolveMessage(undefined, "plan.estimatedCost", { amount: "12.50" })).toBe("Estimated cost: 12.50");
+    expect(DEFAULT_MESSAGES["plan.estimatedCost"]).toBe("Estimated cost: {amount}");
   });
 
   it("aborts an in-flight chat stream when the workspace is disposed", async () => {

--- a/test/operator/operator-workspace.test.ts
+++ b/test/operator/operator-workspace.test.ts
@@ -15,6 +15,7 @@ import {
   type ApprovalDecision,
   type ChatChunk,
   type ExecutionResult,
+  HonuaOperatorApprovalError,
   HonuaOperatorExecutionError,
   OPERATOR_EXECUTION_OUTPUT_KEY,
   type OperatorClient,
@@ -1117,6 +1118,102 @@ describe("OperatorWorkspace", () => {
     expect(workspace.execution.snapshot?.status).toBe("dismissed");
 
     workspace.dispose();
+  });
+
+  it("preserves typed approval errors thrown by the client", async () => {
+    const typedError = new HonuaOperatorApprovalError("policy gate refused the load", {
+      detail: { operationId: "op-typed", reason: "PolicyDenied" },
+    });
+    const client: OperatorClient = {
+      operator: {
+        async *chat(): AsyncIterable<ChatChunk> {
+          yield { turnId: "agent-1", delta: "ok", done: true };
+        },
+        async clarify() {
+          return makeIntent(false);
+        },
+        async getPlan(intentId) {
+          return makePlan(intentId);
+        },
+        async revisePlan(intentId) {
+          return makePlan(intentId);
+        },
+        async submitPlan() {
+          return new FakeJobRun({ kind: "analysis" });
+        },
+        async refineMap() {
+          return makeMapPackage();
+        },
+        async refineApp() {
+          return makeAppPackage();
+        },
+        async getApproval() {
+          throw typedError;
+        },
+        async confirmApproval() {
+          throw typedError;
+        },
+      },
+    };
+    const workspace = new OperatorWorkspace({ client });
+
+    await expect(workspace.approval.load("op-typed")).rejects.toBe(typedError);
+
+    workspace.dispose();
+  });
+
+  it("aborts an in-flight chat stream when the workspace is disposed", async () => {
+    let observedAbort = false;
+    let resolveSlow!: () => void;
+    const slowGate = new Promise<void>((resolve) => {
+      resolveSlow = resolve;
+    });
+    const client: OperatorClient = {
+      operator: {
+        async *chat(_text, signal): AsyncIterable<ChatChunk> {
+          if (signal) {
+            signal.addEventListener("abort", () => {
+              observedAbort = true;
+              resolveSlow();
+            });
+          }
+          await slowGate;
+          if (signal?.aborted) return;
+          yield { turnId: "agent-1", delta: "late", done: true };
+        },
+        async clarify() {
+          return makeIntent(false);
+        },
+        async getPlan(intentId) {
+          return makePlan(intentId);
+        },
+        async revisePlan(intentId) {
+          return makePlan(intentId);
+        },
+        async submitPlan() {
+          return new FakeJobRun({ kind: "analysis" });
+        },
+        async refineMap() {
+          return makeMapPackage();
+        },
+        async refineApp() {
+          return makeAppPackage();
+        },
+        async getApproval() {
+          return makeDecision("pending");
+        },
+        async confirmApproval() {
+          return makeDecision("granted");
+        },
+      },
+    };
+    const workspace = new OperatorWorkspace({ client });
+    const send = workspace.chat.send("hello").catch(() => undefined);
+
+    workspace.dispose();
+    await send;
+
+    expect(observedAbort).toBe(true);
   });
 });
 

--- a/test/operator/operator-workspace.test.ts
+++ b/test/operator/operator-workspace.test.ts
@@ -15,6 +15,7 @@ import {
   type ApprovalDecision,
   type ChatChunk,
   type ExecutionResult,
+  HonuaOperatorExecutionError,
   OPERATOR_EXECUTION_OUTPUT_KEY,
   type OperatorClient,
   OperatorWorkspace,
@@ -254,6 +255,18 @@ async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
 }
 
+async function waitForEvent(
+  events: ReadonlyArray<WorkspaceEvent>,
+  kind: WorkspaceEvent["kind"],
+  maxTicks = 50,
+): Promise<void> {
+  for (let i = 0; i < maxTicks; i += 1) {
+    if (events.some((event) => event.kind === kind)) return;
+    await Promise.resolve();
+  }
+  throw new Error(`event "${kind}" not observed within ${maxTicks} ticks`);
+}
+
 class DismissingJobRun implements IJobRun<ExecutionResult> {
   public readonly id = "op-dismiss";
   public readonly type = "operator-plan";
@@ -347,10 +360,13 @@ describe("OperatorWorkspace", () => {
     expect(clarified.clarifications).toEqual([]);
     expect(events.some((event) => event.kind === "clarification-answered")).toBe(true);
 
-    const plan = await workspace.planReview.load(clarified.id);
+    // Workspace orchestrates the documented chat → clarification →
+    // plan-load → execution-start chain; the test must not call
+    // planReview.load or execution.start manually or the orchestration
+    // path goes untested.
+    await waitForEvent(events, "plan-loaded");
     workspace.planReview.accept();
-    await workspace.execution.start(plan);
-    await flushMicrotasks();
+    await waitForEvent(events, "execution-terminal");
 
     const pending = await workspace.approval.load("op-1");
     const granted = await workspace.approval.confirm("op-1");
@@ -393,4 +409,219 @@ describe("OperatorWorkspace", () => {
 
     workspace.dispose();
   });
+
+  it("drives passive IJobRun polling so watch-only adapters reach a terminal snapshot", async () => {
+    const result: ExecutionResult = { kind: "analysis", summary: "passive" };
+    const run = new PassiveJobRun(result);
+    const workspace = new OperatorWorkspace({ client: makeClientWithRun(run) });
+    const events: WorkspaceEvent[] = [];
+    workspace.on((event) => events.push(event));
+
+    await workspace.execution.start(makePlan("intent-passive"));
+    await waitForEvent(events, "execution-terminal");
+
+    expect(run.resultsCalls).toBe(1);
+    expect(workspace.execution.snapshot?.status).toBe("successful");
+
+    workspace.dispose();
+  });
+
+  it("wraps submitPlan failures in HonuaOperatorExecutionError and routes them through the workspace error stream", async () => {
+    const failure = new Error("transport down");
+    const events: WorkspaceEvent[] = [];
+    const workspace = new OperatorWorkspace({ client: makeFailingSubmitClient(failure) });
+    workspace.on((event) => events.push(event));
+
+    await expect(workspace.execution.start(makePlan("intent-3"))).rejects.toBeInstanceOf(HonuaOperatorExecutionError);
+
+    const errorEvent = events.find((event) => event.kind === "error");
+    expect(errorEvent).toBeDefined();
+    if (errorEvent?.kind !== "error") throw new Error("expected error event");
+    expect(errorEvent.error).toBeInstanceOf(HonuaOperatorExecutionError);
+    expect(errorEvent.error.cause).toBe(failure);
+
+    workspace.dispose();
+  });
+
+  it("recreates ExplorationContext on map refinement when datasetId or sourceIds change", async () => {
+    const map = makeMockMap();
+    const refined: HonuaMapPackage = {
+      mapPackageId: "operator-map-v2",
+      format: HONUA_MAP_PACKAGE_FORMAT_V1,
+      sourceBindings: [
+        {
+          sourceId: "vector-tiles",
+          protocol: "raster_tile",
+          locator: { url: "https://tiles.example.test/v2/{z}/{x}/{y}.png" },
+        },
+      ],
+      mapSpec: {
+        version: 8,
+        sources: {},
+        layers: [{ id: "vector-tiles", type: "raster", source: "vector-tiles" }],
+      },
+      initialView: { center: [-157.85, 21.3], zoom: 9 },
+    };
+    const workspace = new OperatorWorkspace({
+      client: makeRefiningClient(refined),
+      mapFactory: () => ({ map }),
+      mapLoadOptions: {
+        client: new HonuaClient({
+          baseUrl: "https://honua.example.test",
+          fetchFn: async () => new Response("not used", { status: 200 }),
+        }),
+        skipCompatibilityCheck: true,
+      },
+    });
+
+    workspace.map?.bindIntent("intent-refine");
+    await workspace.map!.loadPackage(makeMapPackage());
+    expect(workspace.map?.exploration?.datasetId).toBe("operator-map");
+    expect(workspace.map?.exploration?.sourceIds).toEqual(["tiles"]);
+
+    await workspace.map!.refine("switch source");
+    expect(workspace.map?.exploration?.datasetId).toBe("operator-map-v2");
+    expect(workspace.map?.exploration?.sourceIds).toEqual(["vector-tiles"]);
+
+    workspace.dispose();
+  });
 });
+
+class PassiveJobRun implements IJobRun<ExecutionResult> {
+  public readonly id = "op-passive";
+  public readonly type = "operator-plan";
+  public status: JobStatus = "accepted";
+  public progress: JobProgress | undefined;
+  public resultsCalls = 0;
+
+  readonly #terminal: ExecutionResult;
+  readonly #listeners = new Set<JobSnapshotListener<ExecutionResult>>();
+
+  public constructor(terminal: ExecutionResult) {
+    this.#terminal = terminal;
+  }
+
+  public async poll(): Promise<JobSnapshot<ExecutionResult>> {
+    return { status: this.status, progress: this.progress };
+  }
+
+  // Passive: registers the listener but never drives snapshots on its own.
+  // Mirrors `HonuaOgcProcessJobRun.watch`, which only adds the listener and
+  // relies on `results()` / `runUntilTerminal` to perform the polling loop.
+  public watch(listener: JobSnapshotListener<ExecutionResult>): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+
+  public async results(): Promise<{ outputs: Record<string, ExecutionResult> }> {
+    this.resultsCalls += 1;
+    this.status = "running";
+    for (const listener of [...this.#listeners]) {
+      listener({ status: this.status, progress: { percent: 25 } });
+    }
+    this.status = "successful";
+    const outputs = { [OPERATOR_EXECUTION_OUTPUT_KEY]: this.#terminal };
+    for (const listener of [...this.#listeners]) {
+      listener({ status: this.status, result: { outputs } });
+    }
+    return { outputs };
+  }
+
+  public async cancel(): Promise<JobStatus> {
+    this.status = "dismissed";
+    return this.status;
+  }
+}
+
+function makeClientWithRun(run: IJobRun<ExecutionResult>): OperatorClient {
+  return {
+    operator: {
+      async *chat(): AsyncIterable<ChatChunk> {
+        yield { turnId: "agent-1", delta: "ok", done: true };
+      },
+      async clarify() {
+        return makeIntent(false);
+      },
+      async getPlan(intentId) {
+        return makePlan(intentId);
+      },
+      async submitPlan() {
+        return run;
+      },
+      async refineMap() {
+        return makeMapPackage();
+      },
+      async refineApp() {
+        return makeAppPackage();
+      },
+      async getApproval() {
+        return makeDecision("pending");
+      },
+      async confirmApproval() {
+        return makeDecision("granted");
+      },
+    },
+  };
+}
+
+function makeFailingSubmitClient(failure: Error): OperatorClient {
+  return {
+    operator: {
+      async *chat(): AsyncIterable<ChatChunk> {
+        yield { turnId: "agent-1", delta: "ok", done: true };
+      },
+      async clarify() {
+        return makeIntent(false);
+      },
+      async getPlan(intentId) {
+        return makePlan(intentId);
+      },
+      async submitPlan() {
+        throw failure;
+      },
+      async refineMap() {
+        return makeMapPackage();
+      },
+      async refineApp() {
+        return makeAppPackage();
+      },
+      async getApproval() {
+        return makeDecision("pending");
+      },
+      async confirmApproval() {
+        return makeDecision("granted");
+      },
+    },
+  };
+}
+
+function makeRefiningClient(refined: HonuaMapPackage): OperatorClient {
+  return {
+    operator: {
+      async *chat(): AsyncIterable<ChatChunk> {
+        yield { turnId: "agent-1", delta: "ok", done: true };
+      },
+      async clarify() {
+        return makeIntent(false);
+      },
+      async getPlan(intentId) {
+        return makePlan(intentId);
+      },
+      async submitPlan() {
+        return new FakeJobRun({ kind: "analysis" });
+      },
+      async refineMap() {
+        return refined;
+      },
+      async refineApp() {
+        return makeAppPackage();
+      },
+      async getApproval() {
+        return makeDecision("pending");
+      },
+      async confirmApproval() {
+        return makeDecision("granted");
+      },
+    },
+  };
+}

--- a/test/operator/operator-workspace.test.ts
+++ b/test/operator/operator-workspace.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HonuaClient,
+  type IJobRun,
+  type JobProgress,
+  type JobSnapshot,
+  type JobSnapshotListener,
+  type JobStatus,
+} from "@honua/sdk-js";
+import {
+  type AnalysisIntent,
+  type AnalysisPlan,
+  type AppPackage,
+  type ApprovalDecision,
+  type ChatChunk,
+  type ExecutionResult,
+  OPERATOR_EXECUTION_OUTPUT_KEY,
+  type OperatorClient,
+  OperatorWorkspace,
+  type WorkspaceEvent,
+} from "@honua/sdk-js/operator";
+import { HONUA_MAP_PACKAGE_FORMAT_V1, type HonuaMapPackage, type MaplibreMap } from "@honua/sdk-js/runtime";
+
+interface MockCall {
+  method: string;
+  args: unknown[];
+}
+
+interface MockMap extends MaplibreMap {
+  calls: MockCall[];
+  style: unknown;
+}
+
+function makeMockMap(): MockMap {
+  const calls: MockCall[] = [];
+  const state = new Map<string, Record<string, unknown>>();
+  const map: MockMap = {
+    calls,
+    style: {},
+    setStyle(next) {
+      calls.push({ method: "setStyle", args: [next] });
+      map.style = next;
+    },
+    getStyle() {
+      return map.style;
+    },
+    addSource(id, source) {
+      calls.push({ method: "addSource", args: [id, source] });
+    },
+    removeSource(id) {
+      calls.push({ method: "removeSource", args: [id] });
+    },
+    addLayer(layer, beforeId) {
+      calls.push({ method: "addLayer", args: [layer, beforeId] });
+    },
+    removeLayer(id) {
+      calls.push({ method: "removeLayer", args: [id] });
+    },
+    getLayer(id) {
+      calls.push({ method: "getLayer", args: [id] });
+      return undefined;
+    },
+    setLayoutProperty(layerId, name, value) {
+      calls.push({ method: "setLayoutProperty", args: [layerId, name, value] });
+    },
+    setPaintProperty(layerId, name, value) {
+      calls.push({ method: "setPaintProperty", args: [layerId, name, value] });
+    },
+    setFilter(layerId, filter) {
+      calls.push({ method: "setFilter", args: [layerId, filter] });
+    },
+    getSource(id) {
+      calls.push({ method: "getSource", args: [id] });
+      return undefined;
+    },
+    fitBounds(bounds, options) {
+      calls.push({ method: "fitBounds", args: [bounds, options] });
+    },
+    jumpTo(options) {
+      calls.push({ method: "jumpTo", args: [options] });
+    },
+    easeTo(options) {
+      calls.push({ method: "easeTo", args: [options] });
+    },
+    flyTo(options) {
+      calls.push({ method: "flyTo", args: [options] });
+    },
+    setFeatureState(target, next) {
+      state.set(`${target.source}:${target.id}`, { ...(state.get(`${target.source}:${target.id}`) ?? {}), ...next });
+    },
+    getFeatureState(target) {
+      return state.get(`${target.source}:${target.id}`) ?? {};
+    },
+    removeFeatureState(target) {
+      state.delete(`${target.source}:${target.id}`);
+    },
+    on() {
+      // The workspace fixture does not exercise popup handlers.
+    },
+    off() {
+      // The workspace fixture does not exercise popup handlers.
+    },
+  };
+  return map;
+}
+
+class FakeJobRun implements IJobRun<ExecutionResult> {
+  public readonly id = "op-1";
+  public readonly type = "operator-plan";
+  public status: JobStatus = "accepted";
+  public progress: JobProgress | undefined;
+
+  readonly #terminal: ExecutionResult;
+
+  public constructor(terminal: ExecutionResult) {
+    this.#terminal = terminal;
+  }
+
+  public async poll(): Promise<JobSnapshot<ExecutionResult>> {
+    return { status: this.status, progress: this.progress };
+  }
+
+  public watch(listener: JobSnapshotListener<ExecutionResult>): () => void {
+    let active = true;
+    queueMicrotask(() => {
+      if (!active) return;
+      this.status = "running";
+      this.progress = { percent: 50, message: "composing package" };
+      listener({ status: this.status, progress: this.progress });
+      if (!active) return;
+      this.status = "successful";
+      listener({
+        status: this.status,
+        result: { outputs: { [OPERATOR_EXECUTION_OUTPUT_KEY]: this.#terminal } },
+      });
+    });
+    return () => {
+      active = false;
+    };
+  }
+
+  public async results(): Promise<{ outputs: Record<string, ExecutionResult> }> {
+    return { outputs: { [OPERATOR_EXECUTION_OUTPUT_KEY]: this.#terminal } };
+  }
+
+  public async cancel(): Promise<JobStatus> {
+    this.status = "dismissed";
+    return this.status;
+  }
+}
+
+function makeMapPackage(): HonuaMapPackage {
+  return {
+    mapPackageId: "operator-map",
+    format: HONUA_MAP_PACKAGE_FORMAT_V1,
+    sourceBindings: [
+      {
+        sourceId: "tiles",
+        protocol: "raster_tile",
+        locator: { url: "https://tiles.example.test/{z}/{x}/{y}.png" },
+      },
+    ],
+    mapSpec: {
+      version: 8,
+      sources: {},
+      layers: [{ id: "tiles", type: "raster", source: "tiles" }],
+    },
+    initialView: { center: [-157.85, 21.3], zoom: 9 },
+  };
+}
+
+function makeAppPackage(): AppPackage {
+  return {
+    id: "app-1",
+    version: "1",
+    assets: [{ id: "bundle", kind: "app-package", url: "https://apps.example.test/operator/app.js" }],
+  };
+}
+
+function makeIntent(withClarification = true): AnalysisIntent {
+  return {
+    id: withClarification ? "intent-1" : "intent-2",
+    kind: "analysis",
+    request: "map emergency shelters near Honolulu",
+    clarifications: withClarification ? [{ id: "area", label: "Area", type: "text", required: true }] : [],
+  };
+}
+
+function makePlan(intentId: string): AnalysisPlan {
+  return {
+    id: "plan-1",
+    intentId,
+    kind: "analysis",
+    steps: [
+      { id: "collect", kind: "query", label: "Collect shelter points" },
+      { id: "compose", kind: "map", label: "Compose operator map", requiresApproval: true },
+    ],
+  };
+}
+
+function makeDecision(state: ApprovalDecision["state"]): ApprovalDecision {
+  return {
+    operationId: "op-1",
+    state,
+    scope: "publish-map",
+    reasons: state === "denied" ? ["policy denied"] : [],
+    requiredRoles: ["operator-admin"],
+    audit: [{ at: 1, actor: "policy", action: state }],
+  };
+}
+
+function makeOperatorClient(): OperatorClient {
+  const clarified = makeIntent(false);
+  const result: ExecutionResult = {
+    kind: "analysis",
+    summary: "Shelter map composed",
+    mapPackage: makeMapPackage(),
+    appPackage: makeAppPackage(),
+  };
+  return {
+    operator: {
+      async *chat(): AsyncIterable<ChatChunk> {
+        yield { turnId: "agent-1", delta: "I need the area.", done: false };
+        yield { turnId: "agent-1", delta: " Drafting the workflow.", done: true, intentDraft: makeIntent(true) };
+      },
+      async clarify() {
+        return clarified;
+      },
+      async getPlan(intentId) {
+        return makePlan(intentId);
+      },
+      async submitPlan() {
+        return new FakeJobRun(result);
+      },
+      async refineMap() {
+        return makeMapPackage();
+      },
+      async refineApp() {
+        return makeAppPackage();
+      },
+      async getApproval() {
+        return makeDecision("pending");
+      },
+      async confirmApproval() {
+        return makeDecision("granted");
+      },
+    },
+  };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("OperatorWorkspace", () => {
+  it("assembles the operator flow from composable controllers and package runtime primitives", async () => {
+    const map = makeMockMap();
+    const events: WorkspaceEvent[] = [];
+    const workspace = new OperatorWorkspace({
+      client: makeOperatorClient(),
+      mapFactory: () => ({ map }),
+      mapLoadOptions: {
+        client: new HonuaClient({
+          baseUrl: "https://honua.example.test",
+          fetchFn: async () => new Response("not used", { status: 200 }),
+        }),
+        skipCompatibilityCheck: true,
+      },
+    });
+    workspace.on((event) => events.push(event));
+
+    await workspace.chat.send("Map emergency shelters near Honolulu");
+    expect(events.some((event) => event.kind === "intent-drafted")).toBe(true);
+    expect(events.some((event) => event.kind === "clarification-needed")).toBe(true);
+
+    workspace.clarification.setAnswer("area", "Honolulu");
+    const clarified = await workspace.clarification.submit();
+    expect(clarified.clarifications).toEqual([]);
+    expect(events.some((event) => event.kind === "clarification-answered")).toBe(true);
+
+    const plan = await workspace.planReview.load(clarified.id);
+    workspace.planReview.accept();
+    await workspace.execution.start(plan);
+    await flushMicrotasks();
+
+    const pending = await workspace.approval.load("op-1");
+    const granted = await workspace.approval.confirm("op-1");
+
+    expect(pending.state).toBe("pending");
+    expect(granted.state).toBe("granted");
+    expect(workspace.builder.preview().url).toBe("https://apps.example.test/operator/app.js");
+    expect(workspace.map?.exploration?.datasetId).toBe("operator-map");
+    expect(map.calls.some((call) => call.method === "setStyle")).toBe(true);
+    expect(events.map((event) => event.kind)).toEqual(
+      expect.arrayContaining([
+        "plan-loaded",
+        "plan-accepted",
+        "execution-started",
+        "execution-progress",
+        "execution-terminal",
+        "map-loaded",
+        "app-loaded",
+        "approval-required",
+        "approval-resolved",
+      ]),
+    );
+
+    workspace.dispose();
+  });
+});

--- a/test/operator/operator-workspace.test.ts
+++ b/test/operator/operator-workspace.test.ts
@@ -730,12 +730,15 @@ describe("OperatorWorkspace", () => {
     workspace.clarification.load(intentA);
     workspace.clarification.setAnswer("area", "Honolulu");
     const submission = workspace.clarification.submit();
+    expect(workspace.clarification.state.submitting).toBe(true);
     workspace.clarification.load(intentB);
+    expect(workspace.clarification.state.submitting).toBe(false);
     releaseSlow(revivedA);
     await submission;
     await flushMicrotasks();
 
     expect(workspace.clarification.state.intent?.id).toBe("intent-B");
+    expect(workspace.clarification.state.submitting).toBe(false);
     expect(events.some((event) => event.kind === "clarification-answered")).toBe(false);
 
     workspace.dispose();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,27 @@ const ci = Boolean(process.env.CI);
 export default defineConfig({
   resolve: {
     alias: [
+      // Subpath aliases come first so the prefix-matching parent
+      // aliases below cannot rewrite `@honua/sdk-js/operator/<sub>`
+      // into `src/operator/index.ts/<sub>` (which is a nonexistent
+      // path). Each must be an exact-suffix entry pointing at the
+      // matching `index.ts` for that subpath export.
+      {
+        find: "@honua/sdk-js/operator/controllers",
+        replacement: path.resolve(import.meta.dirname, "src/operator/controllers/index.ts"),
+      },
+      {
+        find: "@honua/sdk-js/operator/workspace",
+        replacement: path.resolve(import.meta.dirname, "src/operator/workspace/index.ts"),
+      },
+      {
+        find: "@honua/sdk-js/operator/theming",
+        replacement: path.resolve(import.meta.dirname, "src/operator/theming/index.ts"),
+      },
+      {
+        find: "@honua/sdk-js/operator/i18n",
+        replacement: path.resolve(import.meta.dirname, "src/operator/i18n/index.ts"),
+      },
       {
         find: "@honua/sdk-js/honua",
         replacement: path.resolve(import.meta.dirname, "src/honua.ts"),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,14 @@ export default defineConfig({
         replacement: path.resolve(import.meta.dirname, "src/honua.ts"),
       },
       {
+        find: "@honua/sdk-js/operator",
+        replacement: path.resolve(import.meta.dirname, "src/operator/index.ts"),
+      },
+      {
+        find: "@honua/sdk-js/runtime",
+        replacement: path.resolve(import.meta.dirname, "src/runtime/index.ts"),
+      },
+      {
         find: "@honua/sdk-js",
         replacement: path.resolve(import.meta.dirname, "src/index.ts"),
       },


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #29
## Summary

Pushed.
## Changes Made

- Pushed.
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally
## Additional Context

Decisions:
- Chose to clear `#submitting` in `load()` rather than rewrite the `submit()` `finally` to always clear — the generation-gated `finally` is intentional to avoid a stale resolution clobbering a newer in-flight submit's `submitting` state. The cleanest place to reset is the supersession entry point itself.
- Test extended in place (per the reviewer's suggested fix) rather than added as a separate case. Three new assertions now live alongside the existing intent-not-revived check, making the supersession contract self-documenting.

Follow-ons:
- None for this branch.

Code kaizen:
Deferred 1 low-priority finding(s) to cleanup backlog. No Claude findings required disposition; the two prior local findings are fixed, but the new operator subpath exports need matching Vitest alias handling.
