### PR TITLE
Add source-qualified exploration selections

### DIFF
--- a/docs/exploration-context.md
+++ b/docs/exploration-context.md
@@ -34,7 +34,7 @@ interface ExplorationState {
   readonly filters: Readonly<Record<string, FilterClause>>;
   readonly spatialFilter?: SpatialFilter;
   readonly extent?: HonuaExtent;
-  readonly selection: ReadonlyArray<FeatureId>;
+  readonly selection: ReadonlyArray<FeatureSelectionTarget>;
   readonly sort: ReadonlyArray<SortSpec>;
   readonly page: PaginationSpec;
   readonly visibleFields: ReadonlyArray<string>;
@@ -60,7 +60,7 @@ the linked-view preset table.
 | `set-filter` / `clear-filter` | `filters` | Add or remove a global filter clause keyed by id. |
 | `set-spatial-filter` | `spatialFilter` | Replace the geometry+relationship that constrains all sources. |
 | `set-extent` | `extent` | Update the viewport extent (typically driven by the map view). |
-| `select` / `deselect` | `selection` | Mutate the cross-view selection set. `select` is additive by default; `deselect` without ids clears the entire selection. |
+| `select` / `deselect` | `selection` | Mutate the cross-view selection set. `select` is additive by default; `deselect` without ids clears the entire selection. Single-source apps may select raw feature ids; multi-source apps should select source-qualified targets. |
 | `set-sort` | `sort` | Apply a sort order shared across grid + chart views. |
 | `set-page` | `page` | Update offset / limit. |
 | `set-visible-fields` | `visibleFields` | Drives field visibility in tables and forms. Empty = "all". |
@@ -161,6 +161,35 @@ filter, and detail components. Component adapters publish semantic intents
 (`setExtent`, `setFilter`, `select`, `setAggregation`) and subscribe to the
 slices they can render. They do not need to imperatively keep peer widgets in
 sync or remember which `viewId` to pass with each intent.
+
+## Selection targets
+
+Single-source apps can keep using raw feature ids:
+
+```ts
+map.select([incidentId], { replace: true });
+```
+
+Multi-source apps should use source-qualified targets so overlapping object
+ids do not collide across map, table, detail, realtime, and MCP handoff:
+
+```ts
+import { sourceFeatureSelectionTarget } from "@honua/sdk-js/exploration";
+
+map.select(
+  [
+    sourceFeatureSelectionTarget("incidents", 101),
+    sourceFeatureSelectionTarget("assets", 101),
+    sourceFeatureSelectionTarget("vector-tiles", 101, { sourceLayer: "hydrants" }),
+  ],
+  { replace: true },
+);
+```
+
+The reducer de-duplicates and deselects source-qualified targets by
+`sourceId`, optional `sourceLayer`, raw id type, and id value. That keeps
+`incidents:101`, `assets:101`, `"101"`, and vector-tile sublayers distinct
+while preserving the old raw-id path for simpler apps.
 
 ## Snapshots
 

--- a/src/exploration/index.ts
+++ b/src/exploration/index.ts
@@ -28,6 +28,7 @@ export type {
   ExplorationViewListener,
   ExplorationViewSubscribeOptions,
   ExplorationViewSubscription,
+  FeatureSelectionTarget,
   FilterClause,
   FilterOperator,
   LinkedViewPolicy,
@@ -44,6 +45,7 @@ export type {
   SetSpatialFilterIntent,
   SetVisibleFieldsIntent,
   SnapshotRestoreIntent,
+  SourceQualifiedFeatureSelectionTarget,
   Unsubscribe,
   ViewBinding,
   ViewHandle,
@@ -53,3 +55,4 @@ export type {
 export { LINKED_VIEW_PRESETS, propagationFor } from "./presets.js";
 export { reduce, type ReducerResult } from "./reducer.js";
 export { createExplorationContext } from "./context.js";
+export { featureSelectionKey, isSourceQualifiedSelectionTarget, sourceFeatureSelectionTarget } from "./selection.js";

--- a/src/exploration/reducer.ts
+++ b/src/exploration/reducer.ts
@@ -11,7 +11,14 @@
 
 import type { AggregationSpec } from "../contract/types.js";
 import type { SpatialFilter } from "../core/spatial-filter.js";
-import type { ExplorationIntent, ExplorationSlice, ExplorationState, FilterClause } from "./types.js";
+import { featureSelectionKey } from "./selection.js";
+import type {
+  ExplorationIntent,
+  ExplorationSlice,
+  ExplorationState,
+  FeatureSelectionTarget,
+  FilterClause,
+} from "./types.js";
 
 export interface ReducerResult {
   readonly state: ExplorationState;
@@ -60,17 +67,17 @@ export function reduce(state: ExplorationState, intent: ExplorationIntent): Redu
     }
     case "select": {
       const incoming = intent.ids;
-      let selection: ReadonlyArray<unknown>;
+      let selection: ReadonlyArray<FeatureSelectionTarget>;
       if (intent.replace === true) {
-        selection = dedupe(incoming);
+        selection = dedupeSelection(incoming);
       } else {
-        selection = dedupe([...state.selection, ...incoming]);
+        selection = dedupeSelection([...state.selection, ...incoming]);
       }
-      if (sequenceEqual(state.selection, selection as ReadonlyArray<(typeof state.selection)[number]>)) {
+      if (selectionEqual(state.selection, selection)) {
         return { state, changedSlices: EMPTY };
       }
       return {
-        state: { ...state, selection: selection as typeof state.selection },
+        state: { ...state, selection },
         changedSlices: only("selection"),
       };
     }
@@ -79,8 +86,8 @@ export function reduce(state: ExplorationState, intent: ExplorationIntent): Redu
         if (state.selection.length === 0) return { state, changedSlices: EMPTY };
         return { state: { ...state, selection: [] }, changedSlices: only("selection") };
       }
-      const removeSet = new Set<unknown>(intent.ids);
-      const selection = state.selection.filter((id) => !removeSet.has(id));
+      const removeSet = new Set(intent.ids.map((target) => featureSelectionKey(target)));
+      const selection = state.selection.filter((target) => !removeSet.has(featureSelectionKey(target)));
       if (selection.length === state.selection.length) {
         return { state, changedSlices: EMPTY };
       }
@@ -238,12 +245,22 @@ function sequenceEqual<T>(a: ReadonlyArray<T>, b: ReadonlyArray<T>): boolean {
   return true;
 }
 
-function dedupe<T>(values: ReadonlyArray<T>): T[] {
-  const seen = new Set<T>();
-  const out: T[] = [];
+function selectionEqual(a: ReadonlyArray<FeatureSelectionTarget>, b: ReadonlyArray<FeatureSelectionTarget>): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (featureSelectionKey(a[i]) !== featureSelectionKey(b[i])) return false;
+  }
+  return true;
+}
+
+function dedupeSelection(values: ReadonlyArray<FeatureSelectionTarget>): FeatureSelectionTarget[] {
+  const seen = new Set<string>();
+  const out: FeatureSelectionTarget[] = [];
   for (const v of values) {
-    if (seen.has(v)) continue;
-    seen.add(v);
+    const key = featureSelectionKey(v);
+    if (seen.has(key)) continue;
+    seen.add(key);
     out.push(v);
   }
   return out;
@@ -271,7 +288,7 @@ function diffSlices(prev: ExplorationState, next: ExplorationState): Set<Explora
   if (!filterMapsEqual(prev.filters, next.filters)) changed.add("filters");
   if (!spatialFiltersEqual(prev.spatialFilter, next.spatialFilter)) changed.add("spatialFilter");
   if (!extentsEqual(prev.extent, next.extent)) changed.add("extent");
-  if (!sequenceEqual(prev.selection, next.selection)) changed.add("selection");
+  if (!selectionEqual(prev.selection, next.selection)) changed.add("selection");
   if (!sortEqual(prev.sort, next.sort)) changed.add("sort");
   if (!pageEqual(prev.page, next.page)) changed.add("page");
   if (!sequenceEqual(prev.visibleFields, next.visibleFields)) changed.add("visibleFields");

--- a/src/exploration/selection.ts
+++ b/src/exploration/selection.ts
@@ -1,0 +1,46 @@
+/**
+ * Selection target helpers for exploration state.
+ *
+ * Raw feature ids remain valid for single-source apps. Multi-source apps
+ * should use source-qualified targets so the same object id in two sources
+ * does not collide in map/table/detail synchronization.
+ *
+ * @module
+ */
+
+import type { FeatureId, SourceId } from "../contract/types.js";
+import type { FeatureSelectionTarget, SourceQualifiedFeatureSelectionTarget } from "./types.js";
+
+/** Build a serializable source-qualified selection target. */
+export function sourceFeatureSelectionTarget(
+  sourceId: SourceId,
+  id: FeatureId,
+  options: { readonly sourceLayer?: string } = {},
+): SourceQualifiedFeatureSelectionTarget {
+  return {
+    sourceId,
+    id,
+    ...(options.sourceLayer !== undefined ? { sourceLayer: options.sourceLayer } : {}),
+  };
+}
+
+/** True when a selection target carries source identity. */
+export function isSourceQualifiedSelectionTarget(
+  target: FeatureSelectionTarget,
+): target is SourceQualifiedFeatureSelectionTarget {
+  return typeof target === "object" && target !== null && "sourceId" in target && "id" in target;
+}
+
+/**
+ * Stable key for de-duplicating and comparing selection targets.
+ *
+ * The key intentionally includes raw-id type and source layer so `"101"`,
+ * `101`, and vector-tile sublayer features remain distinct.
+ */
+export function featureSelectionKey(target: FeatureSelectionTarget): string {
+  if (!isSourceQualifiedSelectionTarget(target)) {
+    return `id:${typeof target}:${String(target)}`;
+  }
+  const layer = target.sourceLayer ?? "";
+  return `source:${target.sourceId}\u0000layer:${layer}\u0000id:${typeof target.id}:${String(target.id)}`;
+}

--- a/src/exploration/types.ts
+++ b/src/exploration/types.ts
@@ -64,8 +64,11 @@ export interface ExplorationState {
   readonly spatialFilter?: SpatialFilter;
   /** Current viewport extent. */
   readonly extent?: HonuaExtent;
-  /** Currently selected feature ids. */
-  readonly selection: ReadonlyArray<FeatureId>;
+  /**
+   * Currently selected features. Raw ids are supported for single-source apps;
+   * multi-source apps should use source-qualified targets.
+   */
+  readonly selection: ReadonlyArray<FeatureSelectionTarget>;
   /** Sort order shared across linked views. */
   readonly sort: ReadonlyArray<SortSpec>;
   /** Pagination offset / limit. */
@@ -178,7 +181,7 @@ export interface SetExtentIntent extends IntentBase {
 
 export interface SelectIntent extends IntentBase {
   readonly kind: "select";
-  readonly ids: ReadonlyArray<FeatureId>;
+  readonly ids: ReadonlyArray<FeatureSelectionTarget>;
   /** When `true`, replaces the selection. Default = additive. */
   readonly replace?: boolean;
 }
@@ -186,7 +189,7 @@ export interface SelectIntent extends IntentBase {
 export interface DeselectIntent extends IntentBase {
   readonly kind: "deselect";
   /** Omit `ids` to clear the entire selection. */
-  readonly ids?: ReadonlyArray<FeatureId>;
+  readonly ids?: ReadonlyArray<FeatureSelectionTarget>;
 }
 
 export interface SetSortIntent extends IntentBase {
@@ -350,8 +353,8 @@ export interface ExplorationViewController extends ViewHandle {
   clearFilter(id: string): void;
   setSpatialFilter(spatialFilter: SpatialFilter | undefined): void;
   setExtent(extent: HonuaExtent | undefined): void;
-  select(ids: ReadonlyArray<FeatureId>, options?: { readonly replace?: boolean }): void;
-  deselect(ids?: ReadonlyArray<FeatureId>): void;
+  select(ids: ReadonlyArray<FeatureSelectionTarget>, options?: { readonly replace?: boolean }): void;
+  deselect(ids?: ReadonlyArray<FeatureSelectionTarget>): void;
   setSort(sort: ReadonlyArray<SortSpec>): void;
   setPage(page: PaginationSpec): void;
   setVisibleFields(fields: ReadonlyArray<string>): void;
@@ -393,3 +396,14 @@ export interface CreateExplorationContextOptions {
   initialState?: Partial<ExplorationState>;
   preset?: LinkedViewPresetName;
 }
+
+// ── Selection targets ─────────────────────────────────────────
+
+export interface SourceQualifiedFeatureSelectionTarget {
+  readonly sourceId: SourceId;
+  readonly id: FeatureId;
+  /** Source layer for vector-tile sources or other layered source identities. */
+  readonly sourceLayer?: string;
+}
+
+export type FeatureSelectionTarget = FeatureId | SourceQualifiedFeatureSelectionTarget;

--- a/src/honua.ts
+++ b/src/honua.ts
@@ -526,8 +526,11 @@ export {
   LINKED_VIEW_PRESETS,
   SLICES,
   createExplorationContext,
+  featureSelectionKey,
+  isSourceQualifiedSelectionTarget,
   propagationFor,
   reduce,
+  sourceFeatureSelectionTarget,
 } from "./exploration/index.js";
 export type {
   ApplyPresetIntent,
@@ -546,6 +549,7 @@ export type {
   ExplorationViewListener,
   ExplorationViewSubscribeOptions,
   ExplorationViewSubscription,
+  FeatureSelectionTarget,
   FilterClause,
   FilterOperator,
   LinkedViewPolicy,
@@ -563,6 +567,7 @@ export type {
   SetSpatialFilterIntent,
   SetVisibleFieldsIntent,
   SnapshotRestoreIntent,
+  SourceQualifiedFeatureSelectionTarget,
   Unsubscribe as ExplorationUnsubscribe,
   ViewBinding,
   ViewHandle,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1229,8 +1229,11 @@ export {
   LINKED_VIEW_PRESETS,
   SLICES,
   createExplorationContext,
+  featureSelectionKey,
+  isSourceQualifiedSelectionTarget,
   propagationFor,
   reduce,
+  sourceFeatureSelectionTarget,
 } from "./exploration/index.js";
 export type {
   ApplyPresetIntent,
@@ -1249,6 +1252,7 @@ export type {
   ExplorationViewListener,
   ExplorationViewSubscribeOptions,
   ExplorationViewSubscription,
+  FeatureSelectionTarget,
   FilterClause,
   FilterOperator,
   LinkedViewPolicy,
@@ -1266,6 +1270,7 @@ export type {
   SetSpatialFilterIntent,
   SetVisibleFieldsIntent,
   SnapshotRestoreIntent,
+  SourceQualifiedFeatureSelectionTarget,
   Unsubscribe as ExplorationUnsubscribe,
   ViewBinding,
   ViewHandle,

--- a/src/interactions/feature-state.ts
+++ b/src/interactions/feature-state.ts
@@ -8,6 +8,9 @@
  * @module
  */
 
+import { sourceFeatureSelectionTarget } from "../exploration/selection.js";
+import type { SourceQualifiedFeatureSelectionTarget } from "../exploration/types.js";
+
 // ── Duck-typed map interfaces ─────────────────────────────────
 
 /** Minimal subset of a MapLibre `Map` needed for feature-state operations. */
@@ -184,6 +187,8 @@ export interface SelectionHandlerOptions {
   sourceLayer?: string;
   /** Called whenever the selection changes. */
   onChange?: (selectedIds: ReadonlySet<string | number>) => void;
+  /** Called whenever the source-qualified selection changes. */
+  onSelectionTargetsChange?: (selectedTargets: ReadonlyArray<SourceQualifiedFeatureSelectionTarget>) => void;
 }
 
 /** Handle returned by {@link createSelectionHandler} for cleanup. */
@@ -192,6 +197,8 @@ export interface SelectionHandle {
   remove(): void;
   /** The set of currently selected feature IDs. */
   readonly selectedIds: ReadonlySet<string | number>;
+  /** The current source-qualified selection targets. */
+  readonly selectedTargets: ReadonlyArray<SourceQualifiedFeatureSelectionTarget>;
   /** Programmatically clear the selection. */
   clearSelection(): void;
   /** Programmatically select a feature by ID. */
@@ -217,7 +224,15 @@ export interface SelectionHandle {
  * ```
  */
 export function createSelectionHandler(map: InteractiveMap, options: SelectionHandlerOptions): SelectionHandle {
-  const { source, layer, stateKey = "selected", multiSelect = false, sourceLayer, onChange } = options;
+  const {
+    source,
+    layer,
+    stateKey = "selected",
+    multiSelect = false,
+    sourceLayer,
+    onChange,
+    onSelectionTargetsChange,
+  } = options;
 
   const selected = new Set<string | number>();
 
@@ -230,6 +245,11 @@ export function createSelectionHandler(map: InteractiveMap, options: SelectionHa
 
   function notifyChange(): void {
     onChange?.(selected);
+    onSelectionTargetsChange?.(selectionTargets());
+  }
+
+  function selectionTargets(): SourceQualifiedFeatureSelectionTarget[] {
+    return [...selected].map((id) => sourceFeatureSelectionTarget(source, id, { sourceLayer }));
   }
 
   function onClick(...args: unknown[]): void {
@@ -261,6 +281,9 @@ export function createSelectionHandler(map: InteractiveMap, options: SelectionHa
     },
     get selectedIds() {
       return selected;
+    },
+    get selectedTargets() {
+      return selectionTargets();
     },
     clearSelection() {
       clearAll();

--- a/test/contract/exploration.test.ts
+++ b/test/contract/exploration.test.ts
@@ -19,8 +19,10 @@ import {
   LINKED_VIEW_PRESETS,
   SLICES,
   createExplorationContext,
+  featureSelectionKey,
   propagationFor,
   reduce,
+  sourceFeatureSelectionTarget,
 } from "../../src/exploration/index.js";
 
 async function flush(): Promise<void> {
@@ -75,6 +77,44 @@ describe("exploration / reduce", () => {
     expect(more.state.selection).toEqual([1, 2, 3]);
     const replaced = reduce(more.state, { kind: "select", ids: [99], replace: true });
     expect(replaced.state.selection).toEqual([99]);
+  });
+
+  it("select distinguishes source-qualified targets that share the same feature id", () => {
+    const sourceA = sourceFeatureSelectionTarget("source-a", 101);
+    const sourceADuplicate = sourceFeatureSelectionTarget("source-a", 101);
+    const sourceB = sourceFeatureSelectionTarget("source-b", 101);
+
+    const selectedA = reduce(EMPTY_STATE, { kind: "select", ids: [sourceA] });
+    const selectedADuplicate = reduce(selectedA.state, { kind: "select", ids: [sourceADuplicate] });
+    expect(selectedADuplicate.changedSlices.size).toBe(0);
+    expect(selectedADuplicate.state.selection).toEqual([sourceA]);
+
+    const selectedB = reduce(selectedA.state, { kind: "select", ids: [sourceB] });
+    expect(selectedB.state.selection).toEqual([sourceA, sourceB]);
+    expect(featureSelectionKey(sourceA)).not.toBe(featureSelectionKey(sourceB));
+  });
+
+  it("deselect removes only the matching source-qualified target", () => {
+    const sourceA = sourceFeatureSelectionTarget("source-a", 101);
+    const sourceB = sourceFeatureSelectionTarget("source-b", 101);
+    const seeded = reduce(EMPTY_STATE, { kind: "select", ids: [sourceA, sourceB] });
+    const deselected = reduce(seeded.state, {
+      kind: "deselect",
+      ids: [sourceFeatureSelectionTarget("source-a", 101)],
+    });
+
+    expect(deselected.state.selection).toEqual([sourceB]);
+    expect(deselected.changedSlices).toEqual(new Set(["selection"]));
+  });
+
+  it("source-qualified selection keeps raw id type and source layer distinct", () => {
+    const numeric = sourceFeatureSelectionTarget("tiles", 101, { sourceLayer: "parcels" });
+    const stringy = sourceFeatureSelectionTarget("tiles", "101", { sourceLayer: "parcels" });
+    const buildings = sourceFeatureSelectionTarget("tiles", 101, { sourceLayer: "buildings" });
+    const selected = reduce(EMPTY_STATE, { kind: "select", ids: [numeric, stringy, buildings] });
+
+    expect(selected.state.selection).toEqual([numeric, stringy, buildings]);
+    expect(new Set(selected.state.selection.map((target) => featureSelectionKey(target))).size).toBe(3);
   });
 
   it("deselect without ids clears the selection", () => {
@@ -214,6 +254,26 @@ describe("exploration / reduce", () => {
     });
     expect(restored.changedSlices.has("selection")).toBe(true);
     expect(restored.changedSlices.has("sort")).toBe(true);
+  });
+
+  it("snapshot-restore treats structurally equal source-qualified selections as unchanged", () => {
+    const seeded = reduce(EMPTY_STATE, {
+      kind: "select",
+      ids: [sourceFeatureSelectionTarget("source-a", 101)],
+    });
+    const restored = reduce(seeded.state, {
+      kind: "snapshot-restore",
+      snapshot: {
+        version: 1,
+        state: {
+          ...seeded.state,
+          selection: [sourceFeatureSelectionTarget("source-a", 101)],
+        },
+      },
+    });
+
+    expect(restored.changedSlices.has("selection")).toBe(false);
+    expect(restored.changedSlices.size).toBe(0);
   });
 });
 
@@ -419,6 +479,24 @@ describe("exploration / createExplorationContext", () => {
     ctx.dispose();
   });
 
+  it("connectView propagates source-qualified selection targets to peers", async () => {
+    const ctx = createExplorationContext({ datasetId: "d", sourceIds: ["source-a", "source-b"] });
+    const map = ctx.connectView({ id: "map", role: "map" });
+    const grid = ctx.connectView({ id: "grid", role: "grid" });
+    const events: ExplorationViewChangeEvent[] = [];
+    grid.subscribe("selection", (event) => events.push(event));
+
+    const target = sourceFeatureSelectionTarget("source-a", 101);
+    map.select([target], { replace: true });
+    await flush();
+
+    expect(events.length).toBe(1);
+    expect(events[0].origin?.viewId).toBe("map");
+    expect(events[0].changedSlices).toEqual(new Set(["selection"]));
+    expect(events[0].state.selection).toEqual([target]);
+    ctx.dispose();
+  });
+
   it("connectView unbind disposes owned subscriptions and rejects later view dispatch", async () => {
     const ctx = createExplorationContext({ datasetId: "d", sourceIds: ["s"] });
     const map = ctx.connectView({ id: "map", role: "map" });
@@ -489,6 +567,39 @@ describe("exploration / createExplorationContext", () => {
     // state must not alias it and must therefore stay at [10].
     (snap.state.selection as Array<number>).push(42);
     expect(ctx.state.selection).toEqual([10]);
+    ctx.dispose();
+  });
+
+  it("snapshot / restore isolates source-qualified selection target objects", async () => {
+    const ctx = createExplorationContext({ datasetId: "d", sourceIds: ["source-a"] });
+    ctx.dispatch({
+      kind: "select",
+      ids: [sourceFeatureSelectionTarget("source-a", 101)],
+      replace: true,
+    });
+    await flush();
+
+    const snap = ctx.snapshot();
+    const target = snap.state.selection[0];
+    if (typeof target === "object") {
+      (target as { sourceId: string }).sourceId = "mutated";
+    }
+
+    expect(ctx.state.selection).toEqual([sourceFeatureSelectionTarget("source-a", 101)]);
+
+    ctx.dispatch({ kind: "deselect" });
+    await flush();
+    ctx.restore({
+      version: 1,
+      state: {
+        ...snap.state,
+        selection: [sourceFeatureSelectionTarget("source-a", 101)],
+      },
+    });
+    await flush();
+    (snap.state.selection as Array<unknown>).push(sourceFeatureSelectionTarget("source-b", 101));
+
+    expect(ctx.state.selection).toEqual([sourceFeatureSelectionTarget("source-a", 101)]);
     ctx.dispose();
   });
 

--- a/test/entrypoints.test.ts
+++ b/test/entrypoints.test.ts
@@ -106,7 +106,10 @@ import {
   LINKED_VIEW_PRESETS,
   SLICES,
   createExplorationContext,
+  featureSelectionKey,
+  isSourceQualifiedSelectionTarget,
   reduce,
+  sourceFeatureSelectionTarget,
 } from "../src/exploration/index.js";
 import {
   HonuaClient,
@@ -123,8 +126,12 @@ import {
   HonuaWfsExceptionError,
   createHonuaOgcFeatures,
   createHonuaService,
+  sourceFeatureSelectionTarget as honuaSourceFeatureSelectionTarget,
 } from "../src/honua.js";
-import { HonuaWfsExceptionError as HonuaWfsExceptionErrorRoot } from "../src/index.js";
+import {
+  HonuaWfsExceptionError as HonuaWfsExceptionErrorRoot,
+  sourceFeatureSelectionTarget as rootSourceFeatureSelectionTarget,
+} from "../src/index.js";
 import {
   buildJsMigrationReport,
   evaluateMigrationGates,
@@ -276,6 +283,11 @@ describe("entrypoint modules", () => {
     expect(SLICES[0]).toBe("all");
     expect(reduce).toBeTypeOf("function");
     expect(createExplorationContext).toBeTypeOf("function");
+    const target = sourceFeatureSelectionTarget("parcels", 101);
+    expect(isSourceQualifiedSelectionTarget(target)).toBe(true);
+    expect(featureSelectionKey(target)).toContain("parcels");
+    expect(rootSourceFeatureSelectionTarget("parcels", 101)).toEqual(target);
+    expect(honuaSourceFeatureSelectionTarget("parcels", 101)).toEqual(target);
     expect(Object.keys(LINKED_VIEW_PRESETS)).toEqual([
       "globalLinked",
       "mapDriven",

--- a/test/feature-state.test.ts
+++ b/test/feature-state.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createHoverHandler,
   createSelectionHandler,
+  featureSelectionKey,
   getFeatureState,
   removeFeatureState,
   setFeatureState,
+  sourceFeatureSelectionTarget,
 } from "../src/index.js";
 import type { InteractiveMap } from "../src/index.js";
 
@@ -260,6 +262,28 @@ describe("createSelectionHandler", () => {
     map._fire("click", "parcel-fill", { features: [{ id: 1 }] });
     expect(onChange).toHaveBeenCalledTimes(2);
     expect(onChange.mock.calls[1][0].size).toBe(0);
+  });
+
+  it("exposes source-qualified selection targets for exploration sync", () => {
+    const onSelectionTargetsChange = vi.fn();
+    const map = createMockMap();
+    const selection = createSelectionHandler(map, {
+      source: "parcels",
+      layer: "parcel-fill",
+      sourceLayer: "parcel-polygons",
+      multiSelect: true,
+      onSelectionTargetsChange,
+    });
+
+    map._fire("click", "parcel-fill", { features: [{ id: 1 }] });
+    map._fire("click", "parcel-fill", { features: [{ id: "2" }] });
+
+    expect(selection.selectedTargets).toEqual([
+      sourceFeatureSelectionTarget("parcels", 1, { sourceLayer: "parcel-polygons" }),
+      sourceFeatureSelectionTarget("parcels", "2", { sourceLayer: "parcel-polygons" }),
+    ]);
+    expect(onSelectionTargetsChange).toHaveBeenLastCalledWith(selection.selectedTargets);
+    expect(new Set(selection.selectedTargets.map((target) => featureSelectionKey(target))).size).toBe(2);
   });
 
   it("programmatic select/deselect/clearSelection", () => {


### PR DESCRIPTION
## Summary

- Add source-qualified exploration selection targets while preserving raw feature-id selection for single-source apps.
- Dedupe, compare, deselect, snapshot, and restore selection targets by stable source/id/source-layer keys.
- Expose selection target helpers from exploration, root, and `honua` entrypoints.
- Let MapLibre feature-state selection handlers emit source-qualified targets for exploration sync.

## Backlog

Closes #80
Refs #67
Refs #72

## Validation

- `npm test -- test/contract/exploration.test.ts test/feature-state.test.ts test/entrypoints.test.ts`
- `npm run typecheck`
- `npm run check`
- `npm run build`
- `npm run verify:split-packages`
