### PR TITLE
[codex] Add cross-SDK contract fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ protocol-neutral contract and exploration state module that wrap (not replace) t
   presets (`globalLinked`, `mapDriven`, `gridDriven`, `chartDriven`, `decoupled`). Full state model and
   worked example: [`docs/exploration-context.md`](./docs/exploration-context.md).
 - Capability coverage per protocol: [`docs/protocol-capability-matrix.md`](./docs/protocol-capability-matrix.md).
+- Cross-SDK semantic alignment for JS/Python/.NET language bindings:
+  [`docs/sdk-surface-alignment.md`](./docs/sdk-surface-alignment.md).
 - Round-trip mapping to the server `SourceBinding` / `MapPackage` document:
   [`docs/source-binding-alignment.md`](./docs/source-binding-alignment.md).
 

--- a/docs/sdk-surface-alignment.md
+++ b/docs/sdk-surface-alignment.md
@@ -1,0 +1,128 @@
+# Cross-SDK Surface Alignment
+
+Status: draft contract anchor for https://github.com/honua-io/honua-sdk-js/issues/44.
+
+The Honua SDKs should share one mental model even when each language keeps its
+own naming conventions. JavaScript may use `queryAll()`, Python may use
+`query_all()`, and .NET may use `QueryAllAsync()`. Those names are allowed to
+differ. The semantics behind them should not.
+
+## Canonical Semantics
+
+Use the `@honua/sdk-js/contract` vocabulary as the current source of truth:
+
+| Concept | Meaning |
+| --- | --- |
+| `Dataset` | Logical grouping of one or more sources plus compatibility checks. |
+| `SourceDescriptor` | Serializable source identity: protocol, locator, capabilities, schema, and attribution. |
+| `Source` | Runtime handle for the common query, edit, related-record, attachment, and escape-hatch surface. |
+| `Protocol` | Stable source protocol identifier. |
+| `Capability` | Stable operation capability identifier. |
+| `Query` | Protocol-neutral request intent. |
+| `Result` | Protocol-neutral result envelope. |
+| `EditEnvelope` / `EditResult` | Protocol-neutral write envelope and result. |
+| `protocol(...)` | Explicit native protocol escape hatch. |
+
+## Language Bindings
+
+Language bindings must be idiomatic. The binding table below is guidance for
+public API names, not a byte-for-byte requirement:
+
+| Concept | TypeScript | Python | .NET |
+| --- | --- | --- | --- |
+| query all records | `queryAll()` | `query_all()` | `QueryAllAsync()` |
+| stream pages | `stream()` | `stream()` / `iter_*()` | `StreamAsync()` / `QueryPagesAsync()` |
+| query object ids | `queryObjectIds()` | `query_object_ids()` | `QueryObjectIdsAsync()` |
+| apply edits | `applyEdits()` | `apply_edits()` | `ApplyEditsAsync()` |
+| return geometry | `returnGeometry` | `return_geometry` | `ReturnGeometry` |
+| output fields | `outFields` | `out_fields` | `OutFields` |
+| pagination | `pagination` | `pagination` / `limit` / `offset` | `Pagination` / `Limit` / `Offset` |
+| native protocol escape hatch | `source.protocol(...)` | `source.protocol(...)` | `source.Protocol(...)` |
+
+Existing SDK names can remain as aliases or facades. For example, Python's
+`FeatureQuery` and .NET's `FeatureQueryRequest` can continue to exist while
+new source-oriented facades converge on the same behavior.
+
+## Stable Protocol IDs
+
+The canonical protocol identifiers are the values exported from
+`PROTOCOLS` in `src/contract/types.ts`. SDKs may accept aliases for already
+shipped public names, but serialized descriptors and docs should prefer the
+canonical identifiers:
+
+- `geoservices-feature-service`
+- `geoservices-map-service`
+- `geoservices-image-service`
+- `geoservices-geometry-service`
+- `geoservices-gp-service`
+- `ogc-features`
+- `ogc-tiles`
+- `ogc-maps`
+- `stac`
+- `wfs`
+- `wms`
+- `wmts`
+- `odata`
+- `maplibre-vector`
+- `maplibre-raster`
+- `maplibre-geojson`
+
+## Stable Capability IDs
+
+The canonical capability identifiers are the values exported from
+`CAPABILITIES` in `src/contract/types.ts`. SDKs should gate behavior on these
+semantic identifiers rather than inventing per-repo names for the same
+operation.
+
+Capability misses must be explicit. The preferred behavior is a typed SDK error
+or an unsupported-capability result that names the missing capability and
+protocol. Returning an empty result for an unsupported operation is not
+acceptable because it is indistinguishable from a valid query with no matches.
+
+## Query Semantics
+
+All SDKs should preserve these query semantics even when the local request type
+uses language-specific names:
+
+- `where`: logical attribute filter. Adapters translate it to SQL-92, CQL2,
+  OData `$filter`, FES, or provider-native syntax as appropriate.
+- `spatialFilter` / `bbox`: spatial constraint. SDKs may expose a compact bbox
+  helper, but the behavior must be documented.
+- `outFields`: fields or properties to return.
+- `orderBy`: provider-supported sort order.
+- `pagination.offset`: records to skip before returning data.
+- `pagination.limit`: record cap. `query()`, `queryAll()`, and `stream()` must
+  document whether the limit is per-page or total.
+- `returnGeometry`: whether returned features include geometry.
+- `outSr`: requested output spatial reference when the protocol supports it.
+- `signal` / cancellation token: caller-driven cancellation.
+
+## Result Semantics
+
+All SDKs should expose the same result facts:
+
+- features are an array, empty when no records matched.
+- each feature has an identifier when available, attributes/properties, and
+  optional geometry.
+- result envelopes preserve paging state (`exceededTransferLimit`,
+  `hasMoreResults`, or an idiomatic alias).
+- total count is present when the protocol reports it.
+- field schema is present when the protocol reports it.
+- extent is present for extent-only or extent-enriched queries.
+- degraded results carry structured reasons with capability, protocol, and
+  optional source id.
+- raw/provider-native payload access remains available for advanced workflows.
+
+## Fixture Pack
+
+The cross-SDK fixture pack lives under
+`test/fixtures/sdk-contract/semantic-contract.v1.json`. It is intentionally
+JSON-only so Python and .NET can consume the same payloads without depending on
+the JS test helpers.
+
+The JS drift gate in `test/contract/sdk-contract-fixtures.test.ts` validates
+that the fixture pack stays aligned with the exported JS contract registries and
+with the documented result/error/degraded semantics.
+
+Downstream SDK work should consume this fixture pack directly or mirror it with
+a clear checksum/update process.

--- a/docs/shared-client-contract.md
+++ b/docs/shared-client-contract.md
@@ -44,6 +44,19 @@ src/contract/
 Public entrypoint: `@honua/sdk-js/contract` (also re-exported from the
 top-level `@honua/sdk-js` and `@honua/sdk-js/honua` barrels).
 
+## Cross-SDK binding policy
+
+This JS contract is also the draft semantic anchor for the Python and .NET SDKs.
+The SDKs should align behavior and vocabulary while keeping language-native
+names and casing. For example, the same operation may surface as `queryAll()`
+in TypeScript, `query_all()` in Python, and `QueryAllAsync()` in .NET.
+
+The binding policy and cross-SDK fixture pack are documented in
+[`sdk-surface-alignment.md`](./sdk-surface-alignment.md). The JSON fixture pack
+lives under `test/fixtures/sdk-contract/`; it is intentionally language-neutral
+so downstream SDKs can consume the same protocol, capability, result,
+unsupported-capability, and degraded-result scenarios.
+
 ## Canonical nouns
 
 | Type | What it is |

--- a/mcp/dist/src/index.js
+++ b/mcp/dist/src/index.js
@@ -14,7 +14,7 @@ import * as queryFeatures from "./tools/query-features.js";
 import * as statistics from "./tools/statistics.js";
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_RETRIES = 2;
-const DEFAULT_SERVER_VERSION = "0.0.1-alpha.0";
+const DEFAULT_SERVER_VERSION = "0.0.3-alpha.0";
 export const SERVER_VERSION = resolveServerVersion();
 function resolveServerVersion() {
     try {

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@honua/mcp-server",
-  "version": "0.0.1-alpha.0",
+  "version": "0.0.3-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@honua/mcp-server",
-      "version": "0.0.1-alpha.0",
+      "version": "0.0.3-alpha.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "zod": "^3.24.0"
@@ -31,7 +31,7 @@
     },
     "..": {
       "name": "@honua/sdk-js",
-      "version": "0.0.1-alpha.0",
+      "version": "0.0.3-alpha.0",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -45,7 +45,11 @@
         "@bufbuild/protoc-gen-es": "^2.0.0",
         "@playwright/test": "^1.58.0",
         "@types/node": "^24.3.1",
+        "@vitest/coverage-v8": "^4.0.18",
+        "cesium": "^1.139.1",
+        "maplibre-gl": "^5.21.1",
         "typescript": "^5.9.2",
+        "vite": "^7.3.1",
         "vitest": "^4.0.16"
       },
       "engines": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honua/mcp-server",
-  "version": "0.0.2-alpha.0",
+  "version": "0.0.3-alpha.0",
   "description": "MCP server for Honua geospatial feature services",
   "type": "module",
   "bin": {

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -25,7 +25,7 @@ export interface RuntimeOptions {
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_RETRIES = 2;
-const DEFAULT_SERVER_VERSION = "0.0.2-alpha.0";
+const DEFAULT_SERVER_VERSION = "0.0.3-alpha.0";
 
 export const SERVER_VERSION = resolveServerVersion();
 

--- a/test/contract/sdk-contract-fixtures.test.ts
+++ b/test/contract/sdk-contract-fixtures.test.ts
@@ -1,0 +1,180 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { CAPABILITIES, PROTOCOLS, PROTOCOL_DEFAULT_CAPABILITIES } from "../../src/contract/index.js";
+
+interface ContractFixture {
+  schemaVersion: number;
+  canonicalNouns: readonly string[];
+  languageBindings: ReadonlyArray<{
+    concept: string;
+    typescript: string;
+    python: string;
+    dotnet: string;
+  }>;
+  protocols: readonly string[];
+  protocolAliases: Record<string, string>;
+  capabilities: readonly string[];
+  defaultCapabilities: Record<string, readonly string[]>;
+  resultScenarios: readonly ResultScenario[];
+  unsupportedCapabilityScenarios: readonly UnsupportedCapabilityScenario[];
+}
+
+interface ResultScenario {
+  id: string;
+  protocol: string;
+  operation?: string;
+  sourceDescriptor?: {
+    id: string;
+    protocol: string;
+    locator: Record<string, unknown>;
+    capabilities: readonly string[];
+  };
+  query: Record<string, unknown>;
+  result: {
+    features: readonly ContractFeature[];
+    exceededTransferLimit: boolean;
+    totalCount?: number;
+    fields?: ReadonlyArray<Record<string, unknown>>;
+    aggregateRows?: ReadonlyArray<Record<string, unknown>>;
+    degraded?: readonly DegradedReason[];
+  };
+}
+
+interface ContractFeature {
+  id?: string | number;
+  attributes: Record<string, unknown>;
+  geometry?: Record<string, unknown> | null;
+}
+
+interface DegradedReason {
+  capability: string;
+  reason: string;
+  protocol?: string;
+  sourceId?: string;
+}
+
+interface UnsupportedCapabilityScenario {
+  id: string;
+  protocol: string;
+  operation: string;
+  requiredCapability: string;
+  expectedError: {
+    name: string;
+    capability: string;
+    protocol: string;
+  };
+}
+
+const fixturesDir = resolve(dirname(fileURLToPath(import.meta.url)), "../fixtures/sdk-contract");
+const fixture = JSON.parse(readFileSync(resolve(fixturesDir, "semantic-contract.v1.json"), "utf8")) as ContractFixture;
+
+describe("cross-SDK contract fixture", () => {
+  it("pins the exported protocol registry", () => {
+    expect(fixture.schemaVersion).toBe(1);
+    expect(fixture.protocols).toEqual(PROTOCOLS);
+  });
+
+  it("pins the exported capability registry", () => {
+    expect(fixture.capabilities).toEqual(CAPABILITIES);
+  });
+
+  it("pins the default capability set for every protocol", () => {
+    expect(Object.keys(fixture.defaultCapabilities)).toEqual(PROTOCOLS);
+
+    for (const protocol of PROTOCOLS) {
+      expect(fixture.defaultCapabilities[protocol]).toEqual([...PROTOCOL_DEFAULT_CAPABILITIES[protocol]]);
+    }
+  });
+
+  it("keeps protocol aliases pointed at canonical protocol ids", () => {
+    for (const [alias, canonical] of Object.entries(fixture.protocolAliases)) {
+      expect(alias).not.toBe(canonical);
+      expect(PROTOCOLS).toContain(canonical);
+    }
+  });
+
+  it("documents idiomatic bindings without requiring identical spelling across languages", () => {
+    const bindingsByConcept = new Map(fixture.languageBindings.map((binding) => [binding.concept, binding]));
+    expect(bindingsByConcept.get("queryAll")).toMatchObject({
+      typescript: "queryAll()",
+      python: "query_all()",
+      dotnet: "QueryAllAsync()",
+    });
+    expect(bindingsByConcept.get("returnGeometry")).toMatchObject({
+      typescript: "returnGeometry",
+      python: "return_geometry",
+      dotnet: "ReturnGeometry",
+    });
+  });
+
+  it("defines the canonical source/query/result nouns used by downstream SDKs", () => {
+    expect(fixture.canonicalNouns).toEqual([
+      "Dataset",
+      "SourceDescriptor",
+      "Source",
+      "Protocol",
+      "Capability",
+      "Query",
+      "Result",
+      "EditEnvelope",
+      "EditResult",
+      "MapBinding",
+    ]);
+  });
+
+  it("validates result scenarios across queryable protocol families", () => {
+    const protocolsWithResults = new Set<string>();
+
+    for (const scenario of fixture.resultScenarios) {
+      protocolsWithResults.add(scenario.protocol);
+      expect(PROTOCOLS).toContain(scenario.protocol);
+      expect(scenario.id).toMatch(/^[a-z0-9-]+$/);
+      expect(typeof scenario.query).toBe("object");
+      expect(Array.isArray(scenario.result.features)).toBe(true);
+      expect(typeof scenario.result.exceededTransferLimit).toBe("boolean");
+
+      if (scenario.sourceDescriptor) {
+        expect(scenario.sourceDescriptor.protocol).toBe(scenario.protocol);
+        for (const capability of scenario.sourceDescriptor.capabilities) {
+          expect(CAPABILITIES).toContain(capability);
+        }
+      }
+
+      for (const feature of scenario.result.features) {
+        expect(feature.attributes).toBeDefined();
+        expect(typeof feature.attributes).toBe("object");
+        if ("geometry" in feature) {
+          expect(feature.geometry === null || typeof feature.geometry === "object").toBe(true);
+        }
+      }
+
+      if (scenario.result.degraded) {
+        for (const reason of scenario.result.degraded) {
+          expect(CAPABILITIES).toContain(reason.capability);
+          if (reason.protocol) expect(PROTOCOLS).toContain(reason.protocol);
+          expect(reason.reason.length).toBeGreaterThan(0);
+        }
+      }
+    }
+
+    expect(protocolsWithResults).toEqual(
+      new Set(["geoservices-feature-service", "ogc-features", "stac", "odata", "wfs"]),
+    );
+  });
+
+  it("validates unsupported-capability scenarios as explicit errors", () => {
+    for (const scenario of fixture.unsupportedCapabilityScenarios) {
+      expect(PROTOCOLS).toContain(scenario.protocol);
+      expect(CAPABILITIES).toContain(scenario.requiredCapability);
+      expect(scenario.expectedError).toEqual({
+        name: "HonuaCapabilityNotSupportedError",
+        capability: scenario.requiredCapability,
+        protocol: scenario.protocol,
+      });
+    }
+  });
+});

--- a/test/fixtures/sdk-contract/README.md
+++ b/test/fixtures/sdk-contract/README.md
@@ -1,0 +1,20 @@
+# SDK Contract Fixtures
+
+These JSON fixtures define cross-SDK semantics for the Honua shared source and
+query contract. They are meant to be consumed by JavaScript, Python, and .NET
+tests.
+
+The fixtures validate behavior and envelopes, not exact method spelling. Each
+SDK should map the same concepts into idiomatic local names.
+
+Current fixture:
+
+- `semantic-contract.v1.json`: protocol and capability registries, common
+  language binding names, result-envelope scenarios, unsupported-capability
+  expectations, and degraded-result expectations.
+
+When this fixture changes, update:
+
+- `docs/sdk-surface-alignment.md`
+- `docs/shared-client-contract.md`
+- Python and .NET consumers once those tickets land

--- a/test/fixtures/sdk-contract/semantic-contract.v1.json
+++ b/test/fixtures/sdk-contract/semantic-contract.v1.json
@@ -1,0 +1,592 @@
+{
+  "schemaVersion": 1,
+  "status": "draft",
+  "tracker": "https://github.com/honua-io/honua-sdk-js/issues/44",
+  "description": "Cross-SDK semantic fixture pack for Honua Dataset/Source/Query/Result behavior. Language bindings may use idiomatic names and casing.",
+  "canonicalNouns": [
+    "Dataset",
+    "SourceDescriptor",
+    "Source",
+    "Protocol",
+    "Capability",
+    "Query",
+    "Result",
+    "EditEnvelope",
+    "EditResult",
+    "MapBinding"
+  ],
+  "languageBindings": [
+    {
+      "concept": "queryAll",
+      "typescript": "queryAll()",
+      "python": "query_all()",
+      "dotnet": "QueryAllAsync()"
+    },
+    {
+      "concept": "stream",
+      "typescript": "stream()",
+      "python": "stream() or iter_*()",
+      "dotnet": "StreamAsync() or QueryPagesAsync()"
+    },
+    {
+      "concept": "queryObjectIds",
+      "typescript": "queryObjectIds()",
+      "python": "query_object_ids()",
+      "dotnet": "QueryObjectIdsAsync()"
+    },
+    {
+      "concept": "applyEdits",
+      "typescript": "applyEdits()",
+      "python": "apply_edits()",
+      "dotnet": "ApplyEditsAsync()"
+    },
+    {
+      "concept": "returnGeometry",
+      "typescript": "returnGeometry",
+      "python": "return_geometry",
+      "dotnet": "ReturnGeometry"
+    },
+    {
+      "concept": "outFields",
+      "typescript": "outFields",
+      "python": "out_fields",
+      "dotnet": "OutFields"
+    },
+    {
+      "concept": "protocolEscapeHatch",
+      "typescript": "source.protocol(...)",
+      "python": "source.protocol(...)",
+      "dotnet": "source.Protocol(...)"
+    }
+  ],
+  "protocols": [
+    "geoservices-feature-service",
+    "geoservices-map-service",
+    "geoservices-image-service",
+    "geoservices-geometry-service",
+    "geoservices-gp-service",
+    "ogc-features",
+    "ogc-tiles",
+    "ogc-maps",
+    "stac",
+    "wfs",
+    "wms",
+    "wmts",
+    "odata",
+    "maplibre-vector",
+    "maplibre-raster",
+    "maplibre-geojson"
+  ],
+  "protocolAliases": {
+    "feature-server": "geoservices-feature-service",
+    "featureserver": "geoservices-feature-service",
+    "feature-service": "geoservices-feature-service",
+    "geoservices-featureserver": "geoservices-feature-service",
+    "map-server": "geoservices-map-service",
+    "mapserver": "geoservices-map-service",
+    "image-server": "geoservices-image-service",
+    "imageserver": "geoservices-image-service",
+    "geometry-server": "geoservices-geometry-service",
+    "geometryserver": "geoservices-geometry-service",
+    "gp-server": "geoservices-gp-service",
+    "gpserver": "geoservices-gp-service",
+    "ogc-api-features": "ogc-features",
+    "ogc_features": "ogc-features",
+    "odata-v4": "odata",
+    "wfs-2.0": "wfs",
+    "wms-1.3.0": "wms",
+    "wmts-1.0.0": "wmts"
+  },
+  "capabilities": [
+    "query",
+    "queryAggregate",
+    "queryExtent",
+    "queryObjectIds",
+    "queryRelated",
+    "applyEdits",
+    "attachments",
+    "render",
+    "tiles",
+    "sql",
+    "stream",
+    "pbf",
+    "connect",
+    "image",
+    "geometry",
+    "geoprocess",
+    "processes"
+  ],
+  "defaultCapabilities": {
+    "geoservices-feature-service": [
+      "query",
+      "queryAggregate",
+      "queryExtent",
+      "queryObjectIds",
+      "queryRelated",
+      "applyEdits",
+      "attachments",
+      "sql",
+      "stream",
+      "pbf",
+      "connect"
+    ],
+    "geoservices-map-service": [
+      "query",
+      "queryAggregate",
+      "queryExtent",
+      "queryObjectIds",
+      "queryRelated",
+      "render",
+      "tiles",
+      "sql",
+      "stream"
+    ],
+    "geoservices-image-service": [
+      "query",
+      "queryExtent",
+      "queryObjectIds",
+      "image",
+      "render",
+      "tiles",
+      "connect"
+    ],
+    "geoservices-geometry-service": [
+      "geometry",
+      "connect"
+    ],
+    "geoservices-gp-service": [
+      "geoprocess",
+      "connect"
+    ],
+    "ogc-features": [
+      "query",
+      "queryObjectIds",
+      "applyEdits",
+      "stream"
+    ],
+    "ogc-tiles": [
+      "render",
+      "tiles"
+    ],
+    "ogc-maps": [
+      "render"
+    ],
+    "stac": [
+      "query",
+      "queryObjectIds",
+      "stream"
+    ],
+    "wfs": [
+      "query",
+      "queryExtent",
+      "queryObjectIds",
+      "applyEdits",
+      "stream"
+    ],
+    "wms": [
+      "render",
+      "tiles",
+      "query"
+    ],
+    "wmts": [
+      "render",
+      "tiles"
+    ],
+    "odata": [
+      "query",
+      "queryObjectIds",
+      "stream",
+      "applyEdits"
+    ],
+    "maplibre-vector": [
+      "render",
+      "tiles"
+    ],
+    "maplibre-raster": [
+      "render",
+      "tiles"
+    ],
+    "maplibre-geojson": [
+      "render"
+    ]
+  },
+  "resultScenarios": [
+    {
+      "id": "featureserver-page",
+      "protocol": "geoservices-feature-service",
+      "sourceDescriptor": {
+        "id": "parcels-fs",
+        "protocol": "geoservices-feature-service",
+        "locator": {
+          "serviceId": "Parcels",
+          "layerId": 0
+        },
+        "capabilities": [
+          "query",
+          "queryExtent",
+          "queryObjectIds"
+        ]
+      },
+      "query": {
+        "where": "STATUS = 'ACTIVE'",
+        "outFields": [
+          "OBJECTID",
+          "NAME",
+          "STATUS"
+        ],
+        "pagination": {
+          "limit": 2
+        },
+        "returnGeometry": true,
+        "outSr": 4326
+      },
+      "result": {
+        "features": [
+          {
+            "id": 1,
+            "attributes": {
+              "OBJECTID": 1,
+              "NAME": "Ala Wai",
+              "STATUS": "ACTIVE"
+            },
+            "geometry": {
+              "x": -157.836,
+              "y": 21.284
+            }
+          },
+          {
+            "id": 2,
+            "attributes": {
+              "OBJECTID": 2,
+              "NAME": "Kapiolani",
+              "STATUS": "ACTIVE"
+            },
+            "geometry": {
+              "x": -157.82,
+              "y": 21.267
+            }
+          }
+        ],
+        "exceededTransferLimit": false,
+        "totalCount": 2,
+        "fields": [
+          {
+            "name": "OBJECTID",
+            "type": "oid"
+          },
+          {
+            "name": "NAME",
+            "type": "string"
+          },
+          {
+            "name": "STATUS",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "id": "ogc-features-page",
+      "protocol": "ogc-features",
+      "sourceDescriptor": {
+        "id": "parcels-ogc",
+        "protocol": "ogc-features",
+        "locator": {
+          "collectionId": "parcels"
+        },
+        "capabilities": [
+          "query",
+          "queryObjectIds",
+          "stream"
+        ]
+      },
+      "query": {
+        "where": "STATUS = 'ACTIVE'",
+        "outFields": [
+          "NAME",
+          "STATUS"
+        ],
+        "pagination": {
+          "limit": 2
+        },
+        "returnGeometry": true
+      },
+      "result": {
+        "features": [
+          {
+            "id": "ogc-1",
+            "attributes": {
+              "NAME": "Ala Wai",
+              "STATUS": "ACTIVE"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -157.836,
+                21.284
+              ]
+            }
+          }
+        ],
+        "exceededTransferLimit": false,
+        "totalCount": 1
+      }
+    },
+    {
+      "id": "stac-search-page",
+      "protocol": "stac",
+      "sourceDescriptor": {
+        "id": "imagery-stac",
+        "protocol": "stac",
+        "locator": {
+          "collectionId": "imagery"
+        },
+        "capabilities": [
+          "query",
+          "queryObjectIds",
+          "stream"
+        ]
+      },
+      "query": {
+        "where": "eo:cloud_cover < 10",
+        "pagination": {
+          "limit": 1
+        },
+        "returnGeometry": true
+      },
+      "result": {
+        "features": [
+          {
+            "id": "scene-001",
+            "attributes": {
+              "collection": "imagery",
+              "eo:cloud_cover": 4.2
+            },
+            "geometry": {
+              "type": "Polygon",
+              "coordinates": [
+                [
+                  [
+                    -158,
+                    21
+                  ],
+                  [
+                    -157,
+                    21
+                  ],
+                  [
+                    -157,
+                    22
+                  ],
+                  [
+                    -158,
+                    22
+                  ],
+                  [
+                    -158,
+                    21
+                  ]
+                ]
+              ]
+            }
+          }
+        ],
+        "exceededTransferLimit": false,
+        "totalCount": 1
+      }
+    },
+    {
+      "id": "odata-page",
+      "protocol": "odata",
+      "sourceDescriptor": {
+        "id": "features-odata",
+        "protocol": "odata",
+        "locator": {
+          "entitySet": "Features"
+        },
+        "capabilities": [
+          "query",
+          "queryObjectIds",
+          "stream",
+          "applyEdits"
+        ]
+      },
+      "query": {
+        "where": "Status eq 'ACTIVE'",
+        "outFields": [
+          "ObjectId",
+          "Name",
+          "Status"
+        ],
+        "pagination": {
+          "limit": 1
+        },
+        "returnGeometry": true
+      },
+      "result": {
+        "features": [
+          {
+            "id": 42,
+            "attributes": {
+              "ObjectId": 42,
+              "Name": "Ala Wai",
+              "Status": "ACTIVE"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -157.836,
+                21.284
+              ]
+            }
+          }
+        ],
+        "exceededTransferLimit": false,
+        "totalCount": 1
+      }
+    },
+    {
+      "id": "wfs-geojson-page",
+      "protocol": "wfs",
+      "sourceDescriptor": {
+        "id": "parcels-wfs",
+        "protocol": "wfs",
+        "locator": {
+          "typeName": "parcels"
+        },
+        "capabilities": [
+          "query",
+          "queryExtent",
+          "queryObjectIds",
+          "stream"
+        ]
+      },
+      "query": {
+        "where": "STATUS = 'ACTIVE'",
+        "pagination": {
+          "limit": 1
+        },
+        "returnGeometry": true
+      },
+      "result": {
+        "features": [
+          {
+            "id": "parcels.1",
+            "attributes": {
+              "NAME": "Ala Wai",
+              "STATUS": "ACTIVE"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -157.836,
+                21.284
+              ]
+            }
+          }
+        ],
+        "exceededTransferLimit": false,
+        "totalCount": 1
+      }
+    },
+    {
+      "id": "empty-page",
+      "protocol": "geoservices-feature-service",
+      "query": {
+        "where": "1 = 0",
+        "pagination": {
+          "limit": 10
+        }
+      },
+      "result": {
+        "features": [],
+        "exceededTransferLimit": false,
+        "totalCount": 0
+      }
+    },
+    {
+      "id": "exceeded-transfer-page",
+      "protocol": "geoservices-feature-service",
+      "query": {
+        "where": "1 = 1",
+        "pagination": {
+          "limit": 1
+        }
+      },
+      "result": {
+        "features": [
+          {
+            "id": 1,
+            "attributes": {
+              "OBJECTID": 1
+            },
+            "geometry": null
+          }
+        ],
+        "exceededTransferLimit": true,
+        "totalCount": 2
+      }
+    },
+    {
+      "id": "ogc-features-aggregate-degraded",
+      "protocol": "ogc-features",
+      "operation": "queryAggregate",
+      "query": {
+        "aggregation": {
+          "groupBy": [
+            "STATUS"
+          ],
+          "metrics": [
+            {
+              "fn": "count",
+              "field": "OBJECTID",
+              "alias": "COUNT_OBJECTID"
+            }
+          ]
+        }
+      },
+      "result": {
+        "features": [],
+        "exceededTransferLimit": false,
+        "aggregateRows": [
+          {
+            "STATUS": "ACTIVE",
+            "COUNT_OBJECTID": 2
+          }
+        ],
+        "degraded": [
+          {
+            "capability": "queryAggregate",
+            "protocol": "ogc-features",
+            "sourceId": "parcels-ogc",
+            "reason": "Server-side aggregation is unavailable; result was computed client-side over drained pages."
+          }
+        ]
+      }
+    }
+  ],
+  "unsupportedCapabilityScenarios": [
+    {
+      "id": "wmts-query-unsupported",
+      "protocol": "wmts",
+      "operation": "query",
+      "requiredCapability": "query",
+      "expectedError": {
+        "name": "HonuaCapabilityNotSupportedError",
+        "capability": "query",
+        "protocol": "wmts"
+      }
+    },
+    {
+      "id": "ogc-tiles-apply-edits-unsupported",
+      "protocol": "ogc-tiles",
+      "operation": "applyEdits",
+      "requiredCapability": "applyEdits",
+      "expectedError": {
+        "name": "HonuaCapabilityNotSupportedError",
+        "capability": "applyEdits",
+        "protocol": "ogc-tiles"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a cross-SDK surface-alignment doc that anchors JS/Python/.NET on shared semantics while preserving idiomatic language naming and casing.
- Adds a language-neutral JSON fixture pack for canonical protocol IDs, capabilities, aliases, query/result scenarios, unsupported-capability expectations, and degraded-result expectations.
- Adds a JS drift-gate test that keeps the fixture pack aligned with `@honua/sdk-js/contract` exports.
- Links the fixture pack from the README and shared contract docs.
- Aligns the MCP package version with the root SDK version so the existing MCP version gate passes on the PR merge checkout.

Closes https://github.com/honua-io/honua-sdk-js/issues/45.
Addresses https://github.com/honua-io/honua-sdk-js/issues/44.

## Validation

- `source ~/.nvm/nvm.sh && nvm use 20.19.0 >/dev/null && npm ci`
- `source ~/.nvm/nvm.sh && nvm use 20.19.0 >/dev/null && npm run typecheck`
- `source ~/.nvm/nvm.sh && nvm use 20.19.0 >/dev/null && npm run build`
- `source ~/.nvm/nvm.sh && nvm use 20.19.0 >/dev/null && npm test -- test/contract/sdk-contract-fixtures.test.ts test/contract/conformance.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20.19.0 >/dev/null && npm test --prefix mcp`
- `npx biome check docs/sdk-surface-alignment.md docs/shared-client-contract.md README.md test/contract/sdk-contract-fixtures.test.ts test/fixtures/sdk-contract/README.md test/fixtures/sdk-contract/semantic-contract.v1.json`
- `npm run lint` passed with pre-existing warnings.

GitHub PR checks are green: JS SDK and MCP SDK.