### PR TITLE
Adopt linked context in quickstart explorer

### DIFF
--- a/examples/maplibre-quickstart/README.md
+++ b/examples/maplibre-quickstart/README.md
@@ -9,6 +9,7 @@ What it exercises:
 - one read-only `queryFeatures()` call against a configured FeatureServer layer
 - Esri JSON to GeoJSON conversion inside the example
 - MapLibre rendering and popup-backed feature inspection
+- `ExplorationContext` plus interaction bindings for map, result list, filters, query projection, and details
 
 ## Fast Local Run
 
@@ -82,6 +83,13 @@ Query shape:
 - `resultRecordCount`: bounded by env, default `25`
 
 MapLibre then fetches the configured basemap style and any dependent assets separately from the Honua API calls above.
+After the initial bounded query, the browser app wires the returned features into a linked exploration context:
+
+- map `moveend` events update the shared extent and spatial filter
+- attribute filter controls update the shared filter slice
+- map clicks and result-list buttons update one shared source-qualified selection
+- the result list and diagnostics panel render from `LinkedViewQueryProjection`
+- MapLibre layer filters are translated from the same projection used by the result list
 
 Response handling:
 
@@ -114,6 +122,8 @@ Expected event types:
 - `query-finished`
 - `map-ready`
 - `feature-selected`
+- `linked-filter-changed`
+- `linked-query-updated`
 - `error`
 
 Runtime state includes:
@@ -123,6 +133,7 @@ Runtime state includes:
 - `featureCount`, `renderableFeatureCount`, and `geometryTypes`
 - `queryDurationMs`
 - `layerIds`, `mapReady`, `selectedFeatureId`, `popupOpen`, and `lastError`
+- `linkedVisibleFeatureCount`, `linkedFilterCount`, and `linkedExtent`
 
 Startup failures are surfaced in the overlay and the inline status panel. For common fixes, use the troubleshooting
 guide at [`docs/quickstart-troubleshooting.md`](../../docs/quickstart-troubleshooting.md).
@@ -131,7 +142,7 @@ guide at [`docs/quickstart-troubleshooting.md`](../../docs/quickstart-troublesho
 
 ```bash
 npm run demo:quickstart:typecheck
-npx vitest run test/quickstart-config.test.ts test/quickstart-data.test.ts
+npx vitest run test/quickstart-config.test.ts test/quickstart-data.test.ts test/quickstart-linked-exploration.test.ts
 npm run test:playwright:quickstart
 ```
 

--- a/examples/maplibre-quickstart/index.html
+++ b/examples/maplibre-quickstart/index.html
@@ -44,6 +44,41 @@
           </article>
         </section>
 
+        <section class="linked-context-panel" aria-label="Linked exploration context">
+          <div class="linked-context-header">
+            <div>
+              <p class="eyebrow">Linked context</p>
+              <h2>Explorer controls</h2>
+            </div>
+            <button id="clear-filter-button" class="secondary-button" type="button">Clear</button>
+          </div>
+          <label class="field-control" for="attribute-filter">
+            <span>Attribute filter</span>
+            <select id="attribute-filter" disabled>
+              <option value="">All rendered features</option>
+            </select>
+          </label>
+          <dl class="linked-context-grid">
+            <div>
+              <dt>Visible Rows</dt>
+              <dd id="linked-visible-count">0</dd>
+            </div>
+            <div>
+              <dt>Filters</dt>
+              <dd id="linked-filter-state">None</dd>
+            </div>
+            <div>
+              <dt>Selection</dt>
+              <dd id="linked-selection-count">0</dd>
+            </div>
+            <div>
+              <dt>Extent</dt>
+              <dd id="linked-extent">No viewport</dd>
+            </div>
+          </dl>
+          <pre id="linked-query-projection" class="query-projection">{}</pre>
+        </section>
+
         <article class="selection-card" aria-label="Selected feature">
           <div class="selection-card-header">
             <div>

--- a/examples/maplibre-quickstart/src/linked-exploration.ts
+++ b/examples/maplibre-quickstart/src/linked-exploration.ts
@@ -1,0 +1,161 @@
+import type { FilterClause } from "@honua/sdk-js/exploration";
+import type { HonuaExtent } from "@honua/sdk-js/honua";
+import type { LinkedViewQueryProjection } from "@honua/sdk-js/interactions";
+
+import type { QuickstartFeatureSummary } from "./data.js";
+import type { QuickstartRenderableGeometryType } from "./esri-geojson.js";
+
+export interface QuickstartFilterOption {
+  field: string;
+  values: string[];
+}
+
+const PREFERRED_FILTER_FIELDS = ["STATUS", "CATEGORY", "status", "category", "TYPE", "type"] as const;
+
+export function createQuickstartFilterOptions(
+  summaries: readonly QuickstartFeatureSummary[],
+): QuickstartFilterOption[] {
+  const valuesByField = new Map<string, Set<string>>();
+
+  for (const summary of summaries) {
+    for (const [field, value] of Object.entries(summary.feature.properties)) {
+      if (!isFilterableValue(value)) continue;
+      const values = valuesByField.get(field) ?? new Set<string>();
+      values.add(String(value));
+      valuesByField.set(field, values);
+    }
+  }
+
+  const entries = [...valuesByField.entries()];
+  const preferredEntries = entries.filter(([field]) =>
+    PREFERRED_FILTER_FIELDS.includes(field as (typeof PREFERRED_FILTER_FIELDS)[number]),
+  );
+
+  return (preferredEntries.length > 0 ? preferredEntries : entries)
+    .filter(([, values]) => values.size > 1 && values.size <= 12)
+    .sort(([left], [right]) => fieldRank(left) - fieldRank(right) || left.localeCompare(right))
+    .map(([field, values]) => ({
+      field,
+      values: [...values].sort((left, right) => left.localeCompare(right)),
+    }));
+}
+
+export function applyQuickstartProjection(
+  summaries: readonly QuickstartFeatureSummary[],
+  projection: LinkedViewQueryProjection,
+): QuickstartFeatureSummary[] {
+  const filters = Object.values(projection.filters);
+  return summaries.filter((summary) => {
+    if (!summaryInExtent(summary, projection.extent)) return false;
+    return filters.every((clause) => matchesClause(summary, clause));
+  });
+}
+
+export function createMapLibreLayerFilter(
+  geometryType: QuickstartRenderableGeometryType,
+  projection: LinkedViewQueryProjection,
+): unknown[] {
+  const clauses = [
+    geometryFilter(geometryType),
+    ...Object.values(projection.filters).map(clauseToMapLibreFilter).filter(isFilterExpression),
+  ];
+
+  return clauses.length === 1 ? clauses[0] : ["all", ...clauses];
+}
+
+export function formatProjectionExtent(extent: HonuaExtent | undefined): string {
+  if (!extent) return "No viewport";
+  return `${formatCoordinate(extent.xmin)}, ${formatCoordinate(extent.ymin)} to ${formatCoordinate(
+    extent.xmax,
+  )}, ${formatCoordinate(extent.ymax)}`;
+}
+
+function fieldRank(field: string): number {
+  const preferredIndex = PREFERRED_FILTER_FIELDS.indexOf(field as (typeof PREFERRED_FILTER_FIELDS)[number]);
+  return preferredIndex >= 0 ? preferredIndex : PREFERRED_FILTER_FIELDS.length;
+}
+
+function isFilterableValue(value: unknown): value is string | number | boolean {
+  return (
+    (typeof value === "string" && value.trim().length > 0) ||
+    (typeof value === "number" && Number.isFinite(value)) ||
+    typeof value === "boolean"
+  );
+}
+
+function summaryInExtent(summary: QuickstartFeatureSummary, extent: HonuaExtent | undefined): boolean {
+  if (!extent || !summary.center) return true;
+  const [x, y] = summary.center;
+  return x >= extent.xmin && x <= extent.xmax && y >= extent.ymin && y <= extent.ymax;
+}
+
+function matchesClause(summary: QuickstartFeatureSummary, clause: FilterClause): boolean {
+  const value = summary.feature.properties[clause.field];
+  switch (clause.operator) {
+    case "=":
+      return value === clause.value;
+    case "!=":
+      return value !== clause.value;
+    case "in":
+      return Array.isArray(clause.value) && clause.value.includes(value);
+    case "not-in":
+      return Array.isArray(clause.value) && !clause.value.includes(value);
+    case "like":
+      return typeof value === "string" && typeof clause.value === "string" && value.includes(clause.value);
+    case "is-null":
+      return value === undefined || value === null;
+    case "is-not-null":
+      return value !== undefined && value !== null;
+    case "<":
+      return typeof value === "number" && typeof clause.value === "number" && value < clause.value;
+    case "<=":
+      return typeof value === "number" && typeof clause.value === "number" && value <= clause.value;
+    case ">":
+      return typeof value === "number" && typeof clause.value === "number" && value > clause.value;
+    case ">=":
+      return typeof value === "number" && typeof clause.value === "number" && value >= clause.value;
+    case "between":
+      return (
+        typeof value === "number" &&
+        Array.isArray(clause.value) &&
+        clause.value.length >= 2 &&
+        typeof clause.value[0] === "number" &&
+        typeof clause.value[1] === "number" &&
+        value >= clause.value[0] &&
+        value <= clause.value[1]
+      );
+  }
+}
+
+function geometryFilter(geometryType: QuickstartRenderableGeometryType): unknown[] {
+  if (geometryType === "point") return ["==", "$type", "Point"];
+  if (geometryType === "line") return ["==", "$type", "LineString"];
+  return ["==", "$type", "Polygon"];
+}
+
+function clauseToMapLibreFilter(clause: FilterClause): unknown[] | undefined {
+  switch (clause.operator) {
+    case "=":
+      return ["==", clause.field, clause.value];
+    case "!=":
+      return ["!=", clause.field, clause.value];
+    case "in":
+      return Array.isArray(clause.value) ? ["in", clause.field, ...clause.value] : undefined;
+    case "not-in":
+      return Array.isArray(clause.value) ? ["!in", clause.field, ...clause.value] : undefined;
+    case "is-null":
+      return ["==", clause.field, null];
+    case "is-not-null":
+      return ["!=", clause.field, null];
+    default:
+      return undefined;
+  }
+}
+
+function isFilterExpression(value: unknown[] | undefined): value is unknown[] {
+  return Array.isArray(value);
+}
+
+function formatCoordinate(value: number): string {
+  return value.toFixed(4);
+}

--- a/examples/maplibre-quickstart/src/main.ts
+++ b/examples/maplibre-quickstart/src/main.ts
@@ -1,10 +1,35 @@
 import "maplibre-gl/dist/maplibre-gl.css";
 
-import maplibregl, { type LngLatLike } from "maplibre-gl";
+import maplibregl from "maplibre-gl";
+
+import {
+  createExplorationContext,
+  isSourceQualifiedSelectionTarget,
+  sourceFeatureSelectionTarget,
+} from "@honua/sdk-js/exploration";
+import type { FeatureSelectionTarget } from "@honua/sdk-js/exploration";
+import type { HonuaExtent } from "@honua/sdk-js/honua";
+import {
+  bindDetailToSelection,
+  bindFilterControlsToExploration,
+  bindMapExtentToExploration,
+  bindMapSelectionToExploration,
+  bindQueryProjectionToExploration,
+  bindTableSelectionToExploration,
+  syncFeatureStateSelection,
+  syncMapLayerFilterToExploration,
+} from "@honua/sdk-js/interactions";
+import type { FeatureStateMap, InteractiveMap, LinkedViewQueryProjection } from "@honua/sdk-js/interactions";
 
 import { resolveQuickstartConfig } from "./config.js";
 import { type QuickstartDataset, type QuickstartFeatureSummary, loadQuickstartDataset } from "./data.js";
-import { toMapLibreBounds } from "./esri-geojson.js";
+import { type QuickstartRenderableGeometryType, toMapLibreBounds } from "./esri-geojson.js";
+import {
+  applyQuickstartProjection,
+  createMapLibreLayerFilter,
+  createQuickstartFilterOptions,
+  formatProjectionExtent,
+} from "./linked-exploration.js";
 import { createQuickstartTelemetry } from "./telemetry.js";
 
 import "./styles.css";
@@ -12,6 +37,12 @@ import "./styles.css";
 interface MapHandle {
   map: maplibregl.Map;
   layerIds: string[];
+  layerFilterBindings: LayerFilterBinding[];
+}
+
+interface LayerFilterBinding {
+  layerId: string;
+  geometryType: QuickstartRenderableGeometryType;
 }
 
 function getElement<T extends Element>(selector: string): T {
@@ -73,6 +104,145 @@ function renderSelection(summary: QuickstartFeatureSummary): void {
     attributes.length > 0 ? attributes : '<div class="empty-copy">No attributes available.</div>';
 }
 
+function renderEmptySelection(): void {
+  setText("#selected-feature-title", "No linked selection");
+  setText("#selected-feature-subtitle", "Select a feature from the map or results list.");
+  setText("#selected-feature-id", "-");
+  setText("#selected-feature-geometry", "-");
+  getElement<HTMLElement>("#selected-feature-attributes").innerHTML =
+    '<div class="empty-copy">Attributes will appear after a linked selection.</div>';
+}
+
+function renderLinkedProjection(projection: LinkedViewQueryProjection, visibleFeatureCount: number): void {
+  const filterIds = Object.keys(projection.filters);
+  setText("#linked-visible-count", String(visibleFeatureCount));
+  setText("#linked-filter-state", filterIds.length > 0 ? filterIds.join(", ") : "None");
+  setText("#linked-extent", formatProjectionExtent(projection.extent));
+  getElement<HTMLElement>("#linked-query-projection").textContent = JSON.stringify(
+    {
+      filters: projection.filters,
+      extent: projection.extent,
+      spatialFilter: projection.spatialFilter,
+      orderBy: projection.orderBy,
+      pagination: projection.pagination,
+    },
+    null,
+    2,
+  );
+}
+
+function renderFilterOptions(select: HTMLSelectElement, dataset: QuickstartDataset): void {
+  const options = createQuickstartFilterOptions(dataset.featureSummaries);
+  select.innerHTML = '<option value="">All rendered features</option>';
+
+  for (const option of options) {
+    const group = document.createElement("optgroup");
+    group.label = option.field;
+    for (const value of option.values) {
+      const item = document.createElement("option");
+      item.value = `${option.field}\u001f${value}`;
+      item.textContent = `${option.field}: ${value}`;
+      group.append(item);
+    }
+    select.append(group);
+  }
+
+  select.disabled = options.length === 0;
+}
+
+function renderFeatureList(
+  summaries: readonly QuickstartFeatureSummary[],
+  selectedFeatureId: string | undefined,
+  onInspect: (summary: QuickstartFeatureSummary) => void,
+): void {
+  const featureList = getElement<HTMLElement>("#feature-list");
+  featureList.innerHTML = "";
+
+  if (summaries.length === 0) {
+    featureList.innerHTML = '<div class="empty-copy">No features match the linked context.</div>';
+    return;
+  }
+
+  for (const summary of summaries) {
+    const item = document.createElement("article");
+    item.className = "feature-list-item";
+    item.innerHTML = `
+      <div>
+        <p class="feature-list-kicker">${escapeHtml(summary.geometryKind ?? "feature")}</p>
+        <h3>${escapeHtml(summary.title)}</h3>
+        <p>${escapeHtml(summary.subtitle)}</p>
+      </div>
+    `;
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "feature-inspect-button";
+    button.dataset.featureId = summary.id;
+    button.dataset.selected = summary.id === selectedFeatureId ? "true" : "false";
+    button.dataset.testid = `inspect-feature-${summary.id}`;
+    button.setAttribute("aria-pressed", summary.id === selectedFeatureId ? "true" : "false");
+    button.textContent = `Inspect ${summary.title}`;
+    button.addEventListener("click", () => onInspect(summary));
+    item.append(button);
+    featureList.append(item);
+  }
+}
+
+function mapBoundsToHonuaExtent(bounds: maplibregl.LngLatBounds): HonuaExtent {
+  const west = bounds.getWest();
+  const east = bounds.getEast();
+  const south = bounds.getSouth();
+  const north = bounds.getNorth();
+  return {
+    xmin: Math.min(west, east),
+    ymin: Math.min(south, north),
+    xmax: Math.max(west, east),
+    ymax: Math.max(south, north),
+    spatialReference: { wkid: 4326 },
+  };
+}
+
+function createMapExtentSource(map: maplibregl.Map) {
+  return {
+    current(): HonuaExtent | undefined {
+      return mapBoundsToHonuaExtent(map.getBounds());
+    },
+    subscribe(listener: (extent: HonuaExtent | undefined) => void) {
+      const emit = () => listener(mapBoundsToHonuaExtent(map.getBounds()));
+      map.on("moveend", emit);
+      return {
+        remove() {
+          map.off("moveend", emit);
+        },
+      };
+    },
+  };
+}
+
+function readSelectedFeatureId(selection: ReadonlyArray<FeatureSelectionTarget>, sourceId: string): string | undefined {
+  const [target] = selection;
+  if (target === undefined) return undefined;
+  if (isSourceQualifiedSelectionTarget(target)) {
+    return target.sourceId === sourceId ? String(target.id) : undefined;
+  }
+  return String(target);
+}
+
+function setFeatureListSelection(featureId: string | undefined): void {
+  document.querySelectorAll<HTMLButtonElement>(".feature-inspect-button").forEach((button) => {
+    const selected = button.dataset.featureId === featureId;
+    button.dataset.selected = selected ? "true" : "false";
+    button.setAttribute("aria-pressed", selected ? "true" : "false");
+  });
+}
+
+function parseFilterValue(value: string): { field: string; value: string } | undefined {
+  if (!value) return undefined;
+  const [field, filterValue] = value.split("\u001f", 2);
+  if (!field || filterValue === undefined) return undefined;
+  return { field, value: filterValue };
+}
+
 function createPopupHtml(summary: QuickstartFeatureSummary): string {
   const attributeRows = Object.entries(summary.feature.properties)
     .slice(0, 5)
@@ -107,6 +277,7 @@ async function createMap(
     const onLoad = () => {
       try {
         const layerIds: string[] = [];
+        const layerFilterBindings: LayerFilterBinding[] = [];
 
         map.addSource(config.sourceId, {
           type: "geojson",
@@ -120,8 +291,8 @@ async function createMap(
             type: "fill",
             filter: ["==", "$type", "Polygon"],
             paint: {
-              "fill-color": "#2f7d6a",
-              "fill-opacity": 0.44,
+              "fill-color": ["case", ["boolean", ["feature-state", "selected"], false], "#c2410c", "#0f766e"],
+              "fill-opacity": ["case", ["boolean", ["feature-state", "selected"], false], 0.68, 0.42],
             },
           });
           map.addLayer({
@@ -130,11 +301,15 @@ async function createMap(
             type: "line",
             filter: ["==", "$type", "Polygon"],
             paint: {
-              "line-color": "#16433b",
-              "line-width": 2,
+              "line-color": ["case", ["boolean", ["feature-state", "selected"], false], "#7c2d12", "#134e4a"],
+              "line-width": ["case", ["boolean", ["feature-state", "selected"], false], 3, 2],
             },
           });
           layerIds.push(config.layerIds.fill, config.layerIds.outline);
+          layerFilterBindings.push(
+            { layerId: config.layerIds.fill, geometryType: "polygon" },
+            { layerId: config.layerIds.outline, geometryType: "polygon" },
+          );
         }
 
         if (dataset.geometryTypes.includes("line")) {
@@ -144,11 +319,12 @@ async function createMap(
             type: "line",
             filter: ["==", "$type", "LineString"],
             paint: {
-              "line-color": "#b55127",
-              "line-width": 3,
+              "line-color": ["case", ["boolean", ["feature-state", "selected"], false], "#c2410c", "#2563eb"],
+              "line-width": ["case", ["boolean", ["feature-state", "selected"], false], 5, 3],
             },
           });
           layerIds.push(config.layerIds.line);
+          layerFilterBindings.push({ layerId: config.layerIds.line, geometryType: "line" });
         }
 
         if (dataset.geometryTypes.includes("point")) {
@@ -158,13 +334,14 @@ async function createMap(
             type: "circle",
             filter: ["==", "$type", "Point"],
             paint: {
-              "circle-radius": 7,
-              "circle-color": "#b55127",
+              "circle-radius": ["case", ["boolean", ["feature-state", "selected"], false], 9, 7],
+              "circle-color": ["case", ["boolean", ["feature-state", "selected"], false], "#c2410c", "#2563eb"],
               "circle-stroke-width": 2,
-              "circle-stroke-color": "#fff7ed",
+              "circle-stroke-color": "#ffffff",
             },
           });
           layerIds.push(config.layerIds.circle);
+          layerFilterBindings.push({ layerId: config.layerIds.circle, geometryType: "point" });
         }
 
         if (dataset.bounds) {
@@ -185,7 +362,7 @@ async function createMap(
         }
 
         cleanup();
-        resolve({ map, layerIds });
+        resolve({ map, layerIds, layerFilterBindings });
       } catch (error) {
         cleanup();
         reject(error);
@@ -218,7 +395,8 @@ async function bootstrap(): Promise<void> {
   const overlay = getElement<HTMLElement>("#map-overlay");
   const overlayTitle = getElement<HTMLElement>(".map-overlay-title");
   const overlayBody = getElement<HTMLElement>(".map-overlay-body");
-  const featureList = getElement<HTMLElement>("#feature-list");
+  const filterSelect = getElement<HTMLSelectElement>("#attribute-filter");
+  const clearFilterButton = getElement<HTMLButtonElement>("#clear-filter-button");
 
   telemetry.patchRuntime({
     baseUrl: config.honuaBaseUrl || "same-origin",
@@ -241,6 +419,7 @@ async function bootstrap(): Promise<void> {
 
     const dataset = await loadQuickstartDataset(config, { telemetry });
     renderStatus(config, dataset);
+    renderFilterOptions(filterSelect, dataset);
     const firstFeature = dataset.featureSummaries[0];
     if (firstFeature) {
       renderSelection(firstFeature);
@@ -249,22 +428,65 @@ async function bootstrap(): Promise<void> {
     overlayTitle.textContent = "Loading the map";
     overlayBody.textContent = "Adding a GeoJSON source, creating render layers, and fitting to the queried features.";
 
-    const { map, layerIds } = await createMap(config, dataset);
+    const { map, layerIds, layerFilterBindings } = await createMap(config, dataset);
     const featureById = new Map(dataset.featureSummaries.map((summary) => [summary.id, summary]));
+    const context = createExplorationContext({
+      datasetId: `${config.serviceId}/${config.layerId}`,
+      sourceIds: [config.sourceId],
+      preset: "globalLinked",
+    });
+    const mapView = context.connectView({ id: "quickstart-map", role: "map" });
+    const tableView = context.connectView({ id: "quickstart-results", role: "grid" });
+    const detailView = context.connectView({ id: "quickstart-detail", role: "form" });
+    const filterView = context.connectView({ id: "quickstart-filter", role: "filter" });
+    const filterControls = bindFilterControlsToExploration(filterView);
+    const tableSelection = bindTableSelectionToExploration(tableView);
+    const removableHandles: Array<{ remove(): void }> = [
+      syncFeatureStateSelection(map as unknown as FeatureStateMap, mapView, { source: config.sourceId }),
+    ];
+    const unsubscribeHandles: Array<() => void> = [];
+    let selectedFeatureId: string | undefined;
+    let latestProjection: LinkedViewQueryProjection | undefined;
 
-    const selectFeature = (featureId: string, popupLngLat?: LngLatLike) => {
-      const summary = featureById.get(featureId);
-      if (!summary) {
+    function renderProjectedResults(projection: LinkedViewQueryProjection): void {
+      latestProjection = projection;
+      const projectedSummaries = applyQuickstartProjection(dataset.featureSummaries, projection);
+      renderLinkedProjection(projection, projectedSummaries.length);
+      renderFeatureList(projectedSummaries, selectedFeatureId, (summary) => {
+        tableSelection.select([sourceFeatureSelectionTarget(config.sourceId, summary.id)], { replace: true });
+      });
+      telemetry.patchRuntime({
+        linkedVisibleFeatureCount: projectedSummaries.length,
+        linkedFilterCount: Object.keys(projection.filters).length,
+        linkedExtent: projection.extent ? formatProjectionExtent(projection.extent) : null,
+      });
+      telemetry.emit("linked-query-updated", {
+        visibleFeatureCount: projectedSummaries.length,
+        filterCount: Object.keys(projection.filters).length,
+        hasExtent: Boolean(projection.extent),
+      });
+    }
+
+    function renderSelectedFeature(featureId: string | undefined): void {
+      selectedFeatureId = featureId;
+      setText("#linked-selection-count", featureId ? "1" : "0");
+      setFeatureListSelection(featureId);
+
+      if (!featureId) {
+        activePopup?.remove();
+        activePopup = null;
+        renderEmptySelection();
+        telemetry.patchRuntime({
+          selectedFeatureId: null,
+          popupOpen: false,
+        });
         return;
       }
 
-      renderSelection(summary);
-      document.querySelectorAll<HTMLButtonElement>(".feature-inspect-button").forEach((button) => {
-        const selected = button.dataset.featureId === featureId;
-        button.dataset.selected = selected ? "true" : "false";
-        button.setAttribute("aria-pressed", selected ? "true" : "false");
-      });
+      const summary = featureById.get(featureId);
+      if (!summary) return;
 
+      renderSelection(summary);
       if (summary.center) {
         activePopup?.remove();
         activePopup = new maplibregl.Popup({
@@ -272,7 +494,7 @@ async function bootstrap(): Promise<void> {
           closeOnClick: false,
           maxWidth: "320px",
         })
-          .setLngLat(popupLngLat ?? summary.center)
+          .setLngLat(summary.center)
           .setHTML(createPopupHtml(summary))
           .addTo(map);
 
@@ -293,7 +515,7 @@ async function bootstrap(): Promise<void> {
         featureId,
         geometryType: summary.geometryKind ?? "unknown",
       });
-    };
+    }
 
     const interactiveLayerIds = [config.layerIds.fill, config.layerIds.line, config.layerIds.circle].filter((id) =>
       layerIds.includes(id),
@@ -306,39 +528,77 @@ async function bootstrap(): Promise<void> {
       map.on("mouseleave", layerId, () => {
         map.getCanvas().style.cursor = "";
       });
-      map.on("click", layerId, (event) => {
-        const clickedFeatureId = event.features?.[0]?.id;
-        if (typeof clickedFeatureId === "string" || typeof clickedFeatureId === "number") {
-          selectFeature(String(clickedFeatureId), event.lngLat);
-        }
+      removableHandles.push(
+        bindMapSelectionToExploration(map as unknown as InteractiveMap, mapView, {
+          source: config.sourceId,
+          layer: layerId,
+        }),
+      );
+    }
+
+    for (const binding of layerFilterBindings) {
+      removableHandles.push(
+        syncMapLayerFilterToExploration(
+          {
+            setFilter(layerId, filter) {
+              map.setFilter(layerId, filter as never);
+            },
+          },
+          mapView,
+          {
+            layerId: binding.layerId,
+            translate(projection) {
+              return createMapLibreLayerFilter(binding.geometryType, projection);
+            },
+          },
+        ),
+      );
+    }
+
+    removableHandles.push(
+      bindMapExtentToExploration(mapView, createMapExtentSource(map), {
+        publishSpatialFilter: true,
+      }),
+    );
+    unsubscribeHandles.push(
+      bindDetailToSelection(detailView, (selection) => {
+        renderSelectedFeature(readSelectedFeatureId(selection, config.sourceId));
+      }),
+      bindQueryProjectionToExploration(tableView, renderProjectedResults, {
+        sourceId: config.sourceId,
+      }),
+    );
+
+    filterSelect.addEventListener("change", () => {
+      const selected = parseFilterValue(filterSelect.value);
+      if (!selected) {
+        filterControls.clearFilter("attribute");
+        telemetry.emit("linked-filter-changed", { active: false });
+        return;
+      }
+      filterControls.setFilter("attribute", {
+        field: selected.field,
+        operator: "=",
+        value: selected.value,
+        appliesTo: [config.sourceId],
       });
+      telemetry.emit("linked-filter-changed", {
+        active: true,
+        field: selected.field,
+        value: selected.value,
+      });
+    });
+    clearFilterButton.addEventListener("click", () => {
+      filterSelect.value = "";
+      filterControls.clearFilter("attribute");
+      telemetry.emit("linked-filter-changed", { active: false });
+    });
+
+    if (latestProjection) {
+      renderProjectedResults(latestProjection);
     }
-
-    featureList.innerHTML = "";
-    for (const summary of dataset.featureSummaries) {
-      const item = document.createElement("article");
-      item.className = "feature-list-item";
-      item.innerHTML = `
-        <div>
-          <p class="feature-list-kicker">${escapeHtml(summary.geometryKind ?? "feature")}</p>
-          <h3>${escapeHtml(summary.title)}</h3>
-          <p>${escapeHtml(summary.subtitle)}</p>
-        </div>
-      `;
-
-      const button = document.createElement("button");
-      button.type = "button";
-      button.className = "feature-inspect-button";
-      button.dataset.featureId = summary.id;
-      button.dataset.testid = `inspect-feature-${summary.id}`;
-      button.textContent = `Inspect ${summary.title}`;
-      button.addEventListener("click", () => selectFeature(summary.id));
-      item.append(button);
-      featureList.append(item);
-    }
-
     if (firstFeature) {
-      selectFeature(firstFeature.id);
+      tableSelection.select([sourceFeatureSelectionTarget(config.sourceId, firstFeature.id)], { replace: true });
     }
 
     telemetry.patchRuntime({
@@ -352,9 +612,12 @@ async function bootstrap(): Promise<void> {
 
     overlay.dataset.state = "ready";
     overlayTitle.textContent = "Map ready";
-    overlayBody.textContent = "Use the inspect buttons or click a rendered feature to open the popup and inspect data.";
+    overlayBody.textContent = "Linked map, filter, result, and detail context is ready.";
 
     window.addEventListener("beforeunload", () => {
+      for (const unsubscribe of unsubscribeHandles) unsubscribe();
+      for (const handle of removableHandles) handle.remove();
+      context.dispose();
       activePopup?.remove();
       map.remove();
     });

--- a/examples/maplibre-quickstart/src/styles.css
+++ b/examples/maplibre-quickstart/src/styles.css
@@ -1,17 +1,16 @@
 :root {
   font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
-  color: #13201e;
-  background:
-    radial-gradient(circle at top left, rgba(250, 242, 224, 0.9), transparent 32rem),
-    linear-gradient(180deg, #f7f1e2 0%, #efe6d1 100%);
+  color: #162029;
+  background: linear-gradient(180deg, #f6f8fb 0%, #e7edf3 100%);
   color-scheme: light;
-  --card: rgba(255, 250, 241, 0.92);
-  --card-border: rgba(24, 54, 47, 0.12);
-  --ink-soft: #4c615c;
-  --accent: #2f7d6a;
-  --accent-strong: #16433b;
-  --highlight: #b55127;
-  --shadow: 0 20px 50px rgba(39, 36, 24, 0.12);
+  --card: rgba(255, 255, 255, 0.94);
+  --card-border: rgba(31, 42, 55, 0.13);
+  --ink-soft: #526170;
+  --accent: #0f766e;
+  --accent-strong: #134e4a;
+  --highlight: #c2410c;
+  --panel-soft: #eef3f7;
+  --shadow: 0 18px 42px rgba(31, 42, 55, 0.12);
 }
 
 * {
@@ -41,7 +40,7 @@ select {
 .control-panel,
 .map-stage {
   border: 1px solid var(--card-border);
-  border-radius: 1.5rem;
+  border-radius: 8px;
   background: var(--card);
   box-shadow: var(--shadow);
   backdrop-filter: blur(18px);
@@ -85,10 +84,11 @@ select {
 
 .status-card,
 .selection-card,
-.feature-list {
+.feature-list,
+.linked-context-panel {
   border: 1px solid var(--card-border);
-  border-radius: 1.1rem;
-  background: rgba(255, 255, 255, 0.66);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
 }
 
 .status-card {
@@ -112,11 +112,13 @@ select {
 }
 
 .selection-card,
-.feature-list {
+.feature-list,
+.linked-context-panel {
   padding: 1rem;
 }
 
-.selection-card-header {
+.selection-card-header,
+.linked-context-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -124,7 +126,8 @@ select {
 }
 
 .selection-card h2,
-.feature-list h2 {
+.feature-list h2,
+.linked-context-panel h2 {
   margin: 0.2rem 0 0.5rem;
   font-size: 1.25rem;
 }
@@ -142,14 +145,18 @@ select {
 }
 
 .selection-meta div,
-.attribute-list {
-  border-radius: 0.9rem;
-  background: rgba(247, 241, 226, 0.8);
+.attribute-list,
+.linked-context-grid div,
+.query-projection {
+  border-radius: 6px;
+  background: var(--panel-soft);
   padding: 0.85rem;
 }
 
 .selection-meta dt,
-.attribute-row dt {
+.attribute-row dt,
+.linked-context-grid dt,
+.field-control span {
   margin: 0;
   font-size: 0.76rem;
   font-weight: 700;
@@ -159,9 +166,58 @@ select {
 }
 
 .selection-meta dd,
-.attribute-row dd {
+.attribute-row dd,
+.linked-context-grid dd {
   margin: 0.25rem 0 0;
   font-weight: 600;
+}
+
+.field-control {
+  display: grid;
+  gap: 0.35rem;
+  margin: 0.75rem 0 0.9rem;
+}
+
+.field-control select {
+  width: 100%;
+  border: 1px solid var(--card-border);
+  border-radius: 6px;
+  background: #ffffff;
+  color: #162029;
+  padding: 0.65rem 0.75rem;
+}
+
+.secondary-button {
+  border: 1px solid var(--card-border);
+  border-radius: 6px;
+  background: #ffffff;
+  color: var(--accent-strong);
+  padding: 0.55rem 0.8rem;
+  cursor: pointer;
+}
+
+.secondary-button:hover {
+  border-color: var(--accent);
+}
+
+.linked-context-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.linked-context-grid div:last-child {
+  grid-column: 1 / -1;
+}
+
+.query-projection {
+  max-height: 10rem;
+  overflow: auto;
+  margin: 0.8rem 0 0;
+  color: #22303c;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
 }
 
 .attribute-list {
@@ -190,8 +246,8 @@ select {
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 0.8rem;
   align-items: center;
-  border-radius: 0.95rem;
-  background: rgba(247, 241, 226, 0.8);
+  border-radius: 6px;
+  background: var(--panel-soft);
   padding: 0.9rem;
 }
 
@@ -207,9 +263,9 @@ select {
 
 .feature-inspect-button {
   border: none;
-  border-radius: 999px;
+  border-radius: 6px;
   background: var(--accent-strong);
-  color: #f9f5ea;
+  color: #ffffff;
   padding: 0.7rem 1rem;
   cursor: pointer;
   transition:
@@ -249,9 +305,9 @@ select {
   gap: 1rem;
   align-items: center;
   padding: 0.95rem 1rem;
-  border-radius: 1rem;
-  background: rgba(21, 41, 38, 0.78);
-  color: #f8f2e5;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.82);
+  color: #f8fafc;
 }
 
 .map-stage-header h2 {
@@ -266,8 +322,8 @@ select {
 
 .map-status span {
   padding: 0.45rem 0.75rem;
-  border-radius: 999px;
-  background: rgba(248, 242, 229, 0.14);
+  border-radius: 6px;
+  background: rgba(248, 250, 252, 0.14);
   font-size: 0.84rem;
 }
 
@@ -282,18 +338,18 @@ select {
   z-index: 2;
   max-width: 26rem;
   padding: 0.95rem 1rem;
-  border-radius: 1rem;
-  border: 1px solid rgba(248, 242, 229, 0.2);
-  background: rgba(21, 41, 38, 0.86);
-  color: #f8f2e5;
+  border-radius: 8px;
+  border: 1px solid rgba(248, 250, 252, 0.2);
+  background: rgba(15, 23, 42, 0.88);
+  color: #f8fafc;
 }
 
 .map-overlay[data-state="ready"] {
-  background: rgba(20, 67, 59, 0.82);
+  background: rgba(19, 78, 74, 0.86);
 }
 
 .map-overlay[data-state="error"] {
-  background: rgba(115, 41, 24, 0.9);
+  background: rgba(124, 45, 18, 0.92);
 }
 
 .map-overlay-title {
@@ -303,7 +359,7 @@ select {
 
 .map-overlay-body {
   margin: 0;
-  color: rgba(248, 242, 229, 0.88);
+  color: rgba(248, 250, 252, 0.88);
   line-height: 1.45;
 }
 
@@ -339,7 +395,7 @@ select {
 }
 
 .maplibregl-popup-content {
-  border-radius: 1rem;
+  border-radius: 8px;
   padding: 1rem;
 }
 
@@ -358,8 +414,13 @@ select {
   }
 
   .status-grid,
-  .selection-meta {
+  .selection-meta,
+  .linked-context-grid {
     grid-template-columns: 1fr;
+  }
+
+  .linked-context-grid div:last-child {
+    grid-column: auto;
   }
 
   .feature-list-item {

--- a/examples/maplibre-quickstart/src/telemetry.ts
+++ b/examples/maplibre-quickstart/src/telemetry.ts
@@ -1,7 +1,16 @@
 import type { QuickstartRenderableGeometryType } from "./esri-geojson.js";
 
 export interface QuickstartTelemetryEvent {
-  type: "init" | "compatibility-ok" | "query-started" | "query-finished" | "map-ready" | "feature-selected" | "error";
+  type:
+    | "init"
+    | "compatibility-ok"
+    | "query-started"
+    | "query-finished"
+    | "map-ready"
+    | "feature-selected"
+    | "linked-filter-changed"
+    | "linked-query-updated"
+    | "error";
   payload: Record<string, unknown>;
   timestamp: string;
 }
@@ -21,6 +30,9 @@ export interface QuickstartRuntimeState {
   lastError?: string | null;
   layerIds?: string[];
   popupOpen?: boolean;
+  linkedVisibleFeatureCount?: number;
+  linkedFilterCount?: number;
+  linkedExtent?: string | null;
 }
 
 declare global {

--- a/examples/maplibre-quickstart/tsconfig.json
+++ b/examples/maplibre-quickstart/tsconfig.json
@@ -12,6 +12,8 @@
     "types": ["vite/client"],
     "paths": {
       "@honua/sdk-js": ["../../src/index.ts"],
+      "@honua/sdk-js/exploration": ["../../src/exploration/index.ts"],
+      "@honua/sdk-js/interactions": ["../../src/interactions/index.ts"],
       "@honua/sdk-js/honua": ["../../src/honua.ts"]
     }
   },

--- a/examples/maplibre-quickstart/vite.config.ts
+++ b/examples/maplibre-quickstart/vite.config.ts
@@ -12,6 +12,14 @@ export default defineConfig({
   resolve: {
     alias: [
       {
+        find: "@honua/sdk-js/exploration",
+        replacement: path.resolve(repoRoot, "src/exploration/index.ts"),
+      },
+      {
+        find: "@honua/sdk-js/interactions",
+        replacement: path.resolve(repoRoot, "src/interactions/index.ts"),
+      },
+      {
         find: "@honua/sdk-js/honua",
         replacement: path.resolve(repoRoot, "src/honua.ts"),
       },

--- a/test/playwright/quickstart-map.spec.mjs
+++ b/test/playwright/quickstart-map.spec.mjs
@@ -26,6 +26,15 @@ test("quickstart app loads fixture-backed data and opens an inspection popup", a
     const layerIds = await page.evaluate(() => window.__HONUA_QUICKSTART_RUNTIME__?.layerIds ?? []);
     expect(layerIds).toContain("quickstart-fill");
 
+    await expect(page.locator("#linked-visible-count")).toHaveText("3");
+    await page.locator("#attribute-filter").selectOption({ label: "STATUS: Ready" });
+    await expect(page.locator("#linked-visible-count")).toHaveText("1");
+    await expect(page.locator("#feature-list")).toContainText("Kakaako utility corridor");
+    await expect(page.locator("#feature-list")).not.toContainText("Harbor response district");
+    await expect(page.locator("#linked-query-projection")).toContainText('"STATUS"');
+    await page.locator("#clear-filter-button").click();
+    await expect(page.locator("#linked-visible-count")).toHaveText("3");
+
     await page.getByRole("button", { name: "Inspect Harbor response district" }).click();
 
     await expect(page.locator("#selected-feature-title")).toHaveText("Harbor response district");

--- a/test/quickstart-linked-exploration.test.ts
+++ b/test/quickstart-linked-exploration.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import type { QuickstartFeatureSummary } from "../examples/maplibre-quickstart/src/data.js";
+import {
+  applyQuickstartProjection,
+  createMapLibreLayerFilter,
+  createQuickstartFilterOptions,
+  formatProjectionExtent,
+} from "../examples/maplibre-quickstart/src/linked-exploration.js";
+import type { LinkedViewQueryProjection } from "../src/index.js";
+
+function summary(id: string, properties: Record<string, unknown>, center: [number, number]): QuickstartFeatureSummary {
+  return {
+    id,
+    title: String(properties.NAME ?? id),
+    subtitle: String(properties.STATUS ?? "Feature"),
+    center,
+    geometryKind: "polygon",
+    feature: {
+      type: "Feature",
+      id,
+      properties,
+      geometry: {
+        type: "Polygon",
+        coordinates: [],
+      },
+    },
+  };
+}
+
+function projection(overrides: Partial<LinkedViewQueryProjection>): LinkedViewQueryProjection {
+  return {
+    filters: {},
+    orderBy: [],
+    pagination: {},
+    grouping: [],
+    selection: [],
+    ...overrides,
+  };
+}
+
+describe("quickstart linked exploration helpers", () => {
+  const features = [
+    summary(
+      "1",
+      { NAME: "Civic center service zone", STATUS: "Monitoring", CATEGORY: "Operations" },
+      [-157.861, 21.306],
+    ),
+    summary(
+      "2",
+      { NAME: "Harbor response district", STATUS: "Field review", CATEGORY: "Maritime" },
+      [-157.885, 21.299],
+    ),
+    summary("3", { NAME: "Kakaako utility corridor", STATUS: "Ready", CATEGORY: "Infrastructure" }, [-157.863, 21.291]),
+  ];
+
+  it("prefers GIS status/category fields for filter controls", () => {
+    expect(createQuickstartFilterOptions(features)).toEqual([
+      {
+        field: "STATUS",
+        values: ["Field review", "Monitoring", "Ready"],
+      },
+      {
+        field: "CATEGORY",
+        values: ["Infrastructure", "Maritime", "Operations"],
+      },
+    ]);
+  });
+
+  it("applies linked filters and map extent to result rows", () => {
+    const visible = applyQuickstartProjection(
+      features,
+      projection({
+        filters: {
+          status: { field: "STATUS", operator: "=", value: "Field review" },
+        },
+        extent: {
+          xmin: -157.89,
+          ymin: 21.295,
+          xmax: -157.88,
+          ymax: 21.305,
+          spatialReference: { wkid: 4326 },
+        },
+      }),
+    );
+
+    expect(visible.map((feature) => feature.id)).toEqual(["2"]);
+  });
+
+  it("translates linked attribute filters into MapLibre layer filters", () => {
+    expect(
+      createMapLibreLayerFilter(
+        "polygon",
+        projection({
+          filters: {
+            status: { field: "STATUS", operator: "=", value: "Ready" },
+          },
+        }),
+      ),
+    ).toEqual(["all", ["==", "$type", "Polygon"], ["==", "STATUS", "Ready"]]);
+  });
+
+  it("formats the viewport extent shown in the linked query panel", () => {
+    expect(
+      formatProjectionExtent({
+        xmin: -157.89,
+        ymin: 21.295,
+        xmax: -157.88,
+        ymax: 21.305,
+      }),
+    ).toBe("-157.8900, 21.2950 to -157.8800, 21.3050");
+  });
+});


### PR DESCRIPTION
## Summary

- wires the MapLibre quickstart into `ExplorationContext` using the split `./exploration` and `./interactions` entrypoints
- adds linked attribute filters, map extent projection, MapLibre layer filter translation, shared source-qualified selection, and a query projection diagnostics panel
- adds helper tests plus Playwright coverage for the linked filter/result/detail flow

Refs #55
Refs #56
Refs #72

## Validation

- `npm run check`
- `npm run demo:quickstart:typecheck`
- `npm run demo:quickstart:build`
- `npm test -- test/quickstart-linked-exploration.test.ts test/interaction-exploration-bindings.test.ts`
- `npm run test:playwright:quickstart`
- `npm run build`
- `npm run typecheck`
- `npm test` (134 files, 1577 tests)
