### PR TITLE
[codex] fix audit and CI gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,14 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Code style
+        run: npm run check
+
       - name: Build
         run: npm run build
+
+      - name: Split package verification
+        run: npm run verify:split-packages
 
       - name: Quickstart example typecheck
         run: npm run demo:quickstart:typecheck
@@ -77,6 +83,9 @@ jobs:
 
       - name: Typecheck
         run: npm run typecheck
+
+      - name: Code style
+        run: npm run check
 
       - name: Build
         run: npm run build

--- a/.github/workflows/publish-js-sdk.yml
+++ b/.github/workflows/publish-js-sdk.yml
@@ -40,10 +40,7 @@ jobs:
         run: npm ci
 
       - name: Security audit (npm dependencies)
-        run: |
-          npm audit --omit=dev || {
-            echo "::warning::npm audit found vulnerabilities. Review before publishing."
-          }
+        run: npm audit --omit=dev
 
       - name: Validate package
         run: |

--- a/.github/workflows/publish-mcp-server.yml
+++ b/.github/workflows/publish-mcp-server.yml
@@ -39,11 +39,14 @@ jobs:
 
       - name: Build JS SDK dependency
         run: |
-          npm ci --prefix ../js
-          npm run build --prefix ../js
+          npm ci --prefix ..
+          npm run build --prefix ..
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Security audit (npm dependencies)
+        run: npm audit --omit=dev
 
       - name: Validate package
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 dist/
+coverage/
+.tmp/
 node_modules
 *.tgz
 a.out

--- a/examples/kepler-analytics/package-lock.json
+++ b/examples/kepler-analytics/package-lock.json
@@ -17,14 +17,14 @@
         "react-palm": "3.3.8",
         "react-redux": "8.1.3",
         "redux": "4.2.1",
-        "styled-components": "6.1.8"
+        "styled-components": "6.4.1"
       },
       "devDependencies": {
         "@types/react": "18.3.28",
         "@types/react-dom": "18.3.7",
         "@vitejs/plugin-react": "6.0.1",
         "typescript": "5.9.2",
-        "vite": "8.0.3"
+        "vite": "8.0.10"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -199,34 +199,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.7"
-      }
-    },
-    "node_modules/@deck.gl/geo-layers/node_modules/@loaders.gl/wms": {
-      "version": "3.4.15",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/wms/-/wms-3.4.15.tgz",
-      "integrity": "sha512-zY++Oxx+cNGF9ptuSTFxCmEnpRbR5VZYjvyLraylaRbuynZv+JiWrehymFzEfq3hJcQ/cGvIjaG6rSVtPuqCIA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "@loaders.gl/images": "3.4.15",
-        "@loaders.gl/loader-utils": "3.4.15",
-        "@loaders.gl/schema": "3.4.15",
-        "@loaders.gl/xml": "3.4.15",
-        "@turf/rewind": "^5.1.5",
-        "deep-strict-equal": "^0.2.0",
-        "lerc": "^4.0.1"
-      }
-    },
-    "node_modules/@deck.gl/geo-layers/node_modules/@loaders.gl/xml": {
-      "version": "3.4.15",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/xml/-/xml-3.4.15.tgz",
-      "integrity": "sha512-iMWHaDzYSe8JoS8W5k9IbxQ6S3VHPr7M+UBejIVeYGCp1jzWF0ri498olwJWWDRvg4kqAWolrkj8Pcgkg8Jf8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.4.15",
-        "@loaders.gl/schema": "3.4.15",
-        "fast-xml-parser": "^4.2.5"
       }
     },
     "node_modules/@deck.gl/geo-layers/node_modules/long": {
@@ -419,6 +391,40 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
@@ -432,12 +438,6 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
       "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/unitless": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
-      "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==",
       "license": "MIT"
     },
     "node_modules/@floating-ui/core": {
@@ -2398,68 +2398,44 @@
       "license": "MIT"
     },
     "node_modules/@loaders.gl/wms": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/wms/-/wms-4.3.2.tgz",
-      "integrity": "sha512-6kkgWbPvxG/StsFYpKkS6aNtNi0yFpXMOXQ2lDbSkNZq1rA6EmXb/Ih82W/KDa/3g4ebshrGo39TmM0cSHe3Bw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/wms/-/wms-4.4.1.tgz",
+      "integrity": "sha512-sIaqyHXPuLQnkN2eebvczZYVvapkjA8EZaI8feaPxj4jZk/Hk5EuZzIbxJ4eftLotZwDHd3XzEVIs6YlFOSJ+Q==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/images": "4.3.2",
-        "@loaders.gl/loader-utils": "4.3.2",
-        "@loaders.gl/schema": "4.3.2",
-        "@loaders.gl/xml": "4.3.2",
+        "@loaders.gl/images": "4.4.1",
+        "@loaders.gl/loader-utils": "4.4.1",
+        "@loaders.gl/schema": "4.4.1",
+        "@loaders.gl/xml": "4.4.1",
         "@turf/rewind": "^5.1.5",
         "deep-strict-equal": "^0.2.0"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/wms/node_modules/@loaders.gl/images": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-4.3.2.tgz",
-      "integrity": "sha512-jGDCweUL/GvmtzSAdYlwe6RZk6zV9wQM++narjj0Q1LdeWdlChFfw3ZAKDHzpHB+PVzlfPgzvYLKjMLLHTUb4A==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-4.4.1.tgz",
+      "integrity": "sha512-v9A4BliEKGxhLuEbh0Ke8ElUlp04KxpKIknUtXXWoEaszAMTSrHI3YhaL/JdRlHraC1VUF/sjzbSBFkKh7nxJg==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.3.2"
+        "@loaders.gl/loader-utils": "4.4.1"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/wms/node_modules/@loaders.gl/loader-utils": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.2.tgz",
-      "integrity": "sha512-W7eg0Eg0pAsqgHwJ7wZ8J+8b/IoL+ZBWBqIqOcMi66QlJ5GR+dtd+86ihccm9+kKgCRxZN+tfTGhheQgG8czUw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.1.tgz",
+      "integrity": "sha512-waosL7VtVRfXsNOXtAM3rOjZyNQD0lQBlhuB5/oY+E+lNzYNFlzgiGXiDOwBpcs7dK7kW2Vv8+KcxyIGIyXOtg==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/schema": "4.3.2",
-        "@loaders.gl/worker-utils": "4.3.2",
-        "@probe.gl/log": "^4.0.2",
-        "@probe.gl/stats": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/wms/node_modules/@loaders.gl/schema": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.2.tgz",
-      "integrity": "sha512-/GWvJ5Cx82BUBihCHoo5obeETdPljg1vnlDynOkuAT3T+n6A1sJYFauMNeDiLlQuM29Up6Vi4WndpfNp94QJuw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "^7946.0.7"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/wms/node_modules/@loaders.gl/worker-utils": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.2.tgz",
-      "integrity": "sha512-3nPmShAbr1bCkC1Xxmn+b7S53SSHgWvRXOkinzeJ4C3J7Ac4QiCU6SV9CRH08/30SDcxz+mPvWnQjhj0Z24TYg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/schema": "4.4.1",
+        "@loaders.gl/worker-utils": "4.4.1",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
       }
     },
     "node_modules/@loaders.gl/wms/node_modules/@probe.gl/env": {
@@ -2493,53 +2469,29 @@
       }
     },
     "node_modules/@loaders.gl/xml": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/xml/-/xml-4.3.2.tgz",
-      "integrity": "sha512-LNSfRcKIMWYPggKTWx178zxkDoXmAv5mtM8Vm35HGcajhwmTRTQFkZlPpWmUaKFcf7ug+L/3VnaMMvYfn/EsjQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/xml/-/xml-4.4.1.tgz",
+      "integrity": "sha512-+8Dtxp0BZZj1CVUkiIlKGDLmhwsPILK9yJvc1P7tuJO9KsaQ5cywJk/b8A7lmqb2SfPkEg0xlQOK2FWIo1ATMA==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.3.2",
-        "@loaders.gl/schema": "4.3.2",
-        "fast-xml-parser": "^4.2.5"
+        "@loaders.gl/loader-utils": "4.4.1",
+        "@loaders.gl/schema": "4.4.1",
+        "fast-xml-parser": "^5.3.6"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/xml/node_modules/@loaders.gl/loader-utils": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.2.tgz",
-      "integrity": "sha512-W7eg0Eg0pAsqgHwJ7wZ8J+8b/IoL+ZBWBqIqOcMi66QlJ5GR+dtd+86ihccm9+kKgCRxZN+tfTGhheQgG8czUw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.1.tgz",
+      "integrity": "sha512-waosL7VtVRfXsNOXtAM3rOjZyNQD0lQBlhuB5/oY+E+lNzYNFlzgiGXiDOwBpcs7dK7kW2Vv8+KcxyIGIyXOtg==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/schema": "4.3.2",
-        "@loaders.gl/worker-utils": "4.3.2",
-        "@probe.gl/log": "^4.0.2",
-        "@probe.gl/stats": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/xml/node_modules/@loaders.gl/schema": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.2.tgz",
-      "integrity": "sha512-/GWvJ5Cx82BUBihCHoo5obeETdPljg1vnlDynOkuAT3T+n6A1sJYFauMNeDiLlQuM29Up6Vi4WndpfNp94QJuw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "^7946.0.7"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/xml/node_modules/@loaders.gl/worker-utils": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.2.tgz",
-      "integrity": "sha512-3nPmShAbr1bCkC1Xxmn+b7S53SSHgWvRXOkinzeJ4C3J7Ac4QiCU6SV9CRH08/30SDcxz+mPvWnQjhj0Z24TYg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/schema": "4.4.1",
+        "@loaders.gl/worker-utils": "4.4.1",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
       }
     },
     "node_modules/@loaders.gl/xml/node_modules/@probe.gl/env": {
@@ -2922,9 +2874,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3034,10 +2986,22 @@
         "indefinitely-typed": "^1.1.0"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3107,9 +3071,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
       "cpu": [
         "arm64"
       ],
@@ -3124,9 +3088,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
       "cpu": [
         "arm64"
       ],
@@ -3141,9 +3105,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
       "cpu": [
         "x64"
       ],
@@ -3158,9 +3122,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
       "cpu": [
         "x64"
       ],
@@ -3175,9 +3139,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
       "cpu": [
         "arm"
       ],
@@ -3192,13 +3156,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3209,13 +3176,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3226,13 +3196,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3243,13 +3216,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3260,13 +3236,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3277,13 +3256,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3294,9 +3276,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
       "cpu": [
         "arm64"
       ],
@@ -3311,9 +3293,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
       "cpu": [
         "wasm32"
       ],
@@ -3321,16 +3303,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
       "cpu": [
         "arm64"
       ],
@@ -3345,9 +3329,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
       "cpu": [
         "x64"
       ],
@@ -4826,12 +4810,6 @@
         "csstype": "^3.2.2"
       }
     },
-    "node_modules/@types/stylis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.0.tgz",
-      "integrity": "sha512-n4sx2bqL0mW1tvDf/loQ+aMX7GQD3lc3fkCMC55VFNDu/vBOabO+LTIeXKM14xK0ppk5TUGcWRjiSpIlUpghKw==",
-      "license": "MIT"
-    },
     "node_modules/@types/supercluster": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
@@ -5552,16 +5530,28 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/d3-brush": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-2.1.0.tgz",
-      "integrity": "sha512-cHLLAFatBATyIKqZOkk/mDHUbzne2B3ZwxkzMHvFTCZCmLaXDpZRihQSn8UNXTkGD/3lb/W2sQz0etAftmHMJQ==",
-      "license": "BSD-3-Clause",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
       "dependencies": {
-        "d3-dispatch": "1 - 2",
-        "d3-drag": "2",
-        "d3-interpolate": "1 - 2",
-        "d3-selection": "2",
-        "d3-transition": "2"
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush/node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-collection": {
@@ -5571,25 +5561,37 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/d3-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
-      "license": "BSD-3-Clause"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-contour": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-1.3.2.tgz",
-      "integrity": "sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==",
-      "license": "BSD-3-Clause",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
       "dependencies": {
-        "d3-array": "^1.1.1"
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-contour/node_modules/d3-array": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
-      "license": "BSD-3-Clause"
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-dispatch": {
       "version": "2.0.0",
@@ -5630,10 +5632,13 @@
       }
     },
     "node_modules/d3-ease": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
-      "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ==",
-      "license": "BSD-3-Clause"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-format": {
       "version": "2.0.0",
@@ -5663,18 +5668,24 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/d3-hierarchy": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz",
-      "integrity": "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==",
-      "license": "BSD-3-Clause"
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-interpolate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
-      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
-      "license": "BSD-3-Clause",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
       "dependencies": {
-        "d3-color": "1 - 2"
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-path": {
@@ -5684,43 +5695,42 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/d3-sankey": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.7.1.tgz",
-      "integrity": "sha512-KAyowBWtTLQxyXq1UhXcdCXKbuCQvL51FgqOS+fKlNTQ/4FfSWabRlWs2DezzwKyredAsOhBSQZN/i0XdeE2tQ==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "1",
-        "d3-collection": "1",
+        "d3-array": "1 - 2",
         "d3-shape": "^1.2.0"
       }
     },
-    "node_modules/d3-sankey/node_modules/d3-array": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/d3-scale": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
-      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
-      "license": "BSD-3-Clause",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
       "dependencies": {
-        "d3-array": "^2.3.0",
-        "d3-format": "1 - 2",
-        "d3-interpolate": "1.2.0 - 2",
-        "d3-time": "^2.1.1",
-        "d3-time-format": "2 - 3"
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-scale-chromatic": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
-      "integrity": "sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==",
-      "license": "BSD-3-Clause",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
       "dependencies": {
-        "d3-color": "1 - 2",
-        "d3-interpolate": "1 - 2"
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-selection": {
@@ -5757,25 +5767,31 @@
       }
     },
     "node_modules/d3-timer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
-      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==",
-      "license": "BSD-3-Clause"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-transition": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
-      "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
-      "license": "BSD-3-Clause",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
       "dependencies": {
-        "d3-color": "1 - 2",
-        "d3-dispatch": "1 - 2",
-        "d3-ease": "1 - 2",
-        "d3-interpolate": "1 - 2",
-        "d3-timer": "1 - 2"
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       },
       "peerDependencies": {
-        "d3-selection": "2"
+        "d3-selection": "2 - 3"
       }
     },
     "node_modules/d3-voronoi": {
@@ -6021,27 +6037,6 @@
       "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
       "license": "ISC"
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -6139,10 +6134,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/fast-xml-parser": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.5.tgz",
-      "integrity": "sha512-cK9c5I/DwIOI7/Q7AlGN3DuTdwN61gwSfL8rvuVPK+0mcCNHHGxRrpiFtaZZRfRMJL3Gl8B2AFlBG6qXf03w9A==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -6151,7 +6146,25 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -6621,16 +6634,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -6942,15 +6945,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
@@ -7090,12 +7084,6 @@
       "resolved": "https://registry.npmjs.org/ktx-parse/-/ktx-parse-0.7.1.tgz",
       "integrity": "sha512-FeA3g56ksdFNwjXJJsc1CCc7co+AJYDp6ipIp878zZ2bU8kWROatLYf39TQEd4/XRSUvBXovQ8gaVKWPXsCLEQ==",
       "license": "MIT"
-    },
-    "node_modules/lerc": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lerc/-/lerc-4.1.1.tgz",
-      "integrity": "sha512-rgMqdHK4+gIUnF80OkWyfRae2u1B96BT8ZAjbLB4xfxIdfCHQ9GOf17haZVCag+5X9WC+40hLNZPbwctFs2FPQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -7377,9 +7365,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -7805,6 +7793,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7820,13 +7809,23 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
       "dependencies": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-int64": {
@@ -8012,6 +8011,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -8109,34 +8123,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -8192,9 +8178,9 @@
       }
     },
     "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
       "license": "MIT"
     },
     "node_modules/pump": {
@@ -8742,93 +8728,90 @@
       }
     },
     "node_modules/react-vis": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/react-vis/-/react-vis-1.11.7.tgz",
-      "integrity": "sha512-vJqS12l/6RHeSq8DVl4PzX0j8iPgbT8H8PtgTRsimKsBNcPjPseO4RICw1FUPrwj8MPrrna34LBtzyC4ATd5Ow==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/react-vis/-/react-vis-1.12.1.tgz",
+      "integrity": "sha512-vH7ihTPlBD6wBuzwPoipheyJnx46kKKMXnVqdk4mv5vq+bJVC6JRYdRZSofa2030+kko99rSq/idnYnNWGr6zA==",
       "license": "MIT",
       "dependencies": {
-        "d3-array": "^1.2.0",
-        "d3-collection": "^1.0.3",
-        "d3-color": "^1.0.3",
-        "d3-contour": "^1.1.0",
-        "d3-format": "^1.2.0",
-        "d3-geo": "^1.6.4",
+        "d3-array": "^3.2.1",
+        "d3-collection": "^1.0.7",
+        "d3-color": "^3.1.0",
+        "d3-contour": "^4.0.0",
+        "d3-format": "^3.1.0",
+        "d3-geo": "^3.1.0",
         "d3-hexbin": "^0.2.2",
-        "d3-hierarchy": "^1.1.4",
-        "d3-interpolate": "^1.1.4",
-        "d3-sankey": "^0.7.1",
-        "d3-scale": "^1.0.5",
-        "d3-shape": "^1.1.0",
-        "d3-voronoi": "^1.1.2",
+        "d3-hierarchy": "^3.1.2",
+        "d3-interpolate": "^3.0.1",
+        "d3-sankey": "^0.12.3",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.2.0",
+        "d3-voronoi": "^1.1.4",
         "deep-equal": "^1.0.1",
         "global": "^4.3.1",
-        "hoek": "4.2.1",
         "prop-types": "^15.5.8",
         "react-motion": "^0.5.2"
       },
       "engines": {
-        "node": ">=0.10.0",
-        "npm": ">=3.0"
+        "node": ">=14.18.0",
+        "npm": ">=6.13.0"
       },
       "peerDependencies": {
-        "react": "15.3.0 - 16.x"
+        "react": "^16.8.3",
+        "react-dom": "^16.8.3"
       }
     },
     "node_modules/react-vis/node_modules/d3-array": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/react-vis/node_modules/d3-color": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==",
-      "license": "BSD-3-Clause"
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/react-vis/node_modules/d3-format": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
-      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/react-vis/node_modules/d3-interpolate": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
-      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-color": "1"
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
-    "node_modules/react-vis/node_modules/d3-scale": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
-      "license": "BSD-3-Clause",
+    "node_modules/react-vis/node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
       "dependencies": {
-        "d3-array": "^1.2.0",
-        "d3-collection": "1",
-        "d3-color": "1",
-        "d3-format": "1",
-        "d3-interpolate": "1",
-        "d3-time": "1",
-        "d3-time-format": "2"
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
-    "node_modules/react-vis/node_modules/d3-time": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
-      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==",
-      "license": "BSD-3-Clause"
+    "node_modules/react-vis/node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
-    "node_modules/react-vis/node_modules/d3-time-format": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
-      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
-      "license": "BSD-3-Clause",
+    "node_modules/react-vis/node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
       "dependencies": {
-        "d3-time": "1"
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/reactcss": {
@@ -9053,14 +9036,14 @@
       "license": "Unlicense"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -9069,27 +9052,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
     },
@@ -9214,12 +9197,6 @@
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "license": "MIT"
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -9286,6 +9263,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -9385,9 +9363,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",
@@ -9397,20 +9375,15 @@
       "license": "MIT"
     },
     "node_modules/styled-components": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.8.tgz",
-      "integrity": "sha512-PQ6Dn+QxlWyEGCKDS71NGsXoVLKfE1c3vApkvDYS5KAK+V8fNWGhbSUEo9Gg2iaID2tjLXegEW3bZDUGpofRWw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.1.tgz",
+      "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "license": "MIT",
       "dependencies": {
-        "@emotion/is-prop-valid": "1.2.1",
-        "@emotion/unitless": "0.8.0",
-        "@types/stylis": "4.2.0",
+        "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
-        "csstype": "3.1.2",
-        "postcss": "8.4.31",
-        "shallowequal": "1.1.0",
-        "stylis": "4.3.1",
-        "tslib": "2.5.0"
+        "csstype": "3.2.3",
+        "stylis": "4.3.6"
       },
       "engines": {
         "node": ">= 16"
@@ -9420,41 +9393,27 @@
         "url": "https://opencollective.com/styled-components"
       },
       "peerDependencies": {
+        "css-to-react-native": ">= 3.2.0",
         "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0"
+        "react-dom": ">= 16.8.0",
+        "react-native": ">= 0.68.0"
+      },
+      "peerDependenciesMeta": {
+        "css-to-react-native": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
-    },
-    "node_modules/styled-components/node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
-      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.8.1"
-      }
-    },
-    "node_modules/styled-components/node_modules/@emotion/memoize": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
-      "license": "MIT"
-    },
-    "node_modules/styled-components/node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "license": "MIT"
-    },
-    "node_modules/styled-components/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-      "license": "0BSD"
     },
     "node_modules/stylis": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.1.tgz",
-      "integrity": "sha512-EQepAV+wMsIaGVGX1RECzgrcqRRU/0sYOHkeLsZ3fzHaHXZy4DaOOX0vOlGQdlsjkh3mFHAIlVimpwAs4dslyQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
       "license": "MIT"
     },
     "node_modules/suncalc": {
@@ -9608,14 +9567,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -9667,6 +9626,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
+      "license": "MIT"
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
     "node_modules/trim-newlines": {
@@ -9828,12 +9793,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {
@@ -9864,17 +9833,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
-      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -9891,7 +9860,7 @@
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
         "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",
@@ -9942,9 +9911,9 @@
       }
     },
     "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {
@@ -9990,11 +9959,27 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/examples/kepler-analytics/package.json
+++ b/examples/kepler-analytics/package.json
@@ -21,14 +21,33 @@
     "react-palm": "3.3.8",
     "react-redux": "8.1.3",
     "redux": "4.2.1",
-    "styled-components": "6.1.8"
+    "styled-components": "6.4.1"
   },
   "devDependencies": {
     "@types/react": "18.3.28",
     "@types/react-dom": "18.3.7",
     "@vitejs/plugin-react": "6.0.1",
     "typescript": "5.9.2",
-    "vite": "8.0.3"
+    "vite": "8.0.10"
+  },
+  "overrides": {
+    "@loaders.gl/wms": "4.4.1",
+    "@loaders.gl/xml": "4.4.1",
+    "d3-brush": "3.0.0",
+    "d3-color": "3.1.0",
+    "d3-interpolate": "3.0.1",
+    "d3-scale": "4.0.2",
+    "d3-scale-chromatic": "3.1.0",
+    "d3-transition": "3.0.1",
+    "fast-xml-parser": "5.7.2",
+    "hoek": "6.1.3",
+    "lodash": "4.18.1",
+    "node-fetch": "2.7.0",
+    "postcss": "8.5.13",
+    "react-vis": "1.12.1",
+    "styled-components": "6.4.1",
+    "uuid": "14.0.0",
+    "vite": "8.0.10"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/examples/storytelling-25d-map/src/data.ts
+++ b/examples/storytelling-25d-map/src/data.ts
@@ -1,6 +1,7 @@
 import { HonuaClient, type HonuaOgcFeatureCollectionResponse, type HonuaOgcFeatureResponse } from "@honua/sdk-js/honua";
 
-import { getBoundsForGeometry, flattenRouteCoordinates, buildRouteMetrics, mergeBounds } from "./geometry.js";
+import { buildRouteMetrics, flattenRouteCoordinates, getBoundsForGeometry, mergeBounds } from "./geometry.js";
+import type { StoryTelemetry } from "./telemetry.js";
 import type {
   StoryAssetFeature,
   StoryAssetProperties,
@@ -14,7 +15,6 @@ import type {
   StoryStopFeature,
   StoryStopProperties,
 } from "./types.js";
-import type { StoryTelemetry } from "./telemetry.js";
 
 const RISK_FIELDS = ["risk_score", "riskScore", "risk", "severity", "priority_score"];
 const HEIGHT_FIELDS = ["extrusion_height_m", "height_m", "height", "heightMeters", "elevation_m", "elevation"];
@@ -93,9 +93,10 @@ function resolveFeatureId(
   return candidate ?? `${fallbackPrefix}-${index + 1}`;
 }
 
-export function normalizeAssets(
-  collection: HonuaOgcFeatureCollectionResponse,
-): { collection: StoryFeatureCollection<StoryAssetFeature>; views: StoryAssetView[] } {
+export function normalizeAssets(collection: HonuaOgcFeatureCollectionResponse): {
+  collection: StoryFeatureCollection<StoryAssetFeature>;
+  views: StoryAssetView[];
+} {
   const features: StoryAssetFeature[] = [];
   const views: StoryAssetView[] = [];
 
@@ -187,7 +188,9 @@ export function normalizeRoute(collection: HonuaOgcFeatureCollectionResponse): S
   };
 }
 
-export function normalizeStops(collection: HonuaOgcFeatureCollectionResponse): StoryFeatureCollection<StoryStopFeature> {
+export function normalizeStops(
+  collection: HonuaOgcFeatureCollectionResponse,
+): StoryFeatureCollection<StoryStopFeature> {
   const features = collection.features
     .map((feature, index) => {
       if (feature.geometry?.type !== "Point") {
@@ -243,9 +246,11 @@ export function buildStoryDataset(
   const priorityCandidates = [...assetViews]
     .sort((left, right) => right.feature.properties.risk_score - left.feature.properties.risk_score)
     .filter((entry) => entry.feature.properties.risk_score >= config.priorityRiskThreshold);
-  const priorityViews = (priorityCandidates.length > 0 ? priorityCandidates : [...assetViews].sort(
-    (left, right) => right.feature.properties.risk_score - left.feature.properties.risk_score,
-  )).slice(0, Math.min(3, assetViews.length));
+  const priorityViews = (
+    priorityCandidates.length > 0
+      ? priorityCandidates
+      : [...assetViews].sort((left, right) => right.feature.properties.risk_score - left.feature.properties.risk_score)
+  ).slice(0, Math.min(3, assetViews.length));
 
   priorityViews.forEach((entry, index) => {
     entry.feature.properties.priority_rank = index + 1;

--- a/examples/storytelling-25d-map/src/map.ts
+++ b/examples/storytelling-25d-map/src/map.ts
@@ -1,8 +1,4 @@
-import {
-  createHoverHandler,
-  createSelectionHandler,
-  type SelectionHandle,
-} from "@honua/sdk-js/honua";
+import { type SelectionHandle, createHoverHandler, createSelectionHandler } from "@honua/sdk-js/honua";
 import maplibregl, { type GeoJSONSource, type Map as MapLibreMap } from "maplibre-gl";
 
 import {
@@ -12,8 +8,8 @@ import {
   toLineFeature,
   toPointFeature,
 } from "./geometry.js";
-import type { StoryDataset, StoryDemoConfig, StoryFeatureId } from "./types.js";
 import type { StoryTelemetry } from "./telemetry.js";
+import type { StoryDataset, StoryDemoConfig, StoryFeatureId } from "./types.js";
 
 const ASSET_EXTRUSION_LAYER_ID = "story-assets-extrusion";
 const ASSET_OUTLINE_LAYER_ID = "story-assets-outline";
@@ -206,26 +202,11 @@ export async function createStoryMap(options: CreateStoryMapOptions): Promise<St
     type: "circle",
     source: options.config.sourceIds.stops,
     paint: {
-      "circle-radius": [
-        "case",
-        ["boolean", ["feature-state", "active"], false],
-        12,
-        8,
-      ],
+      "circle-radius": ["case", ["boolean", ["feature-state", "active"], false], 12, 8],
       "circle-color": "#f5c76d",
-      "circle-opacity": [
-        "case",
-        ["boolean", ["feature-state", "active"], false],
-        0.75,
-        0,
-      ],
+      "circle-opacity": ["case", ["boolean", ["feature-state", "active"], false], 0.75, 0],
       "circle-stroke-color": "#fff7dd",
-      "circle-stroke-width": [
-        "case",
-        ["boolean", ["feature-state", "active"], false],
-        2,
-        0,
-      ],
+      "circle-stroke-width": ["case", ["boolean", ["feature-state", "active"], false], 2, 0],
     },
   });
 
@@ -236,12 +217,7 @@ export async function createStoryMap(options: CreateStoryMapOptions): Promise<St
     paint: {
       "fill-extrusion-height": ["get", "extrusion_height_m"],
       "fill-extrusion-base": 0,
-      "fill-extrusion-opacity": [
-        "case",
-        ["boolean", ["feature-state", "hover"], false],
-        0.95,
-        0.84,
-      ],
+      "fill-extrusion-opacity": ["case", ["boolean", ["feature-state", "hover"], false], 0.95, 0.84],
       "fill-extrusion-color": [
         "case",
         ["boolean", ["feature-state", "selected"], false],
@@ -343,7 +319,10 @@ export async function createStoryMap(options: CreateStoryMapOptions): Promise<St
         {
           type: "Feature",
           id: `${options.dataset.routeFeature.id}-progress`,
-          geometry: toLineFeature(sliceRouteAtProgress(routeMetrics, progress), `${options.dataset.routeFeature.id}-progress`),
+          geometry: toLineFeature(
+            sliceRouteAtProgress(routeMetrics, progress),
+            `${options.dataset.routeFeature.id}-progress`,
+          ),
           properties: { story_id: `${options.dataset.routeFeature.id}-progress` },
         },
       ],

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@honua/mcp-server",
       "version": "0.0.5-alpha.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.12.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^3.24.0"
       },
       "bin": {
@@ -26,7 +26,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@honua/sdk-js": "^0.0.1-alpha.0"
+        "@honua/sdk-js": "^0.0.5-alpha.0"
       }
     },
     "..": {
@@ -289,21 +289,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -312,9 +312,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -323,9 +323,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -367,9 +367,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -407,26 +407,28 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
         "@tybys/wasm-util": "^0.10.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.120.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.120.0.tgz",
-      "integrity": "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==",
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -434,9 +436,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
       "cpu": [
         "arm64"
       ],
@@ -451,9 +453,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
       "cpu": [
         "arm64"
       ],
@@ -468,9 +470,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
       "cpu": [
         "x64"
       ],
@@ -485,9 +487,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
       "cpu": [
         "x64"
       ],
@@ -502,9 +504,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.10.tgz",
-      "integrity": "sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
       "cpu": [
         "arm"
       ],
@@ -519,13 +521,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -536,13 +541,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.10.tgz",
-      "integrity": "sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -553,13 +561,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -570,13 +581,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -587,13 +601,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -604,13 +621,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.10.tgz",
-      "integrity": "sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -621,9 +641,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
       "cpu": [
         "arm64"
       ],
@@ -638,9 +658,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.10.tgz",
-      "integrity": "sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
       "cpu": [
         "wasm32"
       ],
@@ -648,16 +668,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.10.tgz",
-      "integrity": "sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
       "cpu": [
         "arm64"
       ],
@@ -672,9 +694,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.10.tgz",
-      "integrity": "sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
       "cpu": [
         "x64"
       ],
@@ -689,9 +711,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.10.tgz",
-      "integrity": "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1516,9 +1538,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2031,9 +2053,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -2130,9 +2152,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -2154,9 +2176,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2176,9 +2198,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {
@@ -2266,14 +2288,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.10.tgz",
-      "integrity": "sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.120.0",
-        "@rolldown/pluginutils": "1.0.0-rc.10"
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -2282,21 +2304,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.10",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.10",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.10",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.10",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.10",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.10",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.10",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.10",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.10",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.10",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.10",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.10",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.10",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.10",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.10"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/router": {
@@ -2549,14 +2571,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2646,17 +2668,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.1.tgz",
-      "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.10",
-        "tinyglobby": "^0.2.15"
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -2673,7 +2695,7 @@
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
         "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -22,11 +22,11 @@
     "check:fix": "biome check --write src/ test/"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^3.24.0"
   },
   "peerDependencies": {
-    "@honua/sdk-js": "^0.0.1-alpha.0"
+    "@honua/sdk-js": "^0.0.5-alpha.0"
   },
   "devDependencies": {
     "@honua/sdk-js": "file:..",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1138,80 +1138,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
@@ -1911,9 +1837,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -2401,9 +2327,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {
@@ -2437,23 +2363,13 @@
       "license": "ISC"
     },
     "node_modules/protobufjs": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.0.tgz",
-      "integrity": "sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.3.tgz",
+      "integrity": "sha512-LBYnMWkKLB8fE/ljROPDbCl7mgLSlI+oBe1fAAr5MTqFg4TIi0tYrVVurJvQggOjnUYMQtEZBjrej59ojMNTHQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -2462,9 +2378,9 @@
       }
     },
     "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2716,9 +2632,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist",
+    "build": "npm run clean --silent && tsc -p tsconfig.json",
     "build:split-packages": "npm run build --silent && node scripts/prepare-split-packages.mjs",
     "verify:split-packages": "npm run build:split-packages --silent && node scripts/verify-split-packages.mjs",
     "pack:split-packages": "npm run build:split-packages --silent && npm pack ./dist/packages/honua-sdk && npm pack ./dist/packages/honua-sdk-esri-compat && npm pack ./dist/packages/honua-migrate",

--- a/scripts/prepare-split-packages.mjs
+++ b/scripts/prepare-split-packages.mjs
@@ -117,6 +117,7 @@ function createCompatPackage() {
   const packageRoot = path.join(OUTPUT_ROOT, "honua-sdk-esri-compat");
   fs.mkdirSync(packageRoot, { recursive: true });
 
+  copyDirectory(path.join(DIST_SRC_ROOT, "contract"), path.join(packageRoot, "contract"));
   copyDirectory(path.join(DIST_SRC_ROOT, "core"), path.join(packageRoot, "core"));
   copyDirectory(path.join(DIST_SRC_ROOT, "esri-compat"), path.join(packageRoot, "esri-compat"));
   copyDirectory(path.join(DIST_SRC_ROOT, "gen"), path.join(packageRoot, "gen"));

--- a/src/core/grpc-adapter.ts
+++ b/src/core/grpc-adapter.ts
@@ -3,6 +3,7 @@ import {
   type AttributeValue,
   CoordinateSchema,
   CoordinateSequenceSchema,
+  DistanceUnit,
   type FeaturePage,
   FieldType,
   GeometrySchema,
@@ -15,7 +16,6 @@ import {
   type FieldDefinition as ProtoFieldDefinition,
   QueryFeaturesRequestSchema,
   type QueryFeaturesResponse,
-  DistanceUnit,
   SpatialFilterSchema,
   SpatialReferenceSchema,
   SpatialRelationship,
@@ -206,9 +206,7 @@ export function toProtoQueryRequest(request: QueryFeaturesRequest) {
       filter.returnDistance = returnDistance;
     }
 
-    const unit =
-      request.units ??
-      parseExtraString(request.extraParams ?? {}, "units");
+    const unit = request.units ?? parseExtraString(request.extraParams ?? {}, "units");
     if (unit !== undefined) {
       const mappedUnit = ESRI_TO_PROTO_DISTANCE_UNIT_MAP[unit.trim().toLowerCase()];
       if (!mappedUnit) {
@@ -328,10 +326,7 @@ function isIdsOnlyResponse(response: QueryFeaturesResponse): boolean {
   );
 }
 
-function parseExtraBoolean(
-  params: Record<string, string | number | boolean>,
-  key: string,
-): boolean | undefined {
+function parseExtraBoolean(params: Record<string, string | number | boolean>, key: string): boolean | undefined {
   const value = params[key];
   if (value === undefined) {
     return undefined;
@@ -352,10 +347,7 @@ function parseExtraBoolean(
   return undefined;
 }
 
-function parseExtraNumber(
-  params: Record<string, string | number | boolean>,
-  key: string,
-): number | undefined {
+function parseExtraNumber(params: Record<string, string | number | boolean>, key: string): number | undefined {
   const value = params[key];
   if (value === undefined || typeof value === "boolean") {
     return undefined;
@@ -364,10 +356,7 @@ function parseExtraNumber(
   return Number.isFinite(n) ? n : undefined;
 }
 
-function parseExtraString(
-  params: Record<string, string | number | boolean>,
-  key: string,
-): string | undefined {
+function parseExtraString(params: Record<string, string | number | boolean>, key: string): string | undefined {
   const value = params[key];
   if (value === undefined || typeof value === "boolean") {
     return undefined;
@@ -379,8 +368,7 @@ function parseExtraString(
 function toProtoStatistics(
   value: string | readonly Record<string, unknown>[],
 ): ReturnType<typeof create<typeof StatisticDefinitionSchema>>[] {
-  const raw: readonly Record<string, unknown>[] =
-    typeof value === "string" ? parseStatisticsString(value) : value;
+  const raw: readonly Record<string, unknown>[] = typeof value === "string" ? parseStatisticsString(value) : value;
 
   return raw.map((item, index) => {
     const statisticTypeValue = item.statisticType;
@@ -426,9 +414,7 @@ function parseStatisticsString(value: string): readonly Record<string, unknown>[
   return parsed as readonly Record<string, unknown>[];
 }
 
-function toProtoGeometry(
-  geometryValue: string | Record<string, unknown>,
-): {
+function toProtoGeometry(geometryValue: string | Record<string, unknown>): {
   geometry: ReturnType<typeof create<typeof GeometrySchema>>;
   spatialReference?: ReturnType<typeof create<typeof SpatialReferenceSchema>>;
 } {
@@ -496,9 +482,7 @@ function parseGeometryValue(value: string | Record<string, unknown>): Record<str
   return value;
 }
 
-function toProtoSpatialReference(
-  value: unknown,
-): ReturnType<typeof create<typeof SpatialReferenceSchema>> | undefined {
+function toProtoSpatialReference(value: unknown): ReturnType<typeof create<typeof SpatialReferenceSchema>> | undefined {
   if (value === undefined || value === null) {
     return undefined;
   }
@@ -561,7 +545,10 @@ function toProtoSpatialReference(
   return spatialReference;
 }
 
-function toPointGeometryFromArray(value: unknown, context: string): ReturnType<typeof create<typeof PointGeometrySchema>> {
+function toPointGeometryFromArray(
+  value: unknown,
+  context: string,
+): ReturnType<typeof create<typeof PointGeometrySchema>> {
   if (!Array.isArray(value) || value.length < 2) {
     throw new Error(`Invalid coordinate array at ${context}`);
   }
@@ -625,7 +612,9 @@ function isPoint(value: Record<string, unknown>): value is { x: number; y: numbe
   return typeof value.x === "number" && typeof value.y === "number";
 }
 
-function isEnvelope(value: Record<string, unknown>): value is { xmin: number; ymin: number; xmax: number; ymax: number } {
+function isEnvelope(
+  value: Record<string, unknown>,
+): value is { xmin: number; ymin: number; xmax: number; ymax: number } {
   return (
     typeof value.xmin === "number" &&
     typeof value.ymin === "number" &&

--- a/src/core/ogc-conformance.ts
+++ b/src/core/ogc-conformance.ts
@@ -92,7 +92,9 @@ const CONFORMANCE_TABLES: Record<OgcConformanceProtocol, ReadonlyArray<readonly 
 };
 
 /** Subset of `Protocol` for which OGC-style conformance applies. */
-export type OgcConformanceProtocol = Extract<Protocol, "ogc-features" | "ogc-tiles" | "ogc-maps" | "stac"> | "ogc-processes";
+export type OgcConformanceProtocol =
+  | Extract<Protocol, "ogc-features" | "ogc-tiles" | "ogc-maps" | "stac">
+  | "ogc-processes";
 
 /**
  * Translate the server-advertised `conformsTo[]` list into a canonical

--- a/src/core/ogc-processes.ts
+++ b/src/core/ogc-processes.ts
@@ -129,9 +129,7 @@ export class HonuaOgcProcessJobRun<T = unknown> implements IJobRun<T> {
     this.id = options.jobId;
     this.type = options.processId ?? options.initialStatus?.processID ?? "unknown";
     this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
-    this.pollFn =
-      options.pollFn ??
-      ((jobId, signal) => options.client.getOgcProcessJob({ jobId, signal }));
+    this.pollFn = options.pollFn ?? ((jobId, signal) => options.client.getOgcProcessJob({ jobId, signal }));
     const initial = options.initialStatus;
     this.currentStatus = (initial?.status as JobStatus) ?? "accepted";
     this.currentProgress = progressFromOgcStatus(initial);
@@ -335,10 +333,7 @@ function isCompletedJobConflict(error: unknown): boolean {
   return false;
 }
 
-function terminalJobError(
-  status: JobStatus,
-  ogcStatus: HonuaOgcProcessJobStatus,
-): JobError | undefined {
+function terminalJobError(status: JobStatus, ogcStatus: HonuaOgcProcessJobStatus): JobError | undefined {
   if (ogcStatus.exception) {
     return { ...ogcStatus.exception };
   }

--- a/src/core/stac.ts
+++ b/src/core/stac.ts
@@ -93,7 +93,9 @@ export class HonuaStacSearch {
     return items;
   }
 
-  public async *searchStream(request: HonuaStacSearchAllRequest = {}): AsyncGenerator<HonuaStacItemResponse[], void, undefined> {
+  public async *searchStream(
+    request: HonuaStacSearchAllRequest = {},
+  ): AsyncGenerator<HonuaStacItemResponse[], void, undefined> {
     const pageSize = request.pageSize ?? request.limit ?? DEFAULT_STAC_PAGE_SIZE;
     const maxPages = request.maxPages ?? DEFAULT_STAC_MAX_PAGES;
     let cursor: StacPageCursor = { offset: request.offset, next: request.next };
@@ -126,9 +128,7 @@ interface StacPageCursor {
  * link carries it, otherwise fall back to `next`. When the server omits
  * a usable `rel=next` link, return an empty cursor so the caller stops.
  */
-function nextStacCursor(
-  links: HonuaStacItemCollectionResponse["links"] | undefined,
-): StacPageCursor {
+function nextStacCursor(links: HonuaStacItemCollectionResponse["links"] | undefined): StacPageCursor {
   if (!links) return {};
   for (const link of links) {
     if (link.rel !== "next" || typeof link.href !== "string") continue;

--- a/src/core/surfaces.ts
+++ b/src/core/surfaces.ts
@@ -1314,11 +1314,11 @@ export class HonuaImageService {
   }
 
   public async queryRasterCatalogObjectIds(request: HonuaImageServiceQueryRequest = {}): Promise<number[]> {
-    const response = await this.dispatch<{ objectIds?: Array<number | string> }>(
-      "query",
-      request,
-      { ...imageQueryParams(request), where: request.where ?? "1=1", returnIdsOnly: true },
-    );
+    const response = await this.dispatch<{ objectIds?: Array<number | string> }>("query", request, {
+      ...imageQueryParams(request),
+      where: request.where ?? "1=1",
+      returnIdsOnly: true,
+    });
     if (!Array.isArray(response.objectIds)) return [];
     return response.objectIds.map((v) => Number(v)).filter((v) => Number.isFinite(v));
   }
@@ -1358,7 +1358,12 @@ export class HonuaImageService {
     });
   }
 
-  public tileUrl(level: number, row: number, col: number, format: "png" | "jpg" | "jpeg" | "tif" | "tiff" = "png"): string {
+  public tileUrl(
+    level: number,
+    row: number,
+    col: number,
+    format: "png" | "jpg" | "jpeg" | "tif" | "tiff" = "png",
+  ): string {
     const path = `/rest/services/${encodeURIComponent(this.serviceId)}/ImageServer/tile/${level}/${row}/${col}`;
     return `${this.client.serverBaseUrl}${path}?f=${format}`;
   }
@@ -1409,10 +1414,12 @@ function imageExportParams(request: HonuaImageServiceExportRequest): Record<stri
     params.bandIds = Array.isArray(request.bandIds) ? request.bandIds.join(",") : String(request.bandIds);
   }
   if (request.mosaicRule !== undefined) {
-    params.mosaicRule = typeof request.mosaicRule === "string" ? request.mosaicRule : JSON.stringify(request.mosaicRule);
+    params.mosaicRule =
+      typeof request.mosaicRule === "string" ? request.mosaicRule : JSON.stringify(request.mosaicRule);
   }
   if (request.renderingRule !== undefined) {
-    params.renderingRule = typeof request.renderingRule === "string" ? request.renderingRule : JSON.stringify(request.renderingRule);
+    params.renderingRule =
+      typeof request.renderingRule === "string" ? request.renderingRule : JSON.stringify(request.renderingRule);
   }
   if (request.imageSr !== undefined) params.imageSR = String(request.imageSr);
   if (request.bboxSr !== undefined) params.bboxSR = String(request.bboxSr);
@@ -1426,10 +1433,12 @@ function imageIdentifyParams(request: HonuaImageServiceIdentifyRequest): Record<
   if (request.geometryType !== undefined) params.geometryType = request.geometryType;
   if (request.sr !== undefined) params.sr = String(request.sr);
   if (request.mosaicRule !== undefined) {
-    params.mosaicRule = typeof request.mosaicRule === "string" ? request.mosaicRule : JSON.stringify(request.mosaicRule);
+    params.mosaicRule =
+      typeof request.mosaicRule === "string" ? request.mosaicRule : JSON.stringify(request.mosaicRule);
   }
   if (request.renderingRule !== undefined) {
-    params.renderingRule = typeof request.renderingRule === "string" ? request.renderingRule : JSON.stringify(request.renderingRule);
+    params.renderingRule =
+      typeof request.renderingRule === "string" ? request.renderingRule : JSON.stringify(request.renderingRule);
   }
   if (request.pixelSize !== undefined) {
     params.pixelSize = Array.isArray(request.pixelSize) ? request.pixelSize.join(",") : request.pixelSize;
@@ -1590,8 +1599,14 @@ export class HonuaGeometryService {
 function geometryProjectParams(request: HonuaGeometryProjectRequest): Record<string, string | number | boolean> {
   const params: Record<string, string | number | boolean> = {
     geometries: typeof request.geometries === "string" ? request.geometries : JSON.stringify(request.geometries),
-    inSR: typeof request.inSr === "string" || typeof request.inSr === "number" ? String(request.inSr) : JSON.stringify(request.inSr),
-    outSR: typeof request.outSr === "string" || typeof request.outSr === "number" ? String(request.outSr) : JSON.stringify(request.outSr),
+    inSR:
+      typeof request.inSr === "string" || typeof request.inSr === "number"
+        ? String(request.inSr)
+        : JSON.stringify(request.inSr),
+    outSR:
+      typeof request.outSr === "string" || typeof request.outSr === "number"
+        ? String(request.outSr)
+        : JSON.stringify(request.outSr),
   };
   Object.assign(params, request.extraParams ?? {});
   return params;
@@ -1603,9 +1618,13 @@ function geometryBufferParams(request: HonuaGeometryBufferRequest): Record<strin
     distances: Array.isArray(request.distances) ? request.distances.join(",") : String(request.distances),
   };
   if (request.unit !== undefined) params.unit = request.unit;
-  if (request.inSr !== undefined) params.inSR = typeof request.inSr === "object" ? JSON.stringify(request.inSr) : String(request.inSr);
-  if (request.outSr !== undefined) params.outSR = typeof request.outSr === "object" ? JSON.stringify(request.outSr) : String(request.outSr);
-  if (request.bufferSr !== undefined) params.bufferSR = typeof request.bufferSr === "object" ? JSON.stringify(request.bufferSr) : String(request.bufferSr);
+  if (request.inSr !== undefined)
+    params.inSR = typeof request.inSr === "object" ? JSON.stringify(request.inSr) : String(request.inSr);
+  if (request.outSr !== undefined)
+    params.outSR = typeof request.outSr === "object" ? JSON.stringify(request.outSr) : String(request.outSr);
+  if (request.bufferSr !== undefined)
+    params.bufferSR =
+      typeof request.bufferSr === "object" ? JSON.stringify(request.bufferSr) : String(request.bufferSr);
   if (request.unionResults !== undefined) params.unionResults = request.unionResults;
   if (request.geodesic !== undefined) params.geodesic = request.geodesic;
   Object.assign(params, request.extraParams ?? {});
@@ -1616,7 +1635,8 @@ function geometrySimplifyParams(request: HonuaGeometrySimplifyRequest): Record<s
   const params: Record<string, string | number | boolean> = {
     geometries: typeof request.geometries === "string" ? request.geometries : JSON.stringify(request.geometries),
   };
-  if (request.sr !== undefined) params.sr = typeof request.sr === "object" ? JSON.stringify(request.sr) : String(request.sr);
+  if (request.sr !== undefined)
+    params.sr = typeof request.sr === "object" ? JSON.stringify(request.sr) : String(request.sr);
   Object.assign(params, request.extraParams ?? {});
   return params;
 }
@@ -1731,7 +1751,10 @@ export class HonuaGeoprocessingService {
 function gpSubmitParams(request: HonuaGeoprocessingSubmitRequest): Record<string, string | number | boolean> {
   const params: Record<string, string | number | boolean> = {};
   for (const [key, value] of Object.entries(request.parameters)) {
-    params[key] = typeof value === "string" || typeof value === "number" || typeof value === "boolean" ? value : JSON.stringify(value);
+    params[key] =
+      typeof value === "string" || typeof value === "number" || typeof value === "boolean"
+        ? value
+        : JSON.stringify(value);
   }
   Object.assign(params, request.extraParams ?? {});
   return params;

--- a/src/core/wmts.ts
+++ b/src/core/wmts.ts
@@ -12,14 +12,14 @@
  */
 
 import type { HonuaClient } from "./client.js";
-import type { WmtsCapabilities, WmtsCapabilityLayer, WmtsCapabilityTileMatrixSet } from "./wmts-capabilities.js";
-import { findWmtsLayer, findWmtsTileMatrixSet } from "./wmts-capabilities.js";
 import type {
   HonuaWmtsFeatureInfoResponse,
   HonuaWmtsTileResponse,
   WmtsFeatureInfoRequest,
   WmtsTileRequest,
 } from "./wms-types.js";
+import type { WmtsCapabilities, WmtsCapabilityLayer, WmtsCapabilityTileMatrixSet } from "./wmts-capabilities.js";
+import { findWmtsLayer, findWmtsTileMatrixSet } from "./wmts-capabilities.js";
 
 export interface HonuaWmtsOptions {
   client: HonuaClient;

--- a/src/esri-compat/controls.ts
+++ b/src/esri-compat/controls.ts
@@ -54,9 +54,7 @@ export class BaseControlCompat {
     this.view = options.view;
     this.container = options.container ?? null;
     this.eventBus =
-      options.eventBus ??
-      resolveCompatEventBus(options.view, ...extraEventBusCandidates) ??
-      new CompatEventBus();
+      options.eventBus ?? resolveCompatEventBus(options.view, ...extraEventBusCandidates) ?? new CompatEventBus();
     this.loaded = false;
     this.loadStatus = "not-loaded";
     this.watchListeners = new Map();
@@ -538,10 +536,7 @@ export class AttributionCompat extends BaseControlCompat {
   }
 
   public constructor(options: AttributionCompatOptions = {}) {
-    super(
-      { view: options.view, container: options.container, eventBus: options.eventBus },
-      options.map,
-    );
+    super({ view: options.view, container: options.container, eventBus: options.eventBus }, options.map);
     this.map = options.map ?? extractViewMap(options.view);
     this.itemDelimiter = options.itemDelimiter ?? " | ";
     this.attributions = options.attributions ? [...options.attributions] : [];

--- a/src/esri-compat/feature-form.ts
+++ b/src/esri-compat/feature-form.ts
@@ -26,10 +26,7 @@ export interface FeatureFormFieldErrorCompat {
   type: "required" | "range" | "pattern" | "custom";
 }
 
-export type FeatureFormValidationFn = (
-  fieldName: string,
-  value: unknown,
-) => FeatureFormFieldErrorCompat | undefined;
+export type FeatureFormValidationFn = (fieldName: string, value: unknown) => FeatureFormFieldErrorCompat | undefined;
 
 export type FeatureFormLoadStatusCompat = "not-loaded" | "loading" | "loaded";
 
@@ -132,9 +129,7 @@ export class FeatureFormCompat {
    * Runs validation against the provided values (or empty object)
    * and returns any field errors.
    */
-  public validate(
-    values: Readonly<Record<string, unknown>> = {},
-  ): readonly FeatureFormFieldErrorCompat[] {
+  public validate(values: Readonly<Record<string, unknown>> = {}): readonly FeatureFormFieldErrorCompat[] {
     if (!this.validationFunction) {
       return [];
     }

--- a/src/esri-compat/feature-table.ts
+++ b/src/esri-compat/feature-table.ts
@@ -445,10 +445,7 @@ export class FeatureTableCompat {
    * Sorts current rows by the given field name and direction.
    * Returns a new sorted snapshot (does not re-fetch from the server).
    */
-  public sortRows(
-    fieldName: string,
-    direction: "asc" | "desc" = "asc",
-  ): readonly FeatureTableRowCompat[] {
+  public sortRows(fieldName: string, direction: "asc" | "desc" = "asc"): readonly FeatureTableRowCompat[] {
     const sorted = [...this.rows].sort((a, b) => {
       const aVal = a.attributes[fieldName];
       const bVal = b.attributes[fieldName];
@@ -457,11 +454,7 @@ export class FeatureTableCompat {
     });
     (this as { rows: readonly FeatureTableRowCompat[] }).rows = sorted;
     this.notifyWatchers("rows", this.rows);
-    this.eventBus.emit(
-      "feature-table.sorted",
-      { fieldName, direction, rowCount: this.rows.length },
-      this,
-    );
+    this.eventBus.emit("feature-table.sorted", { fieldName, direction, rowCount: this.rows.length }, this);
     return this.rows;
   }
 
@@ -469,9 +462,7 @@ export class FeatureTableCompat {
    * Exports current rows as a JSON-serializable array of attribute records.
    * Optionally accepts a list of field names to include.
    */
-  public exportRows(
-    fieldNames?: readonly string[],
-  ): readonly Record<string, unknown>[] {
+  public exportRows(fieldNames?: readonly string[]): readonly Record<string, unknown>[] {
     return this.rows.map((row) => {
       if (!fieldNames || fieldNames.length === 0) {
         return { ...row.attributes };

--- a/src/esri-compat/identity-manager.ts
+++ b/src/esri-compat/identity-manager.ts
@@ -137,9 +137,7 @@ function normalizeServerUrl(value: string): string | undefined {
 
 function isCredentialExpired(credential: IdentityCredentialCompat): boolean {
   return (
-    typeof credential.expires === "number" &&
-    Number.isFinite(credential.expires) &&
-    credential.expires <= Date.now()
+    typeof credential.expires === "number" && Number.isFinite(credential.expires) && credential.expires <= Date.now()
   );
 }
 

--- a/src/esri-compat/map-image-layer.ts
+++ b/src/esri-compat/map-image-layer.ts
@@ -419,11 +419,7 @@ export class MapImageLayerCompat {
       deletes: options.deletes,
       rollbackOnFailure: options.rollbackOnFailure,
     });
-    this.eventBus.emit(
-      "map-image-layer.edits",
-      { result, layerId: this.id, sublayerId: options.layerId },
-      this,
-    );
+    this.eventBus.emit("map-image-layer.edits", { result, layerId: this.id, sublayerId: options.layerId }, this);
     return result;
   }
 

--- a/src/exploration/presets.ts
+++ b/src/exploration/presets.ts
@@ -8,12 +8,7 @@
  * @module
  */
 
-import type {
-  ExplorationSlice,
-  LinkedViewPolicy,
-  LinkedViewPresetName,
-  ViewRole,
-} from "./types.js";
+import type { ExplorationSlice, LinkedViewPolicy, LinkedViewPresetName, ViewRole } from "./types.js";
 
 const ALL_SLICES: ReadonlyArray<ExplorationSlice> = [
   "filters",
@@ -96,9 +91,7 @@ export const LINKED_VIEW_PRESETS: Readonly<Record<LinkedViewPresetName, LinkedVi
   },
 };
 
-function roleRules(
-  table: Record<ViewRole, ReadonlyArray<ExplorationSlice>>,
-): LinkedViewPolicy["rules"] {
+function roleRules(table: Record<ViewRole, ReadonlyArray<ExplorationSlice>>): LinkedViewPolicy["rules"] {
   return [
     { role: "map", propagatesSlices: table.map },
     { role: "grid", propagatesSlices: table.grid },
@@ -109,10 +102,7 @@ function roleRules(
 }
 
 /** Lookup the slices a role propagates under a given preset. */
-export function propagationFor(
-  preset: LinkedViewPresetName,
-  role: ViewRole,
-): ReadonlySet<ExplorationSlice> {
+export function propagationFor(preset: LinkedViewPresetName, role: ViewRole): ReadonlySet<ExplorationSlice> {
   const policy = LINKED_VIEW_PRESETS[preset];
   const rule = policy.rules.find((r) => r.role === role);
   return new Set(rule?.propagatesSlices ?? NO_SLICES);

--- a/src/exploration/reducer.ts
+++ b/src/exploration/reducer.ts
@@ -9,8 +9,8 @@
  * @module
  */
 
-import type { SpatialFilter } from "../core/spatial-filter.js";
 import type { AggregationSpec } from "../contract/types.js";
+import type { SpatialFilter } from "../core/spatial-filter.js";
 import type { ExplorationIntent, ExplorationSlice, ExplorationState, FilterClause } from "./types.js";
 
 export interface ReducerResult {

--- a/src/geocoding/index.ts
+++ b/src/geocoding/index.ts
@@ -1,9 +1,4 @@
-import {
-  HonuaAbortError,
-  HonuaHttpError,
-  HonuaNetworkError,
-  HonuaTimeoutError,
-} from "../core/errors.js";
+import { HonuaAbortError, HonuaHttpError, HonuaNetworkError, HonuaTimeoutError } from "../core/errors.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -100,9 +95,7 @@ function normalizeBaseUrl(url: string): string {
   return url.replace(/\/+$/, "");
 }
 
-function stringifyAttributes(
-  attrs: Record<string, unknown>,
-): Record<string, string | null> {
+function stringifyAttributes(attrs: Record<string, unknown>): Record<string, string | null> {
   const result: Record<string, string | null> = {};
   for (const [key, value] of Object.entries(attrs)) {
     if (value === null || value === undefined) {
@@ -149,10 +142,7 @@ export class HonuaGeocodingClient {
    * Forward-geocode a single-line address string into one or more candidate
    * locations.
    */
-  public async forwardGeocode(
-    address: string,
-    options?: ForwardGeocodeOptions,
-  ): Promise<GeocodeResult[]> {
+  public async forwardGeocode(address: string, options?: ForwardGeocodeOptions): Promise<GeocodeResult[]> {
     const params = new URLSearchParams();
     params.set("singleLine", address);
     params.set("f", "json");
@@ -171,11 +161,7 @@ export class HonuaGeocodingClient {
     const data = await this.request<FindAddressCandidatesResponse>(url);
 
     if (data.error) {
-      throw new HonuaHttpError(
-        data.error.code,
-        `Geocode server error: ${data.error.message}`,
-        data.error,
-      );
+      throw new HonuaHttpError(data.error.code, `Geocode server error: ${data.error.message}`, data.error);
     }
 
     return (data.candidates ?? []).map((c) => ({
@@ -223,11 +209,7 @@ export class HonuaGeocodingClient {
       if (data.error.code === 400) {
         return null;
       }
-      throw new HonuaHttpError(
-        data.error.code,
-        `Reverse geocode server error: ${data.error.message}`,
-        data.error,
-      );
+      throw new HonuaHttpError(data.error.code, `Reverse geocode server error: ${data.error.message}`, data.error);
     }
 
     if (!data.address || !data.location) {
@@ -249,10 +231,7 @@ export class HonuaGeocodingClient {
   /**
    * Retrieve type-ahead suggestions for a partial address string.
    */
-  public async suggest(
-    text: string,
-    options?: SuggestOptions,
-  ): Promise<GeocodeSuggestion[]> {
+  public async suggest(text: string, options?: SuggestOptions): Promise<GeocodeSuggestion[]> {
     const params = new URLSearchParams();
     params.set("text", text);
     params.set("f", "json");
@@ -268,11 +247,7 @@ export class HonuaGeocodingClient {
     const data = await this.request<SuggestResponse>(url);
 
     if (data.error) {
-      throw new HonuaHttpError(
-        data.error.code,
-        `Suggest server error: ${data.error.message}`,
-        data.error,
-      );
+      throw new HonuaHttpError(data.error.code, `Suggest server error: ${data.error.message}`, data.error);
     }
 
     return (data.suggestions ?? []).map((s) => ({
@@ -334,11 +309,7 @@ export class HonuaGeocodingClient {
       } catch {
         body = await response.text().catch(() => null);
       }
-      throw new HonuaHttpError(
-        response.status,
-        `Geocoding request failed with status ${response.status}`,
-        body,
-      );
+      throw new HonuaHttpError(response.status, `Geocoding request failed with status ${response.status}`, body);
     }
 
     return (await response.json()) as T;

--- a/src/migration/cli.ts
+++ b/src/migration/cli.ts
@@ -2,15 +2,15 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { type CodemodMetricsByKind, type CodemodTarget, runEsriCompatCodemod } from "./codemod.js";
 import { parseWebMap } from "../webmap/parse.js";
 import type { WebMapJson } from "../webmap/types.js";
+import { type CodemodMetricsByKind, type CodemodTarget, runEsriCompatCodemod } from "./codemod.js";
 import {
+  type ContentImportReport,
   runContentExport,
   runContentImport,
   runContentReconcile,
   runContentScan,
-  type ContentImportReport,
 } from "./content.js";
 import { MIGRATION_DEMO_PRIMARY_TARGET } from "./demo-targets.js";
 import { parseGeoservicesServiceUrl, runMigrationDemo } from "./demo.js";

--- a/src/migration/content.ts
+++ b/src/migration/content.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { parseWebMap } from "../webmap/parse.js";
 import type { WebMapJson } from "../webmap/types.js";
-import { runGeoservicesImportJob, type GeoservicesImportJobReport } from "./demo.js";
+import { type GeoservicesImportJobReport, runGeoservicesImportJob } from "./demo.js";
 
 const DEFAULT_PORTAL_PAGE_SIZE = 100;
 const DEFAULT_LAYER_QUERY_PAGE_SIZE = 2_000;
@@ -963,14 +963,8 @@ function redactSensitiveUrl(url: string): string {
 
 function redactSensitiveText(value: string): string {
   return value
-    .replace(
-      /([?&](?:token|api[_-]?key|access[_-]?token|auth[_-]?token)=)[^&#\s]*/gi,
-      `$1${REDACTED_SECRET}`,
-    )
-    .replace(
-      /("(?:token|api[_-]?key|access[_-]?token|auth[_-]?token)"\s*:\s*")([^"]*)(")/gi,
-      `$1${REDACTED_SECRET}$3`,
-    )
+    .replace(/([?&](?:token|api[_-]?key|access[_-]?token|auth[_-]?token)=)[^&#\s]*/gi, `$1${REDACTED_SECRET}`)
+    .replace(/("(?:token|api[_-]?key|access[_-]?token|auth[_-]?token)"\s*:\s*")([^"]*)(")/gi, `$1${REDACTED_SECRET}$3`)
     .replace(/((?:token|api[_-]?key|access[_-]?token|auth[_-]?token)\s*[=:]\s*)([^,\s]+)/gi, `$1${REDACTED_SECRET}`);
 }
 

--- a/src/migration/demo.ts
+++ b/src/migration/demo.ts
@@ -327,9 +327,7 @@ async function fetchJson(fetchFn: typeof fetch, url: string, init: RequestInit):
 
   if (!response.ok) {
     const preview = text.length > 0 ? text.slice(0, 300) : `${response.status} ${response.statusText}`;
-    throw new Error(
-      `HTTP ${response.status} for ${redactSensitiveUrl(url)}: ${redactSensitiveText(preview)}`,
-    );
+    throw new Error(`HTTP ${response.status} for ${redactSensitiveUrl(url)}: ${redactSensitiveText(preview)}`);
   }
 
   return body;
@@ -405,14 +403,8 @@ function redactSensitiveUrl(url: string): string {
 
 function redactSensitiveText(value: string): string {
   return value
-    .replace(
-      /([?&](?:token|api[_-]?key|access[_-]?token|auth[_-]?token)=)[^&#\s]*/gi,
-      `$1${REDACTED_SECRET}`,
-    )
-    .replace(
-      /("(?:token|api[_-]?key|access[_-]?token|auth[_-]?token)"\s*:\s*")([^"]*)(")/gi,
-      `$1${REDACTED_SECRET}$3`,
-    )
+    .replace(/([?&](?:token|api[_-]?key|access[_-]?token|auth[_-]?token)=)[^&#\s]*/gi, `$1${REDACTED_SECRET}`)
+    .replace(/("(?:token|api[_-]?key|access[_-]?token|auth[_-]?token)"\s*:\s*")([^"]*)(")/gi, `$1${REDACTED_SECRET}$3`)
     .replace(/((?:token|api[_-]?key|access[_-]?token|auth[_-]?token)\s*[=:]\s*)([^,\s]+)/gi, `$1${REDACTED_SECRET}`);
 }
 

--- a/src/runtime/diff.ts
+++ b/src/runtime/diff.ts
@@ -63,11 +63,7 @@ export function diffPackages(previous: HonuaMapPackage, next: HonuaMapPackage): 
   }
 
   const styleStructuralReason = detectStructuralChange(previous.mapSpec, next.mapSpec);
-  const sourceStructuralReason = detectSourceBindingChange(
-    addedSourceBindings,
-    removedSourceIds,
-    changedSourceIds,
-  );
+  const sourceStructuralReason = detectSourceBindingChange(addedSourceBindings, removedSourceIds, changedSourceIds);
   const structuralReason = styleStructuralReason ?? sourceStructuralReason;
 
   return {

--- a/src/runtime/legend.ts
+++ b/src/runtime/legend.ts
@@ -40,7 +40,11 @@ export function buildLegend(
 }
 
 function legendEntryId(entry: HonuaMapPackageLegendEntry, index: number): string {
-  const slug = entry.label.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  const slug = entry.label
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
   return slug ? `${slug}-${index}` : `legend-${index}`;
 }
 

--- a/src/runtime/popups.ts
+++ b/src/runtime/popups.ts
@@ -62,17 +62,21 @@ export interface PopupBindingHandle {
  * (all MapLibre `Map` instances do).
  */
 export function bindPopup(
-  map: MapEventTarget & { /* passed through to popup.addTo */ },
+  map: MapEventTarget & {
+    /* passed through to popup.addTo */
+  },
   options: BindPopupOptions,
 ): PopupBindingHandle {
   const { binding, layerId, popupFactory, render = defaultPopupRenderer } = options;
   let current: PopupHandle | undefined;
 
   function onClick(...args: unknown[]): void {
-    const event = args[0] as {
-      lngLat?: { lng: number; lat: number };
-      features?: PopupFeature[];
-    } | undefined;
+    const event = args[0] as
+      | {
+          lngLat?: { lng: number; lat: number };
+          features?: PopupFeature[];
+        }
+      | undefined;
     if (!event?.lngLat || !event.features || event.features.length === 0) return;
 
     const lngLat: [number, number] = [event.lngLat.lng, event.lngLat.lat];

--- a/src/runtime/style-compose.ts
+++ b/src/runtime/style-compose.ts
@@ -78,10 +78,11 @@ export async function applyStyleRefs(
   for (const ref of refs) {
     const body = ref.body ?? (resolve ? await resolve(ref.styleId, ref.presetId) : undefined);
     if (!body) {
-      throw new HonuaMapPackageError(
-        `StyleRef "${ref.styleId}" has no inline body and no resolver was provided`,
-        { packageId: pkg.mapPackageId, stage: "style-compose", detail: { styleId: ref.styleId } },
-      );
+      throw new HonuaMapPackageError(`StyleRef "${ref.styleId}" has no inline body and no resolver was provided`, {
+        packageId: pkg.mapPackageId,
+        stage: "style-compose",
+        detail: { styleId: ref.styleId },
+      });
     }
     for (const [layerId, override] of Object.entries(body)) {
       const idx = nextLayers.findIndex((layer) => layer.id === layerId);
@@ -125,7 +126,10 @@ async function resolveTheme(
   }
 }
 
-function mergeLayerOverride(layer: HonuaLayerSpecification, override: HonuaStyleRefLayerOverride): HonuaLayerSpecification {
+function mergeLayerOverride(
+  layer: HonuaLayerSpecification,
+  override: HonuaStyleRefLayerOverride,
+): HonuaLayerSpecification {
   return {
     ...layer,
     ...(override.filter !== undefined ? { filter: override.filter } : {}),
@@ -146,7 +150,10 @@ function cloneLayer(layer: HonuaLayerSpecification): HonuaLayerSpecification {
   };
 }
 
-function substituteLayerTokens(layer: HonuaLayerSpecification, tokens: Record<string, string | number>): HonuaLayerSpecification {
+function substituteLayerTokens(
+  layer: HonuaLayerSpecification,
+  tokens: Record<string, string | number>,
+): HonuaLayerSpecification {
   return {
     ...layer,
     paint: layer.paint ? substituteTokens(layer.paint, tokens) : layer.paint,
@@ -154,7 +161,10 @@ function substituteLayerTokens(layer: HonuaLayerSpecification, tokens: Record<st
   };
 }
 
-function substituteTokens(obj: Record<string, unknown>, tokens: Record<string, string | number>): Record<string, unknown> {
+function substituteTokens(
+  obj: Record<string, unknown>,
+  tokens: Record<string, string | number>,
+): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj)) {
     out[key] = substituteTokenValue(value, tokens);

--- a/src/webmap/convert-basemap.ts
+++ b/src/webmap/convert-basemap.ts
@@ -6,7 +6,7 @@
 
 import type { HonuaLayerSpecification, HonuaMapServiceSourceSpecification } from "../style/specification.js";
 import type { WebMapBaseMap, WebMapBaseMapLayer } from "./types.js";
-import { warnUnknownProperties, type WarningCollector } from "./warnings.js";
+import { type WarningCollector, warnUnknownProperties } from "./warnings.js";
 
 export interface BasemapConversionResult {
   sources: Record<string, HonuaMapServiceSourceSpecification | { type: string; [key: string]: unknown }>;

--- a/src/webmap/convert-label.ts
+++ b/src/webmap/convert-label.ts
@@ -8,8 +8,8 @@
  */
 
 import type { HonuaLayerSpecification } from "../style/specification.js";
-import type { WebMapLabelClass, WebMapTextSymbol } from "./types.js";
 import { esriColorToCss } from "./convert-symbol.js";
+import type { WebMapLabelClass, WebMapTextSymbol } from "./types.js";
 import type { WarningCollector } from "./warnings.js";
 
 export function convertLabelingInfo(

--- a/src/webmap/convert-layer.ts
+++ b/src/webmap/convert-layer.ts
@@ -13,11 +13,11 @@ import type {
   HonuaMapServiceSourceSpecification,
   HonuaSourceSpecification,
 } from "../style/specification.js";
-import type { WebMapOperationalLayer } from "./types.js";
-import { convertRenderer } from "./convert-renderer.js";
-import { convertPopupInfo, type HonuaPopupConfig } from "./convert-popup.js";
 import { convertLabelingInfo } from "./convert-label.js";
-import { warnUnknownProperties, type WarningCollector } from "./warnings.js";
+import { type HonuaPopupConfig, convertPopupInfo } from "./convert-popup.js";
+import { convertRenderer } from "./convert-renderer.js";
+import type { WebMapOperationalLayer } from "./types.js";
+import { type WarningCollector, warnUnknownProperties } from "./warnings.js";
 
 export interface LayerConversionResult {
   sources: Record<string, HonuaSourceSpecification | { type: string; [key: string]: unknown }>;

--- a/src/webmap/convert-popup.ts
+++ b/src/webmap/convert-popup.ts
@@ -7,8 +7,8 @@
  * @module
  */
 
-import type { WebMapPopupInfo, WebMapFieldInfo, WebMapMediaInfo } from "./types.js";
-import { warnUnknownProperties, type WarningCollector } from "./warnings.js";
+import type { WebMapFieldInfo, WebMapMediaInfo, WebMapPopupInfo } from "./types.js";
+import { type WarningCollector, warnUnknownProperties } from "./warnings.js";
 
 export interface HonuaPopupFieldInfo {
   fieldName: string;

--- a/src/webmap/convert-renderer.ts
+++ b/src/webmap/convert-renderer.ts
@@ -7,8 +7,8 @@
  * @module
  */
 
-import type { WebMapRenderer, WebMapSymbol, WebMapUniqueValueRenderer, WebMapClassBreaksRenderer } from "./types.js";
-import { convertSymbol, esriColorToCss, type SymbolConversionResult } from "./convert-symbol.js";
+import { type SymbolConversionResult, convertSymbol, esriColorToCss } from "./convert-symbol.js";
+import type { WebMapClassBreaksRenderer, WebMapRenderer, WebMapSymbol, WebMapUniqueValueRenderer } from "./types.js";
 import type { WarningCollector } from "./warnings.js";
 
 export interface RendererConversionResult {

--- a/src/webmap/convert-symbol.ts
+++ b/src/webmap/convert-symbol.ts
@@ -7,12 +7,12 @@
 import type { HonuaLayerSpecification } from "../style/specification.js";
 import type {
   EsriColor,
+  WebMapPictureMarkerSymbol,
   WebMapSimpleFillSymbol,
   WebMapSimpleLineSymbol,
   WebMapSimpleMarkerSymbol,
-  WebMapPictureMarkerSymbol,
-  WebMapTextSymbol,
   WebMapSymbol,
+  WebMapTextSymbol,
 } from "./types.js";
 import type { WarningCollector } from "./warnings.js";
 

--- a/src/webmap/parse.ts
+++ b/src/webmap/parse.ts
@@ -5,17 +5,17 @@
  */
 
 import type { HonuaStyleSpecification } from "../style/specification.js";
-import type { WebMapJson, WebMapBookmark, WebMapOperationalLayer } from "./types.js";
-import {
-  createWarningCollector,
-  type WarningCollector,
-  type WebMapWarning,
-  warnUnknownProperties,
-} from "./warnings.js";
 import { convertBasemap } from "./convert-basemap.js";
 import { convertExtent, convertInitialViewpoint } from "./convert-extent.js";
 import { convertOperationalLayer } from "./convert-layer.js";
 import type { HonuaPopupConfig } from "./convert-popup.js";
+import type { WebMapBookmark, WebMapJson, WebMapOperationalLayer } from "./types.js";
+import {
+  type WarningCollector,
+  type WebMapWarning,
+  createWarningCollector,
+  warnUnknownProperties,
+} from "./warnings.js";
 
 export interface ParseWebMapOptions {
   /** If true, include basemap layers. Defaults to true. */

--- a/test/cesium-route-playback.test.ts
+++ b/test/cesium-route-playback.test.ts
@@ -3,11 +3,11 @@ import fs from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import {
+  type RoutePlaybackManifest,
   createExampleConfig,
   createLiveQueryRequest,
   loadRouteSource,
   normalizeRoutePlaybackSource,
-  type RoutePlaybackManifest,
 } from "../docs/examples/cesium-route-playback/data-path.mjs";
 
 function readJson<T>(relativePath: string): T {
@@ -326,7 +326,9 @@ describe("Cesium route playback example helpers", () => {
       secondsFromStart: 0,
     });
     expect(normalized.playbackSamples.at(-1)?.distanceMeters).toBeGreaterThan(0);
-    expect(normalized.preprocessingSteps).toContain("Loaded a checked-in Honua FeatureServer/query fixture for deterministic playback.");
+    expect(normalized.preprocessingSteps).toContain(
+      "Loaded a checked-in Honua FeatureServer/query fixture for deterministic playback.",
+    );
   });
 
   it("matches an explicit routeId in live multi-feature responses", async () => {
@@ -426,7 +428,9 @@ describe("Cesium route playback example helpers", () => {
   });
 
   it("throws instead of guessing across multiple live polyline features without routeId", async () => {
-    const config = createExampleConfig("?mode=live&baseUrl=/mock-honua&serviceId=transport&layerId=0&resultRecordCount=2");
+    const config = createExampleConfig(
+      "?mode=live&baseUrl=/mock-honua&serviceId=transport&layerId=0&resultRecordCount=2",
+    );
     const source = await loadRouteSource(config, {
       HonuaClient: createMockHonuaClient(MULTI_FEATURE_QUERY_RESPONSE),
     });

--- a/test/compat-widgets-event-bus.test.ts
+++ b/test/compat-widgets-event-bus.test.ts
@@ -132,7 +132,11 @@ describe("LayerListCompat", () => {
 
     const layerA = { id: "a", title: "A", visible: true };
     const layerB = { id: "b", title: "B", visible: true };
-    const nested = new GroupLayerCompat({ id: "group", eventBus, layers: [{ id: "nested", title: "Nested", visible: true }] });
+    const nested = new GroupLayerCompat({
+      id: "group",
+      eventBus,
+      layers: [{ id: "nested", title: "Nested", visible: true }],
+    });
 
     map.addMany([layerA, nested]);
 

--- a/test/contract/geoservices-conformance.test.ts
+++ b/test/contract/geoservices-conformance.test.ts
@@ -32,6 +32,7 @@ import {
 } from "../../src/core/surfaces.js";
 
 import {
+  type ParcelAttrs,
   geometryBufferResponse,
   geometryProjectResponse,
   geoservicesAddAttachmentResponse,
@@ -49,11 +50,12 @@ import {
   imageServerIdentifyResponse,
   jsonResponse,
   makeMockClient,
-  type ParcelAttrs,
 } from "./shared.js";
 
 describe("contract / GeoServices FeatureServer parity", () => {
-  function buildFeatureDataset(routes: Array<[string | RegExp, (url: URL, init: RequestInit | undefined) => Response | Promise<Response>]>) {
+  function buildFeatureDataset(
+    routes: Array<[string | RegExp, (url: URL, init: RequestInit | undefined) => Response | Promise<Response>]>,
+  ) {
     const client = makeMockClient({ routes });
     return createDataset({
       id: "parcels",
@@ -243,18 +245,31 @@ describe("contract / GeoServices FeatureServer parity", () => {
 
   it("attachments.list/add/update/delete/query route through the FeatureServer attachments endpoints", async () => {
     const dataset = buildFeatureDataset([
-      ["/rest/services/Parcels/FeatureServer/0/queryAttachments", () => jsonResponse(geoservicesQueryAttachmentsResponse())],
-      ["/rest/services/Parcels/FeatureServer/0/1/attachments", () => jsonResponse(geoservicesAttachmentInfosResponse())],
-      ["/rest/services/Parcels/FeatureServer/0/1/addAttachment", () => jsonResponse(geoservicesAddAttachmentResponse())],
-      ["/rest/services/Parcels/FeatureServer/0/1/updateAttachment", () => jsonResponse(geoservicesUpdateAttachmentResponse())],
-      ["/rest/services/Parcels/FeatureServer/0/1/deleteAttachments", () => jsonResponse(geoservicesDeleteAttachmentsResponse())],
+      [
+        "/rest/services/Parcels/FeatureServer/0/queryAttachments",
+        () => jsonResponse(geoservicesQueryAttachmentsResponse()),
+      ],
+      [
+        "/rest/services/Parcels/FeatureServer/0/1/attachments",
+        () => jsonResponse(geoservicesAttachmentInfosResponse()),
+      ],
+      [
+        "/rest/services/Parcels/FeatureServer/0/1/addAttachment",
+        () => jsonResponse(geoservicesAddAttachmentResponse()),
+      ],
+      [
+        "/rest/services/Parcels/FeatureServer/0/1/updateAttachment",
+        () => jsonResponse(geoservicesUpdateAttachmentResponse()),
+      ],
+      [
+        "/rest/services/Parcels/FeatureServer/0/1/deleteAttachments",
+        () => jsonResponse(geoservicesDeleteAttachmentsResponse()),
+      ],
     ]);
     const source = dataset.source<ParcelAttrs>("parcels-fs")!;
 
     const list = await source.attachments.list(1);
-    expect(list).toEqual([
-      { id: 7, parentId: 1, name: "deed.pdf", contentType: "application/pdf", size: 1024 },
-    ]);
+    expect(list).toEqual([{ id: 7, parentId: 1, name: "deed.pdf", contentType: "application/pdf", size: 1024 }]);
 
     const queryGroups = await source.attachments.query({ parentIds: [1] });
     expect(queryGroups).toHaveLength(1);
@@ -307,17 +322,21 @@ describe("contract / GeoServices FeatureServer parity", () => {
       ],
     });
     const source = dataset.source<ParcelAttrs>("parcels-fs")!;
-    await expect(
-      source.applyEdits({ adds: [{ attributes: { OBJECTID: 0, STATE: "WA", ACRES: 5 } }] }),
-    ).rejects.toThrow(HonuaCapabilityNotSupportedError);
-    await expect(source.queryRelated({ relationshipId: 0, sourceIds: [1] })).rejects.toThrow(HonuaCapabilityNotSupportedError);
+    await expect(source.applyEdits({ adds: [{ attributes: { OBJECTID: 0, STATE: "WA", ACRES: 5 } }] })).rejects.toThrow(
+      HonuaCapabilityNotSupportedError,
+    );
+    await expect(source.queryRelated({ relationshipId: 0, sourceIds: [1] })).rejects.toThrow(
+      HonuaCapabilityNotSupportedError,
+    );
     await expect(source.queryObjectIds()).rejects.toThrow(HonuaCapabilityNotSupportedError);
     await expect(source.attachments.list(1)).rejects.toThrow(HonuaCapabilityNotSupportedError);
   });
 });
 
 describe("contract / GeoServices MapServer parity (read-only)", () => {
-  function buildMapDataset(routes: Array<[string | RegExp, (url: URL, init: RequestInit | undefined) => Response | Promise<Response>]>) {
+  function buildMapDataset(
+    routes: Array<[string | RegExp, (url: URL, init: RequestInit | undefined) => Response | Promise<Response>]>,
+  ) {
     const client = makeMockClient({ routes });
     return createDataset({
       id: "parcels",
@@ -339,7 +358,10 @@ describe("contract / GeoServices MapServer parity (read-only)", () => {
     // more specific `/queryRelatedRecords` matcher must come first or both
     // routes map to the ids-only fixture.
     const dataset = buildMapDataset([
-      ["/rest/services/Parcels/MapServer/0/queryRelatedRecords", () => jsonResponse(geoservicesRelatedRecordsResponse())],
+      [
+        "/rest/services/Parcels/MapServer/0/queryRelatedRecords",
+        () => jsonResponse(geoservicesRelatedRecordsResponse()),
+      ],
       ["/rest/services/Parcels/MapServer/0/query", () => jsonResponse(geoservicesObjectIdsResponse())],
     ]);
     const source = dataset.source<ParcelAttrs>("parcels-ms")!;
@@ -347,15 +369,17 @@ describe("contract / GeoServices MapServer parity (read-only)", () => {
     expect(await source.queryObjectIds()).toEqual([1, 2, 3]);
     const related = await source.queryRelated({ relationshipId: 0, sourceIds: [1] });
     expect(related.groups).toHaveLength(1);
-    await expect(
-      source.applyEdits({ adds: [{ attributes: { OBJECTID: 0, STATE: "WA", ACRES: 5 } }] }),
-    ).rejects.toThrow(HonuaCapabilityNotSupportedError);
+    await expect(source.applyEdits({ adds: [{ attributes: { OBJECTID: 0, STATE: "WA", ACRES: 5 } }] })).rejects.toThrow(
+      HonuaCapabilityNotSupportedError,
+    );
     await expect(source.attachments.list(1)).rejects.toThrow(HonuaCapabilityNotSupportedError);
   });
 });
 
 describe("contract / GeoServices ImageServer parity", () => {
-  function buildImageDataset(routes: Array<[string | RegExp, (url: URL, init: RequestInit | undefined) => Response | Promise<Response>]>) {
+  function buildImageDataset(
+    routes: Array<[string | RegExp, (url: URL, init: RequestInit | undefined) => Response | Promise<Response>]>,
+  ) {
     const client = makeMockClient({ routes });
     return createDataset({
       id: "imagery",
@@ -505,7 +529,17 @@ describe("contract / GeoServices ImageServer parity", () => {
 
     const spatialFilter = {
       geometryType: "esriGeometryPolygon" as const,
-      geometry: { rings: [[[-120, 38], [-119, 38], [-119, 39], [-120, 39], [-120, 38]]] },
+      geometry: {
+        rings: [
+          [
+            [-120, 38],
+            [-119, 38],
+            [-119, 39],
+            [-120, 39],
+            [-120, 38],
+          ],
+        ],
+      },
     };
     await expect(source.query({ spatialFilter })).rejects.toThrow(/spatialFilter is not supported/);
     await expect(source.queryAll({ spatialFilter })).rejects.toThrow(/spatialFilter is not supported/);
@@ -741,12 +775,7 @@ describe("contract / GeoServices Geometry Service parity", () => {
         },
       ] as [string, (url: URL, init: RequestInit | undefined) => Promise<Response>];
     const client = makeMockClient({
-      routes: [
-        captureRoute("intersect"),
-        captureRoute("union"),
-        captureRoute("clip"),
-        captureRoute("difference"),
-      ],
+      routes: [captureRoute("intersect"), captureRoute("union"), captureRoute("clip"), captureRoute("difference")],
     });
     const dataset = createDataset({
       id: "geom",
@@ -765,9 +794,31 @@ describe("contract / GeoServices Geometry Service parity", () => {
 
     const inputGeoms = {
       geometryType: "esriGeometryPolygon",
-      geometries: [{ rings: [[[-120, 38], [-119, 38], [-119, 39], [-120, 39], [-120, 38]]] }],
+      geometries: [
+        {
+          rings: [
+            [
+              [-120, 38],
+              [-119, 38],
+              [-119, 39],
+              [-120, 39],
+              [-120, 38],
+            ],
+          ],
+        },
+      ],
     } as const;
-    const operatorGeom = { rings: [[[-120, 38], [-119.5, 38], [-119.5, 39], [-120, 39], [-120, 38]]] };
+    const operatorGeom = {
+      rings: [
+        [
+          [-120, 38],
+          [-119.5, 38],
+          [-119.5, 39],
+          [-120, 39],
+          [-120, 38],
+        ],
+      ],
+    };
 
     // Binary ops (intersect / clip / difference) all carry geometries, geometry, sr.
     await adapter.intersect({ geometries: inputGeoms, geometry: operatorGeom, sr: 4326 });
@@ -835,7 +886,7 @@ describe("contract / GeoServices Geometry Service parity", () => {
     });
     expect(observedMethod).toBe("GET");
     expect(observedBody).toBeUndefined();
-    expect(observedGeometryParam).toContain("\"x\":-119");
+    expect(observedGeometryParam).toContain('"x":-119');
     expect(observedSr).toBe("4326");
   });
 
@@ -885,8 +936,14 @@ describe("contract / GeoServices GP Service parity", () => {
   it("GP source lifecycle (submitJob -> jobStatus) routes through HonuaGeoprocessingService", async () => {
     const client = makeMockClient({
       routes: [
-        ["/rest/services/Print/GPServer/Export%20Web%20Map%20Task/submitJob", () => jsonResponse(gpSubmitJobResponse())],
-        ["/rest/services/Print/GPServer/Export%20Web%20Map%20Task/jobs/job-001", () => jsonResponse(gpJobStatusResponse())],
+        [
+          "/rest/services/Print/GPServer/Export%20Web%20Map%20Task/submitJob",
+          () => jsonResponse(gpSubmitJobResponse()),
+        ],
+        [
+          "/rest/services/Print/GPServer/Export%20Web%20Map%20Task/jobs/job-001",
+          () => jsonResponse(gpJobStatusResponse()),
+        ],
       ],
     });
     const dataset = createDataset({
@@ -974,7 +1031,8 @@ describe("contract / OGC Features applyEdits via createItem/replaceItem/deleteIt
             const method = init?.method ?? "GET";
             if (method === "PUT") {
               const rawBody = init?.body;
-              const body = typeof rawBody === "string" ? rawBody : rawBody !== undefined ? await (rawBody as Blob).text() : "";
+              const body =
+                typeof rawBody === "string" ? rawBody : rawBody !== undefined ? await (rawBody as Blob).text() : "";
               replaced = { id, body: body ? JSON.parse(body) : null };
               return jsonResponse({ id, type: "Feature", properties: {}, geometry: null });
             }
@@ -989,7 +1047,8 @@ describe("contract / OGC Features applyEdits via createItem/replaceItem/deleteIt
           "/ogc/features/collections/parcels/items",
           async (_url, init) => {
             const rawBody = init?.body;
-            const body = typeof rawBody === "string" ? rawBody : rawBody !== undefined ? await (rawBody as Blob).text() : "";
+            const body =
+              typeof rawBody === "string" ? rawBody : rawBody !== undefined ? await (rawBody as Blob).text() : "";
             const parsed = body ? JSON.parse(body) : {};
             created.push(parsed);
             return jsonResponse({ ...parsed, id: 99 });
@@ -1013,8 +1072,16 @@ describe("contract / OGC Features applyEdits via createItem/replaceItem/deleteIt
     });
     const source = dataset.source<ParcelAttrs>("parcels-ogc")!;
     const result = await source.applyEdits({
-      adds: [{ attributes: { OBJECTID: 0, STATE: "WA", ACRES: 50 }, geometry: { type: "Point", coordinates: [-122, 47] } }],
-      updates: [{ id: 1, attributes: { OBJECTID: 1, STATE: "CA", ACRES: 99 }, geometry: { type: "Point", coordinates: [-120, 38] } }],
+      adds: [
+        { attributes: { OBJECTID: 0, STATE: "WA", ACRES: 50 }, geometry: { type: "Point", coordinates: [-122, 47] } },
+      ],
+      updates: [
+        {
+          id: 1,
+          attributes: { OBJECTID: 1, STATE: "CA", ACRES: 99 },
+          geometry: { type: "Point", coordinates: [-120, 38] },
+        },
+      ],
       deletes: [3],
     });
     expect(result.added[0]).toEqual({ id: 99, success: true });

--- a/test/contract/odata-conformance.test.ts
+++ b/test/contract/odata-conformance.test.ts
@@ -1426,9 +1426,7 @@ describe("odata / geometry-field resolution honors descriptor.schema (review fix
         () =>
           jsonResponse({
             "@odata.context": "https://mock/odata/$metadata#Places",
-            value: [
-              { OBJECTID: 1, STATE: "CA", Location: { type: "Point", coordinates: [-120, 38] } },
-            ],
+            value: [{ OBJECTID: 1, STATE: "CA", Location: { type: "Point", coordinates: [-120, 38] } }],
           }),
       ],
     ]);

--- a/test/contract/ogc-conformance.test.ts
+++ b/test/contract/ogc-conformance.test.ts
@@ -7,10 +7,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import {
-  hasOgcConformanceClass,
-  negotiateOgcCapabilities,
-} from "../../src/core/ogc-conformance.js";
+import { hasOgcConformanceClass, negotiateOgcCapabilities } from "../../src/core/ogc-conformance.js";
 
 describe("ogc-conformance / negotiateOgcCapabilities", () => {
   it("translates OGC API Features 1.0 + Part 3 + Part 4 into canonical capabilities", () => {

--- a/test/contract/ogc-maps.test.ts
+++ b/test/contract/ogc-maps.test.ts
@@ -6,11 +6,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import {
-  PROTOCOL_DEFAULT_CAPABILITIES,
-  createDataset,
-  type SourceDescriptor,
-} from "../../src/contract/index.js";
+import { PROTOCOL_DEFAULT_CAPABILITIES, type SourceDescriptor, createDataset } from "../../src/contract/index.js";
 import { HonuaCapabilityNotSupportedError } from "../../src/core/errors.js";
 import { HonuaOgcCollectionMap, HonuaOgcMaps } from "../../src/core/ogc-maps.js";
 

--- a/test/contract/ogc-processes.test.ts
+++ b/test/contract/ogc-processes.test.ts
@@ -8,11 +8,8 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { isJobTerminal, type IJobRun, type JobSnapshot } from "../../src/contract/index.js";
-import {
-  HonuaJobFailedError,
-  HonuaOgcProcessJobRun,
-} from "../../src/core/ogc-processes.js";
+import { type IJobRun, type JobSnapshot, isJobTerminal } from "../../src/contract/index.js";
+import { HonuaJobFailedError, HonuaOgcProcessJobRun } from "../../src/core/ogc-processes.js";
 import type { HonuaOgcProcessJobStatus } from "../../src/core/types.js";
 
 import { jsonResponse, makeMockClient } from "./shared.js";
@@ -229,10 +226,10 @@ describe("ogc-processes / IJobRun lifecycle", () => {
           (_url, init) => {
             if (init?.method === "DELETE") {
               cancelCalls += 1;
-              return new Response(
-                JSON.stringify({ title: "Cannot dismiss completed job", status: 409 }),
-                { status: 409, headers: { "Content-Type": "application/json" } },
-              );
+              return new Response(JSON.stringify({ title: "Cannot dismiss completed job", status: 409 }), {
+                status: 409,
+                headers: { "Content-Type": "application/json" },
+              });
             }
             statusCalls += 1;
             return jsonResponse({ jobID: "job-race", status: "successful" });
@@ -341,10 +338,10 @@ describe("ogc-processes / IJobRun lifecycle", () => {
           "/ogc/processes/jobs/job-stale",
           (_url, init) => {
             if (init?.method === "DELETE") {
-              return new Response(
-                JSON.stringify({ title: "Cannot dismiss completed job", status: 409 }),
-                { status: 409, headers: { "Content-Type": "application/json" } },
-              );
+              return new Response(JSON.stringify({ title: "Cannot dismiss completed job", status: 409 }), {
+                status: 409,
+                headers: { "Content-Type": "application/json" },
+              });
             }
             return jsonResponse({ jobID: "job-stale", status: "running" });
           },
@@ -371,10 +368,10 @@ describe("ogc-processes / IJobRun lifecycle", () => {
           "/ogc/processes/jobs/job-pollfail",
           (_url, init) => {
             if (init?.method === "DELETE") {
-              return new Response(
-                JSON.stringify({ title: "Cannot dismiss completed job", status: 409 }),
-                { status: 409, headers: { "Content-Type": "application/json" } },
-              );
+              return new Response(JSON.stringify({ title: "Cannot dismiss completed job", status: 409 }), {
+                status: 409,
+                headers: { "Content-Type": "application/json" },
+              });
             }
             return new Response("upstream unavailable", { status: 502 });
           },
@@ -397,14 +394,8 @@ describe("ogc-processes / IJobRun lifecycle", () => {
           "/ogc/processes/processes/buffer/execution",
           () => jsonResponse({ jobID: "job-empty", status: "running", processID: "buffer" }),
         ],
-        [
-          "/ogc/processes/jobs/job-empty/results",
-          () => jsonResponse({}),
-        ],
-        [
-          "/ogc/processes/jobs/job-empty",
-          () => jsonResponse({ jobID: "job-empty", status: "successful" }),
-        ],
+        ["/ogc/processes/jobs/job-empty/results", () => jsonResponse({})],
+        ["/ogc/processes/jobs/job-empty", () => jsonResponse({ jobID: "job-empty", status: "successful" })],
       ],
     });
     const job = await client.ogcProcesses().execute({ processId: "buffer", inputs: {}, mode: "async" });

--- a/test/contract/ogc-tiles.test.ts
+++ b/test/contract/ogc-tiles.test.ts
@@ -8,9 +8,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   PROTOCOL_DEFAULT_CAPABILITIES,
+  type SourceDescriptor,
   capabilities,
   createDataset,
-  type SourceDescriptor,
 } from "../../src/contract/index.js";
 import { HonuaCapabilityNotSupportedError } from "../../src/core/errors.js";
 import { HonuaOgcTiles, HonuaOgcTileset } from "../../src/core/ogc-tiles.js";

--- a/test/contract/stac.test.ts
+++ b/test/contract/stac.test.ts
@@ -7,11 +7,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import {
-  PROTOCOL_DEFAULT_CAPABILITIES,
-  createDataset,
-  type SourceDescriptor,
-} from "../../src/contract/index.js";
+import { PROTOCOL_DEFAULT_CAPABILITIES, type SourceDescriptor, createDataset } from "../../src/contract/index.js";
 import { HonuaCapabilityNotSupportedError } from "../../src/core/errors.js";
 import { HonuaStacSearch } from "../../src/core/stac.js";
 
@@ -88,7 +84,15 @@ describe("stac / wire", () => {
     });
     const intersects = {
       type: "Polygon",
-      coordinates: [[[-122, 37], [-120, 37], [-120, 38], [-122, 38], [-122, 37]]],
+      coordinates: [
+        [
+          [-122, 37],
+          [-120, 37],
+          [-120, 38],
+          [-122, 38],
+          [-122, 37],
+        ],
+      ],
     };
     await client.stac().search({
       intersects,
@@ -277,9 +281,7 @@ describe("stac / paging", () => {
               ],
               numberMatched: 2,
               numberReturned: 1,
-              links: last
-                ? []
-                : [{ rel: "next", href: "https://mock/stac/search?next=opaque-token" }],
+              links: last ? [] : [{ rel: "next", href: "https://mock/stac/search?next=opaque-token" }],
             });
           },
         ],
@@ -352,9 +354,9 @@ describe("stac / Source adapter", () => {
       ],
     });
     const source = dataset.source("sentinel-stac")!;
-    await expect(
-      source.query({ aggregation: { metrics: [{ fn: "sum", field: "cloud_cover" }] } }),
-    ).rejects.toThrow(HonuaCapabilityNotSupportedError);
+    await expect(source.query({ aggregation: { metrics: [{ fn: "sum", field: "cloud_cover" }] } })).rejects.toThrow(
+      HonuaCapabilityNotSupportedError,
+    );
   });
 
   it("stream() yields paged Result envelopes", async () => {

--- a/test/contract/wmts.test.ts
+++ b/test/contract/wmts.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { PROTOCOL_DEFAULT_CAPABILITIES, createDataset, type SourceDescriptor } from "../../src/contract/index.js";
+import { PROTOCOL_DEFAULT_CAPABILITIES, type SourceDescriptor, createDataset } from "../../src/contract/index.js";
 import { HonuaCapabilityNotSupportedError } from "../../src/core/errors.js";
 import { HonuaWmts, HonuaWmtsLayer, HonuaWmtsTileset } from "../../src/core/wmts.js";
 import { buildWmtsRasterSourceSpec } from "../../src/runtime/source-bridge.js";

--- a/test/esri-config-compat.test.ts
+++ b/test/esri-config-compat.test.ts
@@ -1,10 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 
-import {
-  esriConfig,
-  getEsriConfigHonuaInterceptors,
-  resetEsriConfig,
-} from "../src/index.js";
+import { esriConfig, getEsriConfigHonuaInterceptors, resetEsriConfig } from "../src/index.js";
 
 afterEach(() => {
   resetEsriConfig();

--- a/test/esri-request-compat.test.ts
+++ b/test/esri-request-compat.test.ts
@@ -8,11 +8,12 @@ afterEach(() => {
 
 describe("esriRequest compat", () => {
   it("executes JSON requests with query params", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response(JSON.stringify({ ok: true }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -42,11 +43,12 @@ describe("esriRequest compat", () => {
   });
 
   it("supports relative URLs when query params are provided", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response(JSON.stringify({ ok: true }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
     );
     vi.stubGlobal("fetch", fetchMock);
 

--- a/test/expand-compat.test.ts
+++ b/test/expand-compat.test.ts
@@ -65,12 +65,7 @@ describe("ExpandCompat", () => {
     expect(expand.expanded).toBe(false);
     expect(expand.toggle()).toBe(true);
     expect(expand.toggle(false)).toBe(false);
-    expect(events).toEqual([
-      "expand.changed",
-      "expand.changed",
-      "expand.changed",
-      "expand.changed",
-    ]);
+    expect(events).toEqual(["expand.changed", "expand.changed", "expand.changed", "expand.changed"]);
 
     expand.destroy();
   });

--- a/test/expr.test.ts
+++ b/test/expr.test.ts
@@ -2,80 +2,80 @@ import { describe, expect, it } from "vitest";
 
 import {
   Expr,
-  expr,
-  get,
-  has,
-  at,
-  contains,
-  indexOf,
-  slice,
-  length,
-  id,
-  geometryType,
-  properties,
-  featureState,
-  literal,
-  toBoolean,
-  toNumber,
-  exprToString,
-  toColor,
-  typeOf,
-  eq,
-  neq,
-  lt,
-  lte,
-  gt,
-  gte,
-  not,
+  abs,
+  acos,
+  add,
   all,
   any,
-  switchCase,
-  matchExpr,
-  coalesce,
-  add,
-  subtract,
-  multiply,
-  divide,
-  mod,
-  pow,
-  abs,
-  ceil,
-  floor,
-  round,
-  sqrt,
-  ln,
-  log2,
-  log10,
-  sin,
-  cos,
-  tan,
   asin,
-  acos,
+  at,
   atan,
-  min,
-  max,
-  e,
-  pi,
-  ln2Const,
+  ceil,
+  coalesce,
   concat,
-  upcase,
+  contains,
+  cos,
+  cubicBezier,
+  distance,
+  divide,
   downcase,
-  rgb,
-  rgba,
-  step,
+  e,
+  eq,
+  exponential,
+  expr,
+  exprToString,
+  featureState,
+  floor,
+  geometryType,
+  get,
+  gt,
+  gte,
+  has,
+  id,
+  image,
+  indexOf,
   interpolate,
   interpolateHcl,
   interpolateLab,
-  linear,
-  exponential,
-  cubicBezier,
-  zoom,
-  letExpr,
-  varExpr,
-  image,
-  distance,
-  within,
   intersects,
+  length,
+  letExpr,
+  linear,
+  literal,
+  ln,
+  ln2Const,
+  log2,
+  log10,
+  lt,
+  lte,
+  matchExpr,
+  max,
+  min,
+  mod,
+  multiply,
+  neq,
+  not,
+  pi,
+  pow,
+  properties,
+  rgb,
+  rgba,
+  round,
+  sin,
+  slice,
+  sqrt,
+  step,
+  subtract,
+  switchCase,
+  tan,
+  toBoolean,
+  toColor,
+  toNumber,
+  typeOf,
+  upcase,
+  varExpr,
+  within,
+  zoom,
 } from "../src/index.js";
 import type { GeoJsonGeometry } from "../src/index.js";
 
@@ -111,11 +111,7 @@ describe("Lookup expressions", () => {
   });
 
   it("get() with object serializes two-arg form", () => {
-    expect(get("key", properties()).toJSON()).toEqual([
-      "get",
-      "key",
-      ["properties"],
-    ]);
+    expect(get("key", properties()).toJSON()).toEqual(["get", "key", ["properties"]]);
   });
 
   it("has() serializes to property existence test", () => {
@@ -123,47 +119,21 @@ describe("Lookup expressions", () => {
   });
 
   it("at() serializes to array index access", () => {
-    expect(at(0, literal([1, 2, 3])).toJSON()).toEqual([
-      "at",
-      0,
-      ["literal", [1, 2, 3]],
-    ]);
+    expect(at(0, literal([1, 2, 3])).toJSON()).toEqual(["at", 0, ["literal", [1, 2, 3]]]);
   });
 
   it("contains() serializes to 'in' expression", () => {
-    expect(contains("a", get("tags")).toJSON()).toEqual([
-      "in",
-      "a",
-      ["get", "tags"],
-    ]);
+    expect(contains("a", get("tags")).toJSON()).toEqual(["in", "a", ["get", "tags"]]);
   });
 
   it("indexOf() serializes with optional fromIndex", () => {
-    expect(indexOf("x", get("name")).toJSON()).toEqual([
-      "index-of",
-      "x",
-      ["get", "name"],
-    ]);
-    expect(indexOf("x", get("name"), 2).toJSON()).toEqual([
-      "index-of",
-      "x",
-      ["get", "name"],
-      2,
-    ]);
+    expect(indexOf("x", get("name")).toJSON()).toEqual(["index-of", "x", ["get", "name"]]);
+    expect(indexOf("x", get("name"), 2).toJSON()).toEqual(["index-of", "x", ["get", "name"], 2]);
   });
 
   it("slice() serializes with optional end", () => {
-    expect(slice(get("name"), 0, 3).toJSON()).toEqual([
-      "slice",
-      ["get", "name"],
-      0,
-      3,
-    ]);
-    expect(slice(get("name"), 1).toJSON()).toEqual([
-      "slice",
-      ["get", "name"],
-      1,
-    ]);
+    expect(slice(get("name"), 0, 3).toJSON()).toEqual(["slice", ["get", "name"], 0, 3]);
+    expect(slice(get("name"), 1).toJSON()).toEqual(["slice", ["get", "name"], 1]);
   });
 
   it("length() serializes to length expression", () => {
@@ -196,33 +166,19 @@ describe("Type coercion expressions", () => {
   });
 
   it("toBoolean() serializes to to-boolean", () => {
-    expect(toBoolean(get("active")).toJSON()).toEqual([
-      "to-boolean",
-      ["get", "active"],
-    ]);
+    expect(toBoolean(get("active")).toJSON()).toEqual(["to-boolean", ["get", "active"]]);
   });
 
   it("toNumber() accepts variadic fallbacks", () => {
-    expect(toNumber(get("val"), 0).toJSON()).toEqual([
-      "to-number",
-      ["get", "val"],
-      0,
-    ]);
+    expect(toNumber(get("val"), 0).toJSON()).toEqual(["to-number", ["get", "val"], 0]);
   });
 
   it("exprToString() serializes to to-string", () => {
-    expect(exprToString(get("id")).toJSON()).toEqual([
-      "to-string",
-      ["get", "id"],
-    ]);
+    expect(exprToString(get("id")).toJSON()).toEqual(["to-string", ["get", "id"]]);
   });
 
   it("toColor() accepts variadic fallbacks", () => {
-    expect(toColor(get("color"), "#000").toJSON()).toEqual([
-      "to-color",
-      ["get", "color"],
-      "#000",
-    ]);
+    expect(toColor(get("color"), "#000").toJSON()).toEqual(["to-color", ["get", "color"], "#000"]);
   });
 
   it("typeOf() serializes to typeof", () => {
@@ -232,39 +188,15 @@ describe("Type coercion expressions", () => {
 
 describe("Comparison expressions", () => {
   it("eq/neq serialize to ==/!=", () => {
-    expect(eq(get("type"), "park").toJSON()).toEqual([
-      "==",
-      ["get", "type"],
-      "park",
-    ]);
-    expect(neq(get("type"), "park").toJSON()).toEqual([
-      "!=",
-      ["get", "type"],
-      "park",
-    ]);
+    expect(eq(get("type"), "park").toJSON()).toEqual(["==", ["get", "type"], "park"]);
+    expect(neq(get("type"), "park").toJSON()).toEqual(["!=", ["get", "type"], "park"]);
   });
 
   it("lt/lte/gt/gte serialize to comparison operators", () => {
-    expect(lt(get("pop"), 1000).toJSON()).toEqual([
-      "<",
-      ["get", "pop"],
-      1000,
-    ]);
-    expect(lte(get("pop"), 1000).toJSON()).toEqual([
-      "<=",
-      ["get", "pop"],
-      1000,
-    ]);
-    expect(gt(get("pop"), 1000).toJSON()).toEqual([
-      ">",
-      ["get", "pop"],
-      1000,
-    ]);
-    expect(gte(get("pop"), 1000).toJSON()).toEqual([
-      ">=",
-      ["get", "pop"],
-      1000,
-    ]);
+    expect(lt(get("pop"), 1000).toJSON()).toEqual(["<", ["get", "pop"], 1000]);
+    expect(lte(get("pop"), 1000).toJSON()).toEqual(["<=", ["get", "pop"], 1000]);
+    expect(gt(get("pop"), 1000).toJSON()).toEqual([">", ["get", "pop"], 1000]);
+    expect(gte(get("pop"), 1000).toJSON()).toEqual([">=", ["get", "pop"], 1000]);
   });
 });
 
@@ -274,15 +206,11 @@ describe("Logic expressions", () => {
   });
 
   it("all() serializes variadic boolean inputs", () => {
-    expect(
-      all(has("name"), gt(get("pop"), 0)).toJSON(),
-    ).toEqual(["all", ["has", "name"], [">", ["get", "pop"], 0]]);
+    expect(all(has("name"), gt(get("pop"), 0)).toJSON()).toEqual(["all", ["has", "name"], [">", ["get", "pop"], 0]]);
   });
 
   it("any() serializes variadic boolean inputs", () => {
-    expect(
-      any(eq(get("type"), "park"), eq(get("type"), "garden")).toJSON(),
-    ).toEqual([
+    expect(any(eq(get("type"), "park"), eq(get("type"), "garden")).toJSON()).toEqual([
       "any",
       ["==", ["get", "type"], "park"],
       ["==", ["get", "type"], "garden"],
@@ -292,11 +220,7 @@ describe("Logic expressions", () => {
 
 describe("Decision expressions", () => {
   it("switchCase() serializes branches and fallback", () => {
-    const result = switchCase(
-      [gt(get("pop"), 1_000_000), "large"],
-      [gt(get("pop"), 100_000), "medium"],
-      "small",
-    );
+    const result = switchCase([gt(get("pop"), 1_000_000), "large"], [gt(get("pop"), 100_000), "medium"], "small");
     expect(result.toJSON()).toEqual([
       "case",
       [">", ["get", "pop"], 1000000],
@@ -308,12 +232,7 @@ describe("Decision expressions", () => {
   });
 
   it("matchExpr() serializes scalar and array labels", () => {
-    const result = matchExpr(
-      get("type"),
-      ["residential", "#0f0"],
-      [["commercial", "retail"], "#00f"],
-      "#888",
-    );
+    const result = matchExpr(get("type"), ["residential", "#0f0"], [["commercial", "retail"], "#00f"], "#888");
     expect(result.toJSON()).toEqual([
       "match",
       ["get", "type"],
@@ -326,20 +245,14 @@ describe("Decision expressions", () => {
   });
 
   it("coalesce() serializes variadic expressions", () => {
-    expect(
-      coalesce(get("name_en"), get("name")).toJSON(),
-    ).toEqual(["coalesce", ["get", "name_en"], ["get", "name"]]);
+    expect(coalesce(get("name_en"), get("name")).toJSON()).toEqual(["coalesce", ["get", "name_en"], ["get", "name"]]);
   });
 });
 
 describe("Math expressions", () => {
   it("add/multiply accept variadic inputs", () => {
     expect(add(1, 2, 3).toJSON()).toEqual(["+", 1, 2, 3]);
-    expect(multiply(get("a"), get("b")).toJSON()).toEqual([
-      "*",
-      ["get", "a"],
-      ["get", "b"],
-    ]);
+    expect(multiply(get("a"), get("b")).toJSON()).toEqual(["*", ["get", "a"], ["get", "b"]]);
   });
 
   it("subtract() supports negation (1 arg) and subtraction (2 args)", () => {
@@ -387,11 +300,7 @@ describe("Math expressions", () => {
 
 describe("String expressions", () => {
   it("concat() serializes variadic inputs", () => {
-    expect(concat("Hello ", get("name")).toJSON()).toEqual([
-      "concat",
-      "Hello ",
-      ["get", "name"],
-    ]);
+    expect(concat("Hello ", get("name")).toJSON()).toEqual(["concat", "Hello ", ["get", "name"]]);
   });
 
   it("upcase/downcase serialize correctly", () => {
@@ -406,121 +315,39 @@ describe("Color expressions", () => {
   });
 
   it("rgba() serializes to four-component color", () => {
-    expect(rgba(255, 0, 128, 0.5).toJSON()).toEqual([
-      "rgba",
-      255,
-      0,
-      128,
-      0.5,
-    ]);
+    expect(rgba(255, 0, 128, 0.5).toJSON()).toEqual(["rgba", 255, 0, 128, 0.5]);
   });
 });
 
 describe("Interpolation", () => {
   it("step() serializes with default and stops", () => {
-    const result = step(
-      get("population"),
-      "#f7fbff",
-      [10_000, "#6baed6"],
-      [100_000, "#08306b"],
-    );
-    expect(result.toJSON()).toEqual([
-      "step",
-      ["get", "population"],
-      "#f7fbff",
-      10000,
-      "#6baed6",
-      100000,
-      "#08306b",
-    ]);
+    const result = step(get("population"), "#f7fbff", [10_000, "#6baed6"], [100_000, "#08306b"]);
+    expect(result.toJSON()).toEqual(["step", ["get", "population"], "#f7fbff", 10000, "#6baed6", 100000, "#08306b"]);
   });
 
   it("interpolate() serializes with method, input, and stops", () => {
-    const result = interpolate(
-      linear(),
-      zoom(),
-      [0, 0],
-      [10, 1],
-      [20, 5],
-    );
-    expect(result.toJSON()).toEqual([
-      "interpolate",
-      ["linear"],
-      ["zoom"],
-      0,
-      0,
-      10,
-      1,
-      20,
-      5,
-    ]);
+    const result = interpolate(linear(), zoom(), [0, 0], [10, 1], [20, 5]);
+    expect(result.toJSON()).toEqual(["interpolate", ["linear"], ["zoom"], 0, 0, 10, 1, 20, 5]);
   });
 
   it("interpolate() with exponential method", () => {
     const result = interpolate(exponential(1.5), zoom(), [5, 1], [18, 20]);
-    expect(result.toJSON()).toEqual([
-      "interpolate",
-      ["exponential", 1.5],
-      ["zoom"],
-      5,
-      1,
-      18,
-      20,
-    ]);
+    expect(result.toJSON()).toEqual(["interpolate", ["exponential", 1.5], ["zoom"], 5, 1, 18, 20]);
   });
 
   it("interpolate() with cubic-bezier method", () => {
-    const result = interpolate(
-      cubicBezier(0.42, 0, 0.58, 1),
-      zoom(),
-      [0, 0],
-      [22, 100],
-    );
-    expect(result.toJSON()).toEqual([
-      "interpolate",
-      ["cubic-bezier", 0.42, 0, 0.58, 1],
-      ["zoom"],
-      0,
-      0,
-      22,
-      100,
-    ]);
+    const result = interpolate(cubicBezier(0.42, 0, 0.58, 1), zoom(), [0, 0], [22, 100]);
+    expect(result.toJSON()).toEqual(["interpolate", ["cubic-bezier", 0.42, 0, 0.58, 1], ["zoom"], 0, 0, 22, 100]);
   });
 
   it("interpolateHcl() serializes with interpolate-hcl operator", () => {
-    const result = interpolateHcl(
-      linear(),
-      get("value"),
-      [0, "#ff0000"],
-      [100, "#0000ff"],
-    );
-    expect(result.toJSON()).toEqual([
-      "interpolate-hcl",
-      ["linear"],
-      ["get", "value"],
-      0,
-      "#ff0000",
-      100,
-      "#0000ff",
-    ]);
+    const result = interpolateHcl(linear(), get("value"), [0, "#ff0000"], [100, "#0000ff"]);
+    expect(result.toJSON()).toEqual(["interpolate-hcl", ["linear"], ["get", "value"], 0, "#ff0000", 100, "#0000ff"]);
   });
 
   it("interpolateLab() serializes with interpolate-lab operator", () => {
-    const result = interpolateLab(
-      linear(),
-      get("value"),
-      [0, "#ff0000"],
-      [100, "#0000ff"],
-    );
-    expect(result.toJSON()).toEqual([
-      "interpolate-lab",
-      ["linear"],
-      ["get", "value"],
-      0,
-      "#ff0000",
-      100,
-      "#0000ff",
-    ]);
+    const result = interpolateLab(linear(), get("value"), [0, "#ff0000"], [100, "#0000ff"]);
+    expect(result.toJSON()).toEqual(["interpolate-lab", ["linear"], ["get", "value"], 0, "#ff0000", 100, "#0000ff"]);
   });
 });
 
@@ -532,10 +359,7 @@ describe("Zoom expression", () => {
 
 describe("Variable binding", () => {
   it("let/var serialize to variable binding", () => {
-    const result = letExpr(
-      { x: get("population"), y: 1000 },
-      multiply(varExpr("x"), varExpr("y")),
-    );
+    const result = letExpr({ x: get("population"), y: 1000 }, multiply(varExpr("x"), varExpr("y")));
     const json = result.toJSON() as unknown[];
     expect(json[0]).toBe("let");
     expect(json).toContain("x");
@@ -574,10 +398,7 @@ describe("Spatial expressions", () => {
   };
 
   it("distance() serializes with GeoJSON geometry", () => {
-    expect(distance(point).toJSON()).toEqual([
-      "distance",
-      { type: "Point", coordinates: [-122.4194, 37.7749] },
-    ]);
+    expect(distance(point).toJSON()).toEqual(["distance", { type: "Point", coordinates: [-122.4194, 37.7749] }]);
   });
 
   it("within() serializes with GeoJSON polygon", () => {
@@ -617,10 +438,7 @@ describe("Spatial expressions", () => {
   });
 
   it("distance() accepts an expression input", () => {
-    expect(distance(get("target_geom")).toJSON()).toEqual([
-      "distance",
-      ["get", "target_geom"],
-    ]);
+    expect(distance(get("target_geom")).toJSON()).toEqual(["distance", ["get", "target_geom"]]);
   });
 
   it("spatial operators are accessible on expr namespace", () => {
@@ -643,31 +461,15 @@ describe("Spatial expressions", () => {
 
 describe("Composition (design doc examples)", () => {
   it("reproduces the step + featureState hover pattern from the design doc", () => {
-    const fillColor = expr.step(
-      expr.get("assessed_value"),
-      "#f7fbff",
-      [100_000, "#6baed6"],
-      [500_000, "#08306b"],
-    );
+    const fillColor = expr.step(expr.get("assessed_value"), "#f7fbff", [100_000, "#6baed6"], [500_000, "#08306b"]);
 
-    const hoverColor = expr.case(
-      [expr.featureState("hover"), "#ff0"],
-      fillColor,
-    );
+    const hoverColor = expr.case([expr.featureState("hover"), "#ff0"], fillColor);
 
     expect(hoverColor.toJSON()).toEqual([
       "case",
       ["feature-state", "hover"],
       "#ff0",
-      [
-        "step",
-        ["get", "assessed_value"],
-        "#f7fbff",
-        100000,
-        "#6baed6",
-        500000,
-        "#08306b",
-      ],
+      ["step", ["get", "assessed_value"], "#f7fbff", 100000, "#6baed6", 500000, "#08306b"],
     ]);
   });
 

--- a/test/feature-layer-compat.test.ts
+++ b/test/feature-layer-compat.test.ts
@@ -4,18 +4,14 @@ import { CompatEventBus, FeatureLayerCompat, parseFeatureLayerUrl } from "../src
 
 describe("parseFeatureLayerUrl", () => {
   it("parses canonical feature layer URL", () => {
-    const parsed = parseFeatureLayerUrl(
-      "https://example.test/rest/services/transport/FeatureServer/3",
-    );
+    const parsed = parseFeatureLayerUrl("https://example.test/rest/services/transport/FeatureServer/3");
     expect(parsed.baseUrl).toBe("https://example.test");
     expect(parsed.serviceId).toBe("transport");
     expect(parsed.layerId).toBe(3);
   });
 
   it("parses URL with path prefix", () => {
-    const parsed = parseFeatureLayerUrl(
-      "https://example.test/honua/rest/services/transport/FeatureServer/8",
-    );
+    const parsed = parseFeatureLayerUrl("https://example.test/honua/rest/services/transport/FeatureServer/8");
     expect(parsed.baseUrl).toBe("https://example.test/honua");
     expect(parsed.serviceId).toBe("transport");
     expect(parsed.layerId).toBe(8);
@@ -36,9 +32,7 @@ describe("parseFeatureLayerUrl", () => {
   });
 
   it("throws on invalid URL shape", () => {
-    expect(() =>
-      parseFeatureLayerUrl("https://example.test/rest/services/transport/MapServer"),
-    ).toThrow();
+    expect(() => parseFeatureLayerUrl("https://example.test/rest/services/transport/MapServer")).toThrow();
   });
 });
 
@@ -70,9 +64,9 @@ describe("FeatureLayerCompat", () => {
     });
 
     expect(result).toEqual({ features: [] });
-    expect(requestedUrl).toContain("\"serviceId\":\"default\"");
-    expect(requestedUrl).toContain("\"layerId\":1000");
-    expect(requestedUrl).toContain("\"where\":\"1=1\"");
+    expect(requestedUrl).toContain('"serviceId":"default"');
+    expect(requestedUrl).toContain('"layerId":1000');
+    expect(requestedUrl).toContain('"where":"1=1"');
   });
 
   it("supports relative service URLs with default client requests", async () => {

--- a/test/feature-state.test.ts
+++ b/test/feature-state.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
-  setFeatureState,
-  getFeatureState,
-  removeFeatureState,
   createHoverHandler,
   createSelectionHandler,
+  getFeatureState,
+  removeFeatureState,
+  setFeatureState,
 } from "../src/index.js";
 import type { InteractiveMap } from "../src/index.js";
 
@@ -59,7 +59,11 @@ function createMockMap(): InteractiveMap & {
       }
     },
 
-    off(event: string, layerOrHandler: string | ((...args: unknown[]) => void), handler?: (...args: unknown[]) => void) {
+    off(
+      event: string,
+      layerOrHandler: string | ((...args: unknown[]) => void),
+      handler?: (...args: unknown[]) => void,
+    ) {
       if (typeof layerOrHandler === "string" && handler) {
         const key = `${event}:${layerOrHandler}`;
         const list = handlers.get(key);

--- a/test/feature-table-compat.test.ts
+++ b/test/feature-table-compat.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { CompatEventBus, FeatureTableCompat } from "../src/index.js";
 import type { FeatureLayerCompat } from "../src/esri-compat/feature-layer.js";
+import { CompatEventBus, FeatureTableCompat } from "../src/index.js";
 
 describe("FeatureTableCompat", () => {
   it("supports when() and watch() for state/rows/filter changes", async () => {
@@ -70,8 +70,8 @@ describe("FeatureTableCompat", () => {
     const layer = {
       queryFeatures: async () => ({
         features: [
-          { attributes: { OBJECTID: 1, name: "A" }, geometry: { x: -157.85, y: 21.30 } },
-          { attributes: { OBJECTID: 2, name: "B" }, geometry: { x: -157.90, y: 21.31 } },
+          { attributes: { OBJECTID: 1, name: "A" }, geometry: { x: -157.85, y: 21.3 } },
+          { attributes: { OBJECTID: 2, name: "B" }, geometry: { x: -157.9, y: 21.31 } },
         ],
       }),
     } as unknown as FeatureLayerCompat;
@@ -165,9 +165,7 @@ describe("FeatureTableCompat", () => {
       queryRelatedFeatures: async (options: unknown) => {
         calls.push(options);
         return {
-          relatedRecordGroups: [
-            { objectId: 1, relatedRecords: [{ attributes: { OBJECTID: 101 } }] },
-          ],
+          relatedRecordGroups: [{ objectId: 1, relatedRecords: [{ attributes: { OBJECTID: 101 } }] }],
         };
       },
     } as unknown as FeatureLayerCompat;
@@ -422,9 +420,7 @@ describe("FeatureTableCompat", () => {
   it("exportRows filters to specified field names", async () => {
     const layer = {
       queryFeatures: async () => ({
-        features: [
-          { attributes: { OBJECTID: 1, name: "Alpha", status: "active", score: 100 }, geometry: null },
-        ],
+        features: [{ attributes: { OBJECTID: 1, name: "Alpha", status: "active", score: 100 }, geometry: null }],
       }),
     } as unknown as FeatureLayerCompat;
 

--- a/test/geocoding.test.ts
+++ b/test/geocoding.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { HonuaHttpError, HonuaNetworkError, HonuaTimeoutError } from "../src/core/errors.js";
 import {
-  HonuaGeocodingClient,
-  type GeocodeSuggestion,
   type GeocodeResult,
+  type GeocodeSuggestion,
+  HonuaGeocodingClient,
   type ReverseGeocodeResult,
-} from "./index.js";
-import { HonuaHttpError, HonuaNetworkError, HonuaTimeoutError } from "../core/errors.js";
+} from "../src/geocoding/index.js";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/test/geometry-primitives-compat.test.ts
+++ b/test/geometry-primitives-compat.test.ts
@@ -1,12 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  ExtentCompat,
-  PointCompat,
-  PolygonCompat,
-  PolylineCompat,
-  SpatialReferenceCompat,
-} from "../src/index.js";
+import { ExtentCompat, PointCompat, PolygonCompat, PolylineCompat, SpatialReferenceCompat } from "../src/index.js";
 
 describe("geometry primitives compat", () => {
   it("supports when() and watch() lifecycle for point and spatial reference", async () => {

--- a/test/geometry-symbol-compat.test.ts
+++ b/test/geometry-symbol-compat.test.ts
@@ -1,17 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  PointCompat,
-  SimpleFillSymbolCompat,
-  SimpleLineSymbolCompat,
-  SimpleMarkerSymbolCompat,
-} from "../src/index.js";
+import { PointCompat, SimpleFillSymbolCompat, SimpleLineSymbolCompat, SimpleMarkerSymbolCompat } from "../src/index.js";
 
 describe("geometry/symbol compat", () => {
   it("creates point geometry payloads", async () => {
     const point = new PointCompat({
       x: -157.81,
-      y: 21.30,
+      y: 21.3,
       spatialReference: { wkid: 4326 },
     });
     const xValues: unknown[] = [];

--- a/test/grpc-adapter.test.ts
+++ b/test/grpc-adapter.test.ts
@@ -1,30 +1,26 @@
-import { describe, expect, it } from "vitest";
 import { create } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+import { fromProtoQueryResponse, streamProtoPages, toProtoQueryRequest } from "../src/core/grpc-adapter.js";
 import {
-  toProtoQueryRequest,
-  fromProtoQueryResponse,
-  streamProtoPages,
-} from "../src/core/grpc-adapter.js";
-import {
-  QueryFeaturesResponseSchema,
+  AttributeValueSchema,
+  CoordinateSchema,
+  CoordinateSequenceSchema,
+  DistanceUnit,
+  ExtentSchema,
   FeaturePageSchema,
   FeatureSchema,
-  AttributeValueSchema,
-  GeometrySchema,
-  PointGeometrySchema,
-  PolylineGeometrySchema,
-  PolygonGeometrySchema,
-  MultiPointGeometrySchema,
-  CoordinateSequenceSchema,
-  CoordinateSchema,
-  SpatialReferenceSchema,
   FieldDefinitionSchema,
-  ExtentSchema,
   FieldType,
+  GeometrySchema,
   GeometryType,
+  MultiPointGeometrySchema,
   NullValue,
+  PointGeometrySchema,
+  PolygonGeometrySchema,
+  PolylineGeometrySchema,
+  QueryFeaturesResponseSchema,
+  SpatialReferenceSchema,
   SpatialRelationship,
-  DistanceUnit,
   StatisticType,
 } from "../src/gen/honua/v1/feature_service_pb.js";
 
@@ -446,7 +442,12 @@ describe("fromProtoQueryResponse", () => {
     const result = fromProtoQueryResponse(response) as any;
 
     expect(result.features[0].geometry).toEqual({
-      paths: [[[0, 0], [10, 10]]],
+      paths: [
+        [
+          [0, 0],
+          [10, 10],
+        ],
+      ],
     });
   });
 
@@ -458,7 +459,11 @@ describe("fromProtoQueryResponse", () => {
     const polygon = create(PolygonGeometrySchema);
     const ring = create(CoordinateSequenceSchema);
     const coords = [
-      [0, 0], [10, 0], [10, 10], [0, 10], [0, 0],
+      [0, 0],
+      [10, 0],
+      [10, 10],
+      [0, 10],
+      [0, 0],
     ].map(([x, y]) => {
       const c = create(CoordinateSchema);
       c.x = x;
@@ -478,7 +483,15 @@ describe("fromProtoQueryResponse", () => {
     const result = fromProtoQueryResponse(response) as any;
 
     expect(result.features[0].geometry).toEqual({
-      rings: [[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]],
+      rings: [
+        [
+          [0, 0],
+          [10, 0],
+          [10, 10],
+          [0, 10],
+          [0, 0],
+        ],
+      ],
     });
   });
 
@@ -506,7 +519,10 @@ describe("fromProtoQueryResponse", () => {
     const result = fromProtoQueryResponse(response) as any;
 
     expect(result.features[0].geometry).toEqual({
-      points: [[1, 2], [3, 4]],
+      points: [
+        [1, 2],
+        [3, 4],
+      ],
     });
   });
 

--- a/test/honua-dual-protocol-runtime.test.ts
+++ b/test/honua-dual-protocol-runtime.test.ts
@@ -1,7 +1,7 @@
+import { execSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { execSync } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -68,20 +68,14 @@ describe("honua dual protocol runtime", () => {
     const entryPath = path.join(workingCopy, "src", "main.js");
     const source = fs.readFileSync(entryPath, "utf8");
     const honuaEntryHref = pathToFileURL(honuaDistEntry()).href;
-    fs.writeFileSync(
-      entryPath,
-      source.replace("__HONUA_ENTRY__", honuaEntryHref),
-      "utf8",
-    );
+    fs.writeFileSync(entryPath, source.replace("__HONUA_ENTRY__", honuaEntryHref), "utf8");
 
     const requests: Array<{ url: string; method: string; body?: string }> = [];
     (globalThis as Record<string, unknown>).__honuaFetchFn = async (
       input: string | URL | Request,
       init?: RequestInit,
     ): Promise<Response> => {
-      const requestUrl = new URL(
-        typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
-      );
+      const requestUrl = new URL(typeof input === "string" ? input : input instanceof URL ? input.href : input.url);
       const method = String(init?.method ?? "GET").toUpperCase();
       requests.push({
         url: requestUrl.href,
@@ -197,22 +191,14 @@ describe("honua dual protocol runtime", () => {
       ogcDeleteStatus: "deleted",
     });
 
-    expect(
-      requests.some((request) =>
-        request.url.includes("/rest/services/transport/FeatureServer/0/query"),
-      ),
-    ).toBe(true);
-    expect(
-      requests.some((request) => request.url.includes("/rest/services/transport/MapServer/legend")),
-    ).toBe(true);
-    expect(
-      requests.some((request) => request.url.includes("/ogc/features/collections/parcels/items?")),
-    ).toBe(true);
+    expect(requests.some((request) => request.url.includes("/rest/services/transport/FeatureServer/0/query"))).toBe(
+      true,
+    );
+    expect(requests.some((request) => request.url.includes("/rest/services/transport/MapServer/legend"))).toBe(true);
+    expect(requests.some((request) => request.url.includes("/ogc/features/collections/parcels/items?"))).toBe(true);
 
     const createCall = requests.find(
-      (request) =>
-        request.method === "POST" &&
-        request.url.includes("/ogc/features/collections/parcels/items"),
+      (request) => request.method === "POST" && request.url.includes("/ogc/features/collections/parcels/items"),
     );
     expect(createCall).toBeDefined();
     expect(createCall?.body).toContain('"source":"dual-protocol-fixture"');
@@ -220,8 +206,7 @@ describe("honua dual protocol runtime", () => {
     expect(
       requests.some(
         (request) =>
-          request.method === "DELETE" &&
-          request.url.includes("/ogc/features/collections/parcels/items/parcel-3"),
+          request.method === "DELETE" && request.url.includes("/ogc/features/collections/parcels/items/parcel-3"),
       ),
     ).toBe(true);
   });

--- a/test/honua-map.test.ts
+++ b/test/honua-map.test.ts
@@ -1,16 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
-import {
-  HonuaMap,
-  HonuaClient,
-  HonuaFeatureLayer,
-  HonuaMapService,
-} from "../src/index.js";
 import { HonuaOgcFeatureCollection } from "../src/core/surfaces.js";
-import type {
-  HonuaStyleSpecification,
-  HonuaMapEvent,
-} from "../src/index.js";
+import { HonuaClient, HonuaFeatureLayer, HonuaMap, HonuaMapService } from "../src/index.js";
+import type { HonuaMapEvent, HonuaStyleSpecification } from "../src/index.js";
 
 const client = new HonuaClient({ baseUrl: "https://gis.example.com" });
 
@@ -52,9 +44,7 @@ describe("HonuaMap — source management", () => {
 
     const source = map.getSource("boundaries");
     expect(source).toBeInstanceOf(HonuaOgcFeatureCollection);
-    expect((source as HonuaOgcFeatureCollection).collectionId).toBe(
-      "admin-boundaries",
-    );
+    expect((source as HonuaOgcFeatureCollection).collectionId).toBe("admin-boundaries");
   });
 
   it("adds a native MapLibre source and resolves to null", () => {
@@ -142,9 +132,9 @@ describe("HonuaMap — layer management", () => {
 
   it("throws when referencing a non-existent source", () => {
     const map = new HonuaMap({ client });
-    expect(() =>
-      map.addLayer({ id: "bad", source: "missing", type: "fill" }),
-    ).toThrow('source "missing" does not exist');
+    expect(() => map.addLayer({ id: "bad", source: "missing", type: "fill" })).toThrow(
+      'source "missing" does not exist',
+    );
   });
 
   it("throws when adding a duplicate layer ID", () => {
@@ -154,9 +144,7 @@ describe("HonuaMap — layer management", () => {
       url: "https://gis.example.com/rest/services/s/FeatureServer/0",
     });
     map.addLayer({ id: "l", source: "s", type: "fill" });
-    expect(() => map.addLayer({ id: "l", source: "s", type: "line" })).toThrow(
-      'Layer "l" already exists',
-    );
+    expect(() => map.addLayer({ id: "l", source: "s", type: "line" })).toThrow('Layer "l" already exists');
   });
 
   it("inserts a layer before another", () => {
@@ -178,9 +166,7 @@ describe("HonuaMap — layer management", () => {
       type: "honua-feature-service",
       url: "https://gis.example.com/rest/services/s/FeatureServer/0",
     });
-    expect(() =>
-      map.addLayer({ id: "l", source: "s", type: "fill" }, "ghost"),
-    ).toThrow('Cannot insert before "ghost"');
+    expect(() => map.addLayer({ id: "l", source: "s", type: "fill" }, "ghost")).toThrow('Cannot insert before "ghost"');
   });
 
   it("removes a layer by ID", () => {
@@ -371,9 +357,7 @@ describe("HonuaMap — events", () => {
 
     map.moveLayer("b", "a");
 
-    expect(events).toEqual([
-      { type: "layer-moved", layerId: "b", beforeId: "a" },
-    ]);
+    expect(events).toEqual([{ type: "layer-moved", layerId: "b", beforeId: "a" }]);
   });
 
   it("on() returns a removable handle", () => {

--- a/test/honua-mixed-composition-runtime.test.ts
+++ b/test/honua-mixed-composition-runtime.test.ts
@@ -376,11 +376,7 @@ describe("honua mixed composition runtime (E2E, 4 protocols)", () => {
 
       // Failed source absent from composedStyle.sources and from
       // composedStyle.layers; the rest of the composition keeps rendering.
-      expect(Object.keys(runtime.composedStyle.sources).sort()).toEqual([
-        "basemap-tiles",
-        "imagery",
-        "ogc-overlay",
-      ]);
+      expect(Object.keys(runtime.composedStyle.sources).sort()).toEqual(["basemap-tiles", "imagery", "ogc-overlay"]);
       const layerIds = runtime.composedStyle.layers.map((l) => l.id).sort();
       expect(layerIds).not.toContain("parcels-fill");
       expect(layerIds).toEqual(["background", "basemap-line", "imagery-raster", "ogc-circle"]);

--- a/test/honua-surface.test.ts
+++ b/test/honua-surface.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  createHonuaOgcFeatures,
-  createHonuaService,
   HonuaClient,
   HonuaFeatureLayer,
   HonuaMapLayer,
@@ -10,6 +8,8 @@ import {
   HonuaOgcFeatureCollection,
   HonuaOgcFeatures,
   HonuaService,
+  createHonuaOgcFeatures,
+  createHonuaService,
 } from "../src/index.js";
 
 describe("Honua native API surfaces", () => {
@@ -122,16 +122,10 @@ describe("Honua native API surfaces", () => {
         requestedOffsets.push(offset);
 
         if (offset === 0) {
-          return new Response(
-            JSON.stringify({ features: [{ id: 1 }, { id: 2 }] }),
-            { status: 200 },
-          );
+          return new Response(JSON.stringify({ features: [{ id: 1 }, { id: 2 }] }), { status: 200 });
         }
         if (offset === 2) {
-          return new Response(
-            JSON.stringify({ features: [{ id: 3 }] }),
-            { status: 200 },
-          );
+          return new Response(JSON.stringify({ features: [{ id: 3 }] }), { status: 200 });
         }
         return new Response(JSON.stringify({ features: [] }), { status: 200 });
       },
@@ -247,10 +241,9 @@ describe("Honua native API surfaces", () => {
           return new Response(JSON.stringify({ objectIds: [3, "4", "bad", 5] }), { status: 200 });
         }
         if (parsed.searchParams.get("returnExtentOnly") === "true") {
-          return new Response(
-            JSON.stringify({ extent: { xmin: 0, ymin: 0, xmax: 5, ymax: 5 }, count: 6 }),
-            { status: 200 },
-          );
+          return new Response(JSON.stringify({ extent: { xmin: 0, ymin: 0, xmax: 5, ymax: 5 }, count: 6 }), {
+            status: 200,
+          });
         }
         return new Response(JSON.stringify({ features: [] }), { status: 200 });
       },
@@ -317,10 +310,9 @@ describe("Honua native API surfaces", () => {
       baseUrl: "https://example.test",
       fetchFn: async (input) => {
         requestedUrls.push(String(input));
-        return new Response(
-          JSON.stringify({ relatedRecordGroups: [{ objectId: 1, relatedRecords: [] }] }),
-          { status: 200 },
-        );
+        return new Response(JSON.stringify({ relatedRecordGroups: [{ objectId: 1, relatedRecords: [] }] }), {
+          status: 200,
+        });
       },
     });
 
@@ -366,10 +358,7 @@ describe("Honua native API surfaces", () => {
     const client = new HonuaClient({
       baseUrl: "https://example.test",
       fetchFn: async () =>
-        new Response(
-          JSON.stringify({ layers: [{ id: 0 }, { id: "1" }, { id: "bad" }] }),
-          { status: 200 },
-        ),
+        new Response(JSON.stringify({ layers: [{ id: 0 }, { id: "1" }, { id: "bad" }] }), { status: 200 }),
     });
 
     const mapService = client.mapService("basemap");
@@ -392,16 +381,10 @@ describe("Honua native API surfaces", () => {
         const url = String(input);
         requests.push(url);
         if (url.includes("/FeatureServer?")) {
-          return new Response(
-            JSON.stringify({ layers: [{ id: 0 }, { id: "1" }, { id: "bad" }] }),
-            { status: 200 },
-          );
+          return new Response(JSON.stringify({ layers: [{ id: 0 }, { id: "1" }, { id: "bad" }] }), { status: 200 });
         }
         if (url.includes("/MapServer?")) {
-          return new Response(
-            JSON.stringify({ layers: [{ id: 4 }, { id: "5" }, { id: "bad" }] }),
-            { status: 200 },
-          );
+          return new Response(JSON.stringify({ layers: [{ id: 4 }, { id: "5" }, { id: "bad" }] }), { status: 200 });
         }
         return new Response(JSON.stringify({ layers: [] }), { status: 200 });
       },
@@ -445,10 +428,9 @@ describe("Honua native API surfaces", () => {
           return new Response(JSON.stringify({ objectIds: [10, "11", "bad"] }), { status: 200 });
         }
         if (parsed.searchParams.get("returnExtentOnly") === "true") {
-          return new Response(
-            JSON.stringify({ extent: { xmin: 1, ymin: 2, xmax: 3, ymax: 4 }, count: 9 }),
-            { status: 200 },
-          );
+          return new Response(JSON.stringify({ extent: { xmin: 1, ymin: 2, xmax: 3, ymax: 4 }, count: 9 }), {
+            status: 200,
+          });
         }
         return new Response(JSON.stringify({ features: [{ id: 1 }] }), { status: 200 });
       },
@@ -688,9 +670,7 @@ describe("Honua native API surfaces", () => {
         const limit = Number.parseInt(url.searchParams.get("limit") ?? "10", 10);
         const offset = Number.parseInt(url.searchParams.get("offset") ?? "0", 10);
         const data =
-          collectionId === "3"
-            ? [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }]
-            : [{ id: "a" }, { id: "b" }, { id: "c" }];
+          collectionId === "3" ? [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }] : [{ id: "a" }, { id: "b" }, { id: "c" }];
         const page = data.slice(offset, offset + limit);
         return new Response(JSON.stringify({ features: page }), { status: 200 });
       },
@@ -762,14 +742,16 @@ describe("Honua native API surfaces", () => {
     const seenRequests: unknown[] = [];
     const signal = new AbortController().signal;
 
-    (client as unknown as {
-      queryFeaturesStream: (request: unknown) => AsyncGenerator<unknown[], void, undefined>;
-    }).queryFeaturesStream = (async function* (request: unknown) {
+    (
+      client as unknown as {
+        queryFeaturesStream: (request: unknown) => AsyncGenerator<unknown[], void, undefined>;
+      }
+    ).queryFeaturesStream = async function* (request: unknown) {
       seenRequests.push(request);
       yield [{ id: 1 }];
       yield [{ id: 2 }];
       yield [{ id: 3 }];
-    }) as (request: unknown) => AsyncGenerator<unknown[], void, undefined>;
+    } as (request: unknown) => AsyncGenerator<unknown[], void, undefined>;
 
     const layer = client.featureLayer("transport", 4);
     const pages: unknown[][] = [];
@@ -837,8 +819,7 @@ describe("Honua native API surfaces", () => {
   it("queryFeaturesStream stops on empty page", async () => {
     const client = new HonuaClient({
       baseUrl: "https://example.test",
-      fetchFn: async () =>
-        new Response(JSON.stringify({ features: [] }), { status: 200 }),
+      fetchFn: async () => new Response(JSON.stringify({ features: [] }), { status: 200 }),
     });
 
     const layer = client.featureLayer("transport", 4);
@@ -853,8 +834,7 @@ describe("Honua native API surfaces", () => {
   it("queryFeaturesStream stops on partial page", async () => {
     const client = new HonuaClient({
       baseUrl: "https://example.test",
-      fetchFn: async () =>
-        new Response(JSON.stringify({ features: [{ id: 1 }] }), { status: 200 }),
+      fetchFn: async () => new Response(JSON.stringify({ features: [{ id: 1 }] }), { status: 200 }),
     });
 
     const layer = client.featureLayer("transport", 4);
@@ -869,8 +849,7 @@ describe("Honua native API surfaces", () => {
   it("queryFeaturesStream stops at maxPages limit", async () => {
     const client = new HonuaClient({
       baseUrl: "https://example.test",
-      fetchFn: async () =>
-        new Response(JSON.stringify({ features: [{ id: 1 }, { id: 2 }] }), { status: 200 }),
+      fetchFn: async () => new Response(JSON.stringify({ features: [{ id: 1 }, { id: 2 }] }), { status: 200 }),
     });
 
     const layer = client.featureLayer("transport", 4);
@@ -947,10 +926,7 @@ describe("Honua native API surfaces", () => {
       pages.push(page);
     }
 
-    expect(pages).toEqual([
-      [{ id: 10 }, { id: 11 }],
-      [{ id: 12 }],
-    ]);
+    expect(pages).toEqual([[{ id: 10 }, { id: 11 }], [{ id: 12 }]]);
   });
 
   it("OGC collection itemsStream yields pages", async () => {
@@ -975,9 +951,6 @@ describe("Honua native API surfaces", () => {
       pages.push(page);
     }
 
-    expect(pages).toEqual([
-      [{ id: "a" }, { id: "b" }],
-      [{ id: "c" }],
-    ]);
+    expect(pages).toEqual([[{ id: "a" }, { id: "b" }], [{ id: "c" }]]);
   });
 });

--- a/test/layer-list-compat.test.ts
+++ b/test/layer-list-compat.test.ts
@@ -107,9 +107,7 @@ describe("LayerListCompat", () => {
     layerList.on("trigger-action", (event) => {
       actionEvents.push(event);
     });
-    expect(
-      layerList.setItemActions(1, [[{ id: "zoom-to", title: "Zoom To Layer" }]]),
-    ).toBe(true);
+    expect(layerList.setItemActions(1, [[{ id: "zoom-to", title: "Zoom To Layer" }]])).toBe(true);
     expect(layerList.triggerAction("zoom-to", 1)).toBe(true);
     expect(layerList.toggle(1, false)).toBe(true);
     expect(mapImage.sublayer(1)?.visible).toBe(false);

--- a/test/map-view-compat.test.ts
+++ b/test/map-view-compat.test.ts
@@ -326,13 +326,7 @@ describe("MapViewCompat", () => {
     });
     expect(view.center).toEqual({ x: 2, y: 2, spatialReference: undefined });
 
-    await view.goTo(
-      [
-        { geometry: { x: -3, y: 5 } },
-        { geometry: { x: 7, y: 9 } },
-      ],
-      { animate: false, duration: 1200 },
-    );
+    await view.goTo([{ geometry: { x: -3, y: 5 } }, { geometry: { x: 7, y: 9 } }], { animate: false, duration: 1200 });
     expect(view.extent).toEqual({
       xmin: -3,
       ymin: 5,
@@ -346,10 +340,7 @@ describe("MapViewCompat", () => {
     expect(view.center).toEqual([30, 40]);
 
     expect(events).toContainEqual({
-      target: [
-        { geometry: { x: -3, y: 5 } },
-        { geometry: { x: 7, y: 9 } },
-      ],
+      target: [{ geometry: { x: -3, y: 5 } }, { geometry: { x: 7, y: 9 } }],
       options: { animate: false, duration: 1200 },
     });
   });
@@ -676,10 +667,9 @@ describe("MapViewCompat", () => {
     expect(hasAllFeaturesInViewValues).toEqual([false]);
 
     const highlightA = layerViewA.highlight({ attributes: { OBJECTID: 101 } });
-    const highlightB = layerViewA.highlight(
-      [{ attributes: { OBJECTID: 102 } }, { attributes: { OBJECTID: 103 } }],
-      { name: "selection" },
-    );
+    const highlightB = layerViewA.highlight([{ attributes: { OBJECTID: 102 } }, { attributes: { OBJECTID: 103 } }], {
+      name: "selection",
+    });
     expect(layerViewA.highlights).toHaveLength(2);
     highlightA.remove();
     expect(layerViewA.highlights).toHaveLength(1);

--- a/test/measurement-2d-compat.test.ts
+++ b/test/measurement-2d-compat.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  AreaMeasurement2DCompat,
-  CompatEventBus,
-  DistanceMeasurement2DCompat,
-} from "../src/index.js";
+import { AreaMeasurement2DCompat, CompatEventBus, DistanceMeasurement2DCompat } from "../src/index.js";
 
 describe("measurement 2d compat", () => {
   it("supports when() and watch() lifecycle state for distance and area widgets", async () => {

--- a/test/migration-cli-content-webmap.test.ts
+++ b/test/migration-cli-content-webmap.test.ts
@@ -1,10 +1,10 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
+import { getProjectRoot, withCliLock } from "./migration-cli-lock.js";
 
 const tempDirs: string[] = [];
 let builtOnce = false;
@@ -15,38 +15,38 @@ function makeTempDir(): string {
   return dir;
 }
 
-function getProjectRoot(): string {
-  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-}
-
 function ensureBuiltCliArtifacts(): void {
-  const cliPath = path.join(getProjectRoot(), "dist", "src", "migration", "cli.js");
-  if (builtOnce && fs.existsSync(cliPath)) {
-    return;
-  }
+  withCliLock(() => {
+    const cliPath = path.join(getProjectRoot(), "dist", "src", "migration", "cli.js");
+    if (builtOnce && fs.existsSync(cliPath)) {
+      return;
+    }
 
-  const buildResult = spawnSync("npm", ["run", "build", "--silent"], {
-    cwd: getProjectRoot(),
-    encoding: "utf8",
+    const buildResult = spawnSync("npm", ["run", "build", "--silent"], {
+      cwd: getProjectRoot(),
+      encoding: "utf8",
+    });
+    if (buildResult.status !== 0) {
+      throw new Error(buildResult.stderr || buildResult.stdout || "failed to build migration CLI");
+    }
+    builtOnce = true;
   });
-  if (buildResult.status !== 0) {
-    throw new Error(buildResult.stderr || buildResult.stdout || "failed to build migration CLI");
-  }
-  builtOnce = true;
 }
 
 function runCli(args: readonly string[], cwd: string): { status: number | null; stdout: string; stderr: string } {
-  const cliPath = path.join(getProjectRoot(), "dist", "src", "migration", "cli.js");
-  const result = spawnSync("node", [cliPath, ...args], {
-    cwd,
-    encoding: "utf8",
-  });
+  return withCliLock(() => {
+    const cliPath = path.join(getProjectRoot(), "dist", "src", "migration", "cli.js");
+    const result = spawnSync("node", [cliPath, ...args], {
+      cwd,
+      encoding: "utf8",
+    });
 
-  return {
-    status: result.status,
-    stdout: result.stdout,
-    stderr: result.stderr,
-  };
+    return {
+      status: result.status,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  });
 }
 
 afterEach(() => {

--- a/test/migration-cli-content.test.ts
+++ b/test/migration-cli-content.test.ts
@@ -1,10 +1,11 @@
+import { execSync, spawn } from "node:child_process";
 import fs from "node:fs";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
-import { execSync, spawn } from "node:child_process";
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getProjectRoot, withCliLockAsync } from "./migration-cli-lock.js";
 
 let server: http.Server | undefined;
 let portalUrl = "";
@@ -12,52 +13,20 @@ let builtOnce = false;
 
 const tempDirs: string[] = [];
 
-function projectRoot(): string {
-  return path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
-}
-
 function makeTempDir(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "honua-cli-content-"));
   tempDirs.push(dir);
   return dir;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
-
-async function withCliLock<T>(work: () => Promise<T> | T): Promise<T> {
-  const lockDir = path.join(projectRoot(), ".tmp", "vitest-cli-lock");
-  fs.mkdirSync(path.dirname(lockDir), { recursive: true });
-  for (;;) {
-    try {
-      await fs.promises.mkdir(lockDir);
-      break;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
-        throw error;
-      }
-      await sleep(25);
-    }
-  }
-
-  try {
-    return await work();
-  } finally {
-    await fs.promises.rm(lockDir, { recursive: true, force: true });
-  }
-}
-
 async function ensureBuiltCliArtifacts(): Promise<void> {
-  await withCliLock(() => {
+  await withCliLockAsync(() => {
     if (builtOnce) {
       return;
     }
 
     execSync("npm run build --silent", {
-      cwd: projectRoot(),
+      cwd: getProjectRoot(),
       stdio: "pipe",
     });
     builtOnce = true;
@@ -231,9 +200,9 @@ describe("migration cli content", () => {
 });
 
 async function runCli(args: readonly string[]): Promise<{ status: number | null; stdout: string; stderr: string }> {
-  return withCliLock(async () => {
+  return withCliLockAsync(async () => {
     const child = spawn("node", args, {
-      cwd: projectRoot(),
+      cwd: getProjectRoot(),
       stdio: ["ignore", "pipe", "pipe"],
     });
 

--- a/test/migration-cli-demo.test.ts
+++ b/test/migration-cli-demo.test.ts
@@ -1,10 +1,10 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
+import { getProjectRoot, withCliLock } from "./migration-cli-lock.js";
 
 const tempDirs: string[] = [];
 let builtOnce = false;
@@ -13,36 +13,6 @@ function makeTempDir(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "honua-cli-demo-"));
   tempDirs.push(dir);
   return dir;
-}
-
-function getProjectRoot(): string {
-  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-}
-
-function sleep(ms: number): void {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-function withCliLock<T>(work: () => T): T {
-  const lockDir = path.join(getProjectRoot(), ".tmp", "vitest-cli-lock");
-  fs.mkdirSync(path.dirname(lockDir), { recursive: true });
-  for (;;) {
-    try {
-      fs.mkdirSync(lockDir);
-      break;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
-        throw error;
-      }
-      sleep(25);
-    }
-  }
-
-  try {
-    return work();
-  } finally {
-    fs.rmSync(lockDir, { recursive: true, force: true });
-  }
 }
 
 function ensureBuiltCliArtifacts(): void {

--- a/test/migration-cli-fixtures.test.ts
+++ b/test/migration-cli-fixtures.test.ts
@@ -1,10 +1,10 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
+import { getProjectRoot, withCliLock } from "./migration-cli-lock.js";
 
 const tempDirs: string[] = [];
 let builtOnce = false;
@@ -13,36 +13,6 @@ function makeTempDir(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "honua-cli-fixtures-"));
   tempDirs.push(dir);
   return dir;
-}
-
-function getProjectRoot(): string {
-  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-}
-
-function sleep(ms: number): void {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-function withCliLock<T>(work: () => T): T {
-  const lockDir = path.join(getProjectRoot(), ".tmp", "vitest-cli-lock");
-  fs.mkdirSync(path.dirname(lockDir), { recursive: true });
-  for (;;) {
-    try {
-      fs.mkdirSync(lockDir);
-      break;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
-        throw error;
-      }
-      sleep(25);
-    }
-  }
-
-  try {
-    return work();
-  } finally {
-    fs.rmSync(lockDir, { recursive: true, force: true });
-  }
 }
 
 function ensureBuiltCliArtifacts(): void {
@@ -147,15 +117,7 @@ describe("migration cli fixtures metrics", () => {
     const reportPath = path.join(root, "subset-metrics.json");
 
     const result = runCli(
-      [
-        "fixtures",
-        "--target",
-        "esri-leaflet",
-        "--fixtures",
-        "esri-real-sample-network-app",
-        "--report",
-        reportPath,
-      ],
+      ["fixtures", "--target", "esri-leaflet", "--fixtures", "esri-real-sample-network-app", "--report", reportPath],
       getProjectRoot(),
     );
 
@@ -178,9 +140,7 @@ describe("migration cli fixtures metrics", () => {
     expect(report.codemodTarget).toBe("esri-leaflet");
     expect(report.summary.fixtureCount).toBe(1);
     expect(report.fixtureNames).toEqual(["esri-real-sample-network-app"]);
-    expect(report.fixtures).toEqual([
-      expect.objectContaining({ fixture: "esri-real-sample-network-app" }),
-    ]);
+    expect(report.fixtures).toEqual([expect.objectContaining({ fixture: "esri-real-sample-network-app" })]);
   }, 60_000);
 
   it("passes strict fixture gates for honua-compat target", () => {

--- a/test/migration-cli-lock.ts
+++ b/test/migration-cli-lock.ts
@@ -1,0 +1,151 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const LOCK_RETRY_MS = 25;
+const LOCK_WAIT_TIMEOUT_MS = 15 * 60_000;
+const LOCK_OWNER_STALE_MS = 30 * 60_000;
+const UNKNOWN_OWNER_STALE_MS = 5 * 60_000;
+
+interface LockOwner {
+  pid: number;
+  acquiredAt: number;
+}
+
+export function getProjectRoot(): string {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+}
+
+export function withCliLock<T>(work: () => T): T {
+  const release = acquireCliLockSync();
+  try {
+    return work();
+  } finally {
+    release();
+  }
+}
+
+export async function withCliLockAsync<T>(work: () => Promise<T> | T): Promise<T> {
+  const release = await acquireCliLockAsync();
+  try {
+    return await work();
+  } finally {
+    release();
+  }
+}
+
+function acquireCliLockSync(): () => void {
+  const lockDir = cliLockDir();
+  fs.mkdirSync(path.dirname(lockDir), { recursive: true });
+  const startedAt = Date.now();
+
+  for (;;) {
+    try {
+      fs.mkdirSync(lockDir);
+      writeOwner(lockDir);
+      return () => fs.rmSync(lockDir, { recursive: true, force: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error;
+      }
+      maybeRemoveStaleLock(lockDir);
+      if (Date.now() - startedAt > LOCK_WAIT_TIMEOUT_MS) {
+        throw new Error(`Timed out waiting for migration CLI lock: ${lockDir}`);
+      }
+      sleepSync(LOCK_RETRY_MS);
+    }
+  }
+}
+
+async function acquireCliLockAsync(): Promise<() => void> {
+  const lockDir = cliLockDir();
+  fs.mkdirSync(path.dirname(lockDir), { recursive: true });
+  const startedAt = Date.now();
+
+  for (;;) {
+    try {
+      fs.mkdirSync(lockDir);
+      writeOwner(lockDir);
+      return () => fs.rmSync(lockDir, { recursive: true, force: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error;
+      }
+      maybeRemoveStaleLock(lockDir);
+      if (Date.now() - startedAt > LOCK_WAIT_TIMEOUT_MS) {
+        throw new Error(`Timed out waiting for migration CLI lock: ${lockDir}`);
+      }
+      await sleepAsync(LOCK_RETRY_MS);
+    }
+  }
+}
+
+function cliLockDir(): string {
+  return path.join(getProjectRoot(), ".tmp", "vitest-cli-lock");
+}
+
+function writeOwner(lockDir: string): void {
+  const owner: LockOwner = { pid: process.pid, acquiredAt: Date.now() };
+  fs.writeFileSync(path.join(lockDir, "owner.json"), `${JSON.stringify(owner)}\n`, "utf8");
+}
+
+function maybeRemoveStaleLock(lockDir: string): void {
+  if (!isStaleLock(lockDir)) {
+    return;
+  }
+  fs.rmSync(lockDir, { recursive: true, force: true });
+}
+
+function isStaleLock(lockDir: string): boolean {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(lockDir);
+  } catch {
+    return false;
+  }
+
+  const owner = readOwner(lockDir);
+  const ageMs = Date.now() - (owner?.acquiredAt ?? stat.mtimeMs);
+  if (!owner) {
+    return ageMs > UNKNOWN_OWNER_STALE_MS;
+  }
+  if (ageMs > LOCK_OWNER_STALE_MS) {
+    return true;
+  }
+  return !isProcessAlive(owner.pid);
+}
+
+function readOwner(lockDir: string): LockOwner | undefined {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(path.join(lockDir, "owner.json"), "utf8")) as Partial<LockOwner>;
+    if (
+      typeof parsed.pid === "number" &&
+      Number.isInteger(parsed.pid) &&
+      parsed.pid > 0 &&
+      typeof parsed.acquiredAt === "number" &&
+      Number.isFinite(parsed.acquiredAt)
+    ) {
+      return { pid: parsed.pid, acquiredAt: parsed.acquiredAt };
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+async function sleepAsync(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/test/migration-cli-matrix.test.ts
+++ b/test/migration-cli-matrix.test.ts
@@ -1,10 +1,10 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
+import { getProjectRoot, withCliLock } from "./migration-cli-lock.js";
 
 const tempDirs: string[] = [];
 let builtOnce = false;
@@ -13,36 +13,6 @@ function makeTempDir(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "honua-cli-matrix-"));
   tempDirs.push(dir);
   return dir;
-}
-
-function getProjectRoot(): string {
-  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-}
-
-function sleep(ms: number): void {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-function withCliLock<T>(work: () => T): T {
-  const lockDir = path.join(getProjectRoot(), ".tmp", "vitest-cli-lock");
-  fs.mkdirSync(path.dirname(lockDir), { recursive: true });
-  for (;;) {
-    try {
-      fs.mkdirSync(lockDir);
-      break;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
-        throw error;
-      }
-      sleep(25);
-    }
-  }
-
-  try {
-    return work();
-  } finally {
-    fs.rmSync(lockDir, { recursive: true, force: true });
-  }
 }
 
 function ensureBuiltCliArtifacts(): void {
@@ -139,12 +109,8 @@ describe("migration cli parity matrix", () => {
     const tableListWidget = report.matrix.find((row) => row.kind === "table-list-widget");
     const featureTemplatesWidget = report.matrix.find((row) => row.kind === "feature-templates-widget");
     const basemapLayerListWidget = report.matrix.find((row) => row.kind === "basemap-layer-list-widget");
-    const distanceMeasurement2dWidget = report.matrix.find(
-      (row) => row.kind === "distance-measurement-2d-widget",
-    );
-    const areaMeasurement2dWidget = report.matrix.find(
-      (row) => row.kind === "area-measurement-2d-widget",
-    );
+    const distanceMeasurement2dWidget = report.matrix.find((row) => row.kind === "distance-measurement-2d-widget");
+    const areaMeasurement2dWidget = report.matrix.find((row) => row.kind === "area-measurement-2d-widget");
     const query = report.matrix.find((row) => row.kind === "query");
     const oauthInfo = report.matrix.find((row) => row.kind === "oauth-info");
     const identityManager = report.matrix.find((row) => row.kind === "identity-manager");

--- a/test/migration-cli-reconcile.test.ts
+++ b/test/migration-cli-reconcile.test.ts
@@ -1,65 +1,13 @@
+import { execSync, spawn } from "node:child_process";
 import fs from "node:fs";
 import http from "node:http";
-import path from "node:path";
-import { execSync, spawn } from "node:child_process";
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getProjectRoot, withCliLock, withCliLockAsync } from "./migration-cli-lock.js";
 
 let server: http.Server | undefined;
 let baseUrl = "";
 let builtOnce = false;
-
-function projectRoot(): string {
-  return path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
-}
-
-function sleep(ms: number): void {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-function withCliLock<T>(work: () => T): T {
-  const lockDir = path.join(projectRoot(), ".tmp", "vitest-cli-lock");
-  fs.mkdirSync(path.dirname(lockDir), { recursive: true });
-  for (;;) {
-    try {
-      fs.mkdirSync(lockDir);
-      break;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
-        throw error;
-      }
-      sleep(25);
-    }
-  }
-
-  try {
-    return work();
-  } finally {
-    fs.rmSync(lockDir, { recursive: true, force: true });
-  }
-}
-
-async function withCliLockAsync<T>(work: () => Promise<T>): Promise<T> {
-  const lockDir = path.join(projectRoot(), ".tmp", "vitest-cli-lock");
-  fs.mkdirSync(path.dirname(lockDir), { recursive: true });
-  for (;;) {
-    try {
-      fs.mkdirSync(lockDir);
-      break;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
-        throw error;
-      }
-      await new Promise<void>((resolve) => setTimeout(resolve, 25));
-    }
-  }
-
-  try {
-    return await work();
-  } finally {
-    fs.rmSync(lockDir, { recursive: true, force: true });
-  }
-}
 
 function ensureBuiltCliArtifacts(): void {
   withCliLock(() => {
@@ -68,7 +16,7 @@ function ensureBuiltCliArtifacts(): void {
     }
 
     execSync("npm run build --silent", {
-      cwd: projectRoot(),
+      cwd: getProjectRoot(),
       stdio: "pipe",
     });
     builtOnce = true;
@@ -194,7 +142,7 @@ function runCli(
     () =>
       new Promise((resolve, reject) => {
         const child = spawn("node", args, {
-          cwd: projectRoot(),
+          cwd: getProjectRoot(),
           env: {
             ...process.env,
             ...envOverrides,

--- a/test/migration-cli-target.test.ts
+++ b/test/migration-cli-target.test.ts
@@ -1,10 +1,10 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
+import { getProjectRoot, withCliLock } from "./migration-cli-lock.js";
 
 const tempDirs: string[] = [];
 let builtOnce = false;
@@ -13,36 +13,6 @@ function makeTempDir(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "honua-cli-target-"));
   tempDirs.push(dir);
   return dir;
-}
-
-function getProjectRoot(): string {
-  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-}
-
-function sleep(ms: number): void {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-function withCliLock<T>(work: () => T): T {
-  const lockDir = path.join(getProjectRoot(), ".tmp", "vitest-cli-lock");
-  fs.mkdirSync(path.dirname(lockDir), { recursive: true });
-  for (;;) {
-    try {
-      fs.mkdirSync(lockDir);
-      break;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
-        throw error;
-      }
-      sleep(25);
-    }
-  }
-
-  try {
-    return work();
-  } finally {
-    fs.rmSync(lockDir, { recursive: true, force: true });
-  }
 }
 
 function ensureBuiltCliArtifacts(): void {
@@ -94,18 +64,11 @@ describe("migration cli target selection", () => {
 
     fs.writeFileSync(
       appFile,
-      [
-        "import Map from '@arcgis/core/Map';",
-        "const map = new Map({ basemap: 'streets' });",
-        "void map;",
-      ].join("\n"),
+      ["import Map from '@arcgis/core/Map';", "const map = new Map({ basemap: 'streets' });", "void map;"].join("\n"),
       "utf8",
     );
 
-    const result = runCli(
-      ["codemod", root, "--target", "honua", "--write", "--report", reportPath],
-      getProjectRoot(),
-    );
+    const result = runCli(["codemod", root, "--target", "honua", "--write", "--report", reportPath], getProjectRoot());
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("target=honua-compat");
@@ -178,11 +141,9 @@ describe("migration cli target selection", () => {
 
     fs.writeFileSync(
       appFile,
-      [
-        "import * as L from 'esri-leaflet';",
-        "const layer = L.featureLayer({ url: serviceUrl });",
-        "void layer;",
-      ].join("\n"),
+      ["import * as L from 'esri-leaflet';", "const layer = L.featureLayer({ url: serviceUrl });", "void layer;"].join(
+        "\n",
+      ),
       "utf8",
     );
 

--- a/test/migration-codemod.test.ts
+++ b/test/migration-codemod.test.ts
@@ -263,9 +263,7 @@ describe("runEsriCompatCodemod", () => {
       'import { PointCompat, SimpleLineSymbolCompat, SimpleMarkerSymbolCompat } from "@honua/sdk-esri-compat";',
     );
     expect(nextSource).toContain("new PointCompat({ x: -157.81, y: 21.30, spatialReference: { wkid: 4326 } })");
-    expect(nextSource).toContain(
-      "new SimpleLineSymbolCompat({ style: 'solid', color: 'white', width: 1 })",
-    );
+    expect(nextSource).toContain("new SimpleLineSymbolCompat({ style: 'solid', color: 'white', width: 1 })");
     expect(nextSource).toContain(
       "new SimpleMarkerSymbolCompat({ style: 'circle', color: 'orange', size: 12, outline })",
     );
@@ -333,7 +331,9 @@ describe("runEsriCompatCodemod", () => {
     expect(nextSource).toContain("new SpatialReferenceCompat({ wkid: 4326 })");
     expect(nextSource).toContain("new ExtentCompat({ xmin: -10, ymin: -5, xmax: 30, ymax: 15, spatialReference: sr })");
     expect(nextSource).toContain("new PolylineCompat({ paths: [[[0, 0], [1, 1]]], spatialReference: sr })");
-    expect(nextSource).toContain("new PolygonCompat({ rings: [[[0, 0], [10, 0], [10, 10], [0, 0]]], spatialReference: sr })");
+    expect(nextSource).toContain(
+      "new PolygonCompat({ rings: [[[0, 0], [10, 0], [10, 10], [0, 0]]], spatialReference: sr })",
+    );
     expect(nextSource).not.toContain("@arcgis/core/geometry/SpatialReference");
     expect(nextSource).not.toContain("@arcgis/core/geometry/Extent");
     expect(nextSource).not.toContain("@arcgis/core/geometry/Polyline");
@@ -463,7 +463,8 @@ describe("runEsriCompatCodemod", () => {
       expect.arrayContaining([
         expect.objectContaining({
           kind: "label-class",
-          reason: "LabelClass options include unsupported properties: deconflictionStrategy; requires manual migration.",
+          reason:
+            "LabelClass options include unsupported properties: deconflictionStrategy; requires manual migration.",
         }),
       ]),
     );
@@ -595,7 +596,9 @@ describe("runEsriCompatCodemod", () => {
 
     const nextSource = fs.readFileSync(file, "utf8");
     expect(nextSource).toContain("@arcgis/core/renderers/SimpleRenderer");
-    expect(nextSource).toContain("new SimpleRenderer({ symbol: { type: 'simple-fill' }, authoringInfo: { foo: true } })");
+    expect(nextSource).toContain(
+      "new SimpleRenderer({ symbol: { type: 'simple-fill' }, authoringInfo: { foo: true } })",
+    );
   });
 
   it("rewrites safe FeatureSet constructor and removes ArcGIS import", () => {
@@ -842,10 +845,10 @@ describe("runEsriCompatCodemod", () => {
     });
 
     const nextSource = fs.readFileSync(file, "utf8");
+    expect(nextSource).toContain('import { FeatureLayerCompat, FeatureTableCompat } from "@honua/sdk-esri-compat";');
     expect(nextSource).toContain(
-      'import { FeatureLayerCompat, FeatureTableCompat } from "@honua/sdk-esri-compat";',
+      "new FeatureTableCompat({ layer, container: 'feature-table', where: '1=1', objectIdField: 'OBJECTID' })",
     );
-    expect(nextSource).toContain("new FeatureTableCompat({ layer, container: 'feature-table', where: '1=1', objectIdField: 'OBJECTID' })");
     expect(nextSource).not.toContain("@arcgis/core/widgets/FeatureTable");
   });
 
@@ -913,7 +916,9 @@ describe("runEsriCompatCodemod", () => {
     expect(nextSource).toContain(
       'import { FeatureLayerCompat, FeatureTableCompat, MapViewCompat } from "@honua/sdk-esri-compat";',
     );
-    expect(nextSource).toContain("new MapViewCompat({ map, container: 'viewDiv', popup: { dockEnabled: true, dockOptions: { breakpoint: false } } })");
+    expect(nextSource).toContain(
+      "new MapViewCompat({ map, container: 'viewDiv', popup: { dockEnabled: true, dockOptions: { breakpoint: false } } })",
+    );
     expect(nextSource).toContain("const table = new FeatureTableCompat({");
     expect(nextSource).toContain("relatedRecordsEnabled: true");
     expect(nextSource).toContain("filterBySelectionEnabled: false");
@@ -1040,9 +1045,7 @@ describe("runEsriCompatCodemod", () => {
     });
 
     const nextSource = fs.readFileSync(file, "utf8");
-    expect(nextSource).toContain(
-      'import { FeatureCompat, MapCompat, MapViewCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(nextSource).toContain('import { FeatureCompat, MapCompat, MapViewCompat } from "@honua/sdk-esri-compat";');
     expect(nextSource).toContain(
       "new FeatureCompat({ view, container: 'feature-div', title: 'Selected', graphic: { attributes: { OBJECTID: 1 } } })",
     );
@@ -1081,9 +1084,7 @@ describe("runEsriCompatCodemod", () => {
     });
 
     const nextSource = fs.readFileSync(file, "utf8");
-    expect(nextSource).toContain(
-      'import { FeatureFormCompat, FeatureLayerCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(nextSource).toContain('import { FeatureFormCompat, FeatureLayerCompat } from "@honua/sdk-esri-compat";');
     expect(nextSource).toContain(
       "new FeatureFormCompat({ layer, container: 'feature-form', feature: { attributes: { OBJECTID: 1 } }, fieldConfig: [{ name: 'status' }], groupDisplay: 'all', headingLevel: 3, visibleElements: { description: true } })",
     );
@@ -1165,10 +1166,10 @@ describe("runEsriCompatCodemod", () => {
     });
 
     const nextSource = fs.readFileSync(file, "utf8");
+    expect(nextSource).toContain('import { MapCompat, MapViewCompat, PrintCompat } from "@honua/sdk-esri-compat";');
     expect(nextSource).toContain(
-      'import { MapCompat, MapViewCompat, PrintCompat } from "@honua/sdk-esri-compat";',
+      "new PrintCompat({ view, container: 'print-div', printServiceUrl: printUrl, templateOptions: { format: 'pdf', layout: 'a4-landscape' } })",
     );
-    expect(nextSource).toContain("new PrintCompat({ view, container: 'print-div', printServiceUrl: printUrl, templateOptions: { format: 'pdf', layout: 'a4-landscape' } })");
     expect(nextSource).not.toContain("@arcgis/core/widgets/Print");
   });
 
@@ -1206,9 +1207,7 @@ describe("runEsriCompatCodemod", () => {
     });
 
     const nextSource = fs.readFileSync(file, "utf8");
-    expect(nextSource).toContain(
-      'import { MapCompat, MapViewCompat, SwipeCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(nextSource).toContain('import { MapCompat, MapViewCompat, SwipeCompat } from "@honua/sdk-esri-compat";');
     expect(nextSource).toContain(
       "new SwipeCompat({ view, container: 'swipe-div', position: 40, leadingLayers: [], trailingLayers: [] })",
     );
@@ -1314,9 +1313,7 @@ describe("runEsriCompatCodemod", () => {
     });
 
     const nextSource = fs.readFileSync(file, "utf8");
-    expect(nextSource).toContain(
-      'import { MapCompat, MapViewCompat, TableListCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(nextSource).toContain('import { MapCompat, MapViewCompat, TableListCompat } from "@honua/sdk-esri-compat";');
     expect(nextSource).toContain(
       "new TableListCompat({ view, container: 'table-list', tables: [{ id: 'parcels' }], autoRefresh: false })",
     );
@@ -1397,7 +1394,9 @@ describe("runEsriCompatCodemod", () => {
 
     const nextSource = fs.readFileSync(file, "utf8");
     expect(nextSource).toContain('import { GraphicsLayerCompat } from "@honua/sdk-esri-compat";');
-    expect(nextSource).toContain("const graphics = new GraphicsLayerCompat({ id: 'graphics', visible: true, opacity: 0.9 });");
+    expect(nextSource).toContain(
+      "const graphics = new GraphicsLayerCompat({ id: 'graphics', visible: true, opacity: 0.9 });",
+    );
     expect(nextSource).not.toContain("@arcgis/core/layers/GraphicsLayer");
   });
 
@@ -1652,7 +1651,9 @@ describe("runEsriCompatCodemod", () => {
       "const routeLayer = new RouteLayerCompat({ stops: [{ name: 'Start', location: [-157.0, 21.3] }, { name: 'End', location: [-157.01, 21.31] }] });",
     );
     expect(nextSource).toContain("const layerList = new LayerListCompat({ view, container: 'layer-list-div' });");
-    expect(nextSource).toContain("const legend = new LegendCompat({ view, container: 'legend-div', includeHidden: true, autoRefresh: false });");
+    expect(nextSource).toContain(
+      "const legend = new LegendCompat({ view, container: 'legend-div', includeHidden: true, autoRefresh: false });",
+    );
     expect(nextSource).toContain("const popup = new PopupCompat({ view, container: 'popup-div', dockEnabled: true });");
     expect(nextSource).toContain(
       "const home = new HomeCompat({ view, container: 'home-div', viewpoint: { center: [0, 0], zoom: 3 } });",
@@ -1663,7 +1664,9 @@ describe("runEsriCompatCodemod", () => {
     expect(nextSource).toContain(
       "const locate = new LocateCompat({ view, container: 'locate-div', zoom: 12, locateProvider: async () => ({ coords: { latitude: 21.3069, longitude: -157.8583 } }) });",
     );
-    expect(nextSource).toContain("const scaleBar = new ScaleBarCompat({ view, container: 'scale-div', unit: 'dual' });");
+    expect(nextSource).toContain(
+      "const scaleBar = new ScaleBarCompat({ view, container: 'scale-div', unit: 'dual' });",
+    );
     expect(nextSource).toContain(
       "const search = new SearchCompat({ view, container: 'search-div', includeDefaultSources: false, autoRefreshSources: false });",
     );
@@ -1772,12 +1775,8 @@ describe("runEsriCompatCodemod", () => {
     const nextSource = fs.readFileSync(file, "utf8");
     expect(nextSource).toContain('import * as HonuaEsriLeaflet from "esri-leaflet";');
     expect(nextSource).toContain("const fl = HonuaEsriLeaflet.featureLayer({ url: serviceUrl });");
-    expect(nextSource).toContain(
-      "const mil = HonuaEsriLeaflet.dynamicMapLayer({ url: mapUrl, visible: true });",
-    );
-    expect(nextSource).toContain(
-      "const tiled = HonuaEsriLeaflet.tiledMapLayer({ url: tileUrl, opacity: 0.4 });",
-    );
+    expect(nextSource).toContain("const mil = HonuaEsriLeaflet.dynamicMapLayer({ url: mapUrl, visible: true });");
+    expect(nextSource).toContain("const tiled = HonuaEsriLeaflet.tiledMapLayer({ url: tileUrl, opacity: 0.4 });");
     expect(nextSource).not.toContain("@arcgis/core/layers/FeatureLayer");
     expect(nextSource).not.toContain("@arcgis/core/layers/MapImageLayer");
     expect(nextSource).not.toContain("@arcgis/core/layers/TileLayer");
@@ -1936,8 +1935,12 @@ describe("runEsriCompatCodemod", () => {
       'import { AttributionCompat, BasemapGalleryCompat, BasemapToggleCompat, BookmarksCompat, CompassCompat, ExpandCompat, FullscreenCompat, HomeCompat, LayerListCompat, LegendCompat, LocateCompat, MapCompat, MapViewCompat, PopupCompat, ScaleBarCompat, SceneViewCompat, SearchCompat, ZoomCompat } from "@honua/sdk-esri-compat";',
     );
     expect(nextSource).toContain("const map = new MapCompat({ basemap: 'streets' });");
-    expect(nextSource).toContain("const view = new MapViewCompat({ map, container: 'viewDiv', center: [0, 0], zoom: 4 });");
-    expect(nextSource).toContain("const scene = new SceneViewCompat({ map, container: 'sceneDiv', viewingMode: 'global' });");
+    expect(nextSource).toContain(
+      "const view = new MapViewCompat({ map, container: 'viewDiv', center: [0, 0], zoom: 4 });",
+    );
+    expect(nextSource).toContain(
+      "const scene = new SceneViewCompat({ map, container: 'sceneDiv', viewingMode: 'global' });",
+    );
     expect(nextSource).toContain("const layerList = new LayerListCompat({ view });");
     expect(nextSource).toContain("const legend = new LegendCompat({ view });");
     expect(nextSource).toContain("const popup = new PopupCompat({ view });");
@@ -1981,7 +1984,7 @@ describe("runEsriCompatCodemod", () => {
       [
         "import FeatureLayer from '@arcgis/core/layers/FeatureLayer';",
         "const layer = new FeatureLayer({ url: serviceUrl });",
-        "const ids = await layer.queryObjectIds({ where: \"1=1\" });",
+        'const ids = await layer.queryObjectIds({ where: "1=1" });',
         "void ids;",
       ].join("\n"),
       "utf8",
@@ -2004,11 +2007,9 @@ describe("runEsriCompatCodemod", () => {
     });
 
     const nextSource = fs.readFileSync(file, "utf8");
-    expect(nextSource).toContain(
-      'import { FeatureLayerCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(nextSource).toContain('import { FeatureLayerCompat } from "@honua/sdk-esri-compat";');
     expect(nextSource).toContain("const layer = new FeatureLayerCompat({ url: serviceUrl });");
-    expect(nextSource).toContain("const ids = await layer.queryObjectIds({ where: \"1=1\" });");
+    expect(nextSource).toContain('const ids = await layer.queryObjectIds({ where: "1=1" });');
     expect(nextSource).not.toContain('import * as HonuaEsriLeaflet from "esri-leaflet";');
     expect(nextSource).not.toContain("@arcgis/core/layers/FeatureLayer");
   });
@@ -2021,7 +2022,7 @@ describe("runEsriCompatCodemod", () => {
       [
         "import FeatureLayer from '@arcgis/core/layers/FeatureLayer';",
         "const layer = new FeatureLayer({ url: serviceUrl });",
-        "const features = await layer.queryFeatures({ where: \"1=1\" });",
+        'const features = await layer.queryFeatures({ where: "1=1" });',
         "const all = await layer.queryFeaturesAll({ pageSize: 2000 });",
         "void features; void all;",
       ].join("\n"),
@@ -2045,11 +2046,9 @@ describe("runEsriCompatCodemod", () => {
     });
 
     const nextSource = fs.readFileSync(file, "utf8");
-    expect(nextSource).toContain(
-      'import { FeatureLayerCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(nextSource).toContain('import { FeatureLayerCompat } from "@honua/sdk-esri-compat";');
     expect(nextSource).toContain("const layer = new FeatureLayerCompat({ url: serviceUrl });");
-    expect(nextSource).toContain("const features = await layer.queryFeatures({ where: \"1=1\" });");
+    expect(nextSource).toContain('const features = await layer.queryFeatures({ where: "1=1" });');
     expect(nextSource).toContain("const all = await layer.queryFeaturesAll({ pageSize: 2000 });");
     expect(nextSource).not.toContain('import * as HonuaEsriLeaflet from "esri-leaflet";');
     expect(nextSource).not.toContain("@arcgis/core/layers/FeatureLayer");
@@ -2063,7 +2062,7 @@ describe("runEsriCompatCodemod", () => {
       [
         "import MapImageLayer from '@arcgis/core/layers/MapImageLayer';",
         "const layer = new MapImageLayer({ url: serviceUrl });",
-        "const hit = await layer.identify({ geometry: { x: 1, y: 2 }, mapExtent: \"0,0,10,10\", imageDisplay: \"800,600,96\" });",
+        'const hit = await layer.identify({ geometry: { x: 1, y: 2 }, mapExtent: "0,0,10,10", imageDisplay: "800,600,96" });',
         "const related = await layer.queryRelatedFeatures({ layerId: 0, relationshipId: 2, objectIds: [1, 2] });",
         "void related;",
         "void hit;",
@@ -2088,11 +2087,11 @@ describe("runEsriCompatCodemod", () => {
     });
 
     const nextSource = fs.readFileSync(file, "utf8");
-    expect(nextSource).toContain(
-      'import { MapImageLayerCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(nextSource).toContain('import { MapImageLayerCompat } from "@honua/sdk-esri-compat";');
     expect(nextSource).toContain("const layer = new MapImageLayerCompat({ url: serviceUrl });");
-    expect(nextSource).toContain("const hit = await layer.identify({ geometry: { x: 1, y: 2 }, mapExtent: \"0,0,10,10\", imageDisplay: \"800,600,96\" });");
+    expect(nextSource).toContain(
+      'const hit = await layer.identify({ geometry: { x: 1, y: 2 }, mapExtent: "0,0,10,10", imageDisplay: "800,600,96" });',
+    );
     expect(nextSource).toContain(
       "const related = await layer.queryRelatedFeatures({ layerId: 0, relationshipId: 2, objectIds: [1, 2] });",
     );
@@ -2108,10 +2107,10 @@ describe("runEsriCompatCodemod", () => {
       [
         "import MapImageLayer from '@arcgis/core/layers/MapImageLayer';",
         "const layer = new MapImageLayer({ url: serviceUrl });",
-        "const features = await layer.queryFeatures({ layerId: 0, where: \"1=1\" });",
-        "const count = await layer.queryFeatureCount({ layerId: 0, where: \"1=1\" });",
+        'const features = await layer.queryFeatures({ layerId: 0, where: "1=1" });',
+        'const count = await layer.queryFeatureCount({ layerId: 0, where: "1=1" });',
         "const sub = layer.sublayer(0);",
-        "const subFeatures = await sub?.queryFeatures({ where: \"1=1\" });",
+        'const subFeatures = await sub?.queryFeatures({ where: "1=1" });',
         "void features; void count; void subFeatures;",
       ].join("\n"),
       "utf8",
@@ -2134,14 +2133,12 @@ describe("runEsriCompatCodemod", () => {
     });
 
     const nextSource = fs.readFileSync(file, "utf8");
-    expect(nextSource).toContain(
-      'import { MapImageLayerCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(nextSource).toContain('import { MapImageLayerCompat } from "@honua/sdk-esri-compat";');
     expect(nextSource).toContain("const layer = new MapImageLayerCompat({ url: serviceUrl });");
-    expect(nextSource).toContain("const features = await layer.queryFeatures({ layerId: 0, where: \"1=1\" });");
-    expect(nextSource).toContain("const count = await layer.queryFeatureCount({ layerId: 0, where: \"1=1\" });");
+    expect(nextSource).toContain('const features = await layer.queryFeatures({ layerId: 0, where: "1=1" });');
+    expect(nextSource).toContain('const count = await layer.queryFeatureCount({ layerId: 0, where: "1=1" });');
     expect(nextSource).toContain("const sub = layer.sublayer(0);");
-    expect(nextSource).toContain("const subFeatures = await sub?.queryFeatures({ where: \"1=1\" });");
+    expect(nextSource).toContain('const subFeatures = await sub?.queryFeatures({ where: "1=1" });');
     expect(nextSource).not.toContain('import * as HonuaEsriLeaflet from "esri-leaflet";');
     expect(nextSource).not.toContain("@arcgis/core/layers/MapImageLayer");
   });
@@ -2401,10 +2398,7 @@ describe("runEsriCompatCodemod", () => {
     const file = path.join(root, "require-map.cjs");
     fs.writeFileSync(
       file,
-      [
-        "const Map = require('@arcgis/core/Map');",
-        "const map = new Map({ basemap: 'streets' });",
-      ].join("\n"),
+      ["const Map = require('@arcgis/core/Map');", "const map = new Map({ basemap: 'streets' });"].join("\n"),
       "utf8",
     );
 
@@ -2614,9 +2608,7 @@ describe("runEsriCompatCodemod", () => {
     expect(nextSource).toContain("@arcgis/core/layers/FeatureLayer");
     expect(nextSource).toContain('import { FeatureLayerCompat } from "@honua/sdk-esri-compat";');
     expect(nextSource).toContain("const a = new FeatureLayerCompat({ url: serviceUrl });");
-    expect(nextSource).toContain(
-      "const b = new FeatureLayer({ url: serviceUrl, portalItem: { id: 'abc123' } });",
-    );
+    expect(nextSource).toContain("const b = new FeatureLayer({ url: serviceUrl, portalItem: { id: 'abc123' } });");
   });
 
   it("can annotate manual todos inline without duplicating markers on rerun", () => {
@@ -2691,10 +2683,7 @@ describe("runEsriCompatCodemod", () => {
     const file = path.join(root, "esri-config.ts");
     fs.writeFileSync(
       file,
-      [
-        "import esriConfig from '@arcgis/core/config';",
-        "esriConfig.apiKey = token;",
-      ].join("\n"),
+      ["import esriConfig from '@arcgis/core/config';", "esriConfig.apiKey = token;"].join("\n"),
       "utf8",
     );
 
@@ -2750,9 +2739,7 @@ describe("runEsriCompatCodemod", () => {
     });
 
     const nextSource = fs.readFileSync(file, "utf8");
-    expect(nextSource).toContain(
-      'await import("@honua/sdk-esri-compat").then((m) => ({ default: m.esriConfig }))',
-    );
+    expect(nextSource).toContain('await import("@honua/sdk-esri-compat").then((m) => ({ default: m.esriConfig }))');
     expect(nextSource).not.toContain("@arcgis/core/config");
   });
 
@@ -2820,9 +2807,7 @@ describe("runEsriCompatCodemod", () => {
     });
 
     const nextSource = fs.readFileSync(file, "utf8");
-    expect(nextSource).toContain(
-      'await import("@honua/sdk-esri-compat").then((m) => ({ default: m.esriRequest }))',
-    );
+    expect(nextSource).toContain('await import("@honua/sdk-esri-compat").then((m) => ({ default: m.esriRequest }))');
     expect(nextSource).not.toContain("@arcgis/core/request");
   });
 
@@ -2894,9 +2879,7 @@ describe("runEsriCompatCodemod", () => {
     });
 
     const nextSource = fs.readFileSync(file, "utf8");
-    expect(nextSource).toContain(
-      'import { identityManager as IdentityManager } from "@honua/sdk-esri-compat";',
-    );
+    expect(nextSource).toContain('import { identityManager as IdentityManager } from "@honua/sdk-esri-compat";');
     expect(nextSource).not.toContain("@arcgis/core/identity/IdentityManager");
   });
 
@@ -2967,9 +2950,7 @@ describe("runEsriCompatCodemod", () => {
     });
 
     const nextSource = fs.readFileSync(file, "utf8");
-    expect(nextSource).toContain(
-      'import { reactiveUtils } from "@honua/sdk-esri-compat";',
-    );
+    expect(nextSource).toContain('import { reactiveUtils } from "@honua/sdk-esri-compat";');
     expect(nextSource).not.toContain("@arcgis/core/core/reactiveUtils");
   });
 
@@ -3004,9 +2985,7 @@ describe("runEsriCompatCodemod", () => {
     });
 
     const nextSource = fs.readFileSync(file, "utf8");
-    expect(nextSource).toContain(
-      'await import("@honua/sdk-esri-compat").then((m) => ({ default: m.reactiveUtils }))',
-    );
+    expect(nextSource).toContain('await import("@honua/sdk-esri-compat").then((m) => ({ default: m.reactiveUtils }))');
     expect(nextSource).not.toContain("@arcgis/core/core/reactiveUtils");
   });
 
@@ -3047,12 +3026,8 @@ describe("runEsriCompatCodemod", () => {
     });
 
     const nextSource = fs.readFileSync(file, "utf8");
-    expect(nextSource).toContain(
-      'await import("@honua/sdk-esri-compat").then((m) => ({ default: m.MapCompat }))',
-    );
-    expect(nextSource).toContain(
-      'await import("@honua/sdk-esri-compat").then((m) => ({ default: m.MapViewCompat }))',
-    );
+    expect(nextSource).toContain('await import("@honua/sdk-esri-compat").then((m) => ({ default: m.MapCompat }))');
+    expect(nextSource).toContain('await import("@honua/sdk-esri-compat").then((m) => ({ default: m.MapViewCompat }))');
     expect(nextSource).not.toContain("@arcgis/core/Map.js");
     expect(nextSource).not.toContain("@arcgis/core/views/MapView");
   });
@@ -3089,9 +3064,7 @@ describe("runEsriCompatCodemod", () => {
 
     const nextSource = fs.readFileSync(file, "utf8");
     expect(nextSource).toContain('import * as HonuaEsriLeaflet from "esri-leaflet";');
-    expect(nextSource).toContain(
-      "await Promise.resolve({ default: HonuaEsriLeaflet.featureLayer })",
-    );
+    expect(nextSource).toContain("await Promise.resolve({ default: HonuaEsriLeaflet.featureLayer })");
     expect(nextSource).not.toContain("@arcgis/core/layers/FeatureLayer");
   });
 
@@ -3169,10 +3142,7 @@ describe("runEsriCompatCodemod", () => {
 
     fs.writeFileSync(
       brokenFile,
-      [
-        "import FeatureLayer from '@arcgis/core/layers/FeatureLayer';",
-        "const broken = new FeatureLayer({",
-      ].join("\n"),
+      ["import FeatureLayer from '@arcgis/core/layers/FeatureLayer';", "const broken = new FeatureLayer({"].join("\n"),
       "utf8",
     );
     fs.writeFileSync(
@@ -3282,9 +3252,7 @@ describe("runEsriCompatCodemod", () => {
     expect(result.metrics.manualCallSites).toBe(0);
 
     const nextSource = fs.readFileSync(file, "utf8");
-    expect(nextSource).toContain(
-      'import { FeatureLayerCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(nextSource).toContain('import { FeatureLayerCompat } from "@honua/sdk-esri-compat";');
     expect(nextSource).toContain("new FeatureLayerCompat({ url: serviceUrl })");
     expect(nextSource).not.toContain("@arcgis/core/layers");
   });
@@ -3325,9 +3293,7 @@ describe("runEsriCompatCodemod", () => {
     });
 
     const nextAppSource = fs.readFileSync(appFile, "utf8");
-    expect(nextAppSource).toContain(
-      'import { FeatureLayerCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(nextAppSource).toContain('import { FeatureLayerCompat } from "@honua/sdk-esri-compat";');
     expect(nextAppSource).toContain("new FeatureLayerCompat({ url: serviceUrl })");
   });
 
@@ -3336,16 +3302,8 @@ describe("runEsriCompatCodemod", () => {
     const baseWrapper = path.join(root, "arcgis-wrapper.ts");
     const chainWrapper = path.join(root, "chain-wrapper.ts");
     const appFile = path.join(root, "app.ts");
-    fs.writeFileSync(
-      baseWrapper,
-      "export { default as MapView } from '@arcgis/core/views/MapView';\n",
-      "utf8",
-    );
-    fs.writeFileSync(
-      chainWrapper,
-      "export { MapView } from './arcgis-wrapper';\n",
-      "utf8",
-    );
+    fs.writeFileSync(baseWrapper, "export { default as MapView } from '@arcgis/core/views/MapView';\n", "utf8");
+    fs.writeFileSync(chainWrapper, "export { MapView } from './arcgis-wrapper';\n", "utf8");
     fs.writeFileSync(
       appFile,
       [
@@ -3373,9 +3331,7 @@ describe("runEsriCompatCodemod", () => {
     });
 
     const nextAppSource = fs.readFileSync(appFile, "utf8");
-    expect(nextAppSource).toContain(
-      'import { MapViewCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(nextAppSource).toContain('import { MapViewCompat } from "@honua/sdk-esri-compat";');
     expect(nextAppSource).toContain("new MapViewCompat({ map, container: 'viewDiv' })");
   });
 

--- a/test/migration-demo.test.ts
+++ b/test/migration-demo.test.ts
@@ -5,11 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import {
-  parseGeoservicesServiceUrl,
-  runGeoservicesImportJob,
-  runMigrationDemo,
-} from "../src/migration/demo.js";
+import { parseGeoservicesServiceUrl, runGeoservicesImportJob, runMigrationDemo } from "../src/migration/demo.js";
 
 const tempDirs: string[] = [];
 
@@ -31,9 +27,7 @@ afterEach(() => {
 
 describe("migration demo helpers", () => {
   it("parses geoservices service URL details", () => {
-    const parsed = parseGeoservicesServiceUrl(
-      "https://example.test/gis/rest/services/incidents/FeatureServer/3",
-    );
+    const parsed = parseGeoservicesServiceUrl("https://example.test/gis/rest/services/incidents/FeatureServer/3");
 
     expect(parsed).toEqual({
       baseUrl: "https://example.test/gis",
@@ -53,12 +47,7 @@ describe("migration demo helpers", () => {
     let pollCount = 0;
 
     const fetchFn: typeof fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url =
-        typeof input === "string"
-          ? input
-          : input instanceof URL
-            ? input.toString()
-            : input.url;
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       const method = init?.method ?? "GET";
       const headers = normalizeHeaders(init?.headers);
       const body =
@@ -125,7 +114,7 @@ describe("migration demo helpers", () => {
     const startRequest = requests.find((request) => request.url.endsWith("/start"));
     expect(startRequest?.method).toBe("POST");
     expect(startRequest?.headers["x-api-key"]).toBe("demo-key");
-    expect(startRequest?.body).toContain("\"tableName\":\"incidents\"");
+    expect(startRequest?.body).toContain('"tableName":"incidents"');
   });
 
   it("redacts API keys from migration demo error messages", async () => {

--- a/test/migration-esri-leaflet-runtime.test.ts
+++ b/test/migration-esri-leaflet-runtime.test.ts
@@ -1,7 +1,7 @@
+import { execSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { execSync } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -95,107 +95,111 @@ afterEach(() => {
 });
 
 describe("migration esri-leaflet runtime", () => {
-  it("executes migrated map/view/widget flow with esri-leaflet target and compat fallbacks", { timeout: 60_000 }, async () => {
-    ensureBuiltCompatArtifacts();
-    const tempRoot = makeTempDir();
-    const file = path.join(tempRoot, "main.js");
+  it(
+    "executes migrated map/view/widget flow with esri-leaflet target and compat fallbacks",
+    { timeout: 60_000 },
+    async () => {
+      ensureBuiltCompatArtifacts();
+      const tempRoot = makeTempDir();
+      const file = path.join(tempRoot, "main.js");
 
-    writeEsriLeafletStub(path.join(tempRoot, "node_modules", "esri-leaflet"));
+      writeEsriLeafletStub(path.join(tempRoot, "node_modules", "esri-leaflet"));
 
-    fs.writeFileSync(
-      file,
-      [
-        "import FeatureLayer from '@arcgis/core/layers/FeatureLayer';",
-        "import Map from '@arcgis/core/Map';",
-        "import MapView from '@arcgis/core/views/MapView';",
-        "import SceneView from '@arcgis/core/views/SceneView';",
-        "import LayerList from '@arcgis/core/widgets/LayerList';",
-        "import Legend from '@arcgis/core/widgets/Legend';",
-        "import Popup from '@arcgis/core/widgets/Popup';",
-        "import Search from '@arcgis/core/widgets/Search';",
-        "const layer = new FeatureLayer({ url: 'https://example.test/rest/services/default/FeatureServer/0' });",
-        "const map = new Map({ basemap: 'streets', layers: [layer] });",
-        "const view = new MapView({ map, container: 'viewDiv', center: [-157.85, 21.3], zoom: 12 });",
-        "const scene = new SceneView({ map, container: 'sceneDiv', viewingMode: 'global' });",
-        "const layerList = new LayerList({ view });",
-        "const legend = new Legend({ view });",
-        "const popup = new Popup({ view });",
-        "const search = new Search({",
-        "  view,",
-        "  includeDefaultSources: false,",
-        "  autoNavigate: false,",
-        "  sources: [",
-        "    { search: async ({ searchTerm }) => [{ name: `Result ${searchTerm}`, location: { x: 1, y: 2 } }] },",
-        "  ],",
-        "});",
-        "popup.open({ title: 'Runtime', content: 'Smoke', features: [{ id: 1 }] });",
-        "const searchResult = await search.search('honua');",
-        "export default {",
-        "  layerCtor: layer.constructor.name,",
-        "  layerSource: layer.source,",
-        "  mapCtor: map.constructor.name,",
-        "  viewCtor: view.constructor.name,",
-        "  sceneViewCtor: scene.constructor.name,",
-        "  layerListCtor: layerList.constructor.name,",
-        "  legendCtor: legend.constructor.name,",
-        "  popupCtor: popup.constructor.name,",
-        "  searchCtor: search.constructor.name,",
-        "  searchResultCount: searchResult.results.length,",
-        "  mapLayerCount: map.layers.length,",
-        "};",
-      ].join("\n"),
-      "utf8",
-    );
+      fs.writeFileSync(
+        file,
+        [
+          "import FeatureLayer from '@arcgis/core/layers/FeatureLayer';",
+          "import Map from '@arcgis/core/Map';",
+          "import MapView from '@arcgis/core/views/MapView';",
+          "import SceneView from '@arcgis/core/views/SceneView';",
+          "import LayerList from '@arcgis/core/widgets/LayerList';",
+          "import Legend from '@arcgis/core/widgets/Legend';",
+          "import Popup from '@arcgis/core/widgets/Popup';",
+          "import Search from '@arcgis/core/widgets/Search';",
+          "const layer = new FeatureLayer({ url: 'https://example.test/rest/services/default/FeatureServer/0' });",
+          "const map = new Map({ basemap: 'streets', layers: [layer] });",
+          "const view = new MapView({ map, container: 'viewDiv', center: [-157.85, 21.3], zoom: 12 });",
+          "const scene = new SceneView({ map, container: 'sceneDiv', viewingMode: 'global' });",
+          "const layerList = new LayerList({ view });",
+          "const legend = new Legend({ view });",
+          "const popup = new Popup({ view });",
+          "const search = new Search({",
+          "  view,",
+          "  includeDefaultSources: false,",
+          "  autoNavigate: false,",
+          "  sources: [",
+          "    { search: async ({ searchTerm }) => [{ name: `Result ${searchTerm}`, location: { x: 1, y: 2 } }] },",
+          "  ],",
+          "});",
+          "popup.open({ title: 'Runtime', content: 'Smoke', features: [{ id: 1 }] });",
+          "const searchResult = await search.search('honua');",
+          "export default {",
+          "  layerCtor: layer.constructor.name,",
+          "  layerSource: layer.source,",
+          "  mapCtor: map.constructor.name,",
+          "  viewCtor: view.constructor.name,",
+          "  sceneViewCtor: scene.constructor.name,",
+          "  layerListCtor: layerList.constructor.name,",
+          "  legendCtor: legend.constructor.name,",
+          "  popupCtor: popup.constructor.name,",
+          "  searchCtor: search.constructor.name,",
+          "  searchResultCount: searchResult.results.length,",
+          "  mapLayerCount: map.layers.length,",
+          "};",
+        ].join("\n"),
+        "utf8",
+      );
 
-    const codemodResult = runEsriCompatCodemod({
-      rootDir: tempRoot,
-      target: "esri-leaflet",
-      write: true,
-      compatImportPath: compatDistEntry(),
-    });
+      const codemodResult = runEsriCompatCodemod({
+        rootDir: tempRoot,
+        target: "esri-leaflet",
+        write: true,
+        compatImportPath: compatDistEntry(),
+      });
 
-    expect(codemodResult.filesChanged).toBe(1);
-    expect(codemodResult.metrics.totalCodemodScopedCallSites).toBe(8);
-    expect(codemodResult.metrics.autoMigratedCallSites).toBe(8);
-    expect(codemodResult.metrics.manualCallSites).toBe(0);
-    expect(codemodResult.metrics.byKind["feature-layer"]).toMatchObject({ autoMigrated: 1, manual: 0 });
-    expect(codemodResult.metrics.byKind.map).toMatchObject({ autoMigrated: 1, manual: 0 });
-    expect(codemodResult.metrics.byKind["map-view"]).toMatchObject({ autoMigrated: 1, manual: 0 });
-    expect(codemodResult.metrics.byKind["scene-view"]).toMatchObject({ autoMigrated: 1, manual: 0 });
-    expect(codemodResult.metrics.byKind["layer-list"]).toMatchObject({ autoMigrated: 1, manual: 0 });
-    expect(codemodResult.metrics.byKind["legend-widget"]).toMatchObject({ autoMigrated: 1, manual: 0 });
-    expect(codemodResult.metrics.byKind["popup-widget"]).toMatchObject({ autoMigrated: 1, manual: 0 });
-    expect(codemodResult.metrics.byKind["search-widget"]).toMatchObject({ autoMigrated: 1, manual: 0 });
+      expect(codemodResult.filesChanged).toBe(1);
+      expect(codemodResult.metrics.totalCodemodScopedCallSites).toBe(8);
+      expect(codemodResult.metrics.autoMigratedCallSites).toBe(8);
+      expect(codemodResult.metrics.manualCallSites).toBe(0);
+      expect(codemodResult.metrics.byKind["feature-layer"]).toMatchObject({ autoMigrated: 1, manual: 0 });
+      expect(codemodResult.metrics.byKind.map).toMatchObject({ autoMigrated: 1, manual: 0 });
+      expect(codemodResult.metrics.byKind["map-view"]).toMatchObject({ autoMigrated: 1, manual: 0 });
+      expect(codemodResult.metrics.byKind["scene-view"]).toMatchObject({ autoMigrated: 1, manual: 0 });
+      expect(codemodResult.metrics.byKind["layer-list"]).toMatchObject({ autoMigrated: 1, manual: 0 });
+      expect(codemodResult.metrics.byKind["legend-widget"]).toMatchObject({ autoMigrated: 1, manual: 0 });
+      expect(codemodResult.metrics.byKind["popup-widget"]).toMatchObject({ autoMigrated: 1, manual: 0 });
+      expect(codemodResult.metrics.byKind["search-widget"]).toMatchObject({ autoMigrated: 1, manual: 0 });
 
-    const migratedSource = fs.readFileSync(file, "utf8");
-    expect(migratedSource).toContain('import * as HonuaEsriLeaflet from "esri-leaflet";');
-    expect(migratedSource).toContain("const layer = HonuaEsriLeaflet.featureLayer({");
-    expect(migratedSource).toContain("new MapCompat({");
-    expect(migratedSource).toContain("new MapViewCompat({");
-    expect(migratedSource).toContain("new SceneViewCompat({");
-    expect(migratedSource).toContain("new LayerListCompat({");
-    expect(migratedSource).toContain("new LegendCompat({");
-    expect(migratedSource).toContain("new PopupCompat({");
-    expect(migratedSource).toContain("new SearchCompat({");
+      const migratedSource = fs.readFileSync(file, "utf8");
+      expect(migratedSource).toContain('import * as HonuaEsriLeaflet from "esri-leaflet";');
+      expect(migratedSource).toContain("const layer = HonuaEsriLeaflet.featureLayer({");
+      expect(migratedSource).toContain("new MapCompat({");
+      expect(migratedSource).toContain("new MapViewCompat({");
+      expect(migratedSource).toContain("new SceneViewCompat({");
+      expect(migratedSource).toContain("new LayerListCompat({");
+      expect(migratedSource).toContain("new LegendCompat({");
+      expect(migratedSource).toContain("new PopupCompat({");
+      expect(migratedSource).toContain("new SearchCompat({");
 
-    const moduleUrl = `${pathToFileURL(file).href}?cachebust=${Date.now()}`;
-    const migrated = await import(moduleUrl);
-    expect(migrated.default).toEqual(
-      expect.objectContaining({
-        layerCtor: "EsriLeafletFeatureLayerStub",
-        layerSource: "esri-leaflet",
-        mapCtor: "MapCompat",
-        viewCtor: "MapViewCompat",
-        sceneViewCtor: "SceneViewCompat",
-        layerListCtor: "LayerListCompat",
-        legendCtor: "LegendCompat",
-        popupCtor: "PopupCompat",
-        searchCtor: "SearchCompat",
-        searchResultCount: 1,
-        mapLayerCount: 1,
-      }),
-    );
-  });
+      const moduleUrl = `${pathToFileURL(file).href}?cachebust=${Date.now()}`;
+      const migrated = await import(moduleUrl);
+      expect(migrated.default).toEqual(
+        expect.objectContaining({
+          layerCtor: "EsriLeafletFeatureLayerStub",
+          layerSource: "esri-leaflet",
+          mapCtor: "MapCompat",
+          viewCtor: "MapViewCompat",
+          sceneViewCtor: "SceneViewCompat",
+          layerListCtor: "LayerListCompat",
+          legendCtor: "LegendCompat",
+          popupCtor: "PopupCompat",
+          searchCtor: "SearchCompat",
+          searchResultCount: 1,
+          mapLayerCount: 1,
+        }),
+      );
+    },
+  );
 
   it("uses compat layer fallbacks when advanced layer methods are present", { timeout: 60_000 }, async () => {
     ensureBuiltCompatArtifacts();

--- a/test/migration-feature-table-demo-runtime.test.ts
+++ b/test/migration-feature-table-demo-runtime.test.ts
@@ -1,7 +1,7 @@
+import { execSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { execSync } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -83,9 +83,7 @@ afterEach(() => {
 
 describe("feature-table demo runtime", () => {
   it("migrates and executes primary related-records fixture with table/map and legend flows", async () => {
-    const { codemodResult, report, output } = await migrateAndRunFixture(
-      "esri-demo-feature-table-relates-app",
-    );
+    const { codemodResult, report, output } = await migrateAndRunFixture("esri-demo-feature-table-relates-app");
 
     expect(codemodResult.filesChanged).toBe(1);
     expect(codemodResult.metrics.manualCallSites).toBe(0);
@@ -119,12 +117,7 @@ describe("feature-table demo runtime", () => {
     expect(output.layerListCount).toBeGreaterThanOrEqual(2);
     expect(output.legendLayerCount).toBeGreaterThanOrEqual(1);
     expect(output.legendEntryCount).toBeGreaterThanOrEqual(1);
-    expect(output.widgetCtors).toEqual([
-      "FeatureTableCompat",
-      "PopupCompat",
-      "LayerListCompat",
-      "LegendCompat",
-    ]);
+    expect(output.widgetCtors).toEqual(["FeatureTableCompat", "PopupCompat", "LayerListCompat", "LegendCompat"]);
   }, 60_000);
 
   it("migrates and executes fallback popup-interaction fixture", async () => {

--- a/test/migration-gating.test.ts
+++ b/test/migration-gating.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import type { JsMigrationReport } from "../src/migration/report.js";
 import { evaluateMigrationGates } from "../src/migration/gating.js";
+import type { JsMigrationReport } from "../src/migration/report.js";
 
 function createReport(): JsMigrationReport {
   return {

--- a/test/migration-integration.test.ts
+++ b/test/migration-integration.test.ts
@@ -200,22 +200,16 @@ describe("arcgis migration integration", () => {
     expect(migratedMain).toContain(
       'const simple = new FeatureLayerCompat({ url: "https://example.test/rest/services/default/FeatureServer/0" });',
     );
-    expect(migratedMain).toContain(
-      'const map = new MapCompat({ basemap: "streets-vector", layers: [simple] });',
-    );
+    expect(migratedMain).toContain('const map = new MapCompat({ basemap: "streets-vector", layers: [simple] });');
     expect(migratedMain).toContain("const mapView = new MapViewCompat({");
-    expect(migratedMain).toContain(
-      'const complex = new FeatureLayerCompat({ url: layerUrl, outFields: ["*"] });',
-    );
+    expect(migratedMain).toContain('const complex = new FeatureLayerCompat({ url: layerUrl, outFields: ["*"] });');
     expect(migratedMain).not.toContain('import FeatureLayer from "@arcgis/core/layers/FeatureLayer";');
     expect(migratedMain).not.toContain('import WebMap from "@arcgis/core/WebMap";');
     expect(migratedMain).not.toContain('import Map from "@arcgis/core/Map";');
     expect(migratedMain).not.toContain('import MapView from "@arcgis/core/views/MapView";');
 
     const migratedLazy = fs.readFileSync(path.join(workingCopy, "src", "lazy.ts"), "utf8");
-    expect(migratedLazy).toContain(
-      'import("@honua/sdk-esri-compat").then((m) => ({ default: m.SceneViewCompat }))',
-    );
+    expect(migratedLazy).toContain('import("@honua/sdk-esri-compat").then((m) => ({ default: m.SceneViewCompat }))');
     expect(migratedLazy).not.toContain("@arcgis/core/views/SceneView");
   });
 
@@ -272,9 +266,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("migrates a hit-test sample app with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-hit-test-sample-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-hit-test-sample-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -328,9 +320,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("migrates map image layer app flow with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-map-image-layer-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-map-image-layer-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -375,9 +365,7 @@ describe("arcgis migration integration", () => {
     ]);
 
     const migratedMain = fs.readFileSync(path.join(workingCopy, "src", "main.ts"), "utf8");
-    expect(migratedMain).toContain(
-      'import { MapCompat, MapImageLayerCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(migratedMain).toContain('import { MapCompat, MapImageLayerCompat } from "@honua/sdk-esri-compat";');
     expect(migratedMain).toContain("const parcels = new MapImageLayerCompat({");
     expect(migratedMain).toContain("const map = new MapCompat({");
     expect(migratedMain).not.toContain("@arcgis/core/layers/MapImageLayer");
@@ -385,9 +373,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("migrates tile layer app flow with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-tile-layer-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-tile-layer-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -402,9 +388,7 @@ describe("arcgis migration integration", () => {
     expect(report.readiness).toBe("ready");
 
     const migratedMain = fs.readFileSync(path.join(workingCopy, "src", "main.ts"), "utf8");
-    expect(migratedMain).toContain(
-      'import { MapCompat, TileLayerCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(migratedMain).toContain('import { MapCompat, TileLayerCompat } from "@honua/sdk-esri-compat";');
     expect(migratedMain).toContain("const tiled = new TileLayerCompat({");
     expect(migratedMain).toContain("const map = new MapCompat({");
     expect(migratedMain).not.toContain("@arcgis/core/layers/TileLayer");
@@ -412,9 +396,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("migrates basemap constructor fixture with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-basemap-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-basemap-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -440,9 +422,7 @@ describe("arcgis migration integration", () => {
     expect(report.unhandledArcGisModules).toEqual([]);
 
     const migratedMain = fs.readFileSync(path.join(workingCopy, "src", "main.ts"), "utf8");
-    expect(migratedMain).toContain(
-      'import { BasemapCompat, MapCompat, MapViewCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(migratedMain).toContain('import { BasemapCompat, MapCompat, MapViewCompat } from "@honua/sdk-esri-compat";');
     expect(migratedMain).toContain("const basemap = new BasemapCompat({");
     expect(migratedMain).toContain("const map = new MapCompat({");
     expect(migratedMain).toContain("const view = new MapViewCompat({");
@@ -450,9 +430,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("migrates route task fixture with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-route-task-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-route-task-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -474,9 +452,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("migrates reactive-utils fixture with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-reactive-utils-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-reactive-utils-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -492,9 +468,7 @@ describe("arcgis migration integration", () => {
     expect(report.unhandledArcGisModules).toEqual([]);
 
     const migratedMain = fs.readFileSync(path.join(workingCopy, "src", "main.ts"), "utf8");
-    expect(migratedMain).toContain(
-      'import { reactiveUtils } from "@honua/sdk-esri-compat";',
-    );
+    expect(migratedMain).toContain('import { reactiveUtils } from "@honua/sdk-esri-compat";');
     expect(migratedMain).toContain("reactiveUtils.whenOnce(() => ready);");
     expect(migratedMain).not.toContain("@arcgis/core/core/reactiveUtils");
   });
@@ -543,18 +517,14 @@ describe("arcgis migration integration", () => {
     expect(report.unhandledArcGisModules).toEqual([]);
 
     const migratedMain = fs.readFileSync(path.join(workingCopy, "src", "main.ts"), "utf8");
-    expect(migratedMain).toContain(
-      'import { FeatureLayerCompat, QueryCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(migratedMain).toContain('import { FeatureLayerCompat, QueryCompat } from "@honua/sdk-esri-compat";');
     expect(migratedMain).toContain("const parcels = new FeatureLayerCompat({");
     expect(migratedMain).toContain("const query = new QueryCompat({");
     expect(migratedMain).not.toContain("@arcgis/core/rest/support/Query");
   });
 
   it("migrates geometry/symbol fixture with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-graphic-symbols-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-graphic-symbols-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -596,9 +566,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("migrates geometry primitives fixture with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-geometry-primitives-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-geometry-primitives-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -837,9 +805,7 @@ describe("arcgis migration integration", () => {
 
     const migratedMain = fs.readFileSync(path.join(workingCopy, "src", "main.ts"), "utf8");
     expect(migratedMain).toContain('import { esriConfig, OAuthInfoCompat } from "@honua/sdk-esri-compat";');
-    expect(migratedMain).toContain(
-      'import { identityManager as IdentityManager } from "@honua/sdk-esri-compat";',
-    );
+    expect(migratedMain).toContain('import { identityManager as IdentityManager } from "@honua/sdk-esri-compat";');
     expect(migratedMain).toContain("const info = new OAuthInfoCompat({");
     expect(migratedMain).toContain("IdentityManager.registerOAuthInfos([info]);");
     expect(migratedMain).not.toContain("@arcgis/core/identity/OAuthInfo");
@@ -848,9 +814,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("migrates feature table fixture with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-feature-table-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-feature-table-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -871,9 +835,7 @@ describe("arcgis migration integration", () => {
     expect(report.unhandledArcGisModules).toEqual([]);
 
     const migratedMain = fs.readFileSync(path.join(workingCopy, "src", "main.ts"), "utf8");
-    expect(migratedMain).toContain(
-      'import { FeatureLayerCompat, FeatureTableCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(migratedMain).toContain('import { FeatureLayerCompat, FeatureTableCompat } from "@honua/sdk-esri-compat";');
     expect(migratedMain).toContain("const parcels = new FeatureLayerCompat({");
     expect(migratedMain).toContain("const table = new FeatureTableCompat({");
     expect(migratedMain).not.toContain("@arcgis/core/layers/FeatureLayer");
@@ -881,9 +843,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("migrates advanced feature table fixture with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-feature-table-relates-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-feature-table-relates-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -921,14 +881,12 @@ describe("arcgis migration integration", () => {
     expect(migratedMain).toContain("relatedRecordsEnabled: true");
     expect(migratedMain).toContain("attachmentsEnabled: true");
     expect(migratedMain).toContain("table.highlightIds.push(1);");
-    expect(migratedMain).toContain("table.highlightIds.on(\"change\", (event) => {");
+    expect(migratedMain).toContain('table.highlightIds.on("change", (event) => {');
     expect(migratedMain).not.toContain("@arcgis/core/widgets/FeatureTable");
   });
 
   it("migrates feature widget fixture with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-feature-widget-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-feature-widget-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -954,17 +912,13 @@ describe("arcgis migration integration", () => {
     expect(report.unhandledArcGisModules).toEqual([]);
 
     const migratedMain = fs.readFileSync(path.join(workingCopy, "src", "main.ts"), "utf8");
-    expect(migratedMain).toContain(
-      'import { FeatureCompat, MapCompat, MapViewCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(migratedMain).toContain('import { FeatureCompat, MapCompat, MapViewCompat } from "@honua/sdk-esri-compat";');
     expect(migratedMain).toContain("const featureWidget = new FeatureCompat({");
     expect(migratedMain).not.toContain("@arcgis/core/widgets/Feature");
   });
 
   it("migrates feature form fixture with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-feature-form-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-feature-form-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -985,17 +939,13 @@ describe("arcgis migration integration", () => {
     expect(report.unhandledArcGisModules).toEqual([]);
 
     const migratedMain = fs.readFileSync(path.join(workingCopy, "src", "main.ts"), "utf8");
-    expect(migratedMain).toContain(
-      'import { FeatureFormCompat, FeatureLayerCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(migratedMain).toContain('import { FeatureFormCompat, FeatureLayerCompat } from "@honua/sdk-esri-compat";');
     expect(migratedMain).toContain("const form = new FeatureFormCompat({");
     expect(migratedMain).not.toContain("@arcgis/core/widgets/FeatureForm");
   });
 
   it("migrates table list fixture with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-table-list-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-table-list-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -1029,9 +979,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("migrates feature templates fixture with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-feature-templates-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-feature-templates-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -1060,9 +1008,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("migrates basemap layer list fixture with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-basemap-layer-list-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-basemap-layer-list-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -1096,9 +1042,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("migrates print widget fixture with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-print-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-print-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -1124,17 +1068,13 @@ describe("arcgis migration integration", () => {
     expect(report.unhandledArcGisModules).toEqual([]);
 
     const migratedMain = fs.readFileSync(path.join(workingCopy, "src", "main.ts"), "utf8");
-    expect(migratedMain).toContain(
-      'import { MapCompat, MapViewCompat, PrintCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(migratedMain).toContain('import { MapCompat, MapViewCompat, PrintCompat } from "@honua/sdk-esri-compat";');
     expect(migratedMain).toContain("const printer = new PrintCompat({");
     expect(migratedMain).not.toContain("@arcgis/core/widgets/Print");
   });
 
   it("migrates swipe widget fixture with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-swipe-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-swipe-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -1160,17 +1100,13 @@ describe("arcgis migration integration", () => {
     expect(report.unhandledArcGisModules).toEqual([]);
 
     const migratedMain = fs.readFileSync(path.join(workingCopy, "src", "main.ts"), "utf8");
-    expect(migratedMain).toContain(
-      'import { MapCompat, MapViewCompat, SwipeCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(migratedMain).toContain('import { MapCompat, MapViewCompat, SwipeCompat } from "@honua/sdk-esri-compat";');
     expect(migratedMain).toContain("const swipe = new SwipeCompat({");
     expect(migratedMain).not.toContain("@arcgis/core/widgets/Swipe");
   });
 
   it("migrates distance/area measurement 2d fixture with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-measurement-2d-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-measurement-2d-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -1211,10 +1147,9 @@ describe("arcgis migration integration", () => {
   });
 
   it("supports esri-leaflet codemod target for deterministic subset", () => {
-    const { workingCopy, report, codemodResult } = runFixtureMigration(
-      "esri-map-image-layer-app",
-      { target: "esri-leaflet" },
-    );
+    const { workingCopy, report, codemodResult } = runFixtureMigration("esri-map-image-layer-app", {
+      target: "esri-leaflet",
+    });
 
     expect(codemodResult.filesChanged).toBe(1);
     expect(codemodResult.metrics.totalCodemodScopedCallSites).toBe(2);
@@ -1243,9 +1178,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("migrates map + group-layer + graphics-layer fixture with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-layer-tree-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-layer-tree-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -1283,9 +1216,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("migrates layer-list actions fixture with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-layer-list-actions-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-layer-list-actions-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -1333,9 +1264,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("migrates map widgets and controls with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-widget-controls-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-widget-controls-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -1479,11 +1408,17 @@ describe("arcgis migration integration", () => {
     expect(migratedMain).toContain("const popup = new PopupCompat({ view, dockEnabled: true });");
     expect(migratedMain).toContain("const home = new HomeCompat({");
     expect(migratedMain).toContain("viewpoint: { center: [0, 0], zoom: 3 },");
-    expect(migratedMain).toContain('const basemapToggle = new BasemapToggleCompat({ view, nextBasemap: "satellite" });');
+    expect(migratedMain).toContain(
+      'const basemapToggle = new BasemapToggleCompat({ view, nextBasemap: "satellite" });',
+    );
     expect(migratedMain).toContain("const locate = new LocateCompat({ view, zoom: 12 });");
     expect(migratedMain).toContain('const scaleBar = new ScaleBarCompat({ view, unit: "dual" });');
-    expect(migratedMain).toContain('const search = new SearchCompat({ view, container: "search-div", includeDefaultSources: false });');
-    expect(migratedMain).toContain('const basemapGallery = new BasemapGalleryCompat({ view, container: "gallery-div" });');
+    expect(migratedMain).toContain(
+      'const search = new SearchCompat({ view, container: "search-div", includeDefaultSources: false });',
+    );
+    expect(migratedMain).toContain(
+      'const basemapGallery = new BasemapGalleryCompat({ view, container: "gallery-div" });',
+    );
     expect(migratedMain).toContain("const compass = new CompassCompat({ view });");
     expect(migratedMain).toContain("const expand = new ExpandCompat({ view, content: legend, expanded: false });");
     expect(migratedMain).toContain("const bookmarks = new BookmarksCompat({");
@@ -1499,9 +1434,9 @@ describe("arcgis migration integration", () => {
       'const editor = new EditorCompat({ view, layerInfos: [], allowedWorkflows: ["create", "update"] });',
     );
     expect(migratedMain).toContain("const track = new TrackCompat({");
-    expect(migratedMain).toContain('goToLocationEnabled: true');
-    expect(migratedMain).toContain('useHeadingEnabled: true');
-    expect(migratedMain).toContain('rotationEnabled: true');
+    expect(migratedMain).toContain("goToLocationEnabled: true");
+    expect(migratedMain).toContain("useHeadingEnabled: true");
+    expect(migratedMain).toContain("rotationEnabled: true");
     expect(migratedMain).toContain("trackProvider: async () => ({");
     expect(migratedMain).toContain("latitude: 21.3069");
     expect(migratedMain).toContain("longitude: -157.8583");
@@ -1514,9 +1449,7 @@ describe("arcgis migration integration", () => {
     expect(migratedMain).toContain('areaUnit: "square-kilometers"');
     expect(migratedMain).toContain("const timeSlider = new TimeSliderCompat({");
     expect(migratedMain).toContain('mode: "instant"');
-    expect(migratedMain).toContain(
-      'values: ["2024-01-01T00:00:00.000Z", "2024-02-01T00:00:00.000Z"]',
-    );
+    expect(migratedMain).toContain('values: ["2024-01-01T00:00:00.000Z", "2024-02-01T00:00:00.000Z"]');
     expect(migratedMain).toContain('view.ui.add(layerList, "top-right");');
     expect(migratedMain).toContain('view.ui.add([legend, home], "top-left");');
     expect(migratedMain).toContain('view.ui.add(popup, { position: "manual", index: 0 });');
@@ -1562,9 +1495,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("migrates supported dynamic import usage with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-dynamic-map-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-dynamic-map-app");
 
     expect(scanReport.flags).toContain("dynamic-import-detected");
     expect(codemodResult.filesChanged).toBe(1);
@@ -1604,11 +1535,9 @@ describe("arcgis migration integration", () => {
     ]);
 
     const migratedMain = fs.readFileSync(path.join(workingCopy, "src", "main.ts"), "utf8");
-    expect(migratedMain).toContain(
-      'import("@honua/sdk-esri-compat").then((m) => ({ default: m.MapCompat }))',
-    );
+    expect(migratedMain).toContain('import("@honua/sdk-esri-compat").then((m) => ({ default: m.MapCompat }))');
     expect(migratedMain).toContain("return new MapCtor({");
-    expect(migratedMain).not.toContain('@arcgis/core/Map');
+    expect(migratedMain).not.toContain("@arcgis/core/Map");
   });
 
   it("migrates webmap constructor flow with ready gating", () => {
@@ -1652,9 +1581,7 @@ describe("arcgis migration integration", () => {
     ]);
 
     const migratedMain = fs.readFileSync(path.join(workingCopy, "src", "main.ts"), "utf8");
-    expect(migratedMain).toContain(
-      'import { MapViewCompat, WebMapCompat } from "@honua/sdk-esri-compat";',
-    );
+    expect(migratedMain).toContain('import { MapViewCompat, WebMapCompat } from "@honua/sdk-esri-compat";');
     expect(migratedMain).toContain("const map = new WebMapCompat({");
     expect(migratedMain).toContain("const view = new MapViewCompat({");
     expect(migratedMain).not.toContain("@arcgis/core/WebMap");
@@ -1662,9 +1589,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("migrates await import default flow with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-await-import-default-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-await-import-default-app");
 
     expect(scanReport.flags).toContain("dynamic-import-detected");
     expect(codemodResult.filesChanged).toBe(1);
@@ -1708,13 +1633,11 @@ describe("arcgis migration integration", () => {
       '(await import("@honua/sdk-esri-compat").then((m) => ({ default: m.MapCompat }))).default',
     );
     expect(migratedMain).toContain("return new MapCtor({");
-    expect(migratedMain).not.toContain('@arcgis/core/Map');
+    expect(migratedMain).not.toContain("@arcgis/core/Map");
   });
 
   it("migrates related-feature query app flow with ready gating", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-related-features-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-related-features-app");
 
     expect(scanReport.flags).toEqual([]);
     expect(codemodResult.filesChanged).toBe(1);
@@ -1761,9 +1684,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("reports assisted when .cjs require-style usage requires manual migration", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-assisted-require-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-assisted-require-app");
 
     expect(scanReport.flags).toEqual(["commonjs-detected"]);
     expect(codemodResult.filesChanged).toBe(0);
@@ -1813,9 +1734,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("reports assisted when .js CommonJS require usage requires manual migration", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-assisted-require-js-cjs-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-assisted-require-js-cjs-app");
 
     expect(scanReport.flags).toEqual(["commonjs-detected"]);
     expect(codemodResult.filesChanged).toBe(0);
@@ -1865,9 +1784,7 @@ describe("arcgis migration integration", () => {
   });
 
   it("reports assisted for side-effect ArcGIS imports outside codemod scope", () => {
-    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration(
-      "esri-assisted-side-effect-app",
-    );
+    const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-assisted-side-effect-app");
 
     expect(scanReport.flags).toEqual(["auth-or-request-customization-detected"]);
     expect(scanReport.imports).toEqual([

--- a/test/migration-parity-matrix.test.ts
+++ b/test/migration-parity-matrix.test.ts
@@ -52,9 +52,7 @@ describe("JS parity matrix", () => {
     const tableListWidget = matrix.find((row) => row.kind === "table-list-widget");
     const featureTemplatesWidget = matrix.find((row) => row.kind === "feature-templates-widget");
     const basemapLayerListWidget = matrix.find((row) => row.kind === "basemap-layer-list-widget");
-    const distanceMeasurement2dWidget = matrix.find(
-      (row) => row.kind === "distance-measurement-2d-widget",
-    );
+    const distanceMeasurement2dWidget = matrix.find((row) => row.kind === "distance-measurement-2d-widget");
     const areaMeasurement2dWidget = matrix.find((row) => row.kind === "area-measurement-2d-widget");
     const query = matrix.find((row) => row.kind === "query");
     const oauthInfo = matrix.find((row) => row.kind === "oauth-info");
@@ -245,10 +243,7 @@ describe("JS parity matrix", () => {
     const matrix = getJsParityMatrix();
     const summary = summarizeJsParityMatrix(matrix);
     const totalHonua = Object.values(summary.honuaCompat).reduce((acc, value) => acc + value, 0);
-    const totalEsriLeaflet = Object.values(summary.esriLeaflet).reduce(
-      (acc, value) => acc + value,
-      0,
-    );
+    const totalEsriLeaflet = Object.values(summary.esriLeaflet).reduce((acc, value) => acc + value, 0);
 
     expect(totalHonua).toBe(matrix.length);
     expect(totalEsriLeaflet).toBe(matrix.length);

--- a/test/migration-real-sample-runtime.test.ts
+++ b/test/migration-real-sample-runtime.test.ts
@@ -1,7 +1,7 @@
+import { execSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { execSync } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -83,9 +83,7 @@ afterEach(() => {
 
 describe("migration real sample runtime", () => {
   it("migrates and executes ops center sample", { timeout: 60_000 }, async () => {
-    const { codemodResult, report, output } = await migrateAndRunFixture(
-      "esri-real-sample-ops-center-app",
-    );
+    const { codemodResult, report, output } = await migrateAndRunFixture("esri-real-sample-ops-center-app");
 
     expect(codemodResult.filesChanged).toBe(1);
     expect(codemodResult.metrics.totalCodemodScopedCallSites).toBe(16);
@@ -139,9 +137,7 @@ describe("migration real sample runtime", () => {
   });
 
   it("migrates and executes editing workflow sample", { timeout: 60_000 }, async () => {
-    const { codemodResult, report, output } = await migrateAndRunFixture(
-      "esri-real-sample-editing-app",
-    );
+    const { codemodResult, report, output } = await migrateAndRunFixture("esri-real-sample-editing-app");
 
     expect(codemodResult.filesChanged).toBe(1);
     expect(codemodResult.metrics.totalCodemodScopedCallSites).toBe(13);
@@ -195,9 +191,7 @@ describe("migration real sample runtime", () => {
   });
 
   it("migrates and executes network workflow sample", { timeout: 60_000 }, async () => {
-    const { codemodResult, report, output } = await migrateAndRunFixture(
-      "esri-real-sample-network-app",
-    );
+    const { codemodResult, report, output } = await migrateAndRunFixture("esri-real-sample-network-app");
 
     expect(codemodResult.filesChanged).toBe(1);
     expect(codemodResult.metrics.totalCodemodScopedCallSites).toBe(10);
@@ -240,9 +234,7 @@ describe("migration real sample runtime", () => {
   });
 
   it("migrates and executes incident command sample", { timeout: 60_000 }, async () => {
-    const { codemodResult, report, output } = await migrateAndRunFixture(
-      "esri-real-sample-incident-command-app",
-    );
+    const { codemodResult, report, output } = await migrateAndRunFixture("esri-real-sample-incident-command-app");
 
     expect(codemodResult.filesChanged).toBe(1);
     expect(codemodResult.metrics.totalCodemodScopedCallSites).toBe(28);

--- a/test/migration-report.test.ts
+++ b/test/migration-report.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import type { ArcGisScanReport } from "../src/migration/scanner.js";
-import { buildJsMigrationReport } from "../src/migration/report.js";
 import type { EsriCompatCodemodResult } from "../src/migration/codemod.js";
+import { buildJsMigrationReport } from "../src/migration/report.js";
+import type { ArcGisScanReport } from "../src/migration/scanner.js";
 
 function createCodemodResult(): EsriCompatCodemodResult {
   return {

--- a/test/migration-runtime-matrix.test.ts
+++ b/test/migration-runtime-matrix.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  getJsRuntimeParityMatrix,
-  summarizeJsRuntimeParity,
-} from "../src/migration/runtime-matrix.js";
+import { getJsRuntimeParityMatrix, summarizeJsRuntimeParity } from "../src/migration/runtime-matrix.js";
 
 describe("JS runtime parity matrix", () => {
   it("includes migration-critical runtime capabilities", () => {
@@ -12,9 +9,7 @@ describe("JS runtime parity matrix", () => {
     const featureLayerQuery = matrix.find(
       (entry) => entry.surface === "feature-layer" && entry.capability === "query-features",
     );
-    const mapImageFind = matrix.find(
-      (entry) => entry.surface === "map-image-layer" && entry.capability === "find",
-    );
+    const mapImageFind = matrix.find((entry) => entry.surface === "map-image-layer" && entry.capability === "find");
     const mapImageQuery = matrix.find(
       (entry) => entry.surface === "map-image-layer" && entry.capability === "query-features",
     );
@@ -30,9 +25,7 @@ describe("JS runtime parity matrix", () => {
     const mapImageSublayerVisibility = matrix.find(
       (entry) => entry.surface === "map-image-layer" && entry.capability === "sublayer-visibility-and-filters",
     );
-    const mapViewGoTo = matrix.find(
-      (entry) => entry.surface === "map-view" && entry.capability === "navigation-go-to",
-    );
+    const mapViewGoTo = matrix.find((entry) => entry.surface === "map-view" && entry.capability === "navigation-go-to");
     const navigationWidgets = matrix.find(
       (entry) => entry.surface === "widget" && entry.capability === "navigation-widgets",
     );
@@ -96,10 +89,7 @@ describe("JS runtime parity matrix", () => {
     const summary = summarizeJsRuntimeParity(matrix);
 
     const totalHonua = Object.values(summary.honuaCompat).reduce((acc, value) => acc + value, 0);
-    const totalEsriLeaflet = Object.values(summary.esriLeaflet).reduce(
-      (acc, value) => acc + value,
-      0,
-    );
+    const totalEsriLeaflet = Object.values(summary.esriLeaflet).reduce((acc, value) => acc + value, 0);
 
     expect(totalHonua).toBe(matrix.length);
     expect(totalEsriLeaflet).toBe(matrix.length);

--- a/test/migration-runtime-smoke.test.ts
+++ b/test/migration-runtime-smoke.test.ts
@@ -1,7 +1,7 @@
+import { execSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { execSync } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -264,7 +264,7 @@ describe("migration runtime smoke", () => {
         "  directionsStopCount: directionsSummary?.stopCount ?? 0,",
         "  directionsDistanceMeters: directionsSummary?.distanceMeters ?? 0,",
         "  clickEventHits: clickEvents[0] ?? 0,",
-      "};",
+        "};",
       ].join("\n"),
       "utf8",
     );

--- a/test/migration-scanner.test.ts
+++ b/test/migration-scanner.test.ts
@@ -66,10 +66,7 @@ describe("scanArcGisUsage", () => {
     const root = makeTempProject();
     fs.writeFileSync(
       path.join(root, "side-effects.ts"),
-      [
-        "import '@arcgis/core/identity/IdentityManager';",
-        "export const ready = true;",
-      ].join("\n"),
+      ["import '@arcgis/core/identity/IdentityManager';", "export const ready = true;"].join("\n"),
       "utf8",
     );
 
@@ -237,10 +234,7 @@ describe("scanArcGisUsage", () => {
     const root = makeTempProject();
     fs.writeFileSync(
       path.join(root, "advanced.ts"),
-      [
-        "import Geoprocessor from '@arcgis/core/rest/geoprocessor/Geoprocessor';",
-        "void Geoprocessor;",
-      ].join("\n"),
+      ["import Geoprocessor from '@arcgis/core/rest/geoprocessor/Geoprocessor';", "void Geoprocessor;"].join("\n"),
       "utf8",
     );
 
@@ -252,11 +246,9 @@ describe("scanArcGisUsage", () => {
     const root = makeTempProject();
     fs.writeFileSync(
       path.join(root, "leaflet.ts"),
-      [
-        "import * as L from 'esri-leaflet';",
-        "const layer = L.featureLayer({ url: serviceUrl });",
-        "void layer;",
-      ].join("\n"),
+      ["import * as L from 'esri-leaflet';", "const layer = L.featureLayer({ url: serviceUrl });", "void layer;"].join(
+        "\n",
+      ),
       "utf8",
     );
 

--- a/test/oauth-identity-compat.test.ts
+++ b/test/oauth-identity-compat.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 
-import { identityManager, OAuthInfoCompat } from "../src/index.js";
+import { OAuthInfoCompat, identityManager } from "../src/index.js";
 
 afterEach(() => {
   identityManager.reset();
@@ -70,9 +70,7 @@ describe("OAuth/Identity compat", () => {
       userId: "user-1",
     });
 
-    const credential = await identityManager.checkSignInStatus(
-      "https://portal.example.test/sharing/rest",
-    );
+    const credential = await identityManager.checkSignInStatus("https://portal.example.test/sharing/rest");
 
     expect(credential.token).toBe("token-abc");
     expect(credential.userId).toBe("user-1");
@@ -88,9 +86,7 @@ describe("OAuth/Identity compat", () => {
       token: "token-new",
     });
 
-    const credential = await identityManager.checkSignInStatus(
-      "https://portal.example.test/sharing/rest",
-    );
+    const credential = await identityManager.checkSignInStatus("https://portal.example.test/sharing/rest");
 
     expect(credential.token).toBe("token-new");
     expect(identityManager.credentials).toHaveLength(1);
@@ -103,9 +99,9 @@ describe("OAuth/Identity compat", () => {
       expires: Date.now() - 1_000,
     });
 
-    await expect(
-      identityManager.checkSignInStatus("https://portal.example.test/sharing/rest"),
-    ).rejects.toThrow("expired");
+    await expect(identityManager.checkSignInStatus("https://portal.example.test/sharing/rest")).rejects.toThrow(
+      "expired",
+    );
     expect(identityManager.findCredential("https://portal.example.test/sharing/rest")).toBeUndefined();
   });
 

--- a/test/pbf-decoder.test.ts
+++ b/test/pbf-decoder.test.ts
@@ -99,10 +99,7 @@ function buildSpatialReference(wkid: number, latestWkid?: number): number[] {
 }
 
 function buildField(name: string, fieldType: number, alias?: string): number[] {
-  const f = [
-    ...stringField(1, name),
-    ...varintField(2, fieldType),
-  ];
+  const f = [...stringField(1, name), ...varintField(2, fieldType)];
   if (alias) f.push(...stringField(3, alias));
   return f;
 }
@@ -140,18 +137,10 @@ function buildPointGeometry(x: number, y: number): number[] {
   ];
 }
 
-function buildTransform(
-  xScale: number,
-  yScale: number,
-  xTranslate: number,
-  yTranslate: number,
-): number[] {
+function buildTransform(xScale: number, yScale: number, xTranslate: number, yTranslate: number): number[] {
   const scale = [...doubleField(1, xScale), ...doubleField(2, yScale)];
   const translate = [...doubleField(1, xTranslate), ...doubleField(2, yTranslate)];
-  return [
-    ...lengthDelimited(2, scale),
-    ...lengthDelimited(3, translate),
-  ];
+  return [...lengthDelimited(2, scale), ...lengthDelimited(3, translate)];
 }
 
 function buildFeature(values: number[][], geometry?: number[]): number[] {
@@ -189,10 +178,7 @@ function buildFeatureResult(opts: {
 
 function buildFeatureCollectionPBuffer(version: string, featureResult: number[]): number[] {
   const queryResult = lengthDelimited(1, featureResult);
-  return [
-    ...stringField(1, version),
-    ...lengthDelimited(2, queryResult),
-  ];
+  return [...stringField(1, version), ...lengthDelimited(2, queryResult)];
 }
 
 function toBuffer(bytes: number[]): Uint8Array {
@@ -254,7 +240,7 @@ describe("decodePbfQueryResponse", () => {
       spatialReference: { wkid: 4326, latestWkid: 4326 },
       features: [],
     });
-    expect((result.fields as unknown[])).toHaveLength(1);
+    expect(result.fields as unknown[]).toHaveLength(1);
   });
 
   it("decodes feature with string attribute", () => {
@@ -289,7 +275,7 @@ describe("decodePbfQueryResponse", () => {
       fields: [
         buildField("OBJECTID", 6),
         buildField("count", 1), // Integer
-        buildField("area", 3),  // Double
+        buildField("area", 3), // Double
       ],
       features: [
         buildFeature([
@@ -312,15 +298,9 @@ describe("decodePbfQueryResponse", () => {
   it("decodes feature with boolean attribute", () => {
     const featureResult = buildFeatureResult({
       objectIdFieldName: "OBJECTID",
-      fields: [
-        buildField("OBJECTID", 6),
-        buildField("active", 4),
-      ],
+      fields: [buildField("OBJECTID", 6), buildField("active", 4)],
       features: [
-        buildFeature([
-          buildValue({ uintValue: 1, fieldIndex: 0 }),
-          buildValue({ boolValue: true, fieldIndex: 1 }),
-        ]),
+        buildFeature([buildValue({ uintValue: 1, fieldIndex: 0 }), buildValue({ boolValue: true, fieldIndex: 1 })]),
       ],
     });
     const pbf = buildFeatureCollectionPBuffer("1.0", featureResult);
@@ -334,15 +314,9 @@ describe("decodePbfQueryResponse", () => {
   it("decodes feature with null attribute", () => {
     const featureResult = buildFeatureResult({
       objectIdFieldName: "OBJECTID",
-      fields: [
-        buildField("OBJECTID", 6),
-        buildField("name", 4),
-      ],
+      fields: [buildField("OBJECTID", 6), buildField("name", 4)],
       features: [
-        buildFeature([
-          buildValue({ uintValue: 1, fieldIndex: 0 }),
-          buildValue({ isNull: true, fieldIndex: 1 }),
-        ]),
+        buildFeature([buildValue({ uintValue: 1, fieldIndex: 0 }), buildValue({ isNull: true, fieldIndex: 1 })]),
       ],
     });
     const pbf = buildFeatureCollectionPBuffer("1.0", featureResult);
@@ -359,12 +333,7 @@ describe("decodePbfQueryResponse", () => {
       geometryType: 0,
       spatialReference: buildSpatialReference(4326),
       fields: [buildField("OBJECTID", 6)],
-      features: [
-        buildFeature(
-          [buildValue({ uintValue: 1, fieldIndex: 0 })],
-          buildPointGeometry(10, 20),
-        ),
-      ],
+      features: [buildFeature([buildValue({ uintValue: 1, fieldIndex: 0 })], buildPointGeometry(10, 20))],
     });
     const pbf = buildFeatureCollectionPBuffer("1.0", featureResult);
     const result = decodePbfQueryResponse(toBuffer(pbf));
@@ -385,12 +354,7 @@ describe("decodePbfQueryResponse", () => {
       spatialReference: buildSpatialReference(4326),
       transform,
       fields: [buildField("OBJECTID", 6)],
-      features: [
-        buildFeature(
-          [buildValue({ uintValue: 1, fieldIndex: 0 })],
-          buildPointGeometry(5000, 3000),
-        ),
-      ],
+      features: [buildFeature([buildValue({ uintValue: 1, fieldIndex: 0 })], buildPointGeometry(5000, 3000))],
     });
     const pbf = buildFeatureCollectionPBuffer("1.0", featureResult);
     const result = decodePbfQueryResponse(toBuffer(pbf));
@@ -414,12 +378,7 @@ describe("decodePbfQueryResponse", () => {
       geometryType: 2, // Polyline
       spatialReference: buildSpatialReference(4326),
       fields: [buildField("OBJECTID", 6)],
-      features: [
-        buildFeature(
-          [buildValue({ uintValue: 1, fieldIndex: 0 })],
-          geometry,
-        ),
-      ],
+      features: [buildFeature([buildValue({ uintValue: 1, fieldIndex: 0 })], geometry)],
     });
     const pbf = buildFeatureCollectionPBuffer("1.0", featureResult);
     const result = decodePbfQueryResponse(toBuffer(pbf));
@@ -447,12 +406,7 @@ describe("decodePbfQueryResponse", () => {
       geometryType: 3, // Polygon
       spatialReference: buildSpatialReference(4326),
       fields: [buildField("OBJECTID", 6)],
-      features: [
-        buildFeature(
-          [buildValue({ uintValue: 1, fieldIndex: 0 })],
-          geometry,
-        ),
-      ],
+      features: [buildFeature([buildValue({ uintValue: 1, fieldIndex: 0 })], geometry)],
     });
     const pbf = buildFeatureCollectionPBuffer("1.0", featureResult);
     const result = decodePbfQueryResponse(toBuffer(pbf));
@@ -480,12 +434,7 @@ describe("decodePbfQueryResponse", () => {
       geometryType: 1,
       spatialReference: buildSpatialReference(4326),
       fields: [buildField("OBJECTID", 6)],
-      features: [
-        buildFeature(
-          [buildValue({ uintValue: 1, fieldIndex: 0 })],
-          geometry,
-        ),
-      ],
+      features: [buildFeature([buildValue({ uintValue: 1, fieldIndex: 0 })], geometry)],
     });
     const pbf = buildFeatureCollectionPBuffer("1.0", featureResult);
     const result = decodePbfQueryResponse(toBuffer(pbf));
@@ -528,10 +477,7 @@ describe("decodePbfQueryResponse", () => {
       objectIdFieldName: "OBJECTID",
       geometryType: 0,
       spatialReference: buildSpatialReference(4326),
-      fields: [
-        buildField("OBJECTID", 6),
-        buildField("name", 4),
-      ],
+      fields: [buildField("OBJECTID", 6), buildField("name", 4)],
       features: [
         buildFeature([
           buildValue({ uintValue: 1, fieldIndex: 0 }),
@@ -561,13 +507,13 @@ describe("decodePbfQueryResponse", () => {
     const featureResult = buildFeatureResult({
       objectIdFieldName: "OBJECTID",
       fields: [
-        buildField("oid", 6),        // OID
-        buildField("name", 4),       // String
-        buildField("count", 1),      // Integer
-        buildField("val", 3),        // Double
-        buildField("small", 0),      // SmallInteger
-        buildField("guid", 10),      // GUID
-        buildField("big", 13),       // BigInteger
+        buildField("oid", 6), // OID
+        buildField("name", 4), // String
+        buildField("count", 1), // Integer
+        buildField("val", 3), // Double
+        buildField("small", 0), // SmallInteger
+        buildField("guid", 10), // GUID
+        buildField("big", 13), // BigInteger
       ],
       features: [],
     });
@@ -618,9 +564,7 @@ describe("decodePbfQueryResponse", () => {
     const featureResult = buildFeatureResult({
       objectIdFieldName: "OBJECTID",
       fields: [buildField("OBJECTID", 6)],
-      features: [
-        buildFeature([buildValue({ uintValue: 1, fieldIndex: 0 })]),
-      ],
+      features: [buildFeature([buildValue({ uintValue: 1, fieldIndex: 0 })])],
     });
     const pbf = buildFeatureCollectionPBuffer("1.0", featureResult);
     const result = decodePbfQueryResponse(toBuffer(pbf));
@@ -640,14 +584,8 @@ describe("decodePbfQueryResponse", () => {
       transform,
       fields: [buildField("OBJECTID", 6)],
       features: [
-        buildFeature(
-          [buildValue({ uintValue: 1, fieldIndex: 0 })],
-          buildPointGeometry(-1225, 378),
-        ),
-        buildFeature(
-          [buildValue({ uintValue: 2, fieldIndex: 0 })],
-          buildPointGeometry(-734, 211),
-        ),
+        buildFeature([buildValue({ uintValue: 1, fieldIndex: 0 })], buildPointGeometry(-1225, 378)),
+        buildFeature([buildValue({ uintValue: 2, fieldIndex: 0 })], buildPointGeometry(-734, 211)),
       ],
     });
     const pbf = buildFeatureCollectionPBuffer("1.0", featureResult);
@@ -676,12 +614,7 @@ describe("decodePbfQueryResponse", () => {
       geometryType: 2,
       spatialReference: buildSpatialReference(4326),
       fields: [buildField("OBJECTID", 6)],
-      features: [
-        buildFeature(
-          [buildValue({ uintValue: 1, fieldIndex: 0 })],
-          geometry,
-        ),
-      ],
+      features: [buildFeature([buildValue({ uintValue: 1, fieldIndex: 0 })], geometry)],
     });
     const pbf = buildFeatureCollectionPBuffer("1.0", featureResult);
     const result = decodePbfQueryResponse(toBuffer(pbf));
@@ -689,8 +622,14 @@ describe("decodePbfQueryResponse", () => {
     const features = result.features as Record<string, unknown>[];
     const paths = (features[0].geometry as Record<string, unknown>).paths as number[][][];
     expect(paths).toHaveLength(2);
-    expect(paths[0]).toEqual([[0, 0], [10, 10]]);
-    expect(paths[1]).toEqual([[20, 20], [30, 30]]);
+    expect(paths[0]).toEqual([
+      [0, 0],
+      [10, 10],
+    ]);
+    expect(paths[1]).toEqual([
+      [20, 20],
+      [30, 30],
+    ]);
   });
 
   it("omits geometryType and spatialReference when not set", () => {
@@ -710,10 +649,7 @@ describe("decodePbfQueryResponse", () => {
   it("decodes int64 attribute values", () => {
     const featureResult = buildFeatureResult({
       objectIdFieldName: "OBJECTID",
-      fields: [
-        buildField("OBJECTID", 6),
-        buildField("bignum", 13),
-      ],
+      fields: [buildField("OBJECTID", 6), buildField("bignum", 13)],
       features: [
         buildFeature([
           buildValue({ uintValue: 1, fieldIndex: 0 }),
@@ -732,10 +668,7 @@ describe("decodePbfQueryResponse", () => {
   it("decodes field alias correctly", () => {
     const featureResult = buildFeatureResult({
       objectIdFieldName: "OBJECTID",
-      fields: [
-        buildField("OBJECTID", 6, "Object ID"),
-        buildField("name", 4, "Park Name"),
-      ],
+      fields: [buildField("OBJECTID", 6, "Object ID"), buildField("name", 4, "Park Name")],
       features: [],
     });
     const pbf = buildFeatureCollectionPBuffer("1.0", featureResult);

--- a/test/renderer-compat.test.ts
+++ b/test/renderer-compat.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  ClassBreaksRendererCompat,
-  SimpleRendererCompat,
-  UniqueValueRendererCompat,
-} from "../src/index.js";
+import { ClassBreaksRendererCompat, SimpleRendererCompat, UniqueValueRendererCompat } from "../src/index.js";
 
 describe("renderer compat", () => {
   it("supports simple renderer payloads", async () => {

--- a/test/route-layer-compat.test.ts
+++ b/test/route-layer-compat.test.ts
@@ -5,10 +5,7 @@ import { CompatEventBus, RouteLayerCompat } from "../src/index.js";
 describe("RouteLayerCompat", () => {
   it("supports lifecycle loading and watch handles", async () => {
     const layer = new RouteLayerCompat({
-      stops: [
-        { location: [0, 0] },
-        { location: [1, 1] },
-      ],
+      stops: [{ location: [0, 0] }, { location: [1, 1] }],
     });
 
     const loadStatusValues: unknown[] = [];

--- a/test/route-task-compat.test.ts
+++ b/test/route-task-compat.test.ts
@@ -25,10 +25,7 @@ describe("RouteTaskCompat", () => {
       callbackTask = resolvedTask;
     });
     await task.solve({
-      stops: [
-        { location: [-157.8583, 21.3069] },
-        { location: [-157.9076, 21.3035] },
-      ],
+      stops: [{ location: [-157.8583, 21.3069] }, { location: [-157.9076, 21.3035] }],
     });
 
     loadStatusHandle.remove();
@@ -38,10 +35,7 @@ describe("RouteTaskCompat", () => {
       results: resultValues.length,
     };
     await task.solve({
-      stops: [
-        { location: [-157.8583, 21.3069] },
-        { location: [-157.9076, 21.3035] },
-      ],
+      stops: [{ location: [-157.8583, 21.3069] }, { location: [-157.9076, 21.3035] }],
     });
 
     expect(widget).toBe(task);
@@ -93,10 +87,7 @@ describe("RouteTaskCompat", () => {
 
     const task = new RouteTaskCompat({ eventBus });
     await task.solve({
-      stops: [
-        { location: [-157.8583, 21.3069] },
-        { location: [-157.9076, 21.3035] },
-      ],
+      stops: [{ location: [-157.8583, 21.3069] }, { location: [-157.9076, 21.3035] }],
     });
 
     expect(seenTypes).toContain("route-task.solve-started");

--- a/test/runtime/runtime.test.ts
+++ b/test/runtime/runtime.test.ts
@@ -10,18 +10,13 @@ import { describe, expect, test, vi } from "vitest";
 import { HonuaClient } from "../../src/core/client.js";
 import {
   HONUA_MAP_PACKAGE_FORMAT_V1,
-  HonuaMapPackageError,
   type HonuaMapPackage,
+  HonuaMapPackageError,
   type HonuaRuntimeEvent,
   type MaplibreMap,
   loadMapPackage,
 } from "../../src/runtime/index.js";
-import {
-  applyTheme,
-  buildLegend,
-  diffPackages,
-  projectSourceBindings,
-} from "../../src/runtime/index.js";
+import { applyTheme, buildLegend, diffPackages, projectSourceBindings } from "../../src/runtime/index.js";
 import type { PopupFactory, PopupHandle } from "../../src/runtime/popups.js";
 
 // ── Mock map ─────────────────────────────────────────────────
@@ -192,9 +187,7 @@ describe("loadMapPackage", () => {
     expect(runtime.dataset.sourceIds()).toEqual(["parcels"]);
 
     expect(events.some((e) => e.type === "source-ready" && e.sourceId === "parcels")).toBe(true);
-    expect(
-      events.some((e) => e.type === "package-loaded" && e.packageId === pkg.mapPackageId),
-    ).toBe(true);
+    expect(events.some((e) => e.type === "package-loaded" && e.packageId === pkg.mapPackageId)).toBe(true);
   });
 
   test("rejects unsupported package format via HonuaMapPackageError", async () => {
@@ -318,7 +311,9 @@ describe("HonuaMapRuntime", () => {
     const setStyle = map._calls.find((c) => c.method === "setStyle");
     expect(setStyle, "minzoom cannot be patched through paint/layout/filter setters").toBeDefined();
     expect(
-      map._calls.some((c) => c.method === "setPaintProperty" || c.method === "setLayoutProperty" || c.method === "setFilter"),
+      map._calls.some(
+        (c) => c.method === "setPaintProperty" || c.method === "setLayoutProperty" || c.method === "setFilter",
+      ),
     ).toBe(false);
     expect((setStyle?.args[0] as { layers?: Array<{ minzoom?: number }> }).layers?.[0]?.minzoom).toBe(7);
   });
@@ -454,9 +449,7 @@ describe("composeStyle: applyTheme", () => {
       {
         version: 8,
         sources: {},
-        layers: [
-          { id: "x", type: "fill", paint: { "fill-color": "{theme:primary}", "fill-opacity": 0.5 } },
-        ],
+        layers: [{ id: "x", type: "fill", paint: { "fill-color": "{theme:primary}", "fill-opacity": 0.5 } }],
       },
       { tokens: { primary: "#112233" } },
     );
@@ -483,14 +476,11 @@ describe("buildLegend", () => {
   });
 
   test("honors explicit color over style fallback", () => {
-    const entries = buildLegend(
-      [{ label: "Highlighted", color: "#ff00ff" }],
-      {
-        version: 8,
-        sources: {},
-        layers: [{ id: "l", type: "fill", paint: { "fill-color": "#ffffff" } }],
-      },
-    );
+    const entries = buildLegend([{ label: "Highlighted", color: "#ff00ff" }], {
+      version: 8,
+      sources: {},
+      layers: [{ id: "l", type: "fill", paint: { "fill-color": "#ffffff" } }],
+    });
     expect(entries[0].color).toBe("#ff00ff");
   });
 });
@@ -591,9 +581,7 @@ describe("#patchLayer: paint/layout key removal", () => {
     });
     await runtime.updatePackage(next);
 
-    const removedPaint = map._calls.find(
-      (c) => c.method === "setPaintProperty" && c.args[1] === "fill-opacity",
-    );
+    const removedPaint = map._calls.find((c) => c.method === "setPaintProperty" && c.args[1] === "fill-opacity");
     expect(removedPaint, "setPaintProperty should be called for removed fill-opacity").toBeDefined();
     expect(removedPaint?.args[2]).toBeUndefined();
   });
@@ -639,9 +627,7 @@ describe("#patchLayer: paint/layout key removal", () => {
     });
     await runtime.updatePackage(next);
 
-    const removedLayout = map._calls.find(
-      (c) => c.method === "setLayoutProperty" && c.args[1] === "fill-sort-key",
-    );
+    const removedLayout = map._calls.find((c) => c.method === "setLayoutProperty" && c.args[1] === "fill-sort-key");
     expect(removedLayout, "setLayoutProperty should be called for removed fill-sort-key").toBeDefined();
     expect(removedLayout?.args[2]).toBeUndefined();
   });
@@ -731,9 +717,7 @@ describe("loadMapPackage: onEvent captures initial lifecycle events", () => {
     });
 
     expect(captured.some((e) => e.type === "source-ready" && e.sourceId === "parcels")).toBe(true);
-    expect(
-      captured.some((e) => e.type === "package-loaded" && e.packageId === pkg.mapPackageId),
-    ).toBe(true);
+    expect(captured.some((e) => e.type === "package-loaded" && e.packageId === pkg.mapPackageId)).toBe(true);
   });
 });
 
@@ -785,9 +769,7 @@ describe("updatePackage: structural fallback error paths and popup reaping", () 
     });
 
     runtime.bindPopup("parcels-fill");
-    expect(
-      map._listeners.find((l) => l.event === "click" && l.layer === "parcels-fill"),
-    ).toBeDefined();
+    expect(map._listeners.find((l) => l.event === "click" && l.layer === "parcels-fill")).toBeDefined();
 
     // Remove the bound layer in the next package so the diff goes
     // structural (layer set changed) and the popup binding should be
@@ -808,9 +790,7 @@ describe("updatePackage: structural fallback error paths and popup reaping", () 
     });
     await runtime.updatePackage(next);
 
-    expect(
-      map._listeners.find((l) => l.event === "click" && l.layer === "parcels-fill"),
-    ).toBeUndefined();
+    expect(map._listeners.find((l) => l.event === "click" && l.layer === "parcels-fill")).toBeUndefined();
   });
 
   test("changing a package popup binding tears down the active package-resolved listener", async () => {
@@ -824,9 +804,7 @@ describe("updatePackage: structural fallback error paths and popup reaping", () 
     });
 
     runtime.bindPopup("parcels-fill");
-    expect(
-      map._listeners.find((l) => l.event === "click" && l.layer === "parcels-fill"),
-    ).toBeDefined();
+    expect(map._listeners.find((l) => l.event === "click" && l.layer === "parcels-fill")).toBeDefined();
 
     const next = makePackage({
       popupBindings: [{ sourceId: "parcels", fieldName: "OWNER", title: "Owner" }],
@@ -834,9 +812,7 @@ describe("updatePackage: structural fallback error paths and popup reaping", () 
 
     await runtime.updatePackage(next);
 
-    expect(
-      map._listeners.find((l) => l.event === "click" && l.layer === "parcels-fill"),
-    ).toBeUndefined();
+    expect(map._listeners.find((l) => l.event === "click" && l.layer === "parcels-fill")).toBeUndefined();
   });
 });
 

--- a/test/search-compat.test.ts
+++ b/test/search-compat.test.ts
@@ -263,27 +263,27 @@ describe("SearchCompat", () => {
       queryFeatures: async (options?: unknown) => {
         layerQueries.push(options);
         return {
-        features: [
-          {
-            attributes: {
-              NAME: "Central Park",
-              CITY: "Honolulu",
+          features: [
+            {
+              attributes: {
+                NAME: "Central Park",
+                CITY: "Honolulu",
+              },
+              geometry: {
+                x: -157.858,
+                y: 21.307,
+              },
             },
-            geometry: {
-              x: -157.858,
-              y: 21.307,
+            {
+              attributes: {
+                NAME: "Beach",
+              },
+              geometry: {
+                x: -157.9,
+                y: 21.28,
+              },
             },
-          },
-          {
-            attributes: {
-              NAME: "Beach",
-            },
-            geometry: {
-              x: -157.9,
-              y: 21.28,
-            },
-          },
-        ],
+          ],
         };
       },
     };

--- a/test/server-compatibility.test.ts
+++ b/test/server-compatibility.test.ts
@@ -76,9 +76,7 @@ describe("HonuaClient server compatibility helpers", () => {
     const status = await client.checkCompatibility();
 
     expect(status.supported).toBe(false);
-    expect(status.reasons).toContain(
-      "Server release channel 'alpha' is below the minimum supported 'preview'.",
-    );
+    expect(status.reasons).toContain("Server release channel 'alpha' is below the minimum supported 'preview'.");
   });
 
   it("reports unsupported when the server does not expose the compatibility contract", async () => {
@@ -131,11 +129,10 @@ function createCapabilitiesEnvelope(
           basePath: overrides.controlPlaneApi?.basePath ?? "/api/v1/admin",
           deprecated: overrides.controlPlaneApi?.deprecated ?? false,
         },
-        metadataSchemas:
-          overrides.metadataSchemas ?? [
-            { version: "honua.io/v1alpha1", deprecated: false },
-            { version: "honua.io/v1alpha0", deprecated: true },
-          ],
+        metadataSchemas: overrides.metadataSchemas ?? [
+          { version: "honua.io/v1alpha1", deprecated: false },
+          { version: "honua.io/v1alpha0", deprecated: true },
+        ],
         features: overrides.features ?? {
           metadataResources: true,
           manifestExport: true,

--- a/test/split-packages.test.ts
+++ b/test/split-packages.test.ts
@@ -13,9 +13,7 @@ describe("split package manifests", () => {
     expect(packageJson.scripts?.["build:split-packages"]).toContain("prepare-split-packages.mjs");
     expect(packageJson.scripts?.["verify:split-packages"]).toContain("verify-split-packages.mjs");
     expect(packageJson.scripts?.["pack:split-packages"]).toContain("dist/packages/honua-sdk");
-    expect(packageJson.scripts?.["pack:split-packages"]).toContain(
-      "dist/packages/honua-sdk-esri-compat",
-    );
+    expect(packageJson.scripts?.["pack:split-packages"]).toContain("dist/packages/honua-sdk-esri-compat");
     expect(packageJson.scripts?.["pack:split-packages"]).toContain("dist/packages/honua-migrate");
   });
 });

--- a/test/storytelling-25d-data.test.ts
+++ b/test/storytelling-25d-data.test.ts
@@ -4,8 +4,8 @@ import { fileURLToPath } from "node:url";
 
 import { describe, expect, it, vi } from "vitest";
 
-import { buildStoryDataset, loadStoryDataset, normalizeAssets } from "../examples/storytelling-25d-map/src/data.js";
 import { resolveStoryDemoConfig } from "../examples/storytelling-25d-map/src/config.js";
+import { buildStoryDataset, loadStoryDataset, normalizeAssets } from "../examples/storytelling-25d-map/src/data.js";
 
 const fixtureRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "fixtures", "honua-25d-demo");
 

--- a/test/style.test.ts
+++ b/test/style.test.ts
@@ -50,9 +50,7 @@ describe("Type guards", () => {
 describe("URL parsing", () => {
   describe("parseFeatureLayerUrl (re-exported from esri-compat)", () => {
     it("parses a standard Feature Service URL", () => {
-      const result = parseFeatureLayerUrl(
-        "https://gis.example.com/rest/services/parcels/FeatureServer/0",
-      );
+      const result = parseFeatureLayerUrl("https://gis.example.com/rest/services/parcels/FeatureServer/0");
       expect(result).toEqual({
         baseUrl: "https://gis.example.com",
         serviceId: "parcels",
@@ -61,9 +59,7 @@ describe("URL parsing", () => {
     });
 
     it("parses a URL with a path prefix (e.g. /arcgis)", () => {
-      const result = parseFeatureLayerUrl(
-        "https://gis.example.com/arcgis/rest/services/parcels/FeatureServer/3",
-      );
+      const result = parseFeatureLayerUrl("https://gis.example.com/arcgis/rest/services/parcels/FeatureServer/3");
       expect(result).toEqual({
         baseUrl: "https://gis.example.com/arcgis",
         serviceId: "parcels",
@@ -72,17 +68,13 @@ describe("URL parsing", () => {
     });
 
     it("throws on invalid URL", () => {
-      expect(() =>
-        parseFeatureLayerUrl("https://example.com/not-a-service"),
-      ).toThrow("Invalid FeatureLayer URL");
+      expect(() => parseFeatureLayerUrl("https://example.com/not-a-service")).toThrow("Invalid FeatureLayer URL");
     });
   });
 
   describe("parseMapServiceUrl (re-exported from esri-compat)", () => {
     it("parses a standard Map Service URL", () => {
-      const result = parseMapServiceUrl(
-        "https://gis.example.com/rest/services/imagery/MapServer",
-      );
+      const result = parseMapServiceUrl("https://gis.example.com/rest/services/imagery/MapServer");
       expect(result).toEqual({
         baseUrl: "https://gis.example.com",
         serviceId: "imagery",
@@ -90,17 +82,13 @@ describe("URL parsing", () => {
     });
 
     it("throws on invalid URL", () => {
-      expect(() =>
-        parseMapServiceUrl("https://example.com/not-a-service"),
-      ).toThrow("Invalid MapServer URL");
+      expect(() => parseMapServiceUrl("https://example.com/not-a-service")).toThrow("Invalid MapServer URL");
     });
   });
 
   describe("parseOgcFeaturesUrl", () => {
     it("parses a URL with a collection path", () => {
-      const result = parseOgcFeaturesUrl(
-        "https://gis.example.com/ogc/collections/admin-boundaries",
-      );
+      const result = parseOgcFeaturesUrl("https://gis.example.com/ogc/collections/admin-boundaries");
       expect(result).toEqual({
         baseUrl: "https://gis.example.com/ogc",
         collectionId: "admin-boundaries",
@@ -151,9 +139,7 @@ describe("validateHonuaStyle", () => {
           url: "https://gis.example.com/rest/services/parcels/FeatureServer/0",
         },
       },
-      layers: [
-        { id: "parcel-fill", type: "fill", source: "parcels" },
-      ],
+      layers: [{ id: "parcel-fill", type: "fill", source: "parcels" }],
     };
     expect(validateHonuaStyle(style)).toEqual([]);
   });
@@ -255,9 +241,7 @@ describe("createSources", () => {
     const sources = createSources(client, style);
     const boundaries = sources.get("boundaries");
     expect(boundaries).toBeInstanceOf(HonuaOgcFeatureCollection);
-    expect((boundaries as HonuaOgcFeatureCollection).collectionId).toBe(
-      "admin-boundaries",
-    );
+    expect((boundaries as HonuaOgcFeatureCollection).collectionId).toBe("admin-boundaries");
   });
 
   it("uses explicit collectionId over URL-parsed one", () => {
@@ -274,9 +258,7 @@ describe("createSources", () => {
     };
 
     const sources = createSources(client, style);
-    expect(
-      (sources.get("data") as HonuaOgcFeatureCollection).collectionId,
-    ).toBe("new-name");
+    expect((sources.get("data") as HonuaOgcFeatureCollection).collectionId).toBe("new-name");
   });
 
   it("creates HonuaWms (service-level) for honua-wms sources without LAYERS", () => {
@@ -470,15 +452,7 @@ describe("HonuaStyleSpecification (design doc example)", () => {
           source: "parcels",
           type: "fill",
           paint: {
-            "fill-color": [
-              "step",
-              ["get", "assessed_value"],
-              "#f7fbff",
-              100000,
-              "#6baed6",
-              500000,
-              "#08306b",
-            ],
+            "fill-color": ["step", ["get", "assessed_value"], "#f7fbff", 100000, "#6baed6", 500000, "#08306b"],
             "fill-opacity": 0.7,
           },
         },

--- a/test/symbol-label-compat.test.ts
+++ b/test/symbol-label-compat.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  LabelClassCompat,
-  PictureMarkerSymbolCompat,
-  TextSymbolCompat,
-} from "../src/index.js";
+import { LabelClassCompat, PictureMarkerSymbolCompat, TextSymbolCompat } from "../src/index.js";
 
 describe("symbol/label compat", () => {
   it("supports picture marker and text symbols", async () => {

--- a/test/tile-layer-compat.test.ts
+++ b/test/tile-layer-compat.test.ts
@@ -119,9 +119,7 @@ describe("TileLayerCompat", () => {
       eventBus,
     });
 
-    expect(layer.getTileUrl(3, 4, 5)).toBe(
-      "https://example.test/rest/services/tiles/MapServer/tile/3/4/5",
-    );
+    expect(layer.getTileUrl(3, 4, 5)).toBe("https://example.test/rest/services/tiles/MapServer/tile/3/4/5");
 
     layer.setVisibility(false);
     layer.setOpacity(0.6);

--- a/test/typed-responses.test.ts
+++ b/test/typed-responses.test.ts
@@ -1,34 +1,33 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  type HonuaApplyEditsResponse,
+  type HonuaAttachmentListResponse,
   HonuaClient,
+  type HonuaExportMapResponse,
   HonuaFeatureLayer,
+  type HonuaFindResponse,
+  type HonuaIdentifyResponse,
+  type HonuaLayerMetadata,
+  type HonuaLegendResponse,
   HonuaMapLayer,
   HonuaMapService,
   HonuaOgcFeatureCollection,
-  HonuaOgcFeatures,
-  type HonuaQueryResponse,
-  type HonuaApplyEditsResponse,
-  type HonuaLayerMetadata,
-  type HonuaServiceMetadata,
-  type HonuaRelatedRecordsResponse,
-  type HonuaExportMapResponse,
-  type HonuaLegendResponse,
-  type HonuaIdentifyResponse,
-  type HonuaFindResponse,
   type HonuaOgcFeatureCollectionResponse,
   type HonuaOgcFeatureResponse,
-  type HonuaTypedQueryResponse,
-  type HonuaTypedFeature,
-  type HonuaAttachmentListResponse,
+  HonuaOgcFeatures,
   type HonuaQueryAttachmentsResponse,
+  type HonuaQueryResponse,
+  type HonuaRelatedRecordsResponse,
+  type HonuaServiceMetadata,
+  type HonuaTypedFeature,
+  type HonuaTypedQueryResponse,
 } from "../src/index.js";
 
 function createMockClient(responseBody: unknown): HonuaClient {
   return new HonuaClient({
     baseUrl: "https://example.test",
-    fetchFn: async () =>
-      new Response(JSON.stringify(responseBody), { status: 200 }),
+    fetchFn: async () => new Response(JSON.stringify(responseBody), { status: 200 }),
   });
 }
 
@@ -440,9 +439,7 @@ describe("Schema-aware typed collections (Direction 10)", () => {
 
   it("generic layer queryFeaturesAll returns typed features", async () => {
     const body = {
-      features: [
-        { attributes: { parcel_id: "P001", area: 1500, zoning: "R1" } },
-      ],
+      features: [{ attributes: { parcel_id: "P001", area: 1500, zoning: "R1" } }],
     };
     const client = createMockClient(body);
     const parcels = client.featureLayer<ParcelAttributes>("parcels", 0);
@@ -465,9 +462,7 @@ describe("Schema-aware typed collections (Direction 10)", () => {
 
   it("service.featureLayer<T> propagates generic parameter", async () => {
     const body = {
-      features: [
-        { attributes: { parcel_id: "P003", area: 800, zoning: "A1" } },
-      ],
+      features: [{ attributes: { parcel_id: "P003", area: 800, zoning: "A1" } }],
     };
     const client = createMockClient(body);
     const service = client.service("parcels");

--- a/test/watcher-safety.test.ts
+++ b/test/watcher-safety.test.ts
@@ -31,4 +31,3 @@ describe("compat watcher safety", () => {
     expect(violations).toEqual([]);
   });
 });
-

--- a/test/webmap-convert-symbol.test.ts
+++ b/test/webmap-convert-symbol.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { esriColorToCss, esriLineStyleToDashArray, convertSymbol } from "../src/webmap/index.js";
+import { convertSymbol, esriColorToCss, esriLineStyleToDashArray } from "../src/webmap/index.js";
 import { createWarningCollector } from "../src/webmap/warnings.js";
 
 describe("WebMap symbol converter", () => {

--- a/test/webmap-parse.test.ts
+++ b/test/webmap-parse.test.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parseWebMap, validateHonuaStyle } from "../src/index.js";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -49,7 +49,10 @@ export default defineConfig({
   test: {
     include: ["test/**/*.test.ts"],
     exclude: ["dist/**", "node_modules/**"],
-    fileParallelism: !ci,
+    // Several migration CLI tests rebuild and execute the shared dist CLI.
+    // Keep file execution serialized locally as well as in CI so those tests
+    // do not contend for the same generated artifacts.
+    fileParallelism: false,
     maxWorkers: ci ? 1 : undefined,
   },
 });


### PR DESCRIPTION
## Summary

- Harden JS and MCP publish workflows so npm audits fail publishing instead of only warning, and fix the MCP workflow's JS SDK build path.
- Add missing CI gates for Biome style checks and split-package verification.
- Refresh vulnerable dependency locks in the root package, MCP package, and Kepler example; update MCP SDK and peer dependency metadata.
- Fix split package preparation by including the contract runtime in the esri-compat split package.
- Move the geocoding test out of `src`, clean `dist` before SDK builds, ignore generated coverage/scratch directories, and serialize shared migration CLI build artifacts in tests.
- Apply Biome formatting drift cleanup across the repo.

## Validation

- `npm run typecheck`
- `npm run check`
- `npm run build`
- `npm run verify:split-packages`
- `npm pack --dry-run --json`
- `npm run test:coverage` (131 files, 1,547 tests)
- `npm --prefix mcp run typecheck`
- `npm --prefix mcp run check`
- `npm --prefix mcp test` (10 files, 71 tests)
- `npm --prefix examples/kepler-analytics run build`
- `npm run demo:quickstart:typecheck`
- `npm run demo:quickstart:build`
- `npm audit --omit=optional`
- `npm audit --prefix mcp --omit=dev`
- `npm audit` in `examples/kepler-analytics`
- `git diff --check`

## Notes

The Kepler example build still emits existing large-chunk and upstream direct-eval warnings from loader/deck dependencies, but the production build exits successfully and `npm audit` reports zero vulnerabilities for that example on this branch.