### PR TITLE
Add realtime feature state contract

### DIFF
--- a/docs/realtime-subscriptions.md
+++ b/docs/realtime-subscriptions.md
@@ -1,0 +1,51 @@
+# Realtime Feature State
+
+The `@honua/sdk-js/realtime` entrypoint defines the SDK-side contract for live operational layers. It does not require apps to choose SSE, WebSocket, or delta polling directly. A transport adapter emits normalized `RealtimeFeatureEvent` values, and apps consume a reconciled `RealtimeFeatureState`.
+
+## Event Model
+
+- `snapshot`: initial or resumed feature set, optionally replacing the current set.
+- `upsert`: create or update one feature.
+- `delete`: remove one feature and retain a tombstone for selection cleanup.
+- `heartbeat`: keepalive with optional cursor and watermark.
+- `status`: explicit connection status such as `connecting`, `live`, `reconnecting`, `stale`, or `closed`.
+- `error`: recoverable or terminal transport failure.
+
+Events may carry `eventId`, `sequence`, `cursor`, and `watermark`. The reducer ignores duplicate event IDs and out-of-order sequence values, which keeps map/table/detail state stable during reconnect and replay.
+
+## Store Usage
+
+```ts
+import { createRealtimeFeatureStore } from "@honua/sdk-js/realtime";
+
+const store = createRealtimeFeatureStore();
+const unsubscribe = store.subscribe((state) => {
+  renderRows(Object.values(state.records));
+  renderConnectionStatus(state.status, state.cursor, state.watermark);
+});
+
+const handle = store.connect(transport, {
+  sourceId: "incidents",
+  cursor: savedCursor,
+});
+
+// Later
+handle.close();
+unsubscribe();
+```
+
+The same store can be driven manually in tests with `store.apply(event)`.
+
+## Linked Exploration Cleanup
+
+Use `reconcileRealtimeSelection(view, state)` with an `ExplorationViewController` to remove deleted or missing features from shared map/table/detail selection.
+
+```ts
+import { reconcileRealtimeSelection } from "@honua/sdk-js/realtime";
+
+store.subscribe((state) => {
+  reconcileRealtimeSelection(detailView, state, { sourceId: "incidents" });
+});
+```
+
+Metadata and schemas can still use platform metadata caching. Live feature state should be treated as volatile and driven by cursor/watermark semantics rather than long-lived feature-result cache reuse.

--- a/package.json
+++ b/package.json
@@ -63,6 +63,10 @@
       "types": "./dist/src/interactions/index.d.ts",
       "default": "./dist/src/interactions/index.js"
     },
+    "./realtime": {
+      "types": "./dist/src/realtime/index.d.ts",
+      "default": "./dist/src/realtime/index.js"
+    },
     "./runtime": {
       "types": "./dist/src/runtime/index.d.ts",
       "default": "./dist/src/runtime/index.js"

--- a/scripts/prepare-split-packages.mjs
+++ b/scripts/prepare-split-packages.mjs
@@ -50,6 +50,7 @@ function createSdkPackage() {
   copyDirectory(path.join(DIST_SRC_ROOT, "gen"), path.join(packageRoot, "gen"));
   copyDirectory(path.join(DIST_SRC_ROOT, "interactions"), path.join(packageRoot, "interactions"));
   copyDirectory(path.join(DIST_SRC_ROOT, "map"), path.join(packageRoot, "map"));
+  copyDirectory(path.join(DIST_SRC_ROOT, "realtime"), path.join(packageRoot, "realtime"));
   copyDirectory(path.join(DIST_SRC_ROOT, "style"), path.join(packageRoot, "style"));
   copyDirectory(path.join(DIST_SRC_ROOT, "webmap"), path.join(packageRoot, "webmap"));
   copyFile(path.join(DIST_SRC_ROOT, "honua.js"), path.join(packageRoot, "index.js"));
@@ -80,6 +81,10 @@ function createSdkPackage() {
       "./interactions": {
         types: "./interactions/index.d.ts",
         default: "./interactions/index.js",
+      },
+      "./realtime": {
+        types: "./realtime/index.d.ts",
+        default: "./realtime/index.js",
       },
       "./map": {
         types: "./map/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1267,6 +1267,39 @@ export {
   reduce,
   sourceFeatureSelectionTarget,
 } from "./exploration/index.js";
+
+export {
+  createRealtimeFeatureStore,
+  emptyRealtimeFeatureState,
+  filterRealtimeSelection,
+  reconcileRealtimeSelection,
+  reconcileRealtimeStaleness,
+  reduceRealtimeFeatureState,
+  realtimeFeatureKey,
+} from "./realtime/index.js";
+export type {
+  RealtimeConnectionStatus,
+  RealtimeDeleteEvent,
+  RealtimeErrorEvent,
+  RealtimeFeatureEvent,
+  RealtimeFeatureEventBase,
+  RealtimeFeatureObserver,
+  RealtimeFeaturePatch,
+  RealtimeFeatureRecord,
+  RealtimeFeatureState,
+  RealtimeFeatureStore,
+  RealtimeFeatureTombstone,
+  RealtimeFeatureTransport,
+  RealtimeHeartbeatEvent,
+  RealtimeReducerOptions,
+  RealtimeSnapshotEvent,
+  RealtimeStateListener,
+  RealtimeStatusEvent,
+  RealtimeStalenessOptions,
+  RealtimeSubscriptionHandle,
+  RealtimeSubscriptionRequest,
+  RealtimeUpsertEvent,
+} from "./realtime/index.js";
 export type {
   ApplyPresetIntent,
   ChangeEvent,

--- a/src/realtime/exploration.ts
+++ b/src/realtime/exploration.ts
@@ -1,0 +1,49 @@
+/**
+ * Realtime helpers for linked exploration views.
+ *
+ * @module
+ */
+
+import type { SourceId } from "../contract/types.js";
+import { isSourceQualifiedSelectionTarget } from "../exploration/selection.js";
+import type { ExplorationViewController, FeatureSelectionTarget } from "../exploration/types.js";
+import { realtimeFeatureKey } from "./reducer.js";
+import type { RealtimeFeatureState } from "./types.js";
+
+export interface ReconcileRealtimeSelectionOptions {
+  readonly sourceId?: SourceId;
+  /** Remove selections when the record is absent from live state. @default true */
+  readonly requireLiveRecord?: boolean;
+}
+
+export function filterRealtimeSelection<TFeature>(
+  selection: ReadonlyArray<FeatureSelectionTarget>,
+  state: RealtimeFeatureState<TFeature>,
+  options: ReconcileRealtimeSelectionOptions = {},
+): ReadonlyArray<FeatureSelectionTarget> {
+  const { sourceId, requireLiveRecord = true } = options;
+  return selection.filter((target) => {
+    const key = selectionKey(target, sourceId);
+    if (!key) return true;
+    if (state.tombstones[key]) return false;
+    return requireLiveRecord ? Boolean(state.records[key]) : true;
+  });
+}
+
+export function reconcileRealtimeSelection<TFeature>(
+  view: ExplorationViewController,
+  state: RealtimeFeatureState<TFeature>,
+  options: ReconcileRealtimeSelectionOptions = {},
+): void {
+  const next = filterRealtimeSelection(view.state.selection, state, options);
+  if (next.length === view.state.selection.length) return;
+  view.select(next, { replace: true });
+}
+
+function selectionKey(target: FeatureSelectionTarget, sourceId: SourceId | undefined): string | undefined {
+  if (isSourceQualifiedSelectionTarget(target)) {
+    return realtimeFeatureKey(target.sourceId, target.id);
+  }
+  if (!sourceId) return undefined;
+  return realtimeFeatureKey(sourceId, target);
+}

--- a/src/realtime/index.ts
+++ b/src/realtime/index.ts
@@ -1,0 +1,31 @@
+export {
+  emptyRealtimeFeatureState,
+  reconcileRealtimeStaleness,
+  reduceRealtimeFeatureState,
+  realtimeFeatureKey,
+} from "./reducer.js";
+export { createRealtimeFeatureStore } from "./store.js";
+export type { RealtimeFeatureStore } from "./store.js";
+export { filterRealtimeSelection, reconcileRealtimeSelection } from "./exploration.js";
+export type {
+  RealtimeConnectionStatus,
+  RealtimeDeleteEvent,
+  RealtimeErrorEvent,
+  RealtimeFeatureEvent,
+  RealtimeFeatureEventBase,
+  RealtimeFeatureObserver,
+  RealtimeFeaturePatch,
+  RealtimeFeatureRecord,
+  RealtimeFeatureState,
+  RealtimeFeatureTombstone,
+  RealtimeFeatureTransport,
+  RealtimeHeartbeatEvent,
+  RealtimeReducerOptions,
+  RealtimeSnapshotEvent,
+  RealtimeStateListener,
+  RealtimeStatusEvent,
+  RealtimeStalenessOptions,
+  RealtimeSubscriptionHandle,
+  RealtimeSubscriptionRequest,
+  RealtimeUpsertEvent,
+} from "./types.js";

--- a/src/realtime/reducer.ts
+++ b/src/realtime/reducer.ts
@@ -1,0 +1,220 @@
+/**
+ * Pure reducer helpers for realtime feature state.
+ *
+ * @module
+ */
+
+import type { FeatureId, SourceId } from "../contract/types.js";
+import type {
+  RealtimeFeatureEvent,
+  RealtimeFeaturePatch,
+  RealtimeFeatureRecord,
+  RealtimeFeatureState,
+  RealtimeFeatureTombstone,
+  RealtimeReducerOptions,
+  RealtimeStalenessOptions,
+} from "./types.js";
+
+const DEFAULT_MAX_SEEN_EVENT_IDS = 256;
+
+export function emptyRealtimeFeatureState<TFeature = unknown>(): RealtimeFeatureState<TFeature> {
+  return {
+    status: "idle",
+    records: {},
+    tombstones: {},
+    ignoredEventCount: 0,
+    seenEventIds: [],
+  };
+}
+
+export function realtimeFeatureKey(sourceId: SourceId | undefined, id: FeatureId): string {
+  return `${sourceId ?? ""}:${String(id)}`;
+}
+
+export function reduceRealtimeFeatureState<TFeature>(
+  state: RealtimeFeatureState<TFeature>,
+  event: RealtimeFeatureEvent<TFeature>,
+  options: RealtimeReducerOptions = {},
+): RealtimeFeatureState<TFeature> {
+  if (isDuplicateOrOutOfOrder(state, event)) {
+    return {
+      ...state,
+      ignoredEventCount: state.ignoredEventCount + 1,
+    };
+  }
+
+  const receivedAt = event.receivedAt ?? options.now?.() ?? Date.now();
+  const base = withEventMetadata(state, event, receivedAt, options.maxSeenEventIds ?? DEFAULT_MAX_SEEN_EVENT_IDS);
+
+  switch (event.type) {
+    case "snapshot":
+      return applySnapshot(base, event.features, {
+        replace: event.replace ?? true,
+        cursor: event.cursor,
+        sequence: event.sequence,
+        receivedAt,
+      });
+    case "upsert":
+      return applyUpsert(base, event.feature, {
+        cursor: event.cursor,
+        sequence: event.sequence,
+        receivedAt,
+      });
+    case "delete":
+      return applyDelete(base, {
+        id: event.id,
+        sourceId: event.sourceId,
+        cursor: event.cursor,
+        sequence: event.sequence,
+        deletedAt: event.deletedAt ?? receivedAt,
+      });
+    case "heartbeat":
+      return {
+        ...base,
+        status: base.status === "connecting" || base.status === "reconnecting" ? "live" : base.status,
+        lastHeartbeatAt: receivedAt,
+        staleSince: undefined,
+      };
+    case "status":
+      return {
+        ...base,
+        status: event.status,
+        staleSince: event.status === "stale" ? (event.staleSince ?? receivedAt) : undefined,
+        error: event.status === "error" ? base.error : undefined,
+      };
+    case "error":
+      return {
+        ...base,
+        status: event.terminal ? "error" : "reconnecting",
+        error: event.error,
+        staleSince: event.terminal ? base.staleSince : receivedAt,
+      };
+  }
+}
+
+export function reconcileRealtimeStaleness<TFeature>(
+  state: RealtimeFeatureState<TFeature>,
+  options: RealtimeStalenessOptions,
+): RealtimeFeatureState<TFeature> {
+  const now = options.now ?? Date.now();
+  const lastLiveAt = state.lastHeartbeatAt ?? state.lastEventAt;
+  if (!lastLiveAt || now - lastLiveAt <= options.staleAfterMs) return state;
+  if (state.status === "closed" || state.status === "error" || state.status === "offline") return state;
+  return {
+    ...state,
+    status: "stale",
+    staleSince: state.staleSince ?? lastLiveAt + options.staleAfterMs,
+  };
+}
+
+function isDuplicateOrOutOfOrder<TFeature>(
+  state: RealtimeFeatureState<TFeature>,
+  event: RealtimeFeatureEvent<TFeature>,
+): boolean {
+  if (event.eventId && state.seenEventIds.includes(event.eventId)) return true;
+  return (
+    typeof event.sequence === "number" && typeof state.lastSequence === "number" && event.sequence <= state.lastSequence
+  );
+}
+
+function withEventMetadata<TFeature>(
+  state: RealtimeFeatureState<TFeature>,
+  event: RealtimeFeatureEvent<TFeature>,
+  receivedAt: number,
+  maxSeenEventIds: number,
+): RealtimeFeatureState<TFeature> {
+  const seenEventIds = event.eventId
+    ? [...state.seenEventIds, event.eventId].slice(-Math.max(1, maxSeenEventIds))
+    : state.seenEventIds;
+  return {
+    ...state,
+    status:
+      state.status === "idle" || state.status === "connecting" || state.status === "reconnecting"
+        ? "live"
+        : state.status,
+    cursor: event.cursor ?? state.cursor,
+    watermark: event.watermark ?? state.watermark,
+    lastSequence: typeof event.sequence === "number" ? event.sequence : state.lastSequence,
+    lastEventAt: receivedAt,
+    staleSince: undefined,
+    seenEventIds,
+  };
+}
+
+function applySnapshot<TFeature>(
+  state: RealtimeFeatureState<TFeature>,
+  features: ReadonlyArray<RealtimeFeaturePatch<TFeature>>,
+  metadata: {
+    readonly replace: boolean;
+    readonly cursor?: string;
+    readonly sequence?: number;
+    readonly receivedAt: number;
+  },
+): RealtimeFeatureState<TFeature> {
+  const records: Record<string, RealtimeFeatureRecord<TFeature>> = metadata.replace ? {} : { ...state.records };
+  const tombstones: Record<string, RealtimeFeatureTombstone> = metadata.replace ? {} : { ...state.tombstones };
+  for (const feature of features) {
+    const key = realtimeFeatureKey(feature.sourceId, feature.id);
+    records[key] = {
+      ...feature,
+      key,
+      cursor: metadata.cursor,
+      sequence: metadata.sequence,
+      receivedAt: metadata.receivedAt,
+    };
+    delete tombstones[key];
+  }
+  return {
+    ...state,
+    records,
+    tombstones,
+  };
+}
+
+function applyUpsert<TFeature>(
+  state: RealtimeFeatureState<TFeature>,
+  feature: RealtimeFeaturePatch<TFeature>,
+  metadata: {
+    readonly cursor?: string;
+    readonly sequence?: number;
+    readonly receivedAt: number;
+  },
+): RealtimeFeatureState<TFeature> {
+  const key = realtimeFeatureKey(feature.sourceId, feature.id);
+  const tombstones = { ...state.tombstones };
+  delete tombstones[key];
+  return {
+    ...state,
+    records: {
+      ...state.records,
+      [key]: {
+        ...feature,
+        key,
+        cursor: metadata.cursor,
+        sequence: metadata.sequence,
+        receivedAt: metadata.receivedAt,
+      },
+    },
+    tombstones,
+  };
+}
+
+function applyDelete<TFeature>(
+  state: RealtimeFeatureState<TFeature>,
+  tombstone: Omit<RealtimeFeatureTombstone, "key">,
+): RealtimeFeatureState<TFeature> {
+  const key = realtimeFeatureKey(tombstone.sourceId, tombstone.id);
+  const records = { ...state.records };
+  delete records[key];
+  return {
+    ...state,
+    records,
+    tombstones: {
+      ...state.tombstones,
+      [key]: {
+        ...tombstone,
+        key,
+      },
+    },
+  };
+}

--- a/src/realtime/store.ts
+++ b/src/realtime/store.ts
@@ -1,0 +1,93 @@
+/**
+ * Store and transport bridge for realtime feature state.
+ *
+ * @module
+ */
+
+import { emptyRealtimeFeatureState, reconcileRealtimeStaleness, reduceRealtimeFeatureState } from "./reducer.js";
+import type {
+  RealtimeFeatureEvent,
+  RealtimeFeatureState,
+  RealtimeFeatureTransport,
+  RealtimeReducerOptions,
+  RealtimeStalenessOptions,
+  RealtimeStateListener,
+  RealtimeSubscriptionHandle,
+  RealtimeSubscriptionRequest,
+} from "./types.js";
+
+export interface RealtimeFeatureStore<TFeature = unknown> {
+  readonly state: RealtimeFeatureState<TFeature>;
+  apply(event: RealtimeFeatureEvent<TFeature>): RealtimeFeatureState<TFeature>;
+  checkStale(options: RealtimeStalenessOptions): RealtimeFeatureState<TFeature>;
+  subscribe(listener: RealtimeStateListener<TFeature>, options?: { readonly fireImmediately?: boolean }): () => void;
+  connect(
+    transport: RealtimeFeatureTransport<TFeature>,
+    request: RealtimeSubscriptionRequest,
+  ): RealtimeSubscriptionHandle;
+  close(): void;
+}
+
+export function createRealtimeFeatureStore<TFeature = unknown>(
+  initialState: RealtimeFeatureState<TFeature> = emptyRealtimeFeatureState<TFeature>(),
+  options: RealtimeReducerOptions = {},
+): RealtimeFeatureStore<TFeature> {
+  let state = initialState;
+  let activeHandle: RealtimeSubscriptionHandle | undefined;
+  const listeners = new Set<RealtimeStateListener<TFeature>>();
+
+  function emit(event: RealtimeFeatureEvent<TFeature> | undefined): void {
+    for (const listener of [...listeners]) listener(state, event);
+  }
+
+  function setState(
+    next: RealtimeFeatureState<TFeature>,
+    event: RealtimeFeatureEvent<TFeature> | undefined,
+  ): RealtimeFeatureState<TFeature> {
+    if (Object.is(state, next)) return state;
+    state = next;
+    emit(event);
+    return state;
+  }
+
+  return {
+    get state() {
+      return state;
+    },
+    apply(event) {
+      return setState(reduceRealtimeFeatureState(state, event, options), event);
+    },
+    checkStale(stalenessOptions) {
+      return setState(reconcileRealtimeStaleness(state, stalenessOptions), undefined);
+    },
+    subscribe(listener, subscribeOptions = {}) {
+      listeners.add(listener);
+      if (subscribeOptions.fireImmediately) listener(state, undefined);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    connect(transport, request) {
+      activeHandle?.close();
+      this.apply({ type: "status", status: "connecting" });
+      activeHandle = transport.subscribe(request, {
+        next: (event) => this.apply(event),
+        error: (error) => this.apply({ type: "error", error }),
+        complete: () => this.apply({ type: "status", status: "closed" }),
+      });
+      return {
+        close: () => {
+          activeHandle?.close();
+          activeHandle = undefined;
+          this.apply({ type: "status", status: "closed" });
+        },
+      };
+    },
+    close() {
+      activeHandle?.close();
+      activeHandle = undefined;
+      setState({ ...state, status: "closed" }, { type: "status", status: "closed" });
+      listeners.clear();
+    },
+  };
+}

--- a/src/realtime/types.ts
+++ b/src/realtime/types.ts
@@ -1,0 +1,152 @@
+/**
+ * Realtime operational feature state.
+ *
+ * These types model live create/update/delete/snapshot delivery without
+ * committing app code to SSE, WebSocket, or polling. Transport adapters emit
+ * `RealtimeFeatureEvent`s; apps and SDK bindings consume reconciled state.
+ *
+ * @module
+ */
+
+import type { FeatureId, SourceId } from "../contract/types.js";
+
+export type RealtimeConnectionStatus =
+  | "idle"
+  | "connecting"
+  | "live"
+  | "reconnecting"
+  | "stale"
+  | "offline"
+  | "closed"
+  | "error";
+
+export interface RealtimeFeaturePatch<TFeature = unknown> {
+  readonly id: FeatureId;
+  readonly sourceId?: SourceId;
+  readonly feature: TFeature;
+  readonly version?: number;
+  readonly updatedAt?: string;
+}
+
+export interface RealtimeFeatureRecord<TFeature = unknown> extends RealtimeFeaturePatch<TFeature> {
+  readonly key: string;
+  readonly cursor?: string;
+  readonly sequence?: number;
+  readonly receivedAt: number;
+}
+
+export interface RealtimeFeatureTombstone {
+  readonly id: FeatureId;
+  readonly sourceId?: SourceId;
+  readonly key: string;
+  readonly cursor?: string;
+  readonly sequence?: number;
+  readonly deletedAt: number;
+}
+
+export interface RealtimeFeatureEventBase {
+  readonly eventId?: string;
+  readonly cursor?: string;
+  readonly watermark?: string;
+  readonly sequence?: number;
+  readonly receivedAt?: number;
+}
+
+export interface RealtimeSnapshotEvent<TFeature = unknown> extends RealtimeFeatureEventBase {
+  readonly type: "snapshot";
+  readonly features: ReadonlyArray<RealtimeFeaturePatch<TFeature>>;
+  /** Replace the current live set. @default true */
+  readonly replace?: boolean;
+}
+
+export interface RealtimeUpsertEvent<TFeature = unknown> extends RealtimeFeatureEventBase {
+  readonly type: "upsert";
+  readonly feature: RealtimeFeaturePatch<TFeature>;
+}
+
+export interface RealtimeDeleteEvent extends RealtimeFeatureEventBase {
+  readonly type: "delete";
+  readonly id: FeatureId;
+  readonly sourceId?: SourceId;
+  readonly deletedAt?: number;
+}
+
+export interface RealtimeHeartbeatEvent extends RealtimeFeatureEventBase {
+  readonly type: "heartbeat";
+}
+
+export interface RealtimeStatusEvent extends RealtimeFeatureEventBase {
+  readonly type: "status";
+  readonly status: RealtimeConnectionStatus;
+  readonly staleSince?: number;
+}
+
+export interface RealtimeErrorEvent extends RealtimeFeatureEventBase {
+  readonly type: "error";
+  readonly error: unknown;
+  readonly terminal?: boolean;
+}
+
+export type RealtimeFeatureEvent<TFeature = unknown> =
+  | RealtimeSnapshotEvent<TFeature>
+  | RealtimeUpsertEvent<TFeature>
+  | RealtimeDeleteEvent
+  | RealtimeHeartbeatEvent
+  | RealtimeStatusEvent
+  | RealtimeErrorEvent;
+
+export interface RealtimeFeatureState<TFeature = unknown> {
+  readonly status: RealtimeConnectionStatus;
+  readonly records: Readonly<Record<string, RealtimeFeatureRecord<TFeature>>>;
+  readonly tombstones: Readonly<Record<string, RealtimeFeatureTombstone>>;
+  readonly cursor?: string;
+  readonly watermark?: string;
+  readonly lastSequence?: number;
+  readonly lastEventAt?: number;
+  readonly lastHeartbeatAt?: number;
+  readonly staleSince?: number;
+  readonly error?: unknown;
+  readonly ignoredEventCount: number;
+  readonly seenEventIds: ReadonlyArray<string>;
+}
+
+export interface RealtimeReducerOptions {
+  readonly now?: () => number;
+  readonly maxSeenEventIds?: number;
+}
+
+export interface RealtimeStalenessOptions {
+  readonly staleAfterMs: number;
+  readonly now?: number;
+}
+
+export interface RealtimeSubscriptionRequest {
+  readonly sourceId: SourceId;
+  readonly layerId?: string | number;
+  readonly where?: string;
+  readonly cursor?: string;
+  readonly signal?: AbortSignal;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface RealtimeFeatureObserver<TFeature = unknown> {
+  next(event: RealtimeFeatureEvent<TFeature>): void;
+  error(error: unknown): void;
+  complete(): void;
+}
+
+export interface RealtimeSubscriptionHandle {
+  close(): void;
+}
+
+export interface RealtimeFeatureTransport<TFeature = unknown> {
+  subscribe(
+    request: RealtimeSubscriptionRequest,
+    observer: RealtimeFeatureObserver<TFeature>,
+  ): RealtimeSubscriptionHandle;
+}
+
+export type RealtimeStateListener<TFeature = unknown> = (
+  state: RealtimeFeatureState<TFeature>,
+  event: RealtimeFeatureEvent<TFeature> | undefined,
+) => void;

--- a/test/entrypoints.test.ts
+++ b/test/entrypoints.test.ts
@@ -153,6 +153,11 @@ import {
   scanArcGisUsage,
   summarizeJsParityMatrix,
 } from "../src/migration-entry.js";
+import {
+  createRealtimeFeatureStore,
+  emptyRealtimeFeatureState,
+  reduceRealtimeFeatureState,
+} from "../src/realtime/index.js";
 
 describe("entrypoint modules", () => {
   it("exposes honua-first core entrypoint", () => {
@@ -317,5 +322,11 @@ describe("entrypoint modules", () => {
       "chartDriven",
       "decoupled",
     ]);
+  });
+
+  it("exposes the realtime entrypoint", () => {
+    expect(emptyRealtimeFeatureState).toBeTypeOf("function");
+    expect(reduceRealtimeFeatureState).toBeTypeOf("function");
+    expect(createRealtimeFeatureStore).toBeTypeOf("function");
   });
 });

--- a/test/realtime.test.ts
+++ b/test/realtime.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createExplorationContext, sourceFeatureSelectionTarget } from "../src/exploration/index.js";
+import {
+  createRealtimeFeatureStore,
+  emptyRealtimeFeatureState,
+  filterRealtimeSelection,
+  realtimeFeatureKey,
+  reconcileRealtimeSelection,
+  reconcileRealtimeStaleness,
+  reduceRealtimeFeatureState,
+} from "../src/realtime/index.js";
+import type {
+  RealtimeFeatureObserver,
+  RealtimeFeatureTransport,
+  RealtimeSubscriptionRequest,
+} from "../src/realtime/index.js";
+
+describe("realtime feature state", () => {
+  it("applies snapshot, upsert, delete, cursor, and heartbeat events", () => {
+    let state = emptyRealtimeFeatureState<{ status: string }>();
+
+    state = reduceRealtimeFeatureState(state, {
+      type: "snapshot",
+      cursor: "c1",
+      sequence: 1,
+      receivedAt: 100,
+      features: [
+        { sourceId: "incidents", id: 1, feature: { status: "open" } },
+        { sourceId: "incidents", id: 2, feature: { status: "monitoring" } },
+      ],
+    });
+
+    expect(state.status).toBe("live");
+    expect(state.cursor).toBe("c1");
+    expect(Object.keys(state.records)).toEqual(["incidents:1", "incidents:2"]);
+
+    state = reduceRealtimeFeatureState(state, {
+      type: "upsert",
+      cursor: "c2",
+      sequence: 2,
+      receivedAt: 110,
+      feature: { sourceId: "incidents", id: 2, feature: { status: "closed" } },
+    });
+    expect(state.records["incidents:2"]?.feature.status).toBe("closed");
+
+    state = reduceRealtimeFeatureState(state, {
+      type: "delete",
+      cursor: "c3",
+      sequence: 3,
+      receivedAt: 120,
+      sourceId: "incidents",
+      id: 1,
+    });
+    expect(state.records["incidents:1"]).toBeUndefined();
+    expect(state.tombstones["incidents:1"]?.deletedAt).toBe(120);
+
+    state = reduceRealtimeFeatureState(state, { type: "heartbeat", cursor: "c4", receivedAt: 130 });
+    expect(state.lastHeartbeatAt).toBe(130);
+    expect(state.cursor).toBe("c4");
+  });
+
+  it("ignores duplicate event ids and out-of-order sequences", () => {
+    let state = emptyRealtimeFeatureState<{ status: string }>();
+    state = reduceRealtimeFeatureState(state, {
+      type: "upsert",
+      eventId: "e1",
+      sequence: 10,
+      feature: { sourceId: "incidents", id: 1, feature: { status: "open" } },
+    });
+
+    const duplicate = reduceRealtimeFeatureState(state, {
+      type: "upsert",
+      eventId: "e1",
+      sequence: 11,
+      feature: { sourceId: "incidents", id: 1, feature: { status: "closed" } },
+    });
+    expect(duplicate.records["incidents:1"]?.feature.status).toBe("open");
+    expect(duplicate.ignoredEventCount).toBe(1);
+
+    const outOfOrder = reduceRealtimeFeatureState(duplicate, {
+      type: "upsert",
+      eventId: "e2",
+      sequence: 9,
+      feature: { sourceId: "incidents", id: 1, feature: { status: "closed" } },
+    });
+    expect(outOfOrder.records["incidents:1"]?.feature.status).toBe("open");
+    expect(outOfOrder.ignoredEventCount).toBe(2);
+  });
+
+  it("marks live state stale when heartbeats exceed the configured threshold", () => {
+    const state = reduceRealtimeFeatureState(emptyRealtimeFeatureState(), {
+      type: "heartbeat",
+      receivedAt: 1_000,
+    });
+
+    expect(
+      reconcileRealtimeStaleness(state, {
+        staleAfterMs: 250,
+        now: 1_400,
+      }),
+    ).toMatchObject({
+      status: "stale",
+      staleSince: 1_250,
+    });
+  });
+
+  it("bridges mock transports into a subscribable realtime store", () => {
+    let observer: RealtimeFeatureObserver<{ status: string }> | undefined;
+    const close = vi.fn();
+    const transport: RealtimeFeatureTransport<{ status: string }> = {
+      subscribe(_request: RealtimeSubscriptionRequest, nextObserver) {
+        observer = nextObserver;
+        return { close };
+      },
+    };
+    const store = createRealtimeFeatureStore<{ status: string }>();
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    const handle = store.connect(transport, { sourceId: "incidents" });
+    observer?.next({
+      type: "upsert",
+      cursor: "c1",
+      feature: { sourceId: "incidents", id: 7, feature: { status: "open" } },
+    });
+    observer?.next({ type: "status", status: "reconnecting" });
+    observer?.next({ type: "heartbeat", receivedAt: 50 });
+    observer?.complete();
+
+    expect(store.state.records[realtimeFeatureKey("incidents", 7)]?.feature.status).toBe("open");
+    expect(store.state.status).toBe("closed");
+    expect(listener).toHaveBeenCalled();
+    handle.close();
+    expect(close).toHaveBeenCalled();
+  });
+
+  it("filters linked exploration selection against deletes and missing live records", () => {
+    const state = reduceRealtimeFeatureState(emptyRealtimeFeatureState(), {
+      type: "snapshot",
+      features: [{ sourceId: "incidents", id: 1, feature: { status: "open" } }],
+    });
+    const deleted = reduceRealtimeFeatureState(state, {
+      type: "delete",
+      sourceId: "incidents",
+      id: 2,
+    });
+
+    const selection = [
+      sourceFeatureSelectionTarget("incidents", 1),
+      sourceFeatureSelectionTarget("incidents", 2),
+      sourceFeatureSelectionTarget("incidents", 3),
+    ];
+
+    expect(filterRealtimeSelection(selection, deleted)).toEqual([sourceFeatureSelectionTarget("incidents", 1)]);
+  });
+
+  it("can reconcile deleted selection back into an exploration view", async () => {
+    const ctx = createExplorationContext({ datasetId: "ops", sourceIds: ["incidents"] });
+    const view = ctx.connectView({ id: "realtime", role: "custom" });
+    view.select([sourceFeatureSelectionTarget("incidents", 2)], { replace: true });
+
+    const state = reduceRealtimeFeatureState(emptyRealtimeFeatureState(), {
+      type: "delete",
+      sourceId: "incidents",
+      id: 2,
+    });
+    reconcileRealtimeSelection(view, state, { requireLiveRecord: false });
+
+    expect(ctx.state.selection).toEqual([]);
+    ctx.dispose();
+  });
+});


### PR DESCRIPTION
## Summary

- adds `@honua/sdk-js/realtime` as a public SDK entrypoint for live operational feature state
- defines normalized snapshot/upsert/delete/heartbeat/status/error events with cursor, watermark, sequence, stale, and duplicate handling
- adds a subscribable store, mock-transport bridge, and linked exploration selection cleanup helper for map/table/detail coherence
- documents the realtime state contract and cache boundary for incident-dashboard consumers

Refs #65
Refs #57
Refs #72

## Validation

- `npm run check`
- `npm test -- test/realtime.test.ts test/entrypoints.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm run verify:split-packages`
