### PR TITLE
feat: SDK surface alignment RFC: canonical cross-language semantics (#44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,57 @@
 # Honua JS SDK
 
+## Mental Model: `Dataset` → `Source` → `Query` → `Result`
+
+Every Honua SDK — JavaScript, Python, .NET — speaks the same canonical
+vocabulary. A `Dataset` groups one or more `Source`s. Each `Source` accepts a
+protocol-neutral `Query` and returns a protocol-neutral `Result`. Operations the
+canonical surface does not cover stay reachable through the typed
+`source.protocol(...)` escape hatch. Method casing differs by language
+(`queryAll()` / `query_all()` / `QueryAllAsync()`), the semantics do not.
+
+```bash
+npm install @honua/sdk-js
+```
+
+```ts
+import { createDataset, PROTOCOL_DEFAULT_CAPABILITIES } from "@honua/sdk-js/contract";
+import { HonuaClient } from "@honua/sdk-js/honua";
+
+const client = new HonuaClient({ baseUrl: "https://your-honua-server.example" });
+
+const dataset = createDataset({
+  id: "parcels",
+  client,
+  sources: [
+    {
+      id: "parcels-fs",
+      protocol: "geoservices-feature-service",
+      locator: { url: "https://your-honua-server.example", serviceId: "parcels", layerId: 0 },
+      capabilities: PROTOCOL_DEFAULT_CAPABILITIES["geoservices-feature-service"],
+    },
+  ],
+});
+
+const parcels = dataset.source("parcels-fs")!;
+const result = await parcels.queryAll({
+  where: "STATUS = 'ACTIVE'",
+  outFields: ["OBJECTID", "NAME", "STATUS"],
+  returnGeometry: true,
+  pagination: { limit: 500 },
+});
+
+console.log(`Loaded ${result.features.length} features (exceeded=${result.exceededTransferLimit})`);
+```
+
+Cross-language semantics, protocol/capability identifiers, language-binding
+tables, and backwards-compatibility policy live in
+[`docs/sdk-surface-alignment.md`](./docs/sdk-surface-alignment.md). The shared
+contract design and protocol coverage live in
+[`docs/shared-client-contract.md`](./docs/shared-client-contract.md) and
+[`docs/protocol-capability-matrix.md`](./docs/protocol-capability-matrix.md).
+Capability misses throw `HonuaCapabilityNotSupportedError` (under the default
+`strict` policy) rather than silently returning empty results.
+
 ## Quickstart
 
 Canonical runnable browser quickstart from this repo:
@@ -13,9 +65,11 @@ Use [`examples/maplibre-quickstart/`](./examples/maplibre-quickstart/README.md) 
 [`docs/quickstart.md`](./docs/quickstart.md) for the guided quickstart flow, and
 [`docs/quickstart-troubleshooting.md`](./docs/quickstart-troubleshooting.md) for common failure modes.
 
-```bash
-npm install @honua/sdk-js
-```
+The browser quickstart and the snippet below demonstrate the protocol escape
+hatch — `HonuaClient.queryFeatures` is the GeoServices FeatureServer call
+backing `Source.query()` and remains the migration-friendly path for code
+already written against the raw client. New cross-protocol code should reach
+for `createDataset` and `Source` first.
 
 ```ts
 import { HonuaClient } from "@honua/sdk-js/honua";

--- a/docs/sdk-surface-alignment.md
+++ b/docs/sdk-surface-alignment.md
@@ -1,11 +1,13 @@
 # Cross-SDK Surface Alignment
 
-Status: draft contract anchor for https://github.com/honua-io/honua-sdk-js/issues/44.
+Status: pending review for https://github.com/honua-io/honua-sdk-js/issues/44.
+Once the PR merges this becomes the canonical reference for downstream Python
+and .NET SDK alignment work; flip the status line to `reviewed` at that point.
 
 The Honua SDKs should share one mental model even when each language keeps its
 own naming conventions. JavaScript may use `queryAll()`, Python may use
 `query_all()`, and .NET may use `QueryAllAsync()`. Those names are allowed to
-differ. The semantics behind them should not.
+differ. The semantics behind them must not.
 
 ## Canonical Semantics
 
@@ -21,7 +23,14 @@ Use the `@honua/sdk-js/contract` vocabulary as the current source of truth:
 | `Query` | Protocol-neutral request intent. |
 | `Result` | Protocol-neutral result envelope. |
 | `EditEnvelope` / `EditResult` | Protocol-neutral write envelope and result. |
+| `MapBinding` | Source → renderer-layer binding (used by `MapPackage` round-trips). |
 | `protocol(...)` | Explicit native protocol escape hatch. |
+
+These are the canonical nouns pinned in
+[`test/fixtures/sdk-contract/semantic-contract.v1.json`](../test/fixtures/sdk-contract/semantic-contract.v1.json)
+and validated by the drift gate
+([`test/contract/sdk-contract-fixtures.test.ts`](../test/contract/sdk-contract-fixtures.test.ts)).
+Renaming a noun without updating both sites trips CI.
 
 ## Language Bindings
 
@@ -46,9 +55,10 @@ new source-oriented facades converge on the same behavior.
 ## Stable Protocol IDs
 
 The canonical protocol identifiers are the values exported from
-`PROTOCOLS` in `src/contract/types.ts`. SDKs may accept aliases for already
-shipped public names, but serialized descriptors and docs should prefer the
-canonical identifiers:
+`PROTOCOLS` in `src/contract/types.ts`. Serialized descriptors and docs should
+prefer the canonical identifiers; SDKs may accept short or legacy aliases for
+already-shipped public names by normalizing on read through the
+`protocolAliases` map in the fixture pack:
 
 - `geoservices-feature-service`
 - `geoservices-map-service`
@@ -72,12 +82,15 @@ canonical identifiers:
 The canonical capability identifiers are the values exported from
 `CAPABILITIES` in `src/contract/types.ts`. SDKs should gate behavior on these
 semantic identifiers rather than inventing per-repo names for the same
-operation.
+operation. Default capability sets per protocol live in
+`PROTOCOL_DEFAULT_CAPABILITIES` and are mirrored in
+[`docs/protocol-capability-matrix.md`](./protocol-capability-matrix.md).
 
-Capability misses must be explicit. The preferred behavior is a typed SDK error
-or an unsupported-capability result that names the missing capability and
-protocol. Returning an empty result for an unsupported operation is not
-acceptable because it is indistinguishable from a valid query with no matches.
+Capability misses must be explicit. The required behavior is a typed SDK error
+that names the missing capability and protocol (`HonuaCapabilityNotSupportedError`
+in JS; equivalent typed errors in Python and .NET). Returning an empty result
+for an unsupported operation is not acceptable because it is indistinguishable
+from a valid query with no matches.
 
 ## Query Semantics
 
@@ -113,16 +126,118 @@ All SDKs should expose the same result facts:
   optional source id.
 - raw/provider-native payload access remains available for advanced workflows.
 
+## Backwards Compatibility And Deprecation Policy
+
+The RFC aligns semantics — it does not delete shipped APIs.
+
+- **Existing public names are preserved** as aliases or facades over the
+  canonical surface. JS keeps `Source.adapter()` as a documented alias of
+  `Source.protocol()`; Python keeps `FeatureQuery` and friends; .NET keeps
+  `FeatureQueryRequest` and friends. Each binding may add the canonical name
+  alongside the legacy name without renaming the legacy name.
+- **Deprecation requires a documented removal timeline.** A binding that
+  introduces a canonical alternative may mark the legacy name deprecated and
+  remove it at the next major version, never sooner. The deprecation note
+  must point at the canonical replacement and (where applicable) at this RFC.
+- **Protocol aliases normalize on read.** Short and legacy protocol names that
+  already shipped in any SDK appear in the `protocolAliases` map of
+  [`semantic-contract.v1.json`](../test/fixtures/sdk-contract/semantic-contract.v1.json).
+  SDKs accept those aliases as input, but every serialized descriptor — fixture,
+  server `SourceBinding`, telemetry, log line — emits the canonical id.
+  Adding a new alias is backwards-compatible; renaming a canonical id is not.
+- **Capability behavior may not silently change.** Adding a capability to a
+  protocol is backwards-compatible. Removing one (or downgrading from
+  first-party to client-side fallback) is a breaking change and must ship in a
+  major version with a `degraded[]` migration path documented in the
+  per-protocol notes of `docs/protocol-capability-matrix.md`.
+- **`canonicalNouns` is part of the contract.** Renaming `Dataset`,
+  `SourceDescriptor`, `Source`, `Protocol`, `Capability`, `Query`, `Result`,
+  `EditEnvelope`, `EditResult`, or `MapBinding` is a breaking change to every
+  downstream SDK; the drift gate enforces this.
+
+## Decisions Locked By This RFC
+
+These are the alignment points the RFC nails down. Any future change to one of
+these requires a follow-up RFC plus coordinated multi-SDK updates.
+
+- Canonical protocol identifiers and the canonical → alias normalization
+  direction.
+- Canonical capability identifiers and per-protocol default capability sets.
+- Query field names and semantics for `where`, spatial filter / bbox,
+  `outFields`, `orderBy`, `pagination`, `returnGeometry`, `outSr`, and
+  cancellation.
+- Result envelope shape: features array (never undefined), pagination state,
+  `totalCount`, field schema, extent, degraded reasons, and raw payload
+  access.
+- Unsupported-capability behavior: typed error, never a silent no-op or empty
+  result.
+- Native protocol escape hatch: every protocol-specific operation that does
+  not belong on the shared surface lives behind the binding-idiomatic
+  `protocol(...)` accessor (`Source.protocol(...)` in JS / Python,
+  `Source.Protocol(...)` in .NET). The shared surface stays free of
+  protocol-typed structures.
+
 ## Fixture Pack
 
 The cross-SDK fixture pack lives under
-`test/fixtures/sdk-contract/semantic-contract.v1.json`. It is intentionally
-JSON-only so Python and .NET can consume the same payloads without depending on
-the JS test helpers.
+[`test/fixtures/sdk-contract/semantic-contract.v1.json`](../test/fixtures/sdk-contract/semantic-contract.v1.json).
+It is intentionally JSON-only so Python and .NET can consume the same payloads
+without depending on the JS test helpers.
+
+Coverage today:
+
+- `protocols`, `capabilities`, and `defaultCapabilities` are pinned against the
+  live JS exports — drift trips CI.
+- `protocolAliases` records the short / legacy names already shipped (or about
+  to ship) in Python and .NET so each SDK normalizes on read.
+- `canonicalNouns` enumerates the ten contract nouns the drift gate enforces.
+- `languageBindings` documents idiomatic per-language method and field names.
+- `resultScenarios` cover FeatureServer, OGC API Features, STAC, OData, and
+  WFS; included variants exercise nominal queries, empty pages, exceeded
+  transfer limits, and the `queryAggregate` client-side degraded fallback for
+  OGC API Features.
+- `unsupportedCapabilityScenarios` cover render-only protocols (WMTS, OGC API
+  Tiles, OGC API Maps), utility-only GeoServices protocols (Geometry Service,
+  GP Service), and protocol-specific capability gaps (OGC API Features
+  `queryRelated`).
 
 The JS drift gate in `test/contract/sdk-contract-fixtures.test.ts` validates
-that the fixture pack stays aligned with the exported JS contract registries and
-with the documented result/error/degraded semantics.
+that the fixture pack stays aligned with the exported JS contract registries
+and with the documented result/error/degraded semantics. Downstream SDK work
+should consume this fixture pack directly or mirror it with a clear
+checksum/update process.
 
-Downstream SDK work should consume this fixture pack directly or mirror it with
-a clear checksum/update process.
+## Downstream Implementation Work
+
+This RFC is JS-side and docs-only. The Python and .NET SDK alignment lands as
+separate downstream tickets:
+
+- **Python**: `honua-sdk-python` will pin against
+  `semantic-contract.v1.json`, expose the canonical surface as
+  `Source.query_all` / `Source.protocol(...)`, and keep `FeatureQuery` plus
+  the existing free-function helpers as backwards-compatible facades. Track
+  via `honua-io/honua-sdk-python` issue (TODO: add link once issue is filed).
+- **.NET**: `honua-sdk-dotnet` will mirror the same fixture pack, expose
+  `Source.QueryAllAsync` / `Source.Protocol(...)` / `Source.QueryObjectIdsAsync`,
+  and keep `FeatureQueryRequest` as a facade. Track via
+  `honua-io/honua-sdk-dotnet` issue (TODO: add link once issue is filed).
+
+This ticket explicitly does not edit either repository. Filing the downstream
+issues is part of merging this RFC; updating the placeholders above with the
+real issue links is the only follow-up edit allowed inside `honua-sdk-js`
+once the downstream tickets are open.
+
+## References
+
+- Canonical type definitions:
+  [`src/contract/types.ts`](../src/contract/types.ts)
+- Cross-protocol matrix:
+  [`docs/protocol-capability-matrix.md`](./protocol-capability-matrix.md)
+- Shared client contract design:
+  [`docs/shared-client-contract.md`](./shared-client-contract.md)
+- Source-binding round-trip:
+  [`docs/source-binding-alignment.md`](./source-binding-alignment.md)
+- Drift gate test:
+  [`test/contract/sdk-contract-fixtures.test.ts`](../test/contract/sdk-contract-fixtures.test.ts)
+- Tracking issue: https://github.com/honua-io/honua-sdk-js/issues/44
+- Cross-repo coordination: `honua-io/honua-server#813`

--- a/docs/sdk-surface-alignment.md
+++ b/docs/sdk-surface-alignment.md
@@ -142,9 +142,17 @@ The RFC aligns semantics — it does not delete shipped APIs.
 - **Protocol aliases normalize on read.** Short and legacy protocol names that
   already shipped in any SDK appear in the `protocolAliases` map of
   [`semantic-contract.v1.json`](../test/fixtures/sdk-contract/semantic-contract.v1.json).
-  SDKs accept those aliases as input, but every serialized descriptor — fixture,
-  server `SourceBinding`, telemetry, log line — emits the canonical id.
-  Adding a new alias is backwards-compatible; renaming a canonical id is not.
+  SDKs accept those aliases as input, but every SDK-side serialized
+  descriptor — `SourceDescriptor` JSON, fixture pack, telemetry, log line —
+  emits the canonical kebab-case id. The server `SourceBinding` wire format
+  is independent: it stays on its documented snake_case enum
+  (`geoservices_feature_service`, `ogc_features`, …) per
+  [`source-binding-alignment.md`](./source-binding-alignment.md), and the
+  runtime normalizes server wire values to canonical SDK ids inside
+  `src/runtime/source-bridge.ts` before they reach `createDataset`. A
+  server-side wire-format rename would be a coordinated cross-repo contract
+  change, not a downstream SDK edit. Adding a new alias is backwards-
+  compatible; renaming a canonical id is not.
 - **Capability behavior may not silently change.** Adding a capability to a
   protocol is backwards-compatible. Removing one (or downgrading from
   first-party to client-side fallback) is a breaking change and must ship in a

--- a/test/fixtures/sdk-contract/semantic-contract.v1.json
+++ b/test/fixtures/sdk-contract/semantic-contract.v1.json
@@ -571,6 +571,7 @@
       "protocol": "wmts",
       "operation": "query",
       "requiredCapability": "query",
+      "reason": "WMTS is render-only; tile pixels do not project onto the canonical Query.spatialFilter envelope.",
       "expectedError": {
         "name": "HonuaCapabilityNotSupportedError",
         "capability": "query",
@@ -578,14 +579,75 @@
       }
     },
     {
+      "id": "ogc-tiles-query-unsupported",
+      "protocol": "ogc-tiles",
+      "operation": "query",
+      "requiredCapability": "query",
+      "reason": "OGC API Tiles is a render-only conformance class; feature query is not part of the surface.",
+      "expectedError": {
+        "name": "HonuaCapabilityNotSupportedError",
+        "capability": "query",
+        "protocol": "ogc-tiles"
+      }
+    },
+    {
       "id": "ogc-tiles-apply-edits-unsupported",
       "protocol": "ogc-tiles",
       "operation": "applyEdits",
       "requiredCapability": "applyEdits",
+      "reason": "Render-only adapters do not accept edits; mixed-source apps must surface the limitation explicitly.",
       "expectedError": {
         "name": "HonuaCapabilityNotSupportedError",
         "capability": "applyEdits",
         "protocol": "ogc-tiles"
+      }
+    },
+    {
+      "id": "ogc-maps-query-unsupported",
+      "protocol": "ogc-maps",
+      "operation": "query",
+      "requiredCapability": "query",
+      "reason": "OGC API Maps is render-only; the canonical Query family throws rather than silently returning empty.",
+      "expectedError": {
+        "name": "HonuaCapabilityNotSupportedError",
+        "capability": "query",
+        "protocol": "ogc-maps"
+      }
+    },
+    {
+      "id": "geometry-service-query-unsupported",
+      "protocol": "geoservices-geometry-service",
+      "operation": "query",
+      "requiredCapability": "query",
+      "reason": "Geometry Service is a stateless utility — it hosts no feature table. Operations live behind Source.protocol().",
+      "expectedError": {
+        "name": "HonuaCapabilityNotSupportedError",
+        "capability": "query",
+        "protocol": "geoservices-geometry-service"
+      }
+    },
+    {
+      "id": "gp-service-query-unsupported",
+      "protocol": "geoservices-gp-service",
+      "operation": "query",
+      "requiredCapability": "query",
+      "reason": "GP Service runs async tasks rather than hosting features. Job lifecycle lives behind Source.protocol().",
+      "expectedError": {
+        "name": "HonuaCapabilityNotSupportedError",
+        "capability": "query",
+        "protocol": "geoservices-gp-service"
+      }
+    },
+    {
+      "id": "ogc-features-related-unsupported",
+      "protocol": "ogc-features",
+      "operation": "queryRelated",
+      "requiredCapability": "queryRelated",
+      "reason": "OGC API Features does not model related records; queryRelated must throw rather than silently return an empty group.",
+      "expectedError": {
+        "name": "HonuaCapabilityNotSupportedError",
+        "capability": "queryRelated",
+        "protocol": "ogc-features"
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #44
## Summary

SDK surface alignment RFC: canonical cross-language semantics
## Changes Made

- SDK surface alignment RFC: canonical cross-language semantics
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally
## Additional Context

Decisions:
- Picked the reviewer's first suggested fix (narrow the SDK-side scope and call out the server wire format separately) rather than the second (coordinated server-side rename). The second would require honua-server changes plus `source-bridge.ts` updates, which is out of this single-repo ticket and would conflict with the existing `HonuaMapPackageProtocol` snake_case contract documented in `src/runtime/map-package.ts:27-43`.
- Kept the bullet inside the existing Backwards-Compatibility section (no new section) so the cross-reference web stays as-is.

Follow-ons:
- Same as the docs.md artifact: flip status `pending review` → `reviewed` once the PR merges; replace the two `TODO: add link once issue is filed` placeholders with real Python and .NET issue links once filed; expand `protocolAliases` as downstream alias inventory firms up; metadata-driven capability downgrades for non-OData adapters remain follow-up work.

Code kaizen:
Auto-deferred by kaizen policy.
