### PR TITLE
Document linked-view context sync

### DIFF
--- a/docs/linked-view-context-sync.md
+++ b/docs/linked-view-context-sync.md
@@ -1,0 +1,184 @@
+# Linked-View Context Sync
+
+Status: optional SDK/UI integration layer for issue `#72`, building on the
+`ExplorationContext`, `@honua/sdk-js/interactions`, and
+`@honua/sdk-js/realtime` public surfaces.
+
+Linked-view context sync coordinates maps, tables, charts or graphs, filter
+controls, detail panels, and live operational layers without wiring those
+components directly to each other. Each component adapter dispatches typed
+exploration intents into one `ExplorationContext` and subscribes to the slice
+or selector it can render. A map does not call a table, a chart does not call a
+map, and a filter bar does not know which layers or protocols consume its
+clauses.
+
+## Core Pattern
+
+```ts
+import { createExplorationContext, sourceFeatureSelectionTarget } from "@honua/sdk-js/exploration";
+import {
+  bindChartToExploration,
+  bindDetailToSelection,
+  bindFilterControlsToExploration,
+  bindMapExtentToExploration,
+  bindQueryProjectionToExploration,
+  bindTableSelectionToExploration,
+  syncMapLayerFilterToExploration,
+} from "@honua/sdk-js/interactions";
+import { reconcileRealtimeSelection } from "@honua/sdk-js/realtime";
+
+const ctx = createExplorationContext({
+  datasetId: "ops",
+  sourceIds: ["incidents"],
+  preset: "mapDriven",
+});
+
+const mapView = ctx.connectView({ id: "map", role: "map" });
+const tableView = ctx.connectView({ id: "table", role: "grid" });
+const chartView = ctx.connectView({ id: "chart", role: "chart" });
+const filterView = ctx.connectView({ id: "filters", role: "filter" });
+const detailView = ctx.connectView({ id: "detail", role: "detail" });
+```
+
+`connectView()` returns an `ExplorationViewController`. The controller stamps
+the bound `viewId` onto every dispatch, suppresses self-origin callbacks by
+default, and releases subscriptions on `unbind()`.
+
+## Component Adapters
+
+Maps publish viewport and selection intents:
+
+```ts
+bindMapExtentToExploration(mapView, mapExtentSource, {
+  publishSpatialFilter: false,
+});
+
+mapView.select([sourceFeatureSelectionTarget("incidents", 101)], { replace: true });
+```
+
+Tables and charts subscribe to a query projection rather than to the map:
+
+```ts
+bindQueryProjectionToExploration(tableView, async (projection) => {
+  const rows = await source.query({
+    spatialFilter: projection.spatialFilter,
+    orderBy: projection.orderBy,
+    pagination: projection.pagination,
+    outFields: projection.outFields,
+  });
+  renderRows(rows, projection.selection);
+});
+
+bindChartToExploration(chartView).subscribeQuery((projection) => {
+  renderChart({
+    filters: projection.filters,
+    spatialFilter: projection.spatialFilter,
+    grouping: projection.grouping,
+    aggregation: projection.aggregation,
+  });
+});
+```
+
+Filter controls publish structured `FilterClause` values. Map, table, and
+chart adapters translate the same projection at their protocol edge:
+
+```ts
+const filters = bindFilterControlsToExploration(filterView);
+
+syncMapLayerFilterToExploration(maplibreMap, mapView, {
+  layerId: "incident-points",
+  sourceId: "incidents",
+  translate: (projection) => compileMapLibreFilter(projection.filters),
+});
+
+filters.setFilter("status", {
+  field: "STATUS",
+  operator: "=",
+  value: "open",
+  appliesTo: ["incidents"],
+});
+```
+
+Charts or graphs can drive grouped exploration by dispatching grouping,
+aggregation, selected feature targets, and bucket filters:
+
+```ts
+const chart = bindChartToExploration(chartView);
+
+chart.setGrouping(["SEVERITY"]);
+chart.setAggregation({
+  groupBy: ["SEVERITY"],
+  metrics: [{ fn: "count", field: "OBJECTID" }],
+});
+chart.selectBucket({
+  targets: [sourceFeatureSelectionTarget("incidents", 101)],
+  filters: {
+    severity: { field: "SEVERITY", operator: "=", value: "high" },
+  },
+});
+```
+
+Detail panels subscribe to selection:
+
+```ts
+bindDetailToSelection(detailView, ([selected]) => {
+  renderDetail(selected);
+});
+
+const table = bindTableSelectionToExploration(tableView);
+table.clearSelection();
+```
+
+## Presets
+
+Presets decide which bound-view slice notifications propagate to peers. Central
+state still moves for every valid intent, and `"all"` subscribers still observe
+every reducer change for devtools, persistence, and snapshot writing.
+
+| Preset | Use when | Peer propagation |
+| --- | --- | --- |
+| `globalLinked` | Prototypes and fully coordinated apps. | Every role can publish every slice. |
+| `mapDriven` | The map viewport is the primary browsing surface. | Map publishes `extent`, `spatialFilter`, `selection`, and `filters`; filter controls publish `filters` and `spatialFilter`. |
+| `chartDriven` | A chart or graph bucket controls the working set. | Chart publishes `grouping`, `aggregation`, `filters`, and `selection`; filter controls publish `filters`. |
+| `decoupled` | Components should keep local interaction state while sharing one serializable context. | No peer slice notifications; snapshots still contain central state. |
+
+```ts
+ctx.connectView({ id: "map", role: "map" }).applyPreset("chartDriven");
+```
+
+Use `decoupled` when an application wants the SDK state container and snapshot
+format but needs app-owned propagation rules. Because slice listeners stay
+quiet, components must subscribe to `"all"` or use app-specific routing if they
+need to observe local-only movement.
+
+## Realtime Deltas
+
+Realtime feature stores are another producer of typed state. Transport adapters
+emit normalized deltas through `@honua/sdk-js/realtime`; UI adapters reconcile
+the resulting live set against `ExplorationContext` selection.
+
+```ts
+store.subscribe((state) => {
+  reconcileRealtimeSelection(detailView, state, {
+    sourceId: "incidents",
+    requireLiveRecord: true,
+  });
+});
+```
+
+`delete` events create tombstones, and stale or replayed streams keep cursor and
+watermark metadata in the realtime store. Selection reconciliation removes
+tombstoned and, by default, missing live records from the shared selection so
+map highlights, table rows, charts, and detail panels do not point at archived
+features.
+
+## Adoption Paths
+
+Issue `#56` can adopt this layer for sample and application work by binding
+maps, grids, charts, filters, and details through one `ExplorationContext`
+instead of custom pairwise callbacks.
+
+Issue `#57` can reuse the realtime reconciliation path for the incident
+operations dashboard so live feature deltas, map highlights, table rows,
+charts, filters, and detail panels converge through the same context instead
+of pairwise synchronization callbacks.

--- a/test/linked-view-context-sync.test.ts
+++ b/test/linked-view-context-sync.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  bindChartToExploration,
+  bindDetailToSelection,
+  bindFilterControlsToExploration,
+  bindMapExtentToExploration,
+  bindQueryProjectionToExploration,
+  bindTableSelectionToExploration,
+  createExplorationContext,
+  sourceFeatureSelectionTarget,
+  syncMapLayerFilterToExploration,
+} from "../src/index.js";
+import type { HonuaExtent, LinkedViewQueryProjection, MapLayerFilterTarget } from "../src/index.js";
+import {
+  emptyRealtimeFeatureState,
+  reconcileRealtimeSelection,
+  reconcileRealtimeStaleness,
+  reduceRealtimeFeatureState,
+} from "../src/realtime/index.js";
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+class FakeExtentHost {
+  #extent: HonuaExtent | undefined;
+  #listeners = new Set<(extent: HonuaExtent | undefined) => void>();
+
+  current(): HonuaExtent | undefined {
+    return this.#extent;
+  }
+
+  subscribe(listener: (extent: HonuaExtent | undefined) => void): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+
+  moveTo(extent: HonuaExtent | undefined): void {
+    this.#extent = extent;
+    for (const listener of [...this.#listeners]) listener(extent);
+  }
+}
+
+class FakeQueryHost {
+  readonly queries: LinkedViewQueryProjection[] = [];
+
+  apply(projection: LinkedViewQueryProjection): void {
+    this.queries.push(projection);
+  }
+}
+
+class FakeLayerFilterHost implements MapLayerFilterTarget {
+  readonly filters: Array<{ layerId: string; filter: unknown }> = [];
+
+  setFilter(layerId: string, filter: unknown): void {
+    this.filters.push({ layerId, filter });
+  }
+}
+
+describe("optional linked-view context sync layer", () => {
+  it("projects map extent changes into table and chart queries without peer coupling", async () => {
+    const ctx = createExplorationContext({ datasetId: "ops", sourceIds: ["incidents"], preset: "mapDriven" });
+    const mapView = ctx.connectView({ id: "map", role: "map" });
+    const tableView = ctx.connectView({ id: "table", role: "grid" });
+    const chartView = ctx.connectView({ id: "chart", role: "chart" });
+    const extentHost = new FakeExtentHost();
+    const table = new FakeQueryHost();
+    const chart = new FakeQueryHost();
+
+    bindMapExtentToExploration(mapView, extentHost, { coalesce: false });
+    bindQueryProjectionToExploration(tableView, (projection) => table.apply(projection), { applyInitial: false });
+    bindChartToExploration(chartView).subscribeQuery((projection) => chart.apply(projection), { applyInitial: false });
+
+    extentHost.moveTo({ xmin: -157.9, ymin: 21.2, xmax: -157.7, ymax: 21.4, spatialReference: { wkid: 4326 } });
+    await flush();
+
+    expect(table.queries).toHaveLength(1);
+    expect(chart.queries).toHaveLength(1);
+    expect(table.queries[0]).toMatchObject({
+      extent: { xmin: -157.9, ymin: 21.2, xmax: -157.7, ymax: 21.4, spatialReference: { wkid: 4326 } },
+      spatialFilter: {
+        geometry: { xmin: -157.9, ymin: 21.2, xmax: -157.7, ymax: 21.4, spatialReference: { wkid: 4326 } },
+        geometryType: "esriGeometryEnvelope",
+        spatialRel: "esriSpatialRelIntersects",
+      },
+    });
+    expect(chart.queries[0].spatialFilter).toEqual(table.queries[0].spatialFilter);
+    ctx.dispose();
+  });
+
+  it("projects filter controls into map layer filters through a shared selector", async () => {
+    const ctx = createExplorationContext({ datasetId: "ops", sourceIds: ["incidents"], preset: "mapDriven" });
+    const filterView = ctx.connectView({ id: "filters", role: "filter" });
+    const mapView = ctx.connectView({ id: "map", role: "map" });
+    const controls = bindFilterControlsToExploration(filterView);
+    const map = new FakeLayerFilterHost();
+
+    syncMapLayerFilterToExploration(map, mapView, {
+      layerId: "incident-points",
+      applyInitial: false,
+      sourceId: "incidents",
+      translate(projection) {
+        return [
+          "all",
+          ...Object.values(projection.filters).map((clause) => ["==", ["get", clause.field], clause.value]),
+        ];
+      },
+    });
+
+    controls.setFilter("status", { field: "STATUS", operator: "=", value: "open", appliesTo: ["incidents"] });
+    await flush();
+
+    expect(map.filters).toEqual([{ layerId: "incident-points", filter: ["all", ["==", ["get", "STATUS"], "open"]] }]);
+    ctx.dispose();
+  });
+
+  it("shares chart bucket selection and filters with map, table, and detail subscribers", async () => {
+    const ctx = createExplorationContext({ datasetId: "ops", sourceIds: ["incidents"], preset: "chartDriven" });
+    const chartView = ctx.connectView({ id: "chart", role: "chart" });
+    const mapView = ctx.connectView({ id: "map", role: "map" });
+    const tableView = ctx.connectView({ id: "table", role: "grid" });
+    const detailView = ctx.connectView({ id: "detail", role: "detail" });
+    const chart = bindChartToExploration(chartView);
+    const target = sourceFeatureSelectionTarget("incidents", "INC-101");
+    const mapSelections: unknown[] = [];
+    const tableFilters: unknown[] = [];
+    const detail = vi.fn();
+
+    mapView.subscribe("selection", (event) => mapSelections.push(event.state.selection));
+    tableView.subscribe("filters", (event) => tableFilters.push(event.state.filters));
+    bindDetailToSelection(detailView, detail);
+
+    chart.selectBucket({
+      targets: [target],
+      filters: {
+        severity: { field: "SEVERITY", operator: "=", value: "high", appliesTo: ["incidents"] },
+      },
+    });
+    await flush();
+
+    expect(ctx.state.selection).toEqual([target]);
+    expect(ctx.state.filters.severity).toEqual({
+      field: "SEVERITY",
+      operator: "=",
+      value: "high",
+      appliesTo: ["incidents"],
+    });
+    expect(mapSelections).toEqual([[target]]);
+    expect(tableFilters).toEqual([
+      { severity: { field: "SEVERITY", operator: "=", value: "high", appliesTo: ["incidents"] } },
+    ]);
+    expect(detail).toHaveBeenCalledWith([target], expect.objectContaining({ selfOrigin: false }));
+    ctx.dispose();
+  });
+
+  it("clears shared selection through table controls and updates detail panels", async () => {
+    const ctx = createExplorationContext({ datasetId: "ops", sourceIds: ["incidents"], preset: "globalLinked" });
+    const tableView = ctx.connectView({ id: "table", role: "grid" });
+    const detailView = ctx.connectView({ id: "detail", role: "detail" });
+    const table = bindTableSelectionToExploration(tableView);
+    const detail = vi.fn();
+    const target = sourceFeatureSelectionTarget("incidents", 7);
+
+    bindDetailToSelection(detailView, detail);
+    table.select([target], { replace: true });
+    await flush();
+    table.clearSelection();
+    await flush();
+
+    expect(ctx.state.selection).toEqual([]);
+    expect(detail).toHaveBeenLastCalledWith([], expect.objectContaining({ selfOrigin: false }));
+    ctx.dispose();
+  });
+
+  it("reconciles stale realtime tombstones out of shared selection", async () => {
+    const ctx = createExplorationContext({ datasetId: "ops", sourceIds: ["incidents"], preset: "globalLinked" });
+    const realtimeView = ctx.connectView({ id: "realtime", role: "custom" });
+    const detailView = ctx.connectView({ id: "detail", role: "detail" });
+    const detail = vi.fn();
+    const deleted = sourceFeatureSelectionTarget("incidents", "INC-7");
+    const live = sourceFeatureSelectionTarget("incidents", "INC-8");
+    let state = reduceRealtimeFeatureState(emptyRealtimeFeatureState<{ status: string }>(), {
+      type: "snapshot",
+      receivedAt: 1_000,
+      features: [
+        { sourceId: "incidents", id: "INC-7", feature: { status: "open" } },
+        { sourceId: "incidents", id: "INC-8", feature: { status: "open" } },
+      ],
+    });
+
+    bindDetailToSelection(detailView, detail);
+    realtimeView.select([deleted, live], { replace: true });
+    await flush();
+
+    state = reduceRealtimeFeatureState(state, {
+      type: "delete",
+      sourceId: "incidents",
+      id: "INC-7",
+      receivedAt: 1_100,
+    });
+    state = reconcileRealtimeStaleness(state, { staleAfterMs: 50, now: 1_200 });
+    reconcileRealtimeSelection(realtimeView, state);
+    await flush();
+
+    expect(state.status).toBe("stale");
+    expect(state.tombstones["incidents:INC-7"]).toBeDefined();
+    expect(ctx.state.selection).toEqual([live]);
+    expect(detail).toHaveBeenLastCalledWith([live], expect.objectContaining({ selfOrigin: false }));
+    ctx.dispose();
+  });
+
+  it("keeps peer slice subscribers quiet in decoupled mode while central state stays serializable", async () => {
+    const ctx = createExplorationContext({ datasetId: "ops", sourceIds: ["incidents"], preset: "decoupled" });
+    const mapView = ctx.connectView({ id: "map", role: "map" });
+    const tableView = ctx.connectView({ id: "table", role: "grid" });
+    const table = new FakeQueryHost();
+
+    bindQueryProjectionToExploration(tableView, (projection) => table.apply(projection), { applyInitial: false });
+
+    mapView.setExtent({ xmin: 0, ymin: 0, xmax: 1, ymax: 1 });
+    await flush();
+
+    expect(table.queries).toEqual([]);
+    expect(ctx.state.extent).toEqual({ xmin: 0, ymin: 0, xmax: 1, ymax: 1 });
+    expect(JSON.parse(JSON.stringify(ctx.snapshot()))).toMatchObject({
+      version: 1,
+      state: {
+        preset: "decoupled",
+        extent: { xmin: 0, ymin: 0, xmax: 1, ymax: 1 },
+      },
+    });
+    ctx.dispose();
+  });
+});


### PR DESCRIPTION
## Summary
- add linked-view context sync architecture docs for maps, tables, charts, filters, details, and realtime reconciliation
- add integration-style tests covering extent projection, filters, chart buckets, table selection, tombstones, and decoupled mode

## Validation
- npm test -- test/linked-view-context-sync.test.ts
- npm run check

Refs #72