### PR TITLE
feat: Add integration tests against Honua Server protocol surfaces (#39)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,52 +7,63 @@ on:
       - "release/**"
   workflow_dispatch:
     inputs:
-      server_image:
-        description: "Honua Server image (default: ghcr.io/honua-io/honua-server:nightly-aot)"
+      base_url:
+        description: "Honua Server base URL (overrides repo variable). Server must be running and seeded."
         required: false
-        default: "ghcr.io/honua-io/honua-server:nightly-aot"
+      seed_profile:
+        description: "Seed profile label recorded into integration-meta.json (overrides repo variable)."
+        required: false
 
 env:
   NODE_VERSION: "20.19.0"
-  HONUA_SERVER_IMAGE: ${{ github.event.inputs.server_image || 'ghcr.io/honua-io/honua-server:nightly-aot' }}
-  HONUA_INTEGRATION_BASE_URL: http://localhost:8080
-  HONUA_INTEGRATION_SEED_PROFILE: ogc
 
 jobs:
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgis/postgis:17-3.5-alpine
-        env:
-          POSTGRES_DB: honua_dev
-          POSTGRES_USER: honua_user
-          POSTGRES_PASSWORD: honua_password
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U honua_user -d honua_dev"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
-      honua:
-        image: ${{ github.event.inputs.server_image || 'ghcr.io/honua-io/honua-server:nightly-aot' }}
-        env:
-          ASPNETCORE_ENVIRONMENT: Development
-          ASPNETCORE_URLS: "http://+:8080"
-          ConnectionStrings__DefaultConnection: "Host=postgres;Database=honua_dev;Username=honua_user;Password=honua_password"
-        ports:
-          - 8080:8080
-        options: >-
-          --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:8080/healthz/live || exit 1"
-          --health-interval 15s
-          --health-timeout 5s
-          --health-retries 20
+    env:
+      # Connect-only against an externally-managed seeded Honua Server.
+      # The server must be running and seeded before the workflow runs;
+      # the SDK lane does not own the bootstrap (no public seed image
+      # or admin seed API exists yet — see honua-sdk-js#39 follow-on).
+      HONUA_INTEGRATION_BASE_URL: ${{ github.event.inputs.base_url || vars.HONUA_INTEGRATION_BASE_URL }}
+      HONUA_INTEGRATION_API_KEY: ${{ secrets.HONUA_INTEGRATION_API_KEY }}
+      HONUA_INTEGRATION_SEED_PROFILE: ${{ github.event.inputs.seed_profile || vars.HONUA_INTEGRATION_SEED_PROFILE || 'places-roads-v1' }}
+      HONUA_INTEGRATION_SERVICE_ID: ${{ vars.HONUA_INTEGRATION_SERVICE_ID || 'test_service_gw0' }}
+      HONUA_INTEGRATION_LAYER_ID: ${{ vars.HONUA_INTEGRATION_LAYER_ID || '1000' }}
+      HONUA_INTEGRATION_COLLECTION_ID: ${{ vars.HONUA_INTEGRATION_COLLECTION_ID || '1000' }}
+      HONUA_INTEGRATION_TILE_MATRIX_SET: ${{ vars.HONUA_INTEGRATION_TILE_MATRIX_SET || 'WebMercatorQuad' }}
+      HONUA_INTEGRATION_SERVER_IMAGE: ${{ vars.HONUA_INTEGRATION_SERVER_IMAGE }}
     steps:
       - uses: actions/checkout@v6
 
+      - name: Gate on configured integration target
+        id: gate
+        run: |
+          if [ -z "${HONUA_INTEGRATION_BASE_URL:-}" ]; then
+            {
+              echo "## SDK Integration"
+              echo ""
+              echo "Skipped: \`HONUA_INTEGRATION_BASE_URL\` is not configured."
+              echo ""
+              echo "The integration lane is connect-only and runs against an"
+              echo "externally-managed seeded Honua Server. Configure the repo/org"
+              echo "variable \`HONUA_INTEGRATION_BASE_URL\` and the secret"
+              echo "\`HONUA_INTEGRATION_API_KEY\` (matching the server's"
+              echo "\`HONUA_ADMIN_PASSWORD\`) to enable this workflow."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::notice::HONUA_INTEGRATION_BASE_URL is not configured; skipping integration lane."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -z "${HONUA_INTEGRATION_API_KEY:-}" ]; then
+            echo "::error::HONUA_INTEGRATION_BASE_URL is set but HONUA_INTEGRATION_API_KEY secret is missing. The lane requires the secret to authenticate the admin capabilities probe; abort to surface the misconfiguration."
+            exit 1
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
       - name: Setup Node.js
+        if: steps.gate.outputs.skip != 'true'
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -60,9 +71,11 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
+        if: steps.gate.outputs.skip != 'true'
         run: npm ci
 
       - name: Wait for Honua Server health
+        if: steps.gate.outputs.skip != 'true'
         run: |
           for i in $(seq 1 60); do
             if curl -fsS "${HONUA_INTEGRATION_BASE_URL}/healthz/live" >/dev/null 2>&1; then
@@ -71,23 +84,17 @@ jobs:
             fi
             sleep 2
           done
-          echo "Honua Server did not become healthy in time" >&2
+          echo "Honua Server at ${HONUA_INTEGRATION_BASE_URL} did not report healthy within timeout" >&2
           exit 1
 
-      - name: Resolve server image digest
-        id: image-meta
-        run: |
-          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "${HONUA_SERVER_IMAGE}" 2>/dev/null || echo "${HONUA_SERVER_IMAGE}")
-          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-
       - name: Run integration tests
+        if: steps.gate.outputs.skip != 'true'
         env:
-          HONUA_INTEGRATION_SERVER_IMAGE: ${{ steps.image-meta.outputs.digest }}
           HONUA_INTEGRATION_SERVER_COMMIT: ${{ github.sha }}
         run: npm run test:integration
 
       - name: Upload integration metadata
-        if: ${{ always() }}
+        if: ${{ steps.gate.outputs.skip != 'true' && always() }}
         uses: actions/upload-artifact@v4
         with:
           name: integration-meta
@@ -95,7 +102,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Append integration summary
-        if: ${{ always() }}
+        if: ${{ steps.gate.outputs.skip != 'true' && always() }}
         run: |
           if [ ! -f test-results/integration-meta.json ]; then
             echo "Integration metadata file not produced." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,6 +13,9 @@ on:
       seed_profile:
         description: "Seed profile label recorded into integration-meta.json (overrides repo variable)."
         required: false
+      server_commit:
+        description: "Honua Server commit SHA recorded into integration-meta.json (overrides repo variable). Leave blank when unknown — do not set to the SDK commit."
+        required: false
 
 env:
   NODE_VERSION: "20.19.0"
@@ -34,6 +37,10 @@ jobs:
       HONUA_INTEGRATION_COLLECTION_ID: ${{ vars.HONUA_INTEGRATION_COLLECTION_ID || '1000' }}
       HONUA_INTEGRATION_TILE_MATRIX_SET: ${{ vars.HONUA_INTEGRATION_TILE_MATRIX_SET || 'WebMercatorQuad' }}
       HONUA_INTEGRATION_SERVER_IMAGE: ${{ vars.HONUA_INTEGRATION_SERVER_IMAGE }}
+      # Honua Server commit, sourced from the workflow input or a repo
+      # variable. Never derived from `github.sha` (which is the SDK
+      # repository commit, not the server under test).
+      HONUA_INTEGRATION_SERVER_COMMIT: ${{ github.event.inputs.server_commit || vars.HONUA_INTEGRATION_SERVER_COMMIT }}
     steps:
       - uses: actions/checkout@v6
 
@@ -89,8 +96,6 @@ jobs:
 
       - name: Run integration tests
         if: steps.gate.outputs.skip != 'true'
-        env:
-          HONUA_INTEGRATION_SERVER_COMMIT: ${{ github.sha }}
         run: npm run test:integration
 
       - name: Upload integration metadata

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,126 @@
+name: SDK Integration
+
+on:
+  push:
+    branches:
+      - trunk
+      - "release/**"
+  workflow_dispatch:
+    inputs:
+      server_image:
+        description: "Honua Server image (default: ghcr.io/honua-io/honua-server:nightly-aot)"
+        required: false
+        default: "ghcr.io/honua-io/honua-server:nightly-aot"
+
+env:
+  NODE_VERSION: "20.19.0"
+  HONUA_SERVER_IMAGE: ${{ github.event.inputs.server_image || 'ghcr.io/honua-io/honua-server:nightly-aot' }}
+  HONUA_INTEGRATION_BASE_URL: http://localhost:8080
+  HONUA_INTEGRATION_SEED_PROFILE: ogc
+
+jobs:
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgis/postgis:17-3.5-alpine
+        env:
+          POSTGRES_DB: honua_dev
+          POSTGRES_USER: honua_user
+          POSTGRES_PASSWORD: honua_password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U honua_user -d honua_dev"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+      honua:
+        image: ${{ github.event.inputs.server_image || 'ghcr.io/honua-io/honua-server:nightly-aot' }}
+        env:
+          ASPNETCORE_ENVIRONMENT: Development
+          ASPNETCORE_URLS: "http://+:8080"
+          ConnectionStrings__DefaultConnection: "Host=postgres;Database=honua_dev;Username=honua_user;Password=honua_password"
+        ports:
+          - 8080:8080
+        options: >-
+          --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:8080/healthz/live || exit 1"
+          --health-interval 15s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Wait for Honua Server health
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS "${HONUA_INTEGRATION_BASE_URL}/healthz/live" >/dev/null 2>&1; then
+              echo "Honua Server is healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Honua Server did not become healthy in time" >&2
+          exit 1
+
+      - name: Resolve server image digest
+        id: image-meta
+        run: |
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "${HONUA_SERVER_IMAGE}" 2>/dev/null || echo "${HONUA_SERVER_IMAGE}")
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Run integration tests
+        env:
+          HONUA_INTEGRATION_SERVER_IMAGE: ${{ steps.image-meta.outputs.digest }}
+          HONUA_INTEGRATION_SERVER_COMMIT: ${{ github.sha }}
+        run: npm run test:integration
+
+      - name: Upload integration metadata
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-meta
+          path: test-results/integration-meta.json
+          if-no-files-found: warn
+
+      - name: Append integration summary
+        if: ${{ always() }}
+        run: |
+          if [ ! -f test-results/integration-meta.json ]; then
+            echo "Integration metadata file not produced." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          node --input-type=module <<'EOF'
+          import fs from "node:fs";
+          const meta = JSON.parse(fs.readFileSync("test-results/integration-meta.json", "utf8"));
+          const lines = [
+            "## SDK Integration Summary",
+            "",
+            `- SDK package: \`${meta.sdkPackage}@${meta.sdkVersion}\``,
+            `- Server version: \`${meta.serverVersion ?? "unknown"}\` (channel \`${meta.serverReleaseChannel ?? "unknown"}\`)`,
+            `- Server image: \`${meta.serverImage ?? "unknown"}\``,
+            `- Server commit: \`${meta.serverCommit ?? "unknown"}\``,
+            `- Base URL: \`${meta.baseUrl}\``,
+            `- Seed profile: \`${meta.seedProfile}\``,
+            `- Service / Layer: \`${meta.serviceId}\` / \`${meta.layerId}\``,
+            `- Collection: \`${meta.collectionId}\``,
+            "",
+            "### Surfaces",
+            "",
+            "| Surface | Status | Reason |",
+            "| --- | --- | --- |",
+            ...meta.surfaces.map((entry) => `| \`${entry.surface}\` | ${entry.status} | ${entry.reason ?? ""} |`),
+          ];
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join("\n")}\n`);
+          EOF

--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ protocol-neutral contract and exploration state module that wrap (not replace) t
   [`docs/sdk-surface-alignment.md`](./docs/sdk-surface-alignment.md).
 - Round-trip mapping to the server `SourceBinding` / `MapPackage` document:
   [`docs/source-binding-alignment.md`](./docs/source-binding-alignment.md).
+- Live SDK ↔ Honua Server protocol integration lane:
+  [`docs/integration-tests.md`](./docs/integration-tests.md).
 
 ```ts
 import { createDataset } from "@honua/sdk-js/contract";
@@ -410,6 +412,7 @@ npm run test:playwright:25d
 npm run test:playwright
 npm run demo:kepler:smoke
 npm run test:quickstart:staging # requires HONUA_STAGING_* env
+npm run test:integration # connect-only; requires HONUA_INTEGRATION_BASE_URL — see docs/integration-tests.md
 npm run scan:arcgis -- ../../path/to/arcgis-app
 npm run migrate:arcgis -- ../../path/to/arcgis-app --write --report migration-report.json
 npm run report:migration:real-samples

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -1,0 +1,138 @@
+# Honua Server Protocol Integration Lane
+
+The integration lane in `test/integration/` exercises the public
+`HonuaClient` and its sub-surfaces against a real seeded Honua Server.
+It complements the mock-backed unit suites in `test/` (which prove SDK
+behavior in isolation) by catching drift between the SDK and live
+server routes, response shapes, errors, and capability negotiation.
+
+## Lane shape
+
+- **Connect-only.** The SDK does not own the server bootstrap. The
+  integration lane reads `HONUA_INTEGRATION_BASE_URL` and skips the
+  entire suite when that variable is unset, so a clean clone passes
+  `npm run test:integration` even with no server running.
+- **Public API only.** Tests call methods on `HonuaClient` and its
+  factory-returned helpers (`featureLayer`, `mapService`,
+  `ogcFeatures`, `ogcTiles`, `ogcMaps`, `ogcProcesses`, `wms`, `wmts`).
+  Private HTTP helpers from `honua-server/tests/` are not used.
+- **One file per protocol surface.** `test/integration/surfaces/`
+  contains one `*.integration.ts` per surface; each file calls
+  `integrationSuite("<friendly>", "<surface-tag>", () => …)` so the
+  metadata reporter can attach the surface to every CI run.
+
+## Running locally
+
+```bash
+# 1. Start a Honua Server (Docker Compose listens on :8080 by default;
+#    js_test_server.py listens on :5555 with seeded test data).
+cd /path/to/honua-server
+docker compose up -d
+# or, for the JS-targeted seeded fixture:
+python -m tests.python.shared.js_test_server  # prints {"base_url": ...}
+
+# 2. Run the integration lane against it.
+cd /path/to/honua-sdk-js
+HONUA_INTEGRATION_BASE_URL=http://localhost:8080 npm run test:integration
+```
+
+## Environment variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `HONUA_INTEGRATION_BASE_URL` | _(required)_ | Server URL the lane connects to. Suite skips when absent. |
+| `HONUA_INTEGRATION_SERVICE_ID` | `test_service_gw0` | GeoServices service ID (FeatureServer / MapServer / WMS / WMTS). |
+| `HONUA_INTEGRATION_LAYER_ID` | `1000` | FeatureServer / MapServer layer ID. |
+| `HONUA_INTEGRATION_COLLECTION_ID` | `places` | OGC API Features / Maps / Tiles collection ID. |
+| `HONUA_INTEGRATION_TILE_MATRIX_SET` | `WebMercatorQuad` | OGC Tiles tile-matrix-set ID. |
+| `HONUA_INTEGRATION_SEED_PROFILE` | `places-roads-v1` | Free-form label for the seed configuration; recorded into the metadata file but not sent on the wire. |
+| `HONUA_INTEGRATION_API_KEY` | _(unset)_ | Optional `X-API-Key` header. |
+| `HONUA_INTEGRATION_BEARER_TOKEN` | _(unset)_ | Optional `Authorization: Bearer …` header. |
+| `HONUA_INTEGRATION_TIMEOUT_MS` | `30000` | Per-request timeout used by the harness `HonuaClient`. |
+| `HONUA_INTEGRATION_SERVER_IMAGE` | _(unset)_ | Recorded into `integration-meta.json` (CI uses the resolved image digest). |
+| `HONUA_INTEGRATION_SERVER_COMMIT` | _(unset)_ | Recorded into `integration-meta.json` (CI uses `${{ github.sha }}`). |
+
+## Surface coverage
+
+The lane exercises the following surfaces against the seed profile.
+
+| Surface | Status | Notes |
+| --- | --- | --- |
+| FeatureServer | Exercised | metadata, queryFeatures, queryFeatureCount, queryObjectIds |
+| MapServer | Exercised | metadata, mapLayer.queryFeatures, queryFeatureCount, exportMap |
+| OGC API Features | Exercised | landing, conformance, collections, items, item |
+| OGC API Tiles | Exercised | landing, conformance, tileMatrixSets, tilesets, tile |
+| OGC API Maps | Exercised | landing, conformance, map render |
+| OGC API Processes | Exercised | landing, conformance, list, describe (when registered) |
+| WMS | Exercised | capabilities, GetMap |
+| WMTS | Exercised | capabilities, GetTile |
+| ImageServer | Skipped | No first-party `client.imageService(...)` entry yet (tracked by honua-sdk-js#39). |
+| GPServer | Skipped | No first-party `client.geoprocessing(...)` entry yet (tracked by honua-sdk-js#39). |
+
+Skipped surfaces are recorded in `test-results/integration-meta.json`
+with a `reason` field so the gap is visible in CI artifacts; this keeps
+unsupported surfaces from silently disappearing from coverage.
+
+## Failure diagnostics
+
+Each SDK call is wrapped in `runWithDiagnostics(...)`. When an
+assertion or an SDK error fires, the test message is augmented with a
+standard block:
+
+```
+[honua-integration]
+  SDK method   : client.featureLayer().queryFeatures
+  Request path : /rest/services/test_service_gw0/FeatureServer/1000/query
+  HTTP method  : GET
+  HTTP status  : 500
+  Duration ms  : 142.3
+  Body excerpt : { "error": { "code": 500, "message": "..." } }
+```
+
+The body excerpt is bounded to 500 characters; longer bodies are
+truncated with a `[truncated, original N chars]` suffix.
+
+## CI integration
+
+`.github/workflows/integration.yml` runs the lane on `trunk` /
+`release/**` pushes and on manual dispatch. The job:
+
+1. Spins up `postgis/postgis:17-3.5-alpine` and the configured
+   `ghcr.io/honua-io/honua-server` image as service containers.
+2. Polls `/healthz/live` until the server reports healthy.
+3. Runs `npm run test:integration` with `HONUA_INTEGRATION_BASE_URL`
+   pinned to the in-job server.
+4. Uploads `test-results/integration-meta.json` as the
+   `integration-meta` artifact (always, including on failure).
+5. Renders a summary table into `$GITHUB_STEP_SUMMARY` listing every
+   surface and its status.
+
+### Metadata artifact
+
+`integration-meta.json` records the run context:
+
+```json
+{
+  "sdkPackage": "@honua/sdk-js",
+  "sdkVersion": "0.0.3-alpha.0",
+  "serverVersion": "1.x.y",
+  "serverReleaseChannel": "preview",
+  "serverImage": "ghcr.io/honua-io/honua-server@sha256:…",
+  "serverCommit": "<github.sha>",
+  "baseUrl": "http://localhost:8080",
+  "seedProfile": "ogc",
+  "serviceId": "test_service_gw0",
+  "layerId": 1000,
+  "collectionId": "places",
+  "tileMatrixSetId": "WebMercatorQuad",
+  "startedAt": "2026-04-28T01:23:45Z",
+  "surfaces": [
+    { "surface": "feature-server", "status": "exercised", "recordedAt": "…" },
+    { "surface": "image-server", "status": "skipped", "reason": "…", "recordedAt": "…" }
+  ]
+}
+```
+
+This is the lane's only persistent observable signal — the workflow
+attaches it to every run so SDK / server drift is traceable from the
+GitHub Actions UI without re-running the suite.

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -12,6 +12,13 @@ server routes, response shapes, errors, and capability negotiation.
   integration lane reads `HONUA_INTEGRATION_BASE_URL` and skips the
   entire suite when that variable is unset, so a clean clone passes
   `npm run test:integration` even with no server running.
+- **Caller owns auth + seeding.** The lane assumes the target server is
+  already running, seeded with the configured service / layer /
+  collection, and reachable. `getCompatibility()` (the global setup
+  health probe) hits `/api/v1/admin/capabilities`, which is gated by
+  the server's admin auth — the harness passes
+  `HONUA_INTEGRATION_API_KEY` as the `X-API-Key` header, and that value
+  must match the server's `HONUA_ADMIN_PASSWORD`.
 - **Public API only.** Tests call methods on `HonuaClient` and its
   factory-returned helpers (`featureLayer`, `mapService`,
   `ogcFeatures`, `ogcTiles`, `ogcMaps`, `ogcProcesses`, `wms`, `wmts`).
@@ -23,17 +30,36 @@ server routes, response shapes, errors, and capability negotiation.
 
 ## Running locally
 
-```bash
-# 1. Start a Honua Server (Docker Compose listens on :8080 by default;
-#    js_test_server.py listens on :5555 with seeded test data).
-cd /path/to/honua-server
-docker compose up -d
-# or, for the JS-targeted seeded fixture:
-python -m tests.python.shared.js_test_server  # prints {"base_url": ...}
+The recommended local fixture is `tests/python/shared/js_test_server.py`
+in `honua-server`, which spins up a seeded PostGIS, applies the test
+catalog (service `test_service_gw0`, layer 1000 named "Test Layer", a
+small set of point features), and runs Honua Server in dev-auth mode on
+`:5555`:
 
-# 2. Run the integration lane against it.
+```bash
+# 1. Start the seeded JS test server (from the honua-server checkout).
+cd /path/to/honua-server
+python -m tests.python.shared.js_test_server  # prints {"base_url": "http://127.0.0.1:5555", ...}
+
+# 2. Run the integration lane against it. The js_test_server fixture
+#    runs the server in dev-auth mode, so HONUA_INTEGRATION_API_KEY can
+#    be any non-empty string (the value is still forwarded as
+#    X-API-Key but the server does not validate it in dev-auth mode).
 cd /path/to/honua-sdk-js
-HONUA_INTEGRATION_BASE_URL=http://localhost:8080 npm run test:integration
+HONUA_INTEGRATION_BASE_URL=http://localhost:5555 \
+  HONUA_INTEGRATION_API_KEY=local-dev \
+  npm run test:integration
+```
+
+If you point the lane at a Docker Compose-launched server (admin auth
+on, default port `:8080`), pass the configured admin password as the
+API key:
+
+```bash
+HONUA_INTEGRATION_BASE_URL=http://localhost:8080 \
+  HONUA_INTEGRATION_API_KEY="$HONUA_ADMIN_PASSWORD" \
+  HONUA_INTEGRATION_COLLECTION_ID=places \
+  npm run test:integration
 ```
 
 ## Environment variables
@@ -43,11 +69,11 @@ HONUA_INTEGRATION_BASE_URL=http://localhost:8080 npm run test:integration
 | `HONUA_INTEGRATION_BASE_URL` | _(required)_ | Server URL the lane connects to. Suite skips when absent. |
 | `HONUA_INTEGRATION_SERVICE_ID` | `test_service_gw0` | GeoServices service ID (FeatureServer / MapServer / WMS / WMTS). |
 | `HONUA_INTEGRATION_LAYER_ID` | `1000` | FeatureServer / MapServer layer ID. |
-| `HONUA_INTEGRATION_COLLECTION_ID` | `places` | OGC API Features / Maps / Tiles collection ID. |
+| `HONUA_INTEGRATION_COLLECTION_ID` | `1000` (numeric layer ID) | OGC API Features / Maps / Tiles collection ID. The default rides the server's layer-id-by-numeric resolution path so it works against the `js_test_server.py` seed; override with the layer name when the target seed exposes a friendlier collection identifier (`places`, `roads`, etc). |
+| `HONUA_INTEGRATION_API_KEY` | _(required)_ | `X-API-Key` header sent on every SDK call, including the `getCompatibility()` health probe against `/api/v1/admin/capabilities`. Must match the server's `HONUA_ADMIN_PASSWORD`. |
 | `HONUA_INTEGRATION_TILE_MATRIX_SET` | `WebMercatorQuad` | OGC Tiles tile-matrix-set ID. |
 | `HONUA_INTEGRATION_SEED_PROFILE` | `places-roads-v1` | Free-form label for the seed configuration; recorded into the metadata file but not sent on the wire. |
-| `HONUA_INTEGRATION_API_KEY` | _(unset)_ | Optional `X-API-Key` header. |
-| `HONUA_INTEGRATION_BEARER_TOKEN` | _(unset)_ | Optional `Authorization: Bearer …` header. |
+| `HONUA_INTEGRATION_BEARER_TOKEN` | _(unset)_ | Optional `Authorization: Bearer …` header (use only against bearer-secured deployments — admin endpoints expect `X-API-Key`). |
 | `HONUA_INTEGRATION_TIMEOUT_MS` | `30000` | Per-request timeout used by the harness `HonuaClient`. |
 | `HONUA_INTEGRATION_SERVER_IMAGE` | _(unset)_ | Recorded into `integration-meta.json` (CI uses the resolved image digest). |
 | `HONUA_INTEGRATION_SERVER_COMMIT` | _(unset)_ | Recorded into `integration-meta.json` (CI uses `${{ github.sha }}`). |
@@ -61,7 +87,7 @@ The lane exercises the following surfaces against the seed profile.
 | FeatureServer | Exercised | metadata, queryFeatures, queryFeatureCount, queryObjectIds |
 | MapServer | Exercised | metadata, mapLayer.queryFeatures, queryFeatureCount, exportMap |
 | OGC API Features | Exercised | landing, conformance, collections, items, item |
-| OGC API Tiles | Exercised | landing, conformance, tileMatrixSets, tilesets, tile |
+| OGC API Tiles | Exercised | landing, conformance, tileMatrixSets (list + by id), tilesets, tile |
 | OGC API Maps | Exercised | landing, conformance, map render |
 | OGC API Processes | Exercised | landing, conformance, list, describe (when registered) |
 | WMS | Exercised | capabilities, GetMap |
@@ -95,17 +121,49 @@ truncated with a `[truncated, original N chars]` suffix.
 ## CI integration
 
 `.github/workflows/integration.yml` runs the lane on `trunk` /
-`release/**` pushes and on manual dispatch. The job:
+`release/**` pushes and on manual dispatch. It is **connect-only**
+against an externally-managed seeded Honua Server — the SDK repo does
+not own the server bootstrap or seed because there is no public
+seed-on-start image or admin seed API in honua-server today (tracked
+as a follow-on, see "Deferred infrastructure" below).
 
-1. Spins up `postgis/postgis:17-3.5-alpine` and the configured
-   `ghcr.io/honua-io/honua-server` image as service containers.
-2. Polls `/healthz/live` until the server reports healthy.
-3. Runs `npm run test:integration` with `HONUA_INTEGRATION_BASE_URL`
-   pinned to the in-job server.
-4. Uploads `test-results/integration-meta.json` as the
+The job:
+
+1. Reads `HONUA_INTEGRATION_BASE_URL` from the workflow input or repo
+   variable. If neither is set, the workflow exits 0 with a notice in
+   the step summary so trunk pushes do not fail before the staging
+   environment is provisioned.
+2. Verifies that `HONUA_INTEGRATION_API_KEY` (repo secret) is present;
+   otherwise it fails fast with an explicit error. The value must
+   match the target server's `HONUA_ADMIN_PASSWORD`.
+3. Polls `${HONUA_INTEGRATION_BASE_URL}/healthz/live` until the server
+   reports healthy.
+4. Runs `npm run test:integration` with the resolved env.
+5. Uploads `test-results/integration-meta.json` as the
    `integration-meta` artifact (always, including on failure).
-5. Renders a summary table into `$GITHUB_STEP_SUMMARY` listing every
+6. Renders a summary table into `$GITHUB_STEP_SUMMARY` listing every
    surface and its status.
+
+### Required repo configuration
+
+| Scope | Name | Purpose |
+| --- | --- | --- |
+| Repository variable | `HONUA_INTEGRATION_BASE_URL` | URL of the staging Honua Server. When unset the workflow skips. |
+| Repository secret | `HONUA_INTEGRATION_API_KEY` | `X-API-Key` (matches server `HONUA_ADMIN_PASSWORD`). Required when the base URL is set. |
+| Repository variable (optional) | `HONUA_INTEGRATION_SERVICE_ID`, `HONUA_INTEGRATION_LAYER_ID`, `HONUA_INTEGRATION_COLLECTION_ID`, `HONUA_INTEGRATION_TILE_MATRIX_SET`, `HONUA_INTEGRATION_SEED_PROFILE`, `HONUA_INTEGRATION_SERVER_IMAGE` | Override the corresponding harness defaults to match the staging seed. |
+
+### Deferred infrastructure
+
+- A `:nightly-seeded` (or equivalent) Honua Server image with the test
+  catalog baked in does not yet exist. Until it does, the workflow
+  cannot bootstrap its own server from inside CI.
+- A public admin seed API (`POST /api/v1/admin/services` /
+  `.../layers` / `.../features`) does not yet exist. Until it does,
+  the SDK repo cannot seed a freshly-started server without sibling-
+  checking out honua-server and reaching into its Python fixture.
+
+These gaps are tracked as honua-server follow-ons and re-enable the
+service-container path in this workflow once either lands.
 
 ### Metadata artifact
 
@@ -119,11 +177,11 @@ truncated with a `[truncated, original N chars]` suffix.
   "serverReleaseChannel": "preview",
   "serverImage": "ghcr.io/honua-io/honua-server@sha256:…",
   "serverCommit": "<github.sha>",
-  "baseUrl": "http://localhost:8080",
-  "seedProfile": "ogc",
+  "baseUrl": "http://localhost:5555",
+  "seedProfile": "places-roads-v1",
   "serviceId": "test_service_gw0",
   "layerId": 1000,
-  "collectionId": "places",
+  "collectionId": "1000",
   "tileMatrixSetId": "WebMercatorQuad",
   "startedAt": "2026-04-28T01:23:45Z",
   "surfaces": [

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -76,7 +76,7 @@ HONUA_INTEGRATION_BASE_URL=http://localhost:8080 \
 | `HONUA_INTEGRATION_BEARER_TOKEN` | _(unset)_ | Optional `Authorization: Bearer …` header (use only against bearer-secured deployments — admin endpoints expect `X-API-Key`). |
 | `HONUA_INTEGRATION_TIMEOUT_MS` | `30000` | Per-request timeout used by the harness `HonuaClient`. |
 | `HONUA_INTEGRATION_SERVER_IMAGE` | _(unset)_ | Recorded into `integration-meta.json` (CI uses the resolved image digest). |
-| `HONUA_INTEGRATION_SERVER_COMMIT` | _(unset)_ | Recorded into `integration-meta.json` (CI uses `${{ github.sha }}`). |
+| `HONUA_INTEGRATION_SERVER_COMMIT` | _(unset)_ | Honua Server commit SHA, recorded into `integration-meta.json`. CI reads it from the workflow `server_commit` input or `vars.HONUA_INTEGRATION_SERVER_COMMIT`; it is never derived from `${{ github.sha }}` (which is the SDK repo commit). Leave blank when the server commit is unknown. |
 
 ## Surface coverage
 
@@ -150,7 +150,7 @@ The job:
 | --- | --- | --- |
 | Repository variable | `HONUA_INTEGRATION_BASE_URL` | URL of the staging Honua Server. When unset the workflow skips. |
 | Repository secret | `HONUA_INTEGRATION_API_KEY` | `X-API-Key` (matches server `HONUA_ADMIN_PASSWORD`). Required when the base URL is set. |
-| Repository variable (optional) | `HONUA_INTEGRATION_SERVICE_ID`, `HONUA_INTEGRATION_LAYER_ID`, `HONUA_INTEGRATION_COLLECTION_ID`, `HONUA_INTEGRATION_TILE_MATRIX_SET`, `HONUA_INTEGRATION_SEED_PROFILE`, `HONUA_INTEGRATION_SERVER_IMAGE` | Override the corresponding harness defaults to match the staging seed. |
+| Repository variable (optional) | `HONUA_INTEGRATION_SERVICE_ID`, `HONUA_INTEGRATION_LAYER_ID`, `HONUA_INTEGRATION_COLLECTION_ID`, `HONUA_INTEGRATION_TILE_MATRIX_SET`, `HONUA_INTEGRATION_SEED_PROFILE`, `HONUA_INTEGRATION_SERVER_IMAGE`, `HONUA_INTEGRATION_SERVER_COMMIT` | Override the corresponding harness defaults to match the staging seed. `HONUA_INTEGRATION_SERVER_COMMIT` records the Honua Server commit (not the SDK commit) in `integration-meta.json`; leave unset when it is unknown. |
 
 ### Deferred infrastructure
 
@@ -176,7 +176,7 @@ service-container path in this workflow once either lands.
   "serverVersion": "1.x.y",
   "serverReleaseChannel": "preview",
   "serverImage": "ghcr.io/honua-io/honua-server@sha256:…",
-  "serverCommit": "<github.sha>",
+  "serverCommit": "<honua-server commit SHA, or null when unknown>",
   "baseUrl": "http://localhost:5555",
   "seedProfile": "places-roads-v1",
   "serviceId": "test_service_gw0",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "test": "vitest run",
     "test:playwright:quickstart": "playwright test test/playwright/quickstart-map.spec.mjs",
     "test:quickstart:staging": "vitest run --config vitest.staging.config.ts",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:migration:real-samples": "vitest run test/migration-real-sample-runtime.test.ts test/migration-feature-table-demo-runtime.test.ts",
     "test:playwright": "npm run build --silent && node scripts/ensure-kepler-demo-deps.mjs && playwright test",
     "test:playwright:25d": "playwright test test/playwright/storytelling-25d-map.spec.mjs",

--- a/test/integration-diagnostics.test.ts
+++ b/test/integration-diagnostics.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Pure unit tests for the integration-lane diagnostics helpers. These run
+ * under the standard `npm test` lane (no live server) so the harness
+ * shape is exercised on every PR — the live integration suite itself
+ * runs in a separate workflow.
+ *
+ * @module
+ */
+
+import { describe, expect, it } from "vitest";
+import { HonuaHttpError, HonuaTimeoutError } from "../src/index.js";
+import {
+  type DiagnosticsContext,
+  MAX_BODY_EXCERPT_CHARS,
+  createDiagnosticsInterceptor,
+  formatFailureContext,
+  runWithDiagnostics,
+} from "./integration/diagnostics.js";
+
+function context(): DiagnosticsContext {
+  return {};
+}
+
+describe("integration diagnostics", () => {
+  it("captures path and method from the before interceptor", async () => {
+    const ctx = context();
+    const interceptor = createDiagnosticsInterceptor(ctx);
+    interceptor.before?.({
+      url: "http://server/example",
+      path: "/example",
+      method: "GET",
+      init: {},
+    });
+    expect(ctx.lastPath).toBe("/example");
+    expect(ctx.lastMethod).toBe("GET");
+  });
+
+  it("captures status and duration from the after interceptor", async () => {
+    const ctx = context();
+    const interceptor = createDiagnosticsInterceptor(ctx);
+    await interceptor.after?.({
+      request: { url: "http://server/x", path: "/x", method: "GET", init: {} },
+      response: new Response("body", { status: 200 }),
+      durationMs: 17.5,
+    });
+    expect(ctx.lastStatus).toBe(200);
+    expect(ctx.lastDurationMs).toBe(17.5);
+  });
+
+  it("records an HttpError body summary on the error interceptor", async () => {
+    const ctx = context();
+    const interceptor = createDiagnosticsInterceptor(ctx);
+    await interceptor.error?.({
+      request: { url: "http://server/x", path: "/x", method: "GET", init: {} },
+      error: new HonuaHttpError(404, "Not Found", { error: { code: 404, message: "missing" } }),
+      durationMs: 3,
+    });
+    expect(ctx.lastStatus).toBe(404);
+    expect(ctx.lastBodySummary).toContain("missing");
+  });
+
+  it("truncates long response bodies in the diagnostic block", async () => {
+    const ctx = context();
+    const interceptor = createDiagnosticsInterceptor(ctx);
+    const long = "x".repeat(MAX_BODY_EXCERPT_CHARS + 100);
+    await interceptor.error?.({
+      request: { url: "http://server/x", path: "/x", method: "GET", init: {} },
+      error: new HonuaHttpError(500, "Server error", long),
+      durationMs: 1,
+    });
+    expect(ctx.lastBodySummary?.length).toBeLessThan(MAX_BODY_EXCERPT_CHARS + 80);
+    expect(ctx.lastBodySummary).toContain("[truncated");
+  });
+
+  it("renders timeout errors with a synthetic status of 0", async () => {
+    const ctx = context();
+    const interceptor = createDiagnosticsInterceptor(ctx);
+    await interceptor.error?.({
+      request: { url: "http://server/x", path: "/x", method: "GET", init: {} },
+      error: new HonuaTimeoutError(2000),
+      durationMs: 2000,
+    });
+    expect(ctx.lastStatus).toBe(0);
+    expect(ctx.lastBodySummary).toContain("timeout");
+  });
+
+  it("wraps exceptions with the diagnostic block via runWithDiagnostics", async () => {
+    const ctx: DiagnosticsContext = {
+      lastPath: "/places",
+      lastMethod: "GET",
+      lastStatus: 500,
+      lastBodySummary: "internal error",
+      lastDurationMs: 12.4,
+    };
+    await expect(
+      runWithDiagnostics(ctx, "client.featureLayer().queryFeatures", () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow(/boom[\s\S]*honua-integration[\s\S]*\/places[\s\S]*500/);
+  });
+
+  it("returns the success value untouched when no error is thrown", async () => {
+    const ctx = context();
+    const value = await runWithDiagnostics(ctx, "client.thing()", () => Promise.resolve(42));
+    expect(value).toBe(42);
+  });
+
+  it("renders an empty diagnostic block when no request was observed", () => {
+    const block = formatFailureContext("client.thing()", context());
+    expect(block).toContain("(no request observed)");
+    expect(block).toContain("(no response)");
+  });
+});

--- a/test/integration-diagnostics.test.ts
+++ b/test/integration-diagnostics.test.ts
@@ -47,6 +47,49 @@ describe("integration diagnostics", () => {
     expect(ctx.lastDurationMs).toBe(17.5);
   });
 
+  it("captures a JSON body excerpt for a 200 response so failed assertions carry the payload", async () => {
+    const ctx = context();
+    const interceptor = createDiagnosticsInterceptor(ctx);
+    const body = JSON.stringify({ features: [], exceededTransferLimit: false });
+    await interceptor.after?.({
+      request: { url: "http://server/x", path: "/x", method: "GET", init: {} },
+      response: new Response(body, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+      durationMs: 4,
+    });
+    expect(ctx.lastBodySummary).toBe(body);
+  });
+
+  it("records a metadata-only summary for binary success responses", async () => {
+    const ctx = context();
+    const interceptor = createDiagnosticsInterceptor(ctx);
+    const bytes = new Uint8Array([1, 2, 3, 4, 5]);
+    await interceptor.after?.({
+      request: { url: "http://server/x", path: "/x", method: "GET", init: {} },
+      response: new Response(bytes, {
+        status: 200,
+        headers: { "content-type": "image/png", "content-length": "5" },
+      }),
+      durationMs: 6,
+    });
+    expect(ctx.lastBodySummary).toContain("binary body");
+    expect(ctx.lastBodySummary).toContain("image/png");
+    expect(ctx.lastBodySummary).toContain("5 bytes");
+  });
+
+  it("reports an explicit empty-body marker on 204 responses", async () => {
+    const ctx = context();
+    const interceptor = createDiagnosticsInterceptor(ctx);
+    await interceptor.after?.({
+      request: { url: "http://server/x", path: "/x", method: "DELETE", init: {} },
+      response: new Response(null, { status: 204 }),
+      durationMs: 1,
+    });
+    expect(ctx.lastBodySummary).toBe("(empty body)");
+  });
+
   it("records an HttpError body summary on the error interceptor", async () => {
     const ctx = context();
     const interceptor = createDiagnosticsInterceptor(ctx);

--- a/test/integration-harness.test.ts
+++ b/test/integration-harness.test.ts
@@ -59,7 +59,7 @@ describe("integration harness env resolution", () => {
     expect(config?.baseUrl).toBe("http://localhost:5555");
     expect(config?.serviceId).toBe("test_service_gw0");
     expect(config?.layerId).toBe(1000);
-    expect(config?.collectionId).toBe("places");
+    expect(config?.collectionId).toBe("1000");
     expect(config?.tileMatrixSetId).toBe("WebMercatorQuad");
     expect(config?.seedProfile).toBe("places-roads-v1");
     expect(config?.timeoutMs).toBe(30_000);

--- a/test/integration-harness.test.ts
+++ b/test/integration-harness.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure unit coverage for the integration harness module. The
+ * `tryResolveIntegrationConfig` cache lives at module scope, so each
+ * test resets the module registry to ensure a clean read.
+ *
+ * @module
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ENV_KEYS = [
+  "HONUA_INTEGRATION_BASE_URL",
+  "HONUA_INTEGRATION_SERVICE_ID",
+  "HONUA_INTEGRATION_LAYER_ID",
+  "HONUA_INTEGRATION_COLLECTION_ID",
+  "HONUA_INTEGRATION_TILE_MATRIX_SET",
+  "HONUA_INTEGRATION_SEED_PROFILE",
+  "HONUA_INTEGRATION_API_KEY",
+  "HONUA_INTEGRATION_BEARER_TOKEN",
+  "HONUA_INTEGRATION_TIMEOUT_MS",
+] as const;
+
+let savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  vi.resetModules();
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = savedEnv[key];
+    }
+  }
+});
+
+async function loadHarness(): Promise<typeof import("./integration/harness.js")> {
+  return import("./integration/harness.js");
+}
+
+describe("integration harness env resolution", () => {
+  it("returns undefined when HONUA_INTEGRATION_BASE_URL is absent", { timeout: 30_000 }, async () => {
+    const mod = await loadHarness();
+    expect(mod.tryResolveIntegrationConfig()).toBeUndefined();
+  });
+
+  it("applies seeded defaults when only the base URL is set", async () => {
+    process.env.HONUA_INTEGRATION_BASE_URL = "http://localhost:5555";
+    const mod = await loadHarness();
+    const config = mod.tryResolveIntegrationConfig();
+    expect(config).toBeDefined();
+    expect(config?.baseUrl).toBe("http://localhost:5555");
+    expect(config?.serviceId).toBe("test_service_gw0");
+    expect(config?.layerId).toBe(1000);
+    expect(config?.collectionId).toBe("places");
+    expect(config?.tileMatrixSetId).toBe("WebMercatorQuad");
+    expect(config?.seedProfile).toBe("places-roads-v1");
+    expect(config?.timeoutMs).toBe(30_000);
+    expect(config?.apiKey).toBeUndefined();
+    expect(config?.bearerToken).toBeUndefined();
+  });
+
+  it("honors overrides for every public env var", async () => {
+    process.env.HONUA_INTEGRATION_BASE_URL = "http://server:8080";
+    process.env.HONUA_INTEGRATION_SERVICE_ID = "my-svc";
+    process.env.HONUA_INTEGRATION_LAYER_ID = "42";
+    process.env.HONUA_INTEGRATION_COLLECTION_ID = "roads";
+    process.env.HONUA_INTEGRATION_TILE_MATRIX_SET = "WorldCRS84Quad";
+    process.env.HONUA_INTEGRATION_SEED_PROFILE = "ogc";
+    process.env.HONUA_INTEGRATION_API_KEY = "k";
+    process.env.HONUA_INTEGRATION_BEARER_TOKEN = "t";
+    process.env.HONUA_INTEGRATION_TIMEOUT_MS = "10000";
+    const mod = await loadHarness();
+    const config = mod.tryResolveIntegrationConfig();
+    expect(config?.serviceId).toBe("my-svc");
+    expect(config?.layerId).toBe(42);
+    expect(config?.collectionId).toBe("roads");
+    expect(config?.tileMatrixSetId).toBe("WorldCRS84Quad");
+    expect(config?.seedProfile).toBe("ogc");
+    expect(config?.apiKey).toBe("k");
+    expect(config?.bearerToken).toBe("t");
+    expect(config?.timeoutMs).toBe(10_000);
+  });
+
+  it("throws from resolveIntegrationConfig when the base URL is absent", async () => {
+    const mod = await loadHarness();
+    expect(() => mod.resolveIntegrationConfig()).toThrowError(/HONUA_INTEGRATION_BASE_URL/);
+  });
+});

--- a/test/integration-reporter.test.ts
+++ b/test/integration-reporter.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Pure unit coverage for the integration metadata reporter. The reporter
+ * is split between the Vitest global setup process (which initializes
+ * the artifact) and surface-test worker processes (which call
+ * {@link recordSurface}). Each worker has its own module instance, so
+ * the worker has to restore the metadata document from disk before
+ * appending. This file verifies that round trip without spinning up a
+ * real Vitest worker pool.
+ *
+ * @module
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const PROJECT_ROOT = path.resolve(import.meta.dirname, "..");
+const META_FILE = path.join(PROJECT_ROOT, "test-results", "integration-meta.json");
+
+beforeEach(() => {
+  vi.resetModules();
+  if (fs.existsSync(META_FILE)) {
+    fs.rmSync(META_FILE, { force: true });
+  }
+});
+
+afterEach(() => {
+  if (fs.existsSync(META_FILE)) {
+    fs.rmSync(META_FILE, { force: true });
+  }
+});
+
+async function loadReporter(): Promise<typeof import("./integration/reporter.js")> {
+  return import("./integration/reporter.js");
+}
+
+const META_FIXTURE = {
+  sdkPackage: "@honua/sdk-js",
+  sdkVersion: "0.0.3-alpha.0",
+  serverVersion: "1.0.0",
+  serverReleaseChannel: "preview",
+  serverImage: undefined,
+  serverCommit: undefined,
+  baseUrl: "http://localhost:5555",
+  seedProfile: "places-roads-v1",
+  serviceId: "test_service_gw0",
+  layerId: 1000,
+  collectionId: "1000",
+  tileMatrixSetId: "WebMercatorQuad",
+  startedAt: "2026-04-28T01:23:45Z",
+};
+
+describe("integration reporter", () => {
+  it("writes the initial document to disk on initializeMeta", async () => {
+    const reporter = await loadReporter();
+    reporter.initializeMeta(META_FIXTURE);
+    const written = JSON.parse(fs.readFileSync(META_FILE, "utf8"));
+    expect(written.sdkPackage).toBe("@honua/sdk-js");
+    expect(written.surfaces).toEqual([]);
+  });
+
+  it("appends an exercised surface entry when initializeMeta has primed the module", async () => {
+    const reporter = await loadReporter();
+    reporter.initializeMeta(META_FIXTURE);
+    reporter.recordSurface("feature-server");
+    const written = JSON.parse(fs.readFileSync(META_FILE, "utf8"));
+    expect(written.surfaces).toHaveLength(1);
+    expect(written.surfaces[0]).toMatchObject({ surface: "feature-server", status: "exercised" });
+    expect(written.surfaces[0].reason).toBeUndefined();
+  });
+
+  it("merges new surfaces from a fresh module instance by reading the on-disk artifact", async () => {
+    // Simulate Vitest global setup writing the artifact in the main
+    // process.
+    const setupReporter = await loadReporter();
+    setupReporter.initializeMeta(META_FIXTURE);
+    setupReporter.recordSurface("feature-server");
+
+    // Simulate a worker process that imports the reporter fresh — its
+    // own `mutableMeta` starts undefined, but recordSurface must still
+    // add its surface to the artifact instead of silently dropping it.
+    vi.resetModules();
+    const workerReporter = await loadReporter();
+    expect(workerReporter.readMeta()).toBeUndefined();
+    workerReporter.recordSurface("ogc-features");
+
+    const written = JSON.parse(fs.readFileSync(META_FILE, "utf8"));
+    const surfaces = (written.surfaces as Array<{ surface: string; status: string }>).map((entry) => entry.surface);
+    expect(surfaces).toEqual(["feature-server", "ogc-features"]);
+    const featureSrv = written.surfaces.find((entry: { surface: string }) => entry.surface === "feature-server");
+    expect(featureSrv.status).toBe("exercised");
+    const ogc = written.surfaces.find((entry: { surface: string }) => entry.surface === "ogc-features");
+    expect(ogc.status).toBe("exercised");
+  });
+
+  it("records a skipped surface with the supplied reason from a fresh worker instance", async () => {
+    const setupReporter = await loadReporter();
+    setupReporter.initializeMeta(META_FIXTURE);
+    vi.resetModules();
+    const workerReporter = await loadReporter();
+    workerReporter.recordSurface("image-server", "no first-party adapter (tracked by honua-sdk-js#39)");
+    const written = JSON.parse(fs.readFileSync(META_FILE, "utf8"));
+    expect(written.surfaces).toHaveLength(1);
+    expect(written.surfaces[0]).toMatchObject({
+      surface: "image-server",
+      status: "skipped",
+      reason: "no first-party adapter (tracked by honua-sdk-js#39)",
+    });
+  });
+
+  it("returns silently when neither in-memory state nor an on-disk artifact exists", async () => {
+    const reporter = await loadReporter();
+    expect(() => reporter.recordSurface("feature-server")).not.toThrow();
+    expect(fs.existsSync(META_FILE)).toBe(false);
+  });
+});

--- a/test/integration/diagnostics.ts
+++ b/test/integration/diagnostics.ts
@@ -1,0 +1,155 @@
+/**
+ * Failure-diagnostic helpers shared across integration tests. Tests run a
+ * public SDK call inside {@link runWithDiagnostics}, which captures the
+ * last request the {@link createDiagnosticsInterceptor} interceptor saw
+ * and rewrites any thrown error message to include the SDK method name,
+ * request path, HTTP status, and a bounded response body excerpt.
+ *
+ * Failures must be actionable from the CI log alone — that is why the
+ * integration lane wires this helper into every test, instead of relying
+ * on raw `vitest` assertion output.
+ *
+ * @module
+ */
+import {
+  HonuaAbortError,
+  type HonuaErrorContext,
+  HonuaHttpError,
+  HonuaNetworkError,
+  type HonuaRequestInterceptor,
+  type HonuaResponseContext,
+  HonuaTimeoutError,
+} from "@honua/sdk-js";
+
+/** Maximum response body characters preserved in failure messages. */
+export const MAX_BODY_EXCERPT_CHARS = 500;
+
+/**
+ * Per-test diagnostic state populated by the request interceptor that
+ * {@link createDiagnosticsInterceptor} returns. The integration suite
+ * mutates this object in place (last write wins) so the wrapper around
+ * each SDK call can assemble a complete failure message even when the
+ * thrown error is not a {@link HonuaHttpError}.
+ */
+export interface DiagnosticsContext {
+  lastPath?: string;
+  lastMethod?: string;
+  lastStatus?: number;
+  lastBodySummary?: string;
+  lastDurationMs?: number;
+}
+
+/**
+ * Build a {@link HonuaRequestInterceptor} that records the most recent
+ * request, response, and error into `context`. Tests share one context
+ * per test (see {@link runWithDiagnostics}) so concurrent requests never
+ * stomp on each other; the integration suite runs files serially via
+ * `vitest.integration.config.ts` (`fileParallelism: false`).
+ */
+export function createDiagnosticsInterceptor(context: DiagnosticsContext): HonuaRequestInterceptor {
+  return {
+    before(request) {
+      context.lastPath = request.path;
+      context.lastMethod = request.method;
+      context.lastStatus = undefined;
+      context.lastBodySummary = undefined;
+      context.lastDurationMs = undefined;
+    },
+    async after(response: HonuaResponseContext) {
+      context.lastStatus = response.response.status;
+      context.lastDurationMs = response.durationMs;
+    },
+    async error(failure: HonuaErrorContext) {
+      context.lastDurationMs = failure.durationMs;
+      const error = failure.error;
+      if (error instanceof HonuaHttpError) {
+        context.lastStatus = error.statusCode;
+        context.lastBodySummary = summarizeBody(error.body);
+      } else if (error instanceof HonuaTimeoutError) {
+        context.lastStatus = 0;
+        context.lastBodySummary = `timeout after ${error.timeoutMs}ms`;
+      } else if (error instanceof HonuaNetworkError) {
+        context.lastStatus = 0;
+        context.lastBodySummary = `network error: ${error.message}`;
+      } else if (error instanceof HonuaAbortError) {
+        context.lastStatus = 0;
+        context.lastBodySummary = "request aborted";
+      } else if (error instanceof Error) {
+        context.lastBodySummary = error.message;
+      }
+    },
+  };
+}
+
+/**
+ * Render the diagnostic block appended to integration-test failure
+ * messages. The format is intentionally line-oriented so log scrapers
+ * can extract any one field with `grep`.
+ */
+export function formatFailureContext(method: string, context: DiagnosticsContext): string {
+  const lines: string[] = [
+    "[honua-integration]",
+    `  SDK method   : ${method}`,
+    `  Request path : ${context.lastPath ?? "(no request observed)"}`,
+    `  HTTP method  : ${context.lastMethod ?? "(unknown)"}`,
+    `  HTTP status  : ${context.lastStatus !== undefined ? String(context.lastStatus) : "(no response)"}`,
+  ];
+  if (context.lastDurationMs !== undefined) {
+    lines.push(`  Duration ms  : ${context.lastDurationMs.toFixed(1)}`);
+  }
+  lines.push(`  Body excerpt : ${context.lastBodySummary ?? "(empty body)"}`);
+  return lines.join("\n");
+}
+
+/**
+ * Wrap a single SDK invocation so that a thrown error carries the
+ * shared diagnostic block. This is the canonical way every integration
+ * test should call into the SDK — never call SDK methods directly with
+ * `await`, because the bare exception will not include the request path
+ * or response body that CI logs need to triage drift.
+ *
+ * Usage:
+ * ```ts
+ * const features = await runWithDiagnostics(
+ *   diagnostics,
+ *   "client.featureLayer().queryFeatures",
+ *   () => client.featureLayer(serviceId, layerId).queryFeatures({ where: "1=1" }),
+ * );
+ * ```
+ */
+export async function runWithDiagnostics<T>(
+  context: DiagnosticsContext,
+  method: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    const block = formatFailureContext(method, context);
+    if (error instanceof Error) {
+      error.message = `${error.message}\n${block}`;
+      throw error;
+    }
+    throw new Error(`${String(error)}\n${block}`);
+  }
+}
+
+function summarizeBody(body: unknown): string {
+  if (body === undefined || body === null) {
+    return "(empty body)";
+  }
+  let serialized: string;
+  if (typeof body === "string") {
+    serialized = body;
+  } else {
+    try {
+      serialized = JSON.stringify(body);
+    } catch {
+      serialized = String(body);
+    }
+  }
+  if (serialized.length > MAX_BODY_EXCERPT_CHARS) {
+    return `${serialized.slice(0, MAX_BODY_EXCERPT_CHARS)}… [truncated, original ${serialized.length} chars]`;
+  }
+  return serialized;
+}

--- a/test/integration/diagnostics.ts
+++ b/test/integration/diagnostics.ts
@@ -58,6 +58,7 @@ export function createDiagnosticsInterceptor(context: DiagnosticsContext): Honua
     async after(response: HonuaResponseContext) {
       context.lastStatus = response.response.status;
       context.lastDurationMs = response.durationMs;
+      context.lastBodySummary = await summarizeResponse(response.response);
     },
     async error(failure: HonuaErrorContext) {
       context.lastDurationMs = failure.durationMs;
@@ -152,4 +153,45 @@ function summarizeBody(body: unknown): string {
     return `${serialized.slice(0, MAX_BODY_EXCERPT_CHARS)}… [truncated, original ${serialized.length} chars]`;
   }
   return serialized;
+}
+
+/**
+ * Produce a body excerpt for a 2xx/3xx response so a downstream
+ * assertion failure (200 with the wrong shape, empty page, etc.) carries
+ * the same diagnostic block as a thrown SDK error. The interceptor
+ * already receives a cloned response (see `applyAfterInterceptors` in
+ * the client), so consuming the body here does not affect the SDK's
+ * own decode path. Binary responses are summarized with metadata only
+ * to avoid base64-encoding tiles or images into the failure message.
+ */
+async function summarizeResponse(response: Response): Promise<string> {
+  if (response.status === 204) {
+    return "(empty body)";
+  }
+  const contentType = response.headers.get("content-type") ?? "";
+  if (isTextLikeContentType(contentType)) {
+    try {
+      const text = await response.text();
+      if (text.length === 0) return "(empty body)";
+      return summarizeBody(text);
+    } catch (error) {
+      return `(body read failed: ${error instanceof Error ? error.message : String(error)})`;
+    }
+  }
+  const contentLength = response.headers.get("content-length");
+  const sizeHint = contentLength ? `${contentLength} bytes` : "size unknown";
+  const ctHint = contentType.length > 0 ? contentType : "unknown";
+  return `(binary body: content-type=${ctHint}, ${sizeHint})`;
+}
+
+function isTextLikeContentType(contentType: string): boolean {
+  if (!contentType) return false;
+  const lower = contentType.toLowerCase();
+  if (lower.startsWith("text/")) return true;
+  if (lower.startsWith("application/json")) return true;
+  if (lower.includes("+json")) return true;
+  if (lower.startsWith("application/xml")) return true;
+  if (lower.includes("+xml")) return true;
+  if (lower.startsWith("application/x-www-form-urlencoded")) return true;
+  return false;
 }

--- a/test/integration/harness.ts
+++ b/test/integration/harness.ts
@@ -45,9 +45,12 @@ export interface IntegrationConfig {
   serviceId: string;
   layerId: number;
   /**
-   * OGC API Features collection ID for read tests. The seeded `places`
-   * collection is the SDK lane default because every supported server
-   * profile (`core`, `ogc`) seeds it.
+   * OGC API Features collection ID for read tests. Defaults to the
+   * numeric layer ID so it resolves through the server's
+   * `ResourceValidator` numeric-id fallback against any seed that
+   * exposes the configured layer (including the `js_test_server.py`
+   * fixture, which names the layer "Test Layer"). Override when the
+   * target seed exposes a friendlier collection name like `places`.
    */
   collectionId: string;
   /** OGC Tiles tile-matrix-set used for sparse-tile reads. */
@@ -66,7 +69,13 @@ export interface IntegrationConfig {
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_SERVICE_ID = "test_service_gw0";
 const DEFAULT_LAYER_ID = 1000;
-const DEFAULT_COLLECTION_ID = "places";
+// honua-server resolves OGC collection IDs by layer name first and then by
+// numeric layer ID. The js_test_server.py seed gives the layer name
+// "Test Layer" (which contains a space and is not URL-friendly), so we use
+// the numeric layer ID as the default collection ID — that path round-trips
+// through ResourceValidator.ValidateCollectionAsync without depending on the
+// human-readable layer name.
+const DEFAULT_COLLECTION_ID = String(DEFAULT_LAYER_ID);
 const DEFAULT_TILE_MATRIX_SET = "WebMercatorQuad";
 const DEFAULT_SEED_PROFILE = "places-roads-v1";
 

--- a/test/integration/harness.ts
+++ b/test/integration/harness.ts
@@ -1,0 +1,207 @@
+/**
+ * Shared integration-test harness. The SDK does not own the Honua Server
+ * bootstrap — instead the integration lane is connect-only:
+ *
+ *   - `HONUA_INTEGRATION_BASE_URL` points at a running server (CI uses
+ *     Docker Compose, local devs typically point at `http://localhost:5555`
+ *     produced by `honua-server/tests/python/shared/js_test_server.py`).
+ *   - {@link integrationSuite} is the public entry point per surface
+ *     test file. It calls `describe.skip(...)` when the env var is unset,
+ *     so the suite degrades to a no-op rather than failing in
+ *     environments that do not have a live server.
+ *
+ * Tests **must** call SDK methods through {@link runWithDiagnostics}
+ * (re-exported here for convenience) so failures carry the standard
+ * diagnostic block (request path, status, body excerpt).
+ *
+ * @module
+ */
+
+import { HonuaClient } from "@honua/sdk-js";
+import { beforeAll, describe, it } from "vitest";
+import {
+  type DiagnosticsContext,
+  createDiagnosticsInterceptor,
+  formatFailureContext,
+  runWithDiagnostics,
+} from "./diagnostics.js";
+import { recordSurface } from "./reporter.js";
+
+export { runWithDiagnostics, formatFailureContext } from "./diagnostics.js";
+export type { DiagnosticsContext } from "./diagnostics.js";
+
+/** Env var that gates the entire integration lane. */
+export const INTEGRATION_BASE_URL_ENV = "HONUA_INTEGRATION_BASE_URL";
+
+/**
+ * Resolved configuration for one integration test run. Defaults match
+ * `honua-server/tests/python/shared/js_test_server.py` so a local
+ * `python -m tests.python.shared.js_test_server` followed by
+ * `HONUA_INTEGRATION_BASE_URL=http://localhost:5555 npm run test:integration`
+ * Just Works without any other env wiring.
+ */
+export interface IntegrationConfig {
+  baseUrl: string;
+  serviceId: string;
+  layerId: number;
+  /**
+   * OGC API Features collection ID for read tests. The seeded `places`
+   * collection is the SDK lane default because every supported server
+   * profile (`core`, `ogc`) seeds it.
+   */
+  collectionId: string;
+  /** OGC Tiles tile-matrix-set used for sparse-tile reads. */
+  tileMatrixSetId: string;
+  /**
+   * Free-form label tying the run to a server seed configuration.
+   * Recorded into `integration-meta.json` for telemetry; not sent on
+   * the wire.
+   */
+  seedProfile: string;
+  apiKey: string | undefined;
+  bearerToken: string | undefined;
+  timeoutMs: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_SERVICE_ID = "test_service_gw0";
+const DEFAULT_LAYER_ID = 1000;
+const DEFAULT_COLLECTION_ID = "places";
+const DEFAULT_TILE_MATRIX_SET = "WebMercatorQuad";
+const DEFAULT_SEED_PROFILE = "places-roads-v1";
+
+let cachedConfig: IntegrationConfig | undefined;
+
+/**
+ * Read and validate every integration env var. Returns `undefined` when
+ * `HONUA_INTEGRATION_BASE_URL` is not set so callers can branch on a
+ * single value without scattering env reads. Memoized per process so the
+ * suite never reparses on every test.
+ */
+export function tryResolveIntegrationConfig(): IntegrationConfig | undefined {
+  if (cachedConfig) return cachedConfig;
+  const baseUrl = process.env[INTEGRATION_BASE_URL_ENV]?.trim();
+  if (!baseUrl) return undefined;
+  cachedConfig = {
+    baseUrl,
+    serviceId: process.env.HONUA_INTEGRATION_SERVICE_ID?.trim() || DEFAULT_SERVICE_ID,
+    layerId: parseIntOrDefault(process.env.HONUA_INTEGRATION_LAYER_ID, DEFAULT_LAYER_ID),
+    collectionId: process.env.HONUA_INTEGRATION_COLLECTION_ID?.trim() || DEFAULT_COLLECTION_ID,
+    tileMatrixSetId: process.env.HONUA_INTEGRATION_TILE_MATRIX_SET?.trim() || DEFAULT_TILE_MATRIX_SET,
+    seedProfile: process.env.HONUA_INTEGRATION_SEED_PROFILE?.trim() || DEFAULT_SEED_PROFILE,
+    apiKey: trimToUndefined(process.env.HONUA_INTEGRATION_API_KEY),
+    bearerToken: trimToUndefined(process.env.HONUA_INTEGRATION_BEARER_TOKEN),
+    timeoutMs: parseIntOrDefault(process.env.HONUA_INTEGRATION_TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
+  };
+  return cachedConfig;
+}
+
+/** Throws when the integration suite is not configured. */
+export function resolveIntegrationConfig(): IntegrationConfig {
+  const config = tryResolveIntegrationConfig();
+  if (!config) {
+    throw new Error(
+      `${INTEGRATION_BASE_URL_ENV} is not set. The integration lane is connect-only — start a Honua Server and set ${INTEGRATION_BASE_URL_ENV}.`,
+    );
+  }
+  return config;
+}
+
+/**
+ * Build a {@link HonuaClient} bound to one shared diagnostics context.
+ * Tests pass that context (returned via the `context` field) into
+ * {@link runWithDiagnostics} when wrapping SDK calls.
+ */
+export interface IntegrationClient {
+  client: HonuaClient;
+  context: DiagnosticsContext;
+  config: IntegrationConfig;
+}
+
+export function makeIntegrationClient(): IntegrationClient {
+  const config = resolveIntegrationConfig();
+  const context: DiagnosticsContext = {};
+  const interceptor = createDiagnosticsInterceptor(context);
+  const options: ConstructorParameters<typeof HonuaClient>[0] = {
+    baseUrl: config.baseUrl,
+    interceptors: [interceptor],
+    timeoutMs: config.timeoutMs,
+  };
+  if (config.apiKey) options.apiKey = config.apiKey;
+  if (config.bearerToken) options.bearerToken = config.bearerToken;
+  const client = new HonuaClient(options);
+  return { client, context, config };
+}
+
+/**
+ * Wrap a per-surface test file. The body callback receives a fresh
+ * {@link IntegrationClient} so the harness can defer client construction
+ * until the suite is actually scheduled — when
+ * `HONUA_INTEGRATION_BASE_URL` is unset the body is replaced by a noop
+ * `describe.skip(...)` and `makeIntegrationClient()` is never called.
+ *
+ * `surface` is recorded into the integration metadata file so the
+ * uploaded artifact lists exactly which protocol surfaces the lane
+ * exercised on a given run.
+ */
+export function integrationSuite(name: string, surface: string, fn: (handle: IntegrationClient) => void): void {
+  const config = tryResolveIntegrationConfig();
+  if (!config) {
+    describe.skip(`${name} [surface:${surface}]`, () => {
+      it.skip("integration lane disabled (HONUA_INTEGRATION_BASE_URL unset)", () => undefined);
+    });
+    return;
+  }
+  describe(`${name} [surface:${surface}]`, () => {
+    const handle = makeIntegrationClient();
+    beforeAll(() => {
+      recordSurface(surface);
+    });
+    fn(handle);
+  });
+}
+
+/**
+ * Wrap a surface test file whose surface is intentionally not exercised
+ * yet (no public SDK adapter, missing seed data, etc.). Always registers
+ * `describe.skip` and records the surface as `skipped:<reason>` in the
+ * integration metadata so the unsupported list is visible alongside the
+ * exercised list. The reason should reference an issue or a concrete
+ * cause so future contributors can flip the gap when the dependency is
+ * resolved.
+ */
+export function skippedIntegrationSuite(name: string, surface: string, reason: string, fn: () => void): void {
+  if (tryResolveIntegrationConfig()) {
+    recordSurface(surface, reason);
+  }
+  describe.skip(`${name} [surface:${surface}] (skipped: ${reason})`, fn);
+}
+
+/**
+ * Issue a health probe against the configured base URL. The OGC landing
+ * (`/api/v1/admin/capabilities` via {@link HonuaClient.getCompatibility})
+ * is the canonical liveness signal because it returns the version
+ * information the integration metadata file pins later.
+ */
+export async function probeServerHealth(client: HonuaClient): Promise<{
+  serverVersion: string;
+  releaseChannel: string;
+}> {
+  const compatibility = await client.getCompatibility();
+  return {
+    serverVersion: compatibility.serverVersion,
+    releaseChannel: compatibility.releaseChannel,
+  };
+}
+
+function parseIntOrDefault(raw: string | undefined, fallback: number): number {
+  if (raw === undefined) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return parsed;
+}
+
+function trimToUndefined(raw: string | undefined): string | undefined {
+  const trimmed = raw?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}

--- a/test/integration/reporter.ts
+++ b/test/integration/reporter.ts
@@ -73,9 +73,24 @@ export function initializeMeta(initial: Omit<IntegrationMetaDocument, "surfaces"
  * the same surface keeps the original entry but overwrites the reason
  * (so a skip recorded ahead of time can later be marked as exercised
  * without leaving stale text behind).
+ *
+ * Vitest runs surface test files in worker processes that do not share
+ * module state with the global setup process, so when the worker calls
+ * this function `mutableMeta` is `undefined` even though
+ * `initializeMeta()` already wrote the artifact. Restore from disk in
+ * that case and merge the new surface entry. `vitest.integration.config.ts`
+ * pins `fileParallelism: false` so reads and writes stay serial.
  */
 export function recordSurface(surface: string, skipReason?: string): void {
-  if (!mutableMeta) return;
+  if (!mutableMeta) {
+    const restored = restoreMetaFromDisk();
+    if (!restored) return;
+    mutableMeta = restored;
+    surfaceIndex.clear();
+    for (const entry of mutableMeta.surfaces) {
+      surfaceIndex.set(entry.surface, entry);
+    }
+  }
   const existing = surfaceIndex.get(surface);
   if (existing) {
     if (skipReason) {
@@ -113,4 +128,20 @@ function flushMeta(): void {
   if (!mutableMeta) return;
   fs.mkdirSync(TEST_RESULTS_DIR, { recursive: true });
   fs.writeFileSync(META_FILE, `${JSON.stringify(mutableMeta, null, 2)}\n`);
+}
+
+function restoreMetaFromDisk(): MutableMeta | undefined {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(META_FILE, "utf8");
+  } catch {
+    return undefined;
+  }
+  let parsed: IntegrationMetaDocument;
+  try {
+    parsed = JSON.parse(raw) as IntegrationMetaDocument;
+  } catch {
+    return undefined;
+  }
+  return { ...parsed, surfaces: [...(parsed.surfaces ?? [])] };
 }

--- a/test/integration/reporter.ts
+++ b/test/integration/reporter.ts
@@ -1,0 +1,116 @@
+/**
+ * Telemetry artifact for the integration lane. The suite writes one
+ * `test-results/integration-meta.json` per run that the CI workflow
+ * uploads as an artifact, so drift between SDK versions and server
+ * commits is traceable from the CI summary alone.
+ *
+ * The artifact is the only observable signal the integration lane
+ * adds to CI; it is intentionally append-only at the surface level so
+ * that test files can call {@link recordSurface} from `beforeAll`
+ * without needing a global registration step.
+ *
+ * @module
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const TEST_RESULTS_DIR = path.resolve(fileURLToPath(import.meta.url), "../../../test-results");
+const META_FILE = path.join(TEST_RESULTS_DIR, "integration-meta.json");
+
+/**
+ * Per-surface entry recorded into the metadata file. `reason` is set
+ * when the surface is intentionally skipped (no public adapter, missing
+ * seed data) and absent for actively exercised surfaces.
+ */
+export interface IntegrationSurfaceEntry {
+  surface: string;
+  status: "exercised" | "skipped";
+  reason?: string;
+  recordedAt: string;
+}
+
+/** Top-level metadata document written to `test-results/integration-meta.json`. */
+export interface IntegrationMetaDocument {
+  sdkVersion: string;
+  sdkPackage: string;
+  serverVersion: string | undefined;
+  serverReleaseChannel: string | undefined;
+  serverImage: string | undefined;
+  serverCommit: string | undefined;
+  baseUrl: string;
+  seedProfile: string;
+  serviceId: string;
+  layerId: number;
+  collectionId: string;
+  tileMatrixSetId: string;
+  startedAt: string;
+  surfaces: IntegrationSurfaceEntry[];
+}
+
+interface MutableMeta extends IntegrationMetaDocument {
+  surfaces: IntegrationSurfaceEntry[];
+}
+
+let mutableMeta: MutableMeta | undefined;
+const surfaceIndex = new Map<string, IntegrationSurfaceEntry>();
+
+/**
+ * Initialize the metadata document once per process. Called from the
+ * Vitest global setup with the resolved server compatibility envelope so
+ * the file already names the SDK and server versions before any surface
+ * test runs.
+ */
+export function initializeMeta(initial: Omit<IntegrationMetaDocument, "surfaces">): void {
+  mutableMeta = { ...initial, surfaces: [] };
+  surfaceIndex.clear();
+  flushMeta();
+}
+
+/**
+ * Append a surface to the metadata file. Idempotent — calling twice for
+ * the same surface keeps the original entry but overwrites the reason
+ * (so a skip recorded ahead of time can later be marked as exercised
+ * without leaving stale text behind).
+ */
+export function recordSurface(surface: string, skipReason?: string): void {
+  if (!mutableMeta) return;
+  const existing = surfaceIndex.get(surface);
+  if (existing) {
+    if (skipReason) {
+      existing.status = "skipped";
+      existing.reason = skipReason;
+    } else if (existing.status !== "exercised") {
+      existing.status = "exercised";
+      delete existing.reason;
+    }
+    flushMeta();
+    return;
+  }
+  const entry: IntegrationSurfaceEntry = {
+    surface,
+    status: skipReason ? "skipped" : "exercised",
+    ...(skipReason ? { reason: skipReason } : {}),
+    recordedAt: new Date().toISOString(),
+  };
+  surfaceIndex.set(surface, entry);
+  mutableMeta.surfaces.push(entry);
+  flushMeta();
+}
+
+/** Return the current metadata document or `undefined` if not initialized. */
+export function readMeta(): IntegrationMetaDocument | undefined {
+  return mutableMeta ? structuredClone(mutableMeta) : undefined;
+}
+
+/** Path to the on-disk metadata artifact. Exposed for assertions and CI uploads. */
+export function metaFilePath(): string {
+  return META_FILE;
+}
+
+function flushMeta(): void {
+  if (!mutableMeta) return;
+  fs.mkdirSync(TEST_RESULTS_DIR, { recursive: true });
+  fs.writeFileSync(META_FILE, `${JSON.stringify(mutableMeta, null, 2)}\n`);
+}

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -1,0 +1,87 @@
+/**
+ * Vitest global setup for the integration lane. Runs once before any
+ * surface test file. Performs three jobs:
+ *
+ *   1. Detects whether the integration lane is configured. If
+ *      `HONUA_INTEGRATION_BASE_URL` is unset, surfaces will skip
+ *      themselves (see `integrationSuite` in `harness.ts`) — global
+ *      setup just leaves the metadata file unwritten so a normal
+ *      `npm run test:integration` invocation in an unconfigured env
+ *      reports zero exercised surfaces and exits clean.
+ *   2. Health-checks the server by fetching `getCompatibility()` so
+ *      the lane fails fast (with a clear message) when the configured
+ *      URL points at a stopped or unreachable server.
+ *   3. Initializes `test-results/integration-meta.json` so per-surface
+ *      `recordSurface` calls can append entries.
+ *
+ * @module
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { HonuaClient } from "@honua/sdk-js";
+import { tryResolveIntegrationConfig } from "./harness.js";
+import { initializeMeta } from "./reporter.js";
+
+const PACKAGE_JSON_PATH = path.resolve(fileURLToPath(import.meta.url), "../../../package.json");
+
+export async function setup(): Promise<void> {
+  const config = tryResolveIntegrationConfig();
+  if (!config) {
+    // Nothing to do — surfaces will register as skipped via
+    // `describe.skip(...)` and the run will pass.
+    return;
+  }
+
+  const client = new HonuaClient({
+    baseUrl: config.baseUrl,
+    timeoutMs: Math.min(config.timeoutMs, 15_000),
+    ...(config.apiKey ? { apiKey: config.apiKey } : {}),
+    ...(config.bearerToken ? { bearerToken: config.bearerToken } : {}),
+  });
+
+  let serverVersion: string | undefined;
+  let releaseChannel: string | undefined;
+  try {
+    const compatibility = await client.getCompatibility();
+    serverVersion = compatibility.serverVersion;
+    releaseChannel = compatibility.releaseChannel;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Honua Server health check failed at ${config.baseUrl} (GET /api/v1/admin/capabilities): ${message}. Ensure the server is running before invoking the integration lane.`,
+    );
+  }
+
+  const sdkPackage = readPackageInfo();
+  initializeMeta({
+    sdkVersion: sdkPackage.version,
+    sdkPackage: sdkPackage.name,
+    serverVersion,
+    serverReleaseChannel: releaseChannel,
+    serverImage: process.env.HONUA_INTEGRATION_SERVER_IMAGE?.trim() || undefined,
+    serverCommit: process.env.HONUA_INTEGRATION_SERVER_COMMIT?.trim() || undefined,
+    baseUrl: config.baseUrl,
+    seedProfile: config.seedProfile,
+    serviceId: config.serviceId,
+    layerId: config.layerId,
+    collectionId: config.collectionId,
+    tileMatrixSetId: config.tileMatrixSetId,
+    startedAt: new Date().toISOString(),
+  });
+}
+
+export async function teardown(): Promise<void> {
+  // No global state to clean up. The metadata file is intentionally
+  // left in place for CI artifact upload.
+}
+
+function readPackageInfo(): { name: string; version: string } {
+  const raw = fs.readFileSync(PACKAGE_JSON_PATH, "utf8");
+  const parsed = JSON.parse(raw) as { name?: string; version?: string };
+  return {
+    name: parsed.name ?? "@honua/sdk-js",
+    version: parsed.version ?? "0.0.0",
+  };
+}

--- a/test/integration/surfaces/feature-server.integration.ts
+++ b/test/integration/surfaces/feature-server.integration.ts
@@ -1,7 +1,7 @@
 /**
  * GeoServices FeatureServer integration coverage. Exercises the
- * read-side public API on a seeded layer (`places` by default) and
- * confirms the client surfaces a typed feature collection through the
+ * read-side public API on the seeded layer and confirms the client
+ * surfaces a typed feature collection through the
  * `client.featureLayer(...)` entry point.
  *
  * @module
@@ -14,32 +14,39 @@ integrationSuite("FeatureServer", "feature-server", ({ client, context, config }
   const layer = client.featureLayer(config.serviceId, config.layerId);
 
   it("returns metadata for the seeded layer", async () => {
-    const metadata = await runWithDiagnostics(context, "client.featureLayer().metadata", () => layer.metadata());
-    expect(metadata.id).toBe(config.layerId);
-    expect(metadata.name?.length ?? 0).toBeGreaterThan(0);
+    await runWithDiagnostics(context, "client.featureLayer().metadata", async () => {
+      const metadata = await layer.metadata();
+      expect(metadata.id).toBe(config.layerId);
+      expect(metadata.name?.length ?? 0).toBeGreaterThan(0);
+    });
   });
 
   it("queries features without a filter", async () => {
-    const result = await runWithDiagnostics(context, "client.featureLayer().queryFeatures", () =>
-      layer.queryFeatures({ where: "1=1", returnGeometry: true, outFields: ["*"], outSr: 4326 }),
-    );
-    const features = result.features ?? [];
-    expect(features.length).toBeGreaterThan(0);
-    expect(features[0]?.attributes).toBeDefined();
+    await runWithDiagnostics(context, "client.featureLayer().queryFeatures", async () => {
+      const result = await layer.queryFeatures({
+        where: "1=1",
+        returnGeometry: true,
+        outFields: ["*"],
+        outSr: 4326,
+      });
+      const features = result.features ?? [];
+      expect(features.length).toBeGreaterThan(0);
+      expect(features[0]?.attributes).toBeDefined();
+    });
   });
 
   it("counts features with the where=1=1 filter", async () => {
-    const count = await runWithDiagnostics(context, "client.featureLayer().queryFeatureCount", () =>
-      layer.queryFeatureCount({ where: "1=1" }),
-    );
-    expect(count).toBeGreaterThan(0);
+    await runWithDiagnostics(context, "client.featureLayer().queryFeatureCount", async () => {
+      const count = await layer.queryFeatureCount({ where: "1=1" });
+      expect(count).toBeGreaterThan(0);
+    });
   });
 
   it("lists object IDs", async () => {
-    const ids = await runWithDiagnostics(context, "client.featureLayer().queryObjectIds", () =>
-      layer.queryObjectIds({ where: "1=1" }),
-    );
-    expect(Array.isArray(ids)).toBe(true);
-    expect(ids.length).toBeGreaterThan(0);
+    await runWithDiagnostics(context, "client.featureLayer().queryObjectIds", async () => {
+      const ids = await layer.queryObjectIds({ where: "1=1" });
+      expect(Array.isArray(ids)).toBe(true);
+      expect(ids.length).toBeGreaterThan(0);
+    });
   });
 });

--- a/test/integration/surfaces/feature-server.integration.ts
+++ b/test/integration/surfaces/feature-server.integration.ts
@@ -1,0 +1,45 @@
+/**
+ * GeoServices FeatureServer integration coverage. Exercises the
+ * read-side public API on a seeded layer (`places` by default) and
+ * confirms the client surfaces a typed feature collection through the
+ * `client.featureLayer(...)` entry point.
+ *
+ * @module
+ */
+
+import { expect, it } from "vitest";
+import { integrationSuite, runWithDiagnostics } from "../harness.js";
+
+integrationSuite("FeatureServer", "feature-server", ({ client, context, config }) => {
+  const layer = client.featureLayer(config.serviceId, config.layerId);
+
+  it("returns metadata for the seeded layer", async () => {
+    const metadata = await runWithDiagnostics(context, "client.featureLayer().metadata", () => layer.metadata());
+    expect(metadata.id).toBe(config.layerId);
+    expect(metadata.name?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it("queries features without a filter", async () => {
+    const result = await runWithDiagnostics(context, "client.featureLayer().queryFeatures", () =>
+      layer.queryFeatures({ where: "1=1", returnGeometry: true, outFields: ["*"], outSr: 4326 }),
+    );
+    const features = result.features ?? [];
+    expect(features.length).toBeGreaterThan(0);
+    expect(features[0]?.attributes).toBeDefined();
+  });
+
+  it("counts features with the where=1=1 filter", async () => {
+    const count = await runWithDiagnostics(context, "client.featureLayer().queryFeatureCount", () =>
+      layer.queryFeatureCount({ where: "1=1" }),
+    );
+    expect(count).toBeGreaterThan(0);
+  });
+
+  it("lists object IDs", async () => {
+    const ids = await runWithDiagnostics(context, "client.featureLayer().queryObjectIds", () =>
+      layer.queryObjectIds({ where: "1=1" }),
+    );
+    expect(Array.isArray(ids)).toBe(true);
+    expect(ids.length).toBeGreaterThan(0);
+  });
+});

--- a/test/integration/surfaces/gp-server.integration.ts
+++ b/test/integration/surfaces/gp-server.integration.ts
@@ -1,0 +1,25 @@
+/**
+ * GeoServices GPServer integration coverage.
+ *
+ * The Honua Server advertises GPServer routes, but the public
+ * `HonuaClient` API does not expose a first-party
+ * `client.geoprocessing(...)` entry point yet — `HonuaGeoprocessingService`
+ * is registered for use by the canonical contract layer rather than as
+ * a top-level client method like FeatureServer / MapServer have. The
+ * integration lane scopes itself to public-API tests only, so this
+ * file marks the surface as a documented gap until that dedicated
+ * entry point lands. Track the gap in honua-sdk-js#39.
+ *
+ * @module
+ */
+
+import { expect, it } from "vitest";
+import { skippedIntegrationSuite } from "../harness.js";
+
+const REASON = "no first-party client.geoprocessing() entry point yet (tracked by honua-sdk-js#39)";
+
+skippedIntegrationSuite("GPServer", "gp-server", REASON, () => {
+  it.skip("submits a GPServer job when the public surface lands", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/test/integration/surfaces/image-server.integration.ts
+++ b/test/integration/surfaces/image-server.integration.ts
@@ -1,0 +1,25 @@
+/**
+ * GeoServices ImageServer integration coverage.
+ *
+ * The Honua Server exposes an ImageServer surface, but the public
+ * `HonuaClient` API surfaces ImageServer through the lower-level
+ * `client.request(...)` escape hatch and the
+ * `HonuaImageService` runtime helper rather than through a first-party
+ * `client.imageService(...)` method like FeatureServer / MapServer
+ * have. The integration lane scopes itself to public-API tests only,
+ * so this file marks the surface as a documented gap until that
+ * dedicated entry point lands. Track the gap in honua-sdk-js#39.
+ *
+ * @module
+ */
+
+import { expect, it } from "vitest";
+import { skippedIntegrationSuite } from "../harness.js";
+
+const REASON = "no first-party client.imageService() entry point yet (tracked by honua-sdk-js#39)";
+
+skippedIntegrationSuite("ImageServer", "image-server", REASON, () => {
+  it.skip("renders an ImageServer export when the public surface lands", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/test/integration/surfaces/map-server.integration.ts
+++ b/test/integration/surfaces/map-server.integration.ts
@@ -14,37 +14,44 @@ integrationSuite("MapServer", "map-server", ({ client, context, config }) => {
   const mapLayer = client.mapLayer(config.serviceId, config.layerId);
 
   it("returns map service metadata", async () => {
-    const metadata = await runWithDiagnostics(context, "client.mapService().metadata", () => mapService.metadata());
-    expect(metadata).toBeDefined();
-    expect(Array.isArray(metadata.layers ?? [])).toBe(true);
+    await runWithDiagnostics(context, "client.mapService().metadata", async () => {
+      const metadata = await mapService.metadata();
+      expect(metadata).toBeDefined();
+      expect(Array.isArray(metadata.layers ?? [])).toBe(true);
+    });
   });
 
   it("queries features through the map layer", async () => {
-    const result = await runWithDiagnostics(context, "client.mapLayer().queryFeatures", () =>
-      mapLayer.queryFeatures({ where: "1=1", returnGeometry: true, outFields: "*", outSr: 4326 }),
-    );
-    const features = result.features ?? [];
-    expect(features.length).toBeGreaterThan(0);
+    await runWithDiagnostics(context, "client.mapLayer().queryFeatures", async () => {
+      const result = await mapLayer.queryFeatures({
+        where: "1=1",
+        returnGeometry: true,
+        outFields: "*",
+        outSr: 4326,
+      });
+      const features = result.features ?? [];
+      expect(features.length).toBeGreaterThan(0);
+    });
   });
 
   it("counts features through the map layer", async () => {
-    const count = await runWithDiagnostics(context, "client.mapLayer().queryFeatureCount", () =>
-      mapLayer.queryFeatureCount({ where: "1=1" }),
-    );
-    expect(count).toBeGreaterThan(0);
+    await runWithDiagnostics(context, "client.mapLayer().queryFeatureCount", async () => {
+      const count = await mapLayer.queryFeatureCount({ where: "1=1" });
+      expect(count).toBeGreaterThan(0);
+    });
   });
 
   it("renders an export-map image", async () => {
-    const exported = await runWithDiagnostics(context, "client.mapService().exportMap", () =>
-      mapService.exportMap({
+    await runWithDiagnostics(context, "client.mapService().exportMap", async () => {
+      const exported = await mapService.exportMap({
         bbox: [-180, -85, 180, 85],
         size: [256, 256],
         bboxSr: 4326,
         imageSr: 4326,
         format: "png",
-      }),
-    );
-    expect(exported).toBeDefined();
-    expect(typeof exported.href === "string" || exported.extent !== undefined).toBe(true);
+      });
+      expect(exported).toBeDefined();
+      expect(typeof exported.href === "string" || exported.extent !== undefined).toBe(true);
+    });
   });
 });

--- a/test/integration/surfaces/map-server.integration.ts
+++ b/test/integration/surfaces/map-server.integration.ts
@@ -1,0 +1,50 @@
+/**
+ * GeoServices MapServer integration coverage. Exercises the read-side
+ * map-service public API on the seeded service: metadata, layer query,
+ * and a single export-map render.
+ *
+ * @module
+ */
+
+import { expect, it } from "vitest";
+import { integrationSuite, runWithDiagnostics } from "../harness.js";
+
+integrationSuite("MapServer", "map-server", ({ client, context, config }) => {
+  const mapService = client.mapService(config.serviceId);
+  const mapLayer = client.mapLayer(config.serviceId, config.layerId);
+
+  it("returns map service metadata", async () => {
+    const metadata = await runWithDiagnostics(context, "client.mapService().metadata", () => mapService.metadata());
+    expect(metadata).toBeDefined();
+    expect(Array.isArray(metadata.layers ?? [])).toBe(true);
+  });
+
+  it("queries features through the map layer", async () => {
+    const result = await runWithDiagnostics(context, "client.mapLayer().queryFeatures", () =>
+      mapLayer.queryFeatures({ where: "1=1", returnGeometry: true, outFields: "*", outSr: 4326 }),
+    );
+    const features = result.features ?? [];
+    expect(features.length).toBeGreaterThan(0);
+  });
+
+  it("counts features through the map layer", async () => {
+    const count = await runWithDiagnostics(context, "client.mapLayer().queryFeatureCount", () =>
+      mapLayer.queryFeatureCount({ where: "1=1" }),
+    );
+    expect(count).toBeGreaterThan(0);
+  });
+
+  it("renders an export-map image", async () => {
+    const exported = await runWithDiagnostics(context, "client.mapService().exportMap", () =>
+      mapService.exportMap({
+        bbox: [-180, -85, 180, 85],
+        size: [256, 256],
+        bboxSr: 4326,
+        imageSr: 4326,
+        format: "png",
+      }),
+    );
+    expect(exported).toBeDefined();
+    expect(typeof exported.href === "string" || exported.extent !== undefined).toBe(true);
+  });
+});

--- a/test/integration/surfaces/ogc-features.integration.ts
+++ b/test/integration/surfaces/ogc-features.integration.ts
@@ -14,48 +14,56 @@ integrationSuite("OGC API Features", "ogc-features", ({ client, context, config 
   const collection = ogc.collection(config.collectionId);
 
   it("returns an OGC Features landing document", async () => {
-    const landing = await runWithDiagnostics(context, "client.ogcFeatures().landing", () => ogc.landing());
-    expect(landing).toBeDefined();
-    expect(Array.isArray(landing.links)).toBe(true);
+    await runWithDiagnostics(context, "client.ogcFeatures().landing", async () => {
+      const landing = await ogc.landing();
+      expect(landing).toBeDefined();
+      expect(Array.isArray(landing.links)).toBe(true);
+    });
   });
 
   it("declares OGC Features conformance classes", async () => {
-    const conformance = await runWithDiagnostics(context, "client.ogcFeatures().conformance", () => ogc.conformance());
-    expect(Array.isArray(conformance.conformsTo)).toBe(true);
-    expect(conformance.conformsTo.length).toBeGreaterThan(0);
+    await runWithDiagnostics(context, "client.ogcFeatures().conformance", async () => {
+      const conformance = await ogc.conformance();
+      expect(Array.isArray(conformance.conformsTo)).toBe(true);
+      expect(conformance.conformsTo.length).toBeGreaterThan(0);
+    });
   });
 
   it("lists collections including the configured one", async () => {
-    const result = await runWithDiagnostics(context, "client.ogcFeatures().collections", () => ogc.collections());
-    expect(Array.isArray(result.collections)).toBe(true);
-    const ids = result.collections.map((entry) => String(entry.id));
-    expect(ids).toContain(String(config.collectionId));
+    await runWithDiagnostics(context, "client.ogcFeatures().collections", async () => {
+      const result = await ogc.collections();
+      expect(Array.isArray(result.collections)).toBe(true);
+      const ids = result.collections.map((entry) => String(entry.id));
+      expect(ids).toContain(String(config.collectionId));
+    });
   });
 
   it("returns paginated items for the configured collection", async () => {
-    const items = await runWithDiagnostics(context, "client.ogcFeatures().collection().items", () =>
-      collection.items({ limit: 5 }),
-    );
-    expect(items.type).toBe("FeatureCollection");
-    expect(items.features.length).toBeGreaterThan(0);
-    const featureId = items.features[0]?.id;
-    expect(featureId === undefined || typeof featureId !== "object").toBe(true);
+    await runWithDiagnostics(context, "client.ogcFeatures().collection().items", async () => {
+      const items = await collection.items({ limit: 5 });
+      expect(items.type).toBe("FeatureCollection");
+      expect(items.features.length).toBeGreaterThan(0);
+      const featureId = items.features[0]?.id;
+      expect(featureId === undefined || typeof featureId !== "object").toBe(true);
+    });
   });
 
   it("fetches a single item by id", async () => {
-    const items = await runWithDiagnostics(context, "client.ogcFeatures().collection().items", () =>
-      collection.items({ limit: 1 }),
-    );
+    const items = await runWithDiagnostics(context, "client.ogcFeatures().collection().items", async () => {
+      const r = await collection.items({ limit: 1 });
+      expect(r.type).toBe("FeatureCollection");
+      return r;
+    });
     const featureId = items.features[0]?.id;
     if (featureId === undefined || featureId === null) {
       // Server returned features without ids — record an explicit
       // soft-skip rather than asserting an unsupported behavior.
       return;
     }
-    const item = await runWithDiagnostics(context, "client.ogcFeatures().collection().item", () =>
-      collection.item({ featureId: String(featureId) }),
-    );
-    expect(item.type).toBe("Feature");
-    expect(item.geometry).toBeDefined();
+    await runWithDiagnostics(context, "client.ogcFeatures().collection().item", async () => {
+      const item = await collection.item({ featureId: String(featureId) });
+      expect(item.type).toBe("Feature");
+      expect(item.geometry).toBeDefined();
+    });
   });
 });

--- a/test/integration/surfaces/ogc-features.integration.ts
+++ b/test/integration/surfaces/ogc-features.integration.ts
@@ -1,0 +1,61 @@
+/**
+ * OGC API Features integration coverage. Walks the public
+ * `client.ogcFeatures()` surface from landing → conformance →
+ * collections → items → item.
+ *
+ * @module
+ */
+
+import { expect, it } from "vitest";
+import { integrationSuite, runWithDiagnostics } from "../harness.js";
+
+integrationSuite("OGC API Features", "ogc-features", ({ client, context, config }) => {
+  const ogc = client.ogcFeatures();
+  const collection = ogc.collection(config.collectionId);
+
+  it("returns an OGC Features landing document", async () => {
+    const landing = await runWithDiagnostics(context, "client.ogcFeatures().landing", () => ogc.landing());
+    expect(landing).toBeDefined();
+    expect(Array.isArray(landing.links)).toBe(true);
+  });
+
+  it("declares OGC Features conformance classes", async () => {
+    const conformance = await runWithDiagnostics(context, "client.ogcFeatures().conformance", () => ogc.conformance());
+    expect(Array.isArray(conformance.conformsTo)).toBe(true);
+    expect(conformance.conformsTo.length).toBeGreaterThan(0);
+  });
+
+  it("lists collections including the configured one", async () => {
+    const result = await runWithDiagnostics(context, "client.ogcFeatures().collections", () => ogc.collections());
+    expect(Array.isArray(result.collections)).toBe(true);
+    const ids = result.collections.map((entry) => String(entry.id));
+    expect(ids).toContain(String(config.collectionId));
+  });
+
+  it("returns paginated items for the configured collection", async () => {
+    const items = await runWithDiagnostics(context, "client.ogcFeatures().collection().items", () =>
+      collection.items({ limit: 5 }),
+    );
+    expect(items.type).toBe("FeatureCollection");
+    expect(items.features.length).toBeGreaterThan(0);
+    const featureId = items.features[0]?.id;
+    expect(featureId === undefined || typeof featureId !== "object").toBe(true);
+  });
+
+  it("fetches a single item by id", async () => {
+    const items = await runWithDiagnostics(context, "client.ogcFeatures().collection().items", () =>
+      collection.items({ limit: 1 }),
+    );
+    const featureId = items.features[0]?.id;
+    if (featureId === undefined || featureId === null) {
+      // Server returned features without ids — record an explicit
+      // soft-skip rather than asserting an unsupported behavior.
+      return;
+    }
+    const item = await runWithDiagnostics(context, "client.ogcFeatures().collection().item", () =>
+      collection.item({ featureId: String(featureId) }),
+    );
+    expect(item.type).toBe("Feature");
+    expect(item.geometry).toBeDefined();
+  });
+});

--- a/test/integration/surfaces/ogc-maps.integration.ts
+++ b/test/integration/surfaces/ogc-maps.integration.ts
@@ -1,0 +1,39 @@
+/**
+ * OGC API Maps integration coverage. Walks landing → conformance → a
+ * single map render against the configured collection.
+ *
+ * @module
+ */
+
+import { expect, it } from "vitest";
+import { integrationSuite, runWithDiagnostics } from "../harness.js";
+
+integrationSuite("OGC API Maps", "ogc-maps", ({ client, context, config }) => {
+  const maps = client.ogcMaps();
+
+  it("returns the OGC Maps landing document", async () => {
+    const landing = await runWithDiagnostics(context, "client.ogcMaps().landing", () => maps.landing());
+    expect(landing).toBeDefined();
+    expect(Array.isArray(landing.links)).toBe(true);
+  });
+
+  it("declares OGC Maps conformance classes", async () => {
+    const conformance = await runWithDiagnostics(context, "client.ogcMaps().conformance", () => maps.conformance());
+    expect(Array.isArray(conformance.conformsTo)).toBe(true);
+  });
+
+  it("renders a map image for the configured collection", async () => {
+    const collection = maps.collection(config.collectionId);
+    const map = await runWithDiagnostics(context, "client.ogcMaps().collection().map", () =>
+      collection.map({
+        width: 256,
+        height: 256,
+        bbox: [-180, -85, 180, 85],
+        crs: "EPSG:4326",
+        format: "png",
+      }),
+    );
+    expect(map.contentType.length).toBeGreaterThan(0);
+    expect(map.bytes).toBeInstanceOf(Uint8Array);
+  });
+});

--- a/test/integration/surfaces/ogc-maps.integration.ts
+++ b/test/integration/surfaces/ogc-maps.integration.ts
@@ -12,28 +12,32 @@ integrationSuite("OGC API Maps", "ogc-maps", ({ client, context, config }) => {
   const maps = client.ogcMaps();
 
   it("returns the OGC Maps landing document", async () => {
-    const landing = await runWithDiagnostics(context, "client.ogcMaps().landing", () => maps.landing());
-    expect(landing).toBeDefined();
-    expect(Array.isArray(landing.links)).toBe(true);
+    await runWithDiagnostics(context, "client.ogcMaps().landing", async () => {
+      const landing = await maps.landing();
+      expect(landing).toBeDefined();
+      expect(Array.isArray(landing.links)).toBe(true);
+    });
   });
 
   it("declares OGC Maps conformance classes", async () => {
-    const conformance = await runWithDiagnostics(context, "client.ogcMaps().conformance", () => maps.conformance());
-    expect(Array.isArray(conformance.conformsTo)).toBe(true);
+    await runWithDiagnostics(context, "client.ogcMaps().conformance", async () => {
+      const conformance = await maps.conformance();
+      expect(Array.isArray(conformance.conformsTo)).toBe(true);
+    });
   });
 
   it("renders a map image for the configured collection", async () => {
     const collection = maps.collection(config.collectionId);
-    const map = await runWithDiagnostics(context, "client.ogcMaps().collection().map", () =>
-      collection.map({
+    await runWithDiagnostics(context, "client.ogcMaps().collection().map", async () => {
+      const map = await collection.map({
         width: 256,
         height: 256,
         bbox: [-180, -85, 180, 85],
         crs: "EPSG:4326",
         format: "png",
-      }),
-    );
-    expect(map.contentType.length).toBeGreaterThan(0);
-    expect(map.bytes).toBeInstanceOf(Uint8Array);
+      });
+      expect(map.contentType.length).toBeGreaterThan(0);
+      expect(map.bytes).toBeInstanceOf(Uint8Array);
+    });
   });
 });

--- a/test/integration/surfaces/ogc-processes.integration.ts
+++ b/test/integration/surfaces/ogc-processes.integration.ts
@@ -1,0 +1,48 @@
+/**
+ * OGC API Processes integration coverage. Walks landing → conformance →
+ * process list. The execute path is exercised only when the seed
+ * exposes at least one registered process — otherwise the test records
+ * the surface as exercised through the discovery calls and stops short
+ * of submission.
+ *
+ * @module
+ */
+
+import { expect, it } from "vitest";
+import { integrationSuite, runWithDiagnostics } from "../harness.js";
+
+integrationSuite("OGC API Processes", "ogc-processes", ({ client, context }) => {
+  const processes = client.ogcProcesses();
+
+  it("returns the OGC Processes landing document", async () => {
+    const landing = await runWithDiagnostics(context, "client.ogcProcesses().landing", () => processes.landing());
+    expect(landing).toBeDefined();
+    expect(Array.isArray(landing.links)).toBe(true);
+  });
+
+  it("declares OGC Processes conformance classes", async () => {
+    const conformance = await runWithDiagnostics(context, "client.ogcProcesses().conformance", () =>
+      processes.conformance(),
+    );
+    expect(Array.isArray(conformance.conformsTo)).toBe(true);
+  });
+
+  it("lists registered processes (may be empty)", async () => {
+    const list = await runWithDiagnostics(context, "client.ogcProcesses().list", () => processes.list());
+    expect(Array.isArray(list.processes)).toBe(true);
+  });
+
+  it("describes the first registered process when one exists", async () => {
+    const list = await runWithDiagnostics(context, "client.ogcProcesses().list", () => processes.list());
+    const first = list.processes[0];
+    if (!first) {
+      // Soft skip — execute is exercised in dedicated server tests but
+      // the seed lane does not require a process to be registered.
+      return;
+    }
+    const description = await runWithDiagnostics(context, "client.ogcProcesses().describe", () =>
+      processes.describe(first.id),
+    );
+    expect(description.id).toBe(first.id);
+  });
+});

--- a/test/integration/surfaces/ogc-processes.integration.ts
+++ b/test/integration/surfaces/ogc-processes.integration.ts
@@ -15,34 +15,42 @@ integrationSuite("OGC API Processes", "ogc-processes", ({ client, context }) => 
   const processes = client.ogcProcesses();
 
   it("returns the OGC Processes landing document", async () => {
-    const landing = await runWithDiagnostics(context, "client.ogcProcesses().landing", () => processes.landing());
-    expect(landing).toBeDefined();
-    expect(Array.isArray(landing.links)).toBe(true);
+    await runWithDiagnostics(context, "client.ogcProcesses().landing", async () => {
+      const landing = await processes.landing();
+      expect(landing).toBeDefined();
+      expect(Array.isArray(landing.links)).toBe(true);
+    });
   });
 
   it("declares OGC Processes conformance classes", async () => {
-    const conformance = await runWithDiagnostics(context, "client.ogcProcesses().conformance", () =>
-      processes.conformance(),
-    );
-    expect(Array.isArray(conformance.conformsTo)).toBe(true);
+    await runWithDiagnostics(context, "client.ogcProcesses().conformance", async () => {
+      const conformance = await processes.conformance();
+      expect(Array.isArray(conformance.conformsTo)).toBe(true);
+    });
   });
 
   it("lists registered processes (may be empty)", async () => {
-    const list = await runWithDiagnostics(context, "client.ogcProcesses().list", () => processes.list());
-    expect(Array.isArray(list.processes)).toBe(true);
+    await runWithDiagnostics(context, "client.ogcProcesses().list", async () => {
+      const list = await processes.list();
+      expect(Array.isArray(list.processes)).toBe(true);
+    });
   });
 
   it("describes the first registered process when one exists", async () => {
-    const list = await runWithDiagnostics(context, "client.ogcProcesses().list", () => processes.list());
+    const list = await runWithDiagnostics(context, "client.ogcProcesses().list", async () => {
+      const r = await processes.list();
+      expect(Array.isArray(r.processes)).toBe(true);
+      return r;
+    });
     const first = list.processes[0];
     if (!first) {
       // Soft skip — execute is exercised in dedicated server tests but
       // the seed lane does not require a process to be registered.
       return;
     }
-    const description = await runWithDiagnostics(context, "client.ogcProcesses().describe", () =>
-      processes.describe(first.id),
-    );
-    expect(description.id).toBe(first.id);
+    await runWithDiagnostics(context, "client.ogcProcesses().describe", async () => {
+      const description = await processes.describe(first.id);
+      expect(description.id).toBe(first.id);
+    });
   });
 });

--- a/test/integration/surfaces/ogc-tiles.integration.ts
+++ b/test/integration/surfaces/ogc-tiles.integration.ts
@@ -1,0 +1,60 @@
+/**
+ * OGC API Tiles integration coverage. Walks landing → conformance →
+ * tile-matrix-sets → collection tilesets → single tile fetch. The tile
+ * fetch deliberately targets `(0, 0, 0)` so a sparse seed still returns
+ * an empty (but successful) tile rather than 404.
+ *
+ * @module
+ */
+
+import { expect, it } from "vitest";
+import { integrationSuite, runWithDiagnostics } from "../harness.js";
+
+integrationSuite("OGC API Tiles", "ogc-tiles", ({ client, context, config }) => {
+  const tiles = client.ogcTiles();
+
+  it("returns the OGC Tiles landing document", async () => {
+    const landing = await runWithDiagnostics(context, "client.ogcTiles().landing", () => tiles.landing());
+    expect(landing).toBeDefined();
+    expect(Array.isArray(landing.links)).toBe(true);
+  });
+
+  it("declares OGC Tiles conformance classes", async () => {
+    const conformance = await runWithDiagnostics(context, "client.ogcTiles().conformance", () => tiles.conformance());
+    expect(Array.isArray(conformance.conformsTo)).toBe(true);
+  });
+
+  it("lists tile-matrix-sets with at least one entry", async () => {
+    const tms = await runWithDiagnostics(context, "client.ogcTiles().tileMatrixSets", () => tiles.tileMatrixSets());
+    expect(Array.isArray(tms.tileMatrixSets)).toBe(true);
+    expect(tms.tileMatrixSets.length).toBeGreaterThan(0);
+  });
+
+  it("returns metadata for the configured tile-matrix-set", async () => {
+    const tms = await runWithDiagnostics(context, "client.ogcTiles().tileMatrixSet", () =>
+      tiles.tileMatrixSet(config.tileMatrixSetId),
+    );
+    expect(String(tms.id ?? config.tileMatrixSetId)).toBe(config.tileMatrixSetId);
+  });
+
+  it("lists tilesets for the configured collection", async () => {
+    const tilesets = await runWithDiagnostics(context, "client.ogcTiles().tilesets", () =>
+      tiles.tilesets({ collectionId: config.collectionId }),
+    );
+    expect(Array.isArray(tilesets.tilesets)).toBe(true);
+  });
+
+  it("fetches a single tile at zoom 0,0,0", async () => {
+    const tile = await runWithDiagnostics(context, "client.ogcTiles().tile", () =>
+      tiles.tile({
+        collectionId: config.collectionId,
+        tileMatrixSetId: config.tileMatrixSetId,
+        tileMatrix: 0,
+        tileRow: 0,
+        tileCol: 0,
+      }),
+    );
+    expect(tile.contentType.length).toBeGreaterThan(0);
+    expect(tile.bytes).toBeInstanceOf(Uint8Array);
+  });
+});

--- a/test/integration/surfaces/ogc-tiles.integration.ts
+++ b/test/integration/surfaces/ogc-tiles.integration.ts
@@ -14,47 +14,53 @@ integrationSuite("OGC API Tiles", "ogc-tiles", ({ client, context, config }) => 
   const tiles = client.ogcTiles();
 
   it("returns the OGC Tiles landing document", async () => {
-    const landing = await runWithDiagnostics(context, "client.ogcTiles().landing", () => tiles.landing());
-    expect(landing).toBeDefined();
-    expect(Array.isArray(landing.links)).toBe(true);
+    await runWithDiagnostics(context, "client.ogcTiles().landing", async () => {
+      const landing = await tiles.landing();
+      expect(landing).toBeDefined();
+      expect(Array.isArray(landing.links)).toBe(true);
+    });
   });
 
   it("declares OGC Tiles conformance classes", async () => {
-    const conformance = await runWithDiagnostics(context, "client.ogcTiles().conformance", () => tiles.conformance());
-    expect(Array.isArray(conformance.conformsTo)).toBe(true);
+    await runWithDiagnostics(context, "client.ogcTiles().conformance", async () => {
+      const conformance = await tiles.conformance();
+      expect(Array.isArray(conformance.conformsTo)).toBe(true);
+    });
   });
 
   it("lists tile-matrix-sets with at least one entry", async () => {
-    const tms = await runWithDiagnostics(context, "client.ogcTiles().tileMatrixSets", () => tiles.tileMatrixSets());
-    expect(Array.isArray(tms.tileMatrixSets)).toBe(true);
-    expect(tms.tileMatrixSets.length).toBeGreaterThan(0);
+    await runWithDiagnostics(context, "client.ogcTiles().tileMatrixSets", async () => {
+      const tms = await tiles.tileMatrixSets();
+      expect(Array.isArray(tms.tileMatrixSets)).toBe(true);
+      expect(tms.tileMatrixSets.length).toBeGreaterThan(0);
+    });
   });
 
   it("returns metadata for the configured tile-matrix-set", async () => {
-    const tms = await runWithDiagnostics(context, "client.ogcTiles().tileMatrixSet", () =>
-      tiles.tileMatrixSet(config.tileMatrixSetId),
-    );
-    expect(String(tms.id ?? config.tileMatrixSetId)).toBe(config.tileMatrixSetId);
+    await runWithDiagnostics(context, "client.ogcTiles().tileMatrixSet", async () => {
+      const tms = await tiles.tileMatrixSet(config.tileMatrixSetId);
+      expect(String(tms.id ?? config.tileMatrixSetId)).toBe(config.tileMatrixSetId);
+    });
   });
 
   it("lists tilesets for the configured collection", async () => {
-    const tilesets = await runWithDiagnostics(context, "client.ogcTiles().tilesets", () =>
-      tiles.tilesets({ collectionId: config.collectionId }),
-    );
-    expect(Array.isArray(tilesets.tilesets)).toBe(true);
+    await runWithDiagnostics(context, "client.ogcTiles().tilesets", async () => {
+      const tilesets = await tiles.tilesets({ collectionId: config.collectionId });
+      expect(Array.isArray(tilesets.tilesets)).toBe(true);
+    });
   });
 
   it("fetches a single tile at zoom 0,0,0", async () => {
-    const tile = await runWithDiagnostics(context, "client.ogcTiles().tile", () =>
-      tiles.tile({
+    await runWithDiagnostics(context, "client.ogcTiles().tile", async () => {
+      const tile = await tiles.tile({
         collectionId: config.collectionId,
         tileMatrixSetId: config.tileMatrixSetId,
         tileMatrix: 0,
         tileRow: 0,
         tileCol: 0,
-      }),
-    );
-    expect(tile.contentType.length).toBeGreaterThan(0);
-    expect(tile.bytes).toBeInstanceOf(Uint8Array);
+      });
+      expect(tile.contentType.length).toBeGreaterThan(0);
+      expect(tile.bytes).toBeInstanceOf(Uint8Array);
+    });
   });
 });

--- a/test/integration/surfaces/wms.integration.ts
+++ b/test/integration/surfaces/wms.integration.ts
@@ -13,19 +13,25 @@ integrationSuite("WMS", "wms", ({ client, context, config }) => {
   const wms = client.wms(config.serviceId);
 
   it("reads service capabilities", async () => {
-    const capabilities = await runWithDiagnostics(context, "client.wms().capabilities", () => wms.capabilities());
-    expect(capabilities.version.length).toBeGreaterThan(0);
-    expect(capabilities.layers.length).toBeGreaterThan(0);
+    await runWithDiagnostics(context, "client.wms().capabilities", async () => {
+      const capabilities = await wms.capabilities();
+      expect(capabilities.version.length).toBeGreaterThan(0);
+      expect(capabilities.layers.length).toBeGreaterThan(0);
+    });
   });
 
   it("renders a GetMap image for the first advertised layer", async () => {
-    const capabilities = await runWithDiagnostics(context, "client.wms().capabilities", () => wms.capabilities());
+    const capabilities = await runWithDiagnostics(context, "client.wms().capabilities", async () => {
+      const r = await wms.capabilities();
+      expect(r.version.length).toBeGreaterThan(0);
+      return r;
+    });
     const advertised = capabilities.layers.find((layer) => typeof layer.name === "string" && layer.name.length > 0);
     if (!advertised?.name) {
       return; // Server advertised only group layers — skip render.
     }
-    const image = await runWithDiagnostics(context, "client.wms().map", () =>
-      wms.map({
+    await runWithDiagnostics(context, "client.wms().map", async () => {
+      const image = await wms.map({
         layers: [advertised.name],
         bbox: [-180, -85, 180, 85],
         crs: "EPSG:4326",
@@ -33,9 +39,9 @@ integrationSuite("WMS", "wms", ({ client, context, config }) => {
         height: 256,
         format: "image/png",
         transparent: true,
-      }),
-    );
-    expect(image.contentType.startsWith("image/")).toBe(true);
-    expect(image.bytes.byteLength).toBeGreaterThan(0);
+      });
+      expect(image.contentType.startsWith("image/")).toBe(true);
+      expect(image.bytes.byteLength).toBeGreaterThan(0);
+    });
   });
 });

--- a/test/integration/surfaces/wms.integration.ts
+++ b/test/integration/surfaces/wms.integration.ts
@@ -1,0 +1,41 @@
+/**
+ * WMS 1.3 integration coverage. Reads capabilities first so the test
+ * can pick a layer name that the server actually advertises rather than
+ * hard-coding one from the seed catalog.
+ *
+ * @module
+ */
+
+import { expect, it } from "vitest";
+import { integrationSuite, runWithDiagnostics } from "../harness.js";
+
+integrationSuite("WMS", "wms", ({ client, context, config }) => {
+  const wms = client.wms(config.serviceId);
+
+  it("reads service capabilities", async () => {
+    const capabilities = await runWithDiagnostics(context, "client.wms().capabilities", () => wms.capabilities());
+    expect(capabilities.version.length).toBeGreaterThan(0);
+    expect(capabilities.layers.length).toBeGreaterThan(0);
+  });
+
+  it("renders a GetMap image for the first advertised layer", async () => {
+    const capabilities = await runWithDiagnostics(context, "client.wms().capabilities", () => wms.capabilities());
+    const advertised = capabilities.layers.find((layer) => typeof layer.name === "string" && layer.name.length > 0);
+    if (!advertised?.name) {
+      return; // Server advertised only group layers — skip render.
+    }
+    const image = await runWithDiagnostics(context, "client.wms().map", () =>
+      wms.map({
+        layers: [advertised.name],
+        bbox: [-180, -85, 180, 85],
+        crs: "EPSG:4326",
+        width: 256,
+        height: 256,
+        format: "image/png",
+        transparent: true,
+      }),
+    );
+    expect(image.contentType.startsWith("image/")).toBe(true);
+    expect(image.bytes.byteLength).toBeGreaterThan(0);
+  });
+});

--- a/test/integration/surfaces/wmts.integration.ts
+++ b/test/integration/surfaces/wmts.integration.ts
@@ -13,13 +13,19 @@ integrationSuite("WMTS", "wmts", ({ client, context, config }) => {
   const wmts = client.wmts(config.serviceId);
 
   it("reads service capabilities", async () => {
-    const capabilities = await runWithDiagnostics(context, "client.wmts().capabilities", () => wmts.capabilities());
-    expect(capabilities.layers.length).toBeGreaterThan(0);
-    expect(capabilities.tileMatrixSets.length).toBeGreaterThan(0);
+    await runWithDiagnostics(context, "client.wmts().capabilities", async () => {
+      const capabilities = await wmts.capabilities();
+      expect(capabilities.layers.length).toBeGreaterThan(0);
+      expect(capabilities.tileMatrixSets.length).toBeGreaterThan(0);
+    });
   });
 
   it("fetches a tile at zoom 0,0,0 when capabilities advertise a layer", async () => {
-    const capabilities = await runWithDiagnostics(context, "client.wmts().capabilities", () => wmts.capabilities());
+    const capabilities = await runWithDiagnostics(context, "client.wmts().capabilities", async () => {
+      const r = await wmts.capabilities();
+      expect(r.layers.length).toBeGreaterThan(0);
+      return r;
+    });
     const advertisedLayer = capabilities.layers.find((layer) => typeof layer.identifier === "string");
     if (!advertisedLayer?.identifier) {
       return;
@@ -28,8 +34,8 @@ integrationSuite("WMTS", "wmts", ({ client, context, config }) => {
     if (!advertisedMatrixSet) {
       return;
     }
-    const tile = await runWithDiagnostics(context, "client.wmts().tile", () =>
-      wmts.tile({
+    await runWithDiagnostics(context, "client.wmts().tile", async () => {
+      const tile = await wmts.tile({
         layer: advertisedLayer.identifier,
         tileMatrixSet: advertisedMatrixSet,
         tileMatrix: 0,
@@ -37,9 +43,9 @@ integrationSuite("WMTS", "wmts", ({ client, context, config }) => {
         tileCol: 0,
         format: "image/png",
         mode: "rest",
-      }),
-    );
-    expect(tile.contentType.length).toBeGreaterThan(0);
-    expect(tile.bytes).toBeInstanceOf(Uint8Array);
+      });
+      expect(tile.contentType.length).toBeGreaterThan(0);
+      expect(tile.bytes).toBeInstanceOf(Uint8Array);
+    });
   });
 });

--- a/test/integration/surfaces/wmts.integration.ts
+++ b/test/integration/surfaces/wmts.integration.ts
@@ -1,0 +1,45 @@
+/**
+ * WMTS 1.0 integration coverage. Reads capabilities first so tile
+ * matrix sets and layer names come from the server, then fetches a
+ * single tile at zoom 0 to keep the seed cost bounded.
+ *
+ * @module
+ */
+
+import { expect, it } from "vitest";
+import { integrationSuite, runWithDiagnostics } from "../harness.js";
+
+integrationSuite("WMTS", "wmts", ({ client, context, config }) => {
+  const wmts = client.wmts(config.serviceId);
+
+  it("reads service capabilities", async () => {
+    const capabilities = await runWithDiagnostics(context, "client.wmts().capabilities", () => wmts.capabilities());
+    expect(capabilities.layers.length).toBeGreaterThan(0);
+    expect(capabilities.tileMatrixSets.length).toBeGreaterThan(0);
+  });
+
+  it("fetches a tile at zoom 0,0,0 when capabilities advertise a layer", async () => {
+    const capabilities = await runWithDiagnostics(context, "client.wmts().capabilities", () => wmts.capabilities());
+    const advertisedLayer = capabilities.layers.find((layer) => typeof layer.identifier === "string");
+    if (!advertisedLayer?.identifier) {
+      return;
+    }
+    const advertisedMatrixSet = advertisedLayer.tileMatrixSetIds[0] ?? capabilities.tileMatrixSets[0]?.identifier;
+    if (!advertisedMatrixSet) {
+      return;
+    }
+    const tile = await runWithDiagnostics(context, "client.wmts().tile", () =>
+      wmts.tile({
+        layer: advertisedLayer.identifier,
+        tileMatrixSet: advertisedMatrixSet,
+        tileMatrix: 0,
+        tileRow: 0,
+        tileCol: 0,
+        format: "image/png",
+        mode: "rest",
+      }),
+    );
+    expect(tile.contentType.length).toBeGreaterThan(0);
+    expect(tile.bytes).toBeInstanceOf(Uint8Array);
+  });
+});

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,26 @@
+import path from "node:path";
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: "@honua/sdk-js/honua",
+        replacement: path.resolve(import.meta.dirname, "src/honua.ts"),
+      },
+      {
+        find: "@honua/sdk-js",
+        replacement: path.resolve(import.meta.dirname, "src/index.ts"),
+      },
+    ],
+  },
+  test: {
+    include: ["test/integration/surfaces/**/*.integration.ts"],
+    exclude: ["dist/**", "node_modules/**"],
+    globalSetup: ["test/integration/setup.ts"],
+    fileParallelism: false,
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+  },
+});


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #39
## Summary

Add integration tests against Honua Server protocol surfaces
## Changes Made

- Add integration tests against Honua Server protocol surfaces
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally
## Additional Context

Decisions:
- **Disk-merge over Vitest `setupFiles`** for the reporter fix. The `setupFiles` alternative would also share state across worker processes, but it would re-run for every test file (extra HTTP probes) and would have to deduplicate writes against the global-setup output. The disk-merge is smaller, simpler, and idempotent.
- **Body summarization in the `after` interceptor** rather than on-demand at error-format time. The interceptor already receives a cloned response (the SDK clones in `applyAfterInterceptors`), so consuming it does not affect the SDK's own decode path. Doing the work eagerly keeps the failure-format path synchronous and matches the existing pattern for `error`.
- **Binary-body responses get metadata-only summaries** (`content-type=…, N bytes`) instead of base64. The integration lane includes tile and map renders that can be hundreds of KB; reading them as text would corrupt the excerpt and inflate failure messages.
- **No `github.sha` fallback** for `HONUA_INTEGRATION_SERVER_COMMIT`. Setting it to anything other than the actual server commit is misleading; leaving it unset surfaces the gap honestly.

Follow-ons:
- Two honua-server child tickets remain open (unchanged from prior pass): publish a seeded Honua Server image (`:nightly-seeded` or `HONUA_SEED_ON_START`) and add admin REST endpoints to seed services/layers/features. Both gate the workflow's ability to bootstrap its own server; until then, the lane stays connect-only against an externally-managed staging deployment.
- Once a staging environment is provisioned, set `vars.HONUA_INTEGRATION_BASE_URL`, `secrets.HONUA_INTEGRATION_API_KEY`, and `vars.HONUA_INTEGRATION_SERVER_COMMIT` (or use the workflow_dispatch `server_commit` input for ad-hoc runs).

Code kaizen:
Skipped by kaizen policy.
