### PR TITLE
Add exploration interaction bindings

### DIFF
--- a/docs/exploration-context.md
+++ b/docs/exploration-context.md
@@ -162,6 +162,30 @@ filter, and detail components. Component adapters publish semantic intents
 slices they can render. They do not need to imperatively keep peer widgets in
 sync or remember which `viewId` to pass with each intent.
 
+`@honua/sdk-js/interactions` includes thin bindings for common map/table/detail
+selection flows:
+
+```ts
+import {
+  bindDetailToSelection,
+  bindMapSelectionToExploration,
+  bindTableSelectionToExploration,
+  syncFeatureStateSelection,
+} from "@honua/sdk-js";
+
+bindMapSelectionToExploration(maplibreMap, mapView, {
+  source: "incidents",
+  layer: "incident-points",
+});
+
+syncFeatureStateSelection(maplibreMap, mapView, { source: "incidents" });
+
+const table = bindTableSelectionToExploration(gridView);
+table.select([sourceFeatureSelectionTarget("incidents", 101)], { replace: true });
+
+bindDetailToSelection(detailView, ([selected]) => renderDetail(selected));
+```
+
 ## Selection targets
 
 Single-source apps can keep using raw feature ids:

--- a/src/honua.ts
+++ b/src/honua.ts
@@ -107,6 +107,10 @@ export {
   removeFeatureState,
   createHoverHandler,
   createSelectionHandler,
+  bindDetailToSelection,
+  bindMapSelectionToExploration,
+  bindTableSelectionToExploration,
+  syncFeatureStateSelection,
 } from "./interactions/index.js";
 export type {
   FeatureStateMap,
@@ -117,6 +121,11 @@ export type {
   HoverHandle,
   SelectionHandlerOptions,
   SelectionHandle,
+  FeatureStateSelectionSyncOptions,
+  InteractionBindingHandle,
+  MapSelectionExplorationBindingOptions,
+  SelectionDetailListener,
+  TableSelectionExplorationBinding,
 } from "./interactions/index.js";
 export { HonuaMap } from "./map/index.js";
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,6 +168,10 @@ export {
   removeFeatureState,
   createHoverHandler,
   createSelectionHandler,
+  bindDetailToSelection,
+  bindMapSelectionToExploration,
+  bindTableSelectionToExploration,
+  syncFeatureStateSelection,
 } from "./interactions/index.js";
 export type {
   FeatureStateMap,
@@ -178,6 +182,11 @@ export type {
   HoverHandle,
   SelectionHandlerOptions,
   SelectionHandle,
+  FeatureStateSelectionSyncOptions,
+  InteractionBindingHandle,
+  MapSelectionExplorationBindingOptions,
+  SelectionDetailListener,
+  TableSelectionExplorationBinding,
 } from "./interactions/index.js";
 export { HonuaMap } from "./map/index.js";
 export type {

--- a/src/interactions/exploration-bindings.ts
+++ b/src/interactions/exploration-bindings.ts
@@ -1,0 +1,181 @@
+/**
+ * Interaction bindings between map/table/detail surfaces and
+ * `ExplorationViewController`.
+ *
+ * These helpers keep component adapters small: maps publish source-qualified
+ * selection targets, tables publish the same targets, maps observe shared
+ * selection to update feature-state, and detail panels subscribe to the
+ * shared selection slice.
+ *
+ * @module
+ */
+
+import type { FeatureId } from "../contract/types.js";
+import {
+  featureSelectionKey,
+  isSourceQualifiedSelectionTarget,
+  sourceFeatureSelectionTarget,
+} from "../exploration/selection.js";
+import type {
+  ExplorationViewChangeEvent,
+  ExplorationViewController,
+  ExplorationViewSubscribeOptions,
+  FeatureSelectionTarget,
+  SourceQualifiedFeatureSelectionTarget,
+  Unsubscribe,
+} from "../exploration/types.js";
+import { createSelectionHandler } from "./feature-state.js";
+import type {
+  FeatureStateMap,
+  FeatureTarget,
+  InteractiveMap,
+  SelectionHandle,
+  SelectionHandlerOptions,
+} from "./feature-state.js";
+
+export interface MapSelectionExplorationBindingOptions extends SelectionHandlerOptions {
+  /** Replace the exploration selection with the map selection. @default true */
+  readonly replaceSelection?: boolean;
+}
+
+/**
+ * Bind a MapLibre-style selection handler to an exploration view.
+ *
+ * The map handler already knows its source and source layer, so this publishes
+ * source-qualified targets into the shared exploration selection slice.
+ */
+export function bindMapSelectionToExploration(
+  map: InteractiveMap,
+  view: ExplorationViewController,
+  options: MapSelectionExplorationBindingOptions,
+): SelectionHandle {
+  const { replaceSelection = true, onSelectionTargetsChange } = options;
+  return createSelectionHandler(map, {
+    ...options,
+    onSelectionTargetsChange(targets) {
+      view.select(targets, { replace: replaceSelection });
+      onSelectionTargetsChange?.(targets);
+    },
+  });
+}
+
+export interface FeatureStateSelectionSyncOptions {
+  readonly source: string;
+  readonly sourceLayer?: string;
+  readonly stateKey?: string;
+  /** Apply raw legacy ids to this source. @default true */
+  readonly includeRawIds?: boolean;
+  /** Apply current view state immediately. @default true */
+  readonly applyInitial?: boolean;
+  readonly subscribeOptions?: ExplorationViewSubscribeOptions;
+}
+
+export interface InteractionBindingHandle {
+  remove(): void;
+}
+
+/**
+ * Reflect exploration selection into MapLibre feature-state.
+ *
+ * This is the table-to-map path: a table or detail panel can call
+ * `view.select(...)`; the map observes the shared selection slice and toggles
+ * feature-state for matching source-qualified targets.
+ */
+export function syncFeatureStateSelection(
+  map: FeatureStateMap,
+  view: ExplorationViewController,
+  options: FeatureStateSelectionSyncOptions,
+): InteractionBindingHandle {
+  const { source, sourceLayer, stateKey = "selected", includeRawIds = true, applyInitial = true } = options;
+  let active = new Map<string, FeatureTarget>();
+
+  function apply(selection: ReadonlyArray<FeatureSelectionTarget>): void {
+    const next = new Map<string, FeatureTarget>();
+    for (const target of selection) {
+      const featureTarget = toFeatureTarget(target, source, sourceLayer, includeRawIds);
+      if (!featureTarget) continue;
+      next.set(featureTargetKey(featureTarget), featureTarget);
+    }
+
+    for (const [key, target] of active) {
+      if (!next.has(key)) map.setFeatureState(target, { [stateKey]: false });
+    }
+    for (const [key, target] of next) {
+      if (!active.has(key)) map.setFeatureState(target, { [stateKey]: true });
+    }
+    active = next;
+  }
+
+  const unsubscribe = view.subscribe("selection", (event) => apply(event.state.selection), options.subscribeOptions);
+  if (applyInitial) apply(view.state.selection);
+
+  return {
+    remove(): void {
+      unsubscribe();
+      for (const target of active.values()) {
+        map.setFeatureState(target, { [stateKey]: false });
+      }
+      active.clear();
+    },
+  };
+}
+
+export type SelectionDetailListener = (
+  selection: ReadonlyArray<FeatureSelectionTarget>,
+  event: ExplorationViewChangeEvent,
+) => void;
+
+/** Subscribe a detail panel to the shared exploration selection. */
+export function bindDetailToSelection(
+  view: ExplorationViewController,
+  listener: SelectionDetailListener,
+  options?: ExplorationViewSubscribeOptions,
+): Unsubscribe {
+  return view.subscribe("selection", (event) => listener(event.state.selection, event), options);
+}
+
+export interface TableSelectionExplorationBinding {
+  select(targets: ReadonlyArray<FeatureSelectionTarget>, options?: { readonly replace?: boolean }): void;
+  clearSelection(): void;
+  subscribe(listener: SelectionDetailListener, options?: ExplorationViewSubscribeOptions): Unsubscribe;
+}
+
+/** Small adapter for table/grid components that publish and observe selection. */
+export function bindTableSelectionToExploration(view: ExplorationViewController): TableSelectionExplorationBinding {
+  return {
+    select(targets, options): void {
+      view.select(targets, options);
+    },
+    clearSelection(): void {
+      view.deselect();
+    },
+    subscribe(listener, options): Unsubscribe {
+      return bindDetailToSelection(view, listener, options);
+    },
+  };
+}
+
+function toFeatureTarget(
+  target: FeatureSelectionTarget,
+  source: string,
+  sourceLayer: string | undefined,
+  includeRawIds: boolean,
+): FeatureTarget | undefined {
+  if (isSourceQualifiedSelectionTarget(target)) {
+    if (target.sourceId !== source) return undefined;
+    if ((target.sourceLayer ?? "") !== (sourceLayer ?? "")) return undefined;
+    return { source, id: target.id, sourceLayer };
+  }
+
+  if (!includeRawIds) return undefined;
+  return { source, id: target, sourceLayer };
+}
+
+function featureTargetKey(target: FeatureTarget): string {
+  const selectionTarget: SourceQualifiedFeatureSelectionTarget = sourceFeatureSelectionTarget(
+    target.source,
+    target.id as FeatureId,
+    { sourceLayer: target.sourceLayer },
+  );
+  return featureSelectionKey(selectionTarget);
+}

--- a/src/interactions/index.ts
+++ b/src/interactions/index.ts
@@ -5,6 +5,12 @@ export {
   createHoverHandler,
   createSelectionHandler,
 } from "./feature-state.js";
+export {
+  bindDetailToSelection,
+  bindMapSelectionToExploration,
+  bindTableSelectionToExploration,
+  syncFeatureStateSelection,
+} from "./exploration-bindings.js";
 export type {
   FeatureStateMap,
   MapEventTarget,
@@ -15,3 +21,10 @@ export type {
   SelectionHandlerOptions,
   SelectionHandle,
 } from "./feature-state.js";
+export type {
+  FeatureStateSelectionSyncOptions,
+  InteractionBindingHandle,
+  MapSelectionExplorationBindingOptions,
+  SelectionDetailListener,
+  TableSelectionExplorationBinding,
+} from "./exploration-bindings.js";

--- a/test/entrypoints.test.ts
+++ b/test/entrypoints.test.ts
@@ -130,7 +130,9 @@ import {
 } from "../src/honua.js";
 import {
   HonuaWfsExceptionError as HonuaWfsExceptionErrorRoot,
+  bindMapSelectionToExploration,
   sourceFeatureSelectionTarget as rootSourceFeatureSelectionTarget,
+  syncFeatureStateSelection,
 } from "../src/index.js";
 import {
   buildJsMigrationReport,
@@ -288,6 +290,8 @@ describe("entrypoint modules", () => {
     expect(featureSelectionKey(target)).toContain("parcels");
     expect(rootSourceFeatureSelectionTarget("parcels", 101)).toEqual(target);
     expect(honuaSourceFeatureSelectionTarget("parcels", 101)).toEqual(target);
+    expect(bindMapSelectionToExploration).toBeTypeOf("function");
+    expect(syncFeatureStateSelection).toBeTypeOf("function");
     expect(Object.keys(LINKED_VIEW_PRESETS)).toEqual([
       "globalLinked",
       "mapDriven",

--- a/test/interaction-exploration-bindings.test.ts
+++ b/test/interaction-exploration-bindings.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  bindDetailToSelection,
+  bindMapSelectionToExploration,
+  bindTableSelectionToExploration,
+  createExplorationContext,
+  sourceFeatureSelectionTarget,
+  syncFeatureStateSelection,
+} from "../src/index.js";
+import type { FeatureStateMap, InteractiveMap } from "../src/index.js";
+
+function createMockMap(): InteractiveMap & {
+  readonly _state: Map<string, Record<string, unknown>>;
+  readonly _handlers: Map<string, Array<(...args: unknown[]) => void>>;
+  _fire(event: string, layer: string, ...args: unknown[]): void;
+} {
+  const state = new Map<string, Record<string, unknown>>();
+  const handlers = new Map<string, Array<(...args: unknown[]) => void>>();
+
+  function key(target: { source: string; id: string | number; sourceLayer?: string }): string {
+    return `${target.source}:${target.sourceLayer ?? ""}:${target.id}`;
+  }
+
+  return {
+    _state: state,
+    _handlers: handlers,
+    setFeatureState(target, patch) {
+      const targetKey = key(target);
+      state.set(targetKey, { ...(state.get(targetKey) ?? {}), ...patch });
+    },
+    getFeatureState(target) {
+      return state.get(key(target)) ?? {};
+    },
+    removeFeatureState(target, removeKey?) {
+      const targetKey = key(target);
+      if (!removeKey) {
+        state.delete(targetKey);
+        return;
+      }
+      const existing = state.get(targetKey);
+      if (existing) delete existing[removeKey];
+    },
+    on(event, layerOrHandler, handler) {
+      if (typeof layerOrHandler !== "string" || !handler) return;
+      const handlerKey = `${event}:${layerOrHandler}`;
+      if (!handlers.has(handlerKey)) handlers.set(handlerKey, []);
+      handlers.get(handlerKey)!.push(handler);
+    },
+    off(event, layerOrHandler, handler) {
+      if (typeof layerOrHandler !== "string" || !handler) return;
+      const handlerKey = `${event}:${layerOrHandler}`;
+      const list = handlers.get(handlerKey);
+      if (!list) return;
+      const index = list.indexOf(handler);
+      if (index >= 0) list.splice(index, 1);
+    },
+    _fire(event, layer, ...args) {
+      for (const handler of handlers.get(`${event}:${layer}`) ?? []) {
+        handler(...args);
+      }
+    },
+  };
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("interaction exploration bindings", () => {
+  it("publishes map selection as source-qualified exploration selection", async () => {
+    const ctx = createExplorationContext({ datasetId: "d", sourceIds: ["parcels"] });
+    const mapView = ctx.connectView({ id: "map", role: "map" });
+    const tableView = ctx.connectView({ id: "table", role: "grid" });
+    const map = createMockMap();
+    const tableEvents: Array<ReadonlyArray<unknown>> = [];
+    tableView.subscribe("selection", (event) => tableEvents.push(event.state.selection));
+
+    bindMapSelectionToExploration(map, mapView, {
+      source: "parcels",
+      sourceLayer: "parcel-fill",
+      layer: "parcel-fill",
+    });
+    map._fire("click", "parcel-fill", { features: [{ id: 101 }] });
+    await flush();
+
+    expect(ctx.state.selection).toEqual([sourceFeatureSelectionTarget("parcels", 101, { sourceLayer: "parcel-fill" })]);
+    expect(tableEvents).toEqual([[sourceFeatureSelectionTarget("parcels", 101, { sourceLayer: "parcel-fill" })]]);
+    ctx.dispose();
+  });
+
+  it("reflects table selection into map feature-state without cross-source collisions", async () => {
+    const ctx = createExplorationContext({ datasetId: "d", sourceIds: ["parcels", "assets"] });
+    const mapView = ctx.connectView({ id: "map", role: "map" });
+    const tableView = ctx.connectView({ id: "table", role: "grid" });
+    const map = createMockMap();
+    syncFeatureStateSelection(map as FeatureStateMap, mapView, {
+      source: "parcels",
+      sourceLayer: "parcel-fill",
+    });
+
+    tableView.select(
+      [
+        sourceFeatureSelectionTarget("parcels", 101, { sourceLayer: "parcel-fill" }),
+        sourceFeatureSelectionTarget("assets", 101),
+      ],
+      { replace: true },
+    );
+    await flush();
+
+    expect(map._state.get("parcels:parcel-fill:101")).toEqual({ selected: true });
+    expect(map._state.has("assets::101")).toBe(false);
+
+    tableView.select([sourceFeatureSelectionTarget("assets", 101)], { replace: true });
+    await flush();
+
+    expect(map._state.get("parcels:parcel-fill:101")).toEqual({ selected: false });
+    expect(map._state.has("assets::101")).toBe(false);
+    ctx.dispose();
+  });
+
+  it("binds table and detail adapters to the shared selection slice", async () => {
+    const ctx = createExplorationContext({ datasetId: "d", sourceIds: ["parcels"] });
+    const tableView = ctx.connectView({ id: "table", role: "grid" });
+    const detailView = ctx.connectView({ id: "detail", role: "form" });
+    const table = bindTableSelectionToExploration(tableView);
+    const detailListener = vi.fn();
+    const tableListener = vi.fn();
+    bindDetailToSelection(detailView, detailListener);
+    table.subscribe(tableListener);
+
+    const target = sourceFeatureSelectionTarget("parcels", 7);
+    table.select([target], { replace: true });
+    await flush();
+
+    expect(detailListener).toHaveBeenCalledWith([target], expect.objectContaining({ selfOrigin: false }));
+    expect(tableListener).not.toHaveBeenCalled();
+
+    table.clearSelection();
+    await flush();
+
+    expect(detailListener).toHaveBeenLastCalledWith([], expect.objectContaining({ selfOrigin: false }));
+    ctx.dispose();
+  });
+});


### PR DESCRIPTION
## Summary

- Add framework-neutral map/table/detail selection bindings on top of `ExplorationViewController`.
- Publish MapLibre feature-state selections into source-qualified exploration selection targets.
- Sync shared exploration selection back into map feature-state without same-id cross-source collisions.
- Add table/detail adapter helpers, exports, docs, and contract tests.

## Backlog

Refs #67
Refs #72
Builds on #80

## Validation

- `npm test -- test/interaction-exploration-bindings.test.ts test/feature-state.test.ts test/contract/exploration.test.ts test/entrypoints.test.ts`
- `npm run typecheck`
- `npm run check`
- `npm run build`
- `npm run verify:split-packages`
