### PR TITLE
Add scene workspace interop API

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -22,4 +22,4 @@ This repository owns the JavaScript/TypeScript SDK, browser runtime helpers, mig
 
 ## 3D Status
 
-The SDK has `SceneViewCompat`, 2.5D MapLibre examples, WebMap conversion warnings for unsupported 3D properties, and a Cesium route-playback spike. Full 3D scene workspace interop across Cesium, map, table, and detail views is still tracked as backlog.
+The SDK has `SceneViewCompat`, 2.5D MapLibre examples, WebMap conversion warnings for unsupported 3D properties, a Cesium route-playback spike, and a renderer-neutral scene workspace contract for Cesium/map/table/detail/timeline/evidence interop. See `docs/scene-workspace.md` for the sample adapter pattern. Renderer-specific production adapters and richer hosted samples remain follow-on backlog.

--- a/docs/scene-workspace.md
+++ b/docs/scene-workspace.md
@@ -1,0 +1,84 @@
+# Scene Workspace Interop
+
+`@honua/sdk-js/scene-workspace` is a renderer-neutral coordination layer for
+apps that combine a 3D scene, 2D map, table, detail panel, timeline, evidence
+tray, and realtime status. It does not import Cesium, MapLibre, or a UI
+framework. Renderers translate their native events into typed workspace intents
+and subscribe to narrow slices or selectors.
+
+## Sample Pattern
+
+```ts
+import {
+  createSceneWorkspace,
+  sceneWorkspaceIntentFromAdapterEvent,
+  selectSceneEvidenceForFeature,
+  selectSceneVisibleLayers,
+} from "@honua/sdk-js/scene-workspace";
+import { sourceFeatureSelectionTarget } from "@honua/sdk-js/exploration";
+
+const workspace = createSceneWorkspace({
+  sceneId: "incident-command",
+  title: "Incident Command Scene",
+  layers: {
+    buildings: { id: "buildings", sourceId: "buildings", title: "Buildings", visible: true, kind: "scene" },
+    incidents: { id: "incidents", sourceId: "incidents", title: "Incidents", visible: true, kind: "feature" },
+  },
+});
+
+const unsubscribeScene = workspace.subscribe("camera", ({ state }) => {
+  cesiumAdapter.flyTo(state.camera);
+});
+
+const unsubscribeLayers = workspace.subscribe("layers", ({ state }) => {
+  mapAdapter.setVisibleLayers(selectSceneVisibleLayers(state));
+});
+
+const unsubscribeSelection = workspace.subscribe("selection", ({ state }) => {
+  tableAdapter.highlight(state.selection);
+  detailAdapter.renderEvidence(selectSceneEvidenceForFeature(state, "INC-7"));
+});
+
+cesiumAdapter.onCameraChange((camera) => {
+  workspace.dispatch(sceneWorkspaceIntentFromAdapterEvent({ type: "camera-change", camera }, "scene"));
+});
+
+mapAdapter.onFeatureClick((sourceId, id) => {
+  workspace.dispatch({
+    kind: "set-selection",
+    source: "map",
+    selection: [sourceFeatureSelectionTarget(sourceId, id)],
+  });
+});
+
+realtimeAdapter.onStatus((realtime) => {
+  workspace.dispatch({ kind: "set-realtime", source: "realtime", realtime });
+});
+```
+
+The important property is that no adapter calls another adapter directly. The
+scene publishes camera or selection state, the map publishes selected features,
+the table and detail panel observe the same source-qualified selection, and the
+timeline/realtime layer shares status through the same state model.
+
+## Demo Fit
+
+The incident operations dashboard can use this workspace when the map expands
+from 2D incident points into a 3D command scene. The same source-qualified
+selection targets keep a clicked building, table row, evidence packet, and
+detail panel aligned. Realtime transport remains separate; it only publishes
+status or deltas that the workspace can expose to renderers.
+
+The Palantir-style operations sample can layer the scene workspace beside the
+app workspace from issue `#71`: the app workspace owns cross-app metadata,
+jobs, source cache, and reviewable MCP/AI drafts; the scene workspace owns
+renderer-neutral 3D view state and scene-specific evidence.
+
+## Boundaries
+
+- Renderer adapters own Cesium/MapLibre/OpenLayers objects.
+- The workspace owns serializable scene state and source-qualified selection.
+- Cloud Honua queries, realtime subscriptions, and job runs stay in the SDK
+  client/app workspace and feed scene intents at the protocol edge.
+- Snapshot and restore are value-detached so saved state can be persisted
+  without retaining renderer-owned objects.

--- a/package.json
+++ b/package.json
@@ -71,6 +71,10 @@
       "types": "./dist/src/app-workspace/index.d.ts",
       "default": "./dist/src/app-workspace/index.js"
     },
+    "./scene-workspace": {
+      "types": "./dist/src/scene-workspace/index.d.ts",
+      "default": "./dist/src/scene-workspace/index.js"
+    },
     "./runtime": {
       "types": "./dist/src/runtime/index.d.ts",
       "default": "./dist/src/runtime/index.js"

--- a/scripts/prepare-split-packages.mjs
+++ b/scripts/prepare-split-packages.mjs
@@ -52,6 +52,7 @@ function createSdkPackage() {
   copyDirectory(path.join(DIST_SRC_ROOT, "app-workspace"), path.join(packageRoot, "app-workspace"));
   copyDirectory(path.join(DIST_SRC_ROOT, "map"), path.join(packageRoot, "map"));
   copyDirectory(path.join(DIST_SRC_ROOT, "realtime"), path.join(packageRoot, "realtime"));
+  copyDirectory(path.join(DIST_SRC_ROOT, "scene-workspace"), path.join(packageRoot, "scene-workspace"));
   copyDirectory(path.join(DIST_SRC_ROOT, "style"), path.join(packageRoot, "style"));
   copyDirectory(path.join(DIST_SRC_ROOT, "webmap"), path.join(packageRoot, "webmap"));
   copyFile(path.join(DIST_SRC_ROOT, "honua.js"), path.join(packageRoot, "index.js"));
@@ -90,6 +91,10 @@ function createSdkPackage() {
       "./realtime": {
         types: "./realtime/index.d.ts",
         default: "./realtime/index.js",
+      },
+      "./scene-workspace": {
+        types: "./scene-workspace/index.d.ts",
+        default: "./scene-workspace/index.js",
       },
       "./map": {
         types: "./map/index.d.ts",

--- a/scripts/verify-split-packages.mjs
+++ b/scripts/verify-split-packages.mjs
@@ -86,6 +86,10 @@ import {
   selectHonuaAppWorkspaceMetadataCacheModel,
 } from "@honua/sdk/app-workspace";
 import {
+  createSceneWorkspace,
+  sceneWorkspaceIntentFromAdapterEvent,
+} from "@honua/sdk/scene-workspace";
+import {
   AttributionCompat,
   BasemapCompat,
   BasemapToggleCompat,
@@ -208,6 +212,10 @@ if (typeof createHonuaAppWorkspace !== "function")
   throw new Error("createHonuaAppWorkspace export missing from @honua/sdk/app-workspace");
 if (typeof selectHonuaAppWorkspaceMetadataCacheModel !== "function")
   throw new Error("selectHonuaAppWorkspaceMetadataCacheModel export missing from @honua/sdk/app-workspace");
+if (typeof createSceneWorkspace !== "function")
+  throw new Error("createSceneWorkspace export missing from @honua/sdk/scene-workspace");
+if (typeof sceneWorkspaceIntentFromAdapterEvent !== "function")
+  throw new Error("sceneWorkspaceIntentFromAdapterEvent export missing from @honua/sdk/scene-workspace");
 if (typeof CompatEventBus !== "function") throw new Error("CompatEventBus export missing");
 if (typeof CoordinateConversionCompat !== "function") throw new Error("CoordinateConversionCompat export missing");
 if (typeof createEsriRequestInterceptors !== "function") throw new Error("createEsriRequestInterceptors export missing");

--- a/src/honua.ts
+++ b/src/honua.ts
@@ -150,6 +150,33 @@ export type {
   SelectionDetailListener,
   TableSelectionExplorationBinding,
 } from "./interactions/index.js";
+export {
+  createSceneWorkspace,
+  emptySceneWorkspaceState,
+  reduceSceneWorkspaceState,
+  sceneWorkspaceIntentFromAdapterEvent,
+  selectSceneEvidenceForFeature,
+  selectSceneVisibleLayers,
+} from "./scene-workspace/index.js";
+export { SCENE_WORKSPACE_SLICES } from "./scene-workspace/index.js";
+export type {
+  SceneBookmark,
+  SceneCameraState,
+  SceneEvidenceReference,
+  SceneLayerState,
+  SceneRealtimeState,
+  SceneTimelineState,
+  SceneWorkspace,
+  SceneWorkspaceAdapterEvent,
+  SceneWorkspaceChangeEvent,
+  SceneWorkspaceHistoryEntry,
+  SceneWorkspaceIntent,
+  SceneWorkspaceListener,
+  SceneWorkspaceSlice,
+  SceneWorkspaceSnapshot,
+  SceneWorkspaceState,
+  SceneWorkspaceUnsubscribe,
+} from "./scene-workspace/index.js";
 export { HonuaMap } from "./map/index.js";
 export type {
   HonuaMapOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,6 +211,33 @@ export type {
   SelectionDetailListener,
   TableSelectionExplorationBinding,
 } from "./interactions/index.js";
+export {
+  createSceneWorkspace,
+  emptySceneWorkspaceState,
+  reduceSceneWorkspaceState,
+  sceneWorkspaceIntentFromAdapterEvent,
+  selectSceneEvidenceForFeature,
+  selectSceneVisibleLayers,
+} from "./scene-workspace/index.js";
+export { SCENE_WORKSPACE_SLICES } from "./scene-workspace/index.js";
+export type {
+  SceneBookmark,
+  SceneCameraState,
+  SceneEvidenceReference,
+  SceneLayerState,
+  SceneRealtimeState,
+  SceneTimelineState,
+  SceneWorkspace,
+  SceneWorkspaceAdapterEvent,
+  SceneWorkspaceChangeEvent,
+  SceneWorkspaceHistoryEntry,
+  SceneWorkspaceIntent,
+  SceneWorkspaceListener,
+  SceneWorkspaceSlice,
+  SceneWorkspaceSnapshot,
+  SceneWorkspaceState,
+  SceneWorkspaceUnsubscribe,
+} from "./scene-workspace/index.js";
 export { HonuaMap } from "./map/index.js";
 export type {
   HonuaMapOptions,

--- a/src/scene-workspace/index.ts
+++ b/src/scene-workspace/index.ts
@@ -1,0 +1,27 @@
+export {
+  createSceneWorkspace,
+  emptySceneWorkspaceState,
+  reduceSceneWorkspaceState,
+  sceneWorkspaceIntentFromAdapterEvent,
+  selectSceneEvidenceForFeature,
+  selectSceneVisibleLayers,
+} from "./workspace.js";
+export { SCENE_WORKSPACE_SLICES } from "./types.js";
+export type {
+  SceneBookmark,
+  SceneCameraState,
+  SceneEvidenceReference,
+  SceneLayerState,
+  SceneRealtimeState,
+  SceneTimelineState,
+  SceneWorkspace,
+  SceneWorkspaceAdapterEvent,
+  SceneWorkspaceChangeEvent,
+  SceneWorkspaceHistoryEntry,
+  SceneWorkspaceIntent,
+  SceneWorkspaceListener,
+  SceneWorkspaceSlice,
+  SceneWorkspaceSnapshot,
+  SceneWorkspaceState,
+  SceneWorkspaceUnsubscribe,
+} from "./types.js";

--- a/src/scene-workspace/types.ts
+++ b/src/scene-workspace/types.ts
@@ -1,0 +1,255 @@
+/**
+ * Renderer-neutral 3D scene workspace contracts.
+ *
+ * These types intentionally describe state and adapter events without
+ * importing Cesium, MapLibre, or any rendering package.
+ *
+ * @module
+ */
+
+import type { FeatureId, SourceId } from "../contract/types.js";
+import type { FeatureSelectionTarget } from "../exploration/index.js";
+import type { RealtimeConnectionStatus } from "../realtime/index.js";
+
+export type SceneWorkspaceSlice =
+  | "all"
+  | "scene"
+  | "camera"
+  | "layers"
+  | "selection"
+  | "timeline"
+  | "evidence"
+  | "realtime"
+  | "history";
+
+export const SCENE_WORKSPACE_SLICES: readonly SceneWorkspaceSlice[] = [
+  "all",
+  "scene",
+  "camera",
+  "layers",
+  "selection",
+  "timeline",
+  "evidence",
+  "realtime",
+  "history",
+] as const;
+
+export interface SceneLayerState {
+  readonly id: string;
+  readonly sourceId?: SourceId;
+  readonly title?: string;
+  readonly visible: boolean;
+  readonly opacity?: number;
+  readonly kind?: "scene" | "feature" | "imagery" | "tiles" | "evidence" | "custom";
+}
+
+export interface SceneCameraState {
+  readonly longitude: number;
+  readonly latitude: number;
+  readonly height: number;
+  readonly heading?: number;
+  readonly pitch?: number;
+  readonly roll?: number;
+}
+
+export interface SceneBookmark {
+  readonly id: string;
+  readonly label: string;
+  readonly camera: SceneCameraState;
+}
+
+export interface SceneTimelineState {
+  readonly currentTime?: string;
+  readonly startTime?: string;
+  readonly endTime?: string;
+  readonly playing?: boolean;
+  readonly progress?: number;
+}
+
+export interface SceneEvidenceReference {
+  readonly id: string;
+  readonly label: string;
+  readonly kind: "image" | "video" | "document" | "point-cloud" | "model" | "sensor" | "custom";
+  readonly sourceId?: SourceId;
+  readonly featureId?: FeatureId;
+  readonly url?: string;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface SceneRealtimeState {
+  readonly status: RealtimeConnectionStatus;
+  readonly cursor?: string;
+  readonly staleSince?: number;
+}
+
+export interface SceneWorkspaceState {
+  readonly sceneId?: string;
+  readonly title?: string;
+  readonly layers: Readonly<Record<string, SceneLayerState>>;
+  readonly camera?: SceneCameraState;
+  readonly bookmarks: Readonly<Record<string, SceneBookmark>>;
+  readonly selection: ReadonlyArray<FeatureSelectionTarget>;
+  readonly activeAssetId?: FeatureId;
+  readonly timeline: SceneTimelineState;
+  readonly evidence: Readonly<Record<string, SceneEvidenceReference>>;
+  readonly realtime: SceneRealtimeState;
+  readonly history: ReadonlyArray<SceneWorkspaceHistoryEntry>;
+}
+
+export interface SceneWorkspaceHistoryEntry {
+  readonly id: string;
+  readonly label: string;
+  readonly at: string;
+  readonly intentKind: SceneWorkspaceIntent["kind"];
+}
+
+export interface SceneWorkspaceSnapshot {
+  readonly version: 1;
+  readonly state: SceneWorkspaceState;
+}
+
+export type SceneWorkspaceIntent =
+  | SetSceneIntent
+  | SetSceneLayersIntent
+  | SetLayerVisibilityIntent
+  | SetCameraIntent
+  | ApplyBookmarkIntent
+  | SetSelectionIntent
+  | ClearSelectionIntent
+  | SetActiveAssetIntent
+  | SetTimelineIntent
+  | AddEvidenceIntent
+  | RemoveEvidenceIntent
+  | SetRealtimeIntent
+  | RestoreSceneWorkspaceIntent;
+
+interface IntentBase {
+  readonly source?: "scene" | "map" | "table" | "detail" | "timeline" | "realtime" | "workspace" | "custom";
+  readonly historyLabel?: string;
+  readonly at?: string;
+}
+
+export interface SetSceneIntent extends IntentBase {
+  readonly kind: "set-scene";
+  readonly sceneId: string | undefined;
+  readonly title?: string;
+}
+
+export interface SetSceneLayersIntent extends IntentBase {
+  readonly kind: "set-layers";
+  readonly layers: ReadonlyArray<SceneLayerState>;
+}
+
+export interface SetLayerVisibilityIntent extends IntentBase {
+  readonly kind: "set-layer-visibility";
+  readonly layerId: string;
+  readonly visible: boolean;
+}
+
+export interface SetCameraIntent extends IntentBase {
+  readonly kind: "set-camera";
+  readonly camera: SceneCameraState | undefined;
+}
+
+export interface ApplyBookmarkIntent extends IntentBase {
+  readonly kind: "apply-bookmark";
+  readonly bookmark: SceneBookmark;
+}
+
+export interface SetSelectionIntent extends IntentBase {
+  readonly kind: "set-selection";
+  readonly selection: ReadonlyArray<FeatureSelectionTarget>;
+}
+
+export interface ClearSelectionIntent extends IntentBase {
+  readonly kind: "clear-selection";
+}
+
+export interface SetActiveAssetIntent extends IntentBase {
+  readonly kind: "set-active-asset";
+  readonly id: FeatureId | undefined;
+}
+
+export interface SetTimelineIntent extends IntentBase {
+  readonly kind: "set-timeline";
+  readonly timeline: SceneTimelineState;
+}
+
+export interface AddEvidenceIntent extends IntentBase {
+  readonly kind: "add-evidence";
+  readonly evidence: SceneEvidenceReference;
+}
+
+export interface RemoveEvidenceIntent extends IntentBase {
+  readonly kind: "remove-evidence";
+  readonly id: string;
+}
+
+export interface SetRealtimeIntent extends IntentBase {
+  readonly kind: "set-realtime";
+  readonly realtime: SceneRealtimeState;
+}
+
+export interface RestoreSceneWorkspaceIntent extends IntentBase {
+  readonly kind: "restore";
+  readonly snapshot: SceneWorkspaceSnapshot;
+}
+
+export type SceneWorkspaceAdapterEvent =
+  | SceneWorkspaceCameraEvent
+  | SceneWorkspaceLayerVisibilityEvent
+  | SceneWorkspaceSelectionEvent
+  | SceneWorkspaceTimelineEvent
+  | SceneWorkspaceEvidenceEvent
+  | SceneWorkspaceRealtimeEvent;
+
+export interface SceneWorkspaceCameraEvent {
+  readonly type: "camera-change";
+  readonly camera: SceneCameraState | undefined;
+}
+
+export interface SceneWorkspaceLayerVisibilityEvent {
+  readonly type: "layer-visibility-change";
+  readonly layerId: string;
+  readonly visible: boolean;
+}
+
+export interface SceneWorkspaceSelectionEvent {
+  readonly type: "selection-change";
+  readonly selection: ReadonlyArray<FeatureSelectionTarget>;
+}
+
+export interface SceneWorkspaceTimelineEvent {
+  readonly type: "timeline-change";
+  readonly timeline: SceneTimelineState;
+}
+
+export interface SceneWorkspaceEvidenceEvent {
+  readonly type: "evidence-add" | "evidence-remove";
+  readonly evidence?: SceneEvidenceReference;
+  readonly id?: string;
+}
+
+export interface SceneWorkspaceRealtimeEvent {
+  readonly type: "realtime-status";
+  readonly realtime: SceneRealtimeState;
+}
+
+export interface SceneWorkspaceChangeEvent {
+  readonly state: SceneWorkspaceState;
+  readonly previous: SceneWorkspaceState;
+  readonly changedSlices: ReadonlySet<SceneWorkspaceSlice>;
+  readonly intent: SceneWorkspaceIntent;
+}
+
+export type SceneWorkspaceListener = (event: SceneWorkspaceChangeEvent) => void;
+export type SceneWorkspaceUnsubscribe = () => void;
+
+export interface SceneWorkspace {
+  readonly state: SceneWorkspaceState;
+  dispatch(intent: SceneWorkspaceIntent): SceneWorkspaceState;
+  subscribe(slice: SceneWorkspaceSlice, listener: SceneWorkspaceListener): SceneWorkspaceUnsubscribe;
+  snapshot(): SceneWorkspaceSnapshot;
+  restore(snapshot: SceneWorkspaceSnapshot): SceneWorkspaceState;
+  dispose(): void;
+}

--- a/src/scene-workspace/workspace.ts
+++ b/src/scene-workspace/workspace.ts
@@ -1,0 +1,336 @@
+import { featureSelectionKey } from "../exploration/index.js";
+import type {
+  SceneEvidenceReference,
+  SceneLayerState,
+  SceneWorkspace,
+  SceneWorkspaceAdapterEvent,
+  SceneWorkspaceChangeEvent,
+  SceneWorkspaceIntent,
+  SceneWorkspaceListener,
+  SceneWorkspaceSlice,
+  SceneWorkspaceSnapshot,
+  SceneWorkspaceState,
+  SceneWorkspaceUnsubscribe,
+} from "./types.js";
+
+export function emptySceneWorkspaceState(): SceneWorkspaceState {
+  return {
+    layers: {},
+    bookmarks: {},
+    selection: [],
+    timeline: {},
+    evidence: {},
+    realtime: { status: "idle" },
+    history: [],
+  };
+}
+
+export function createSceneWorkspace(initialState: Partial<SceneWorkspaceState> = {}): SceneWorkspace {
+  let state: SceneWorkspaceState = mergeState(emptySceneWorkspaceState(), initialState);
+  const listeners = new Map<SceneWorkspaceSlice, Set<SceneWorkspaceListener>>();
+  let disposed = false;
+
+  function ensureLive(): void {
+    if (disposed) throw new Error("SceneWorkspace has been disposed.");
+  }
+
+  function emit(event: SceneWorkspaceChangeEvent): void {
+    for (const listener of listeners.get("all") ?? []) listener(event);
+    for (const slice of event.changedSlices) {
+      if (slice === "all") continue;
+      for (const listener of listeners.get(slice) ?? []) listener(event);
+    }
+  }
+
+  return {
+    get state() {
+      return state;
+    },
+    dispatch(intent) {
+      ensureLive();
+      const previous = state;
+      const next = reduceSceneWorkspaceState(state, intent);
+      const changedSlices = changedSceneWorkspaceSlices(previous, next);
+      if (changedSlices.size === 0) return state;
+      state = next;
+      emit({ state, previous, changedSlices, intent });
+      return state;
+    },
+    subscribe(slice, listener) {
+      ensureLive();
+      const sliceListeners = listeners.get(slice) ?? new Set<SceneWorkspaceListener>();
+      sliceListeners.add(listener);
+      listeners.set(slice, sliceListeners);
+      return () => {
+        sliceListeners.delete(listener);
+      };
+    },
+    snapshot() {
+      ensureLive();
+      return { version: 1, state: cloneSceneWorkspaceState(state) };
+    },
+    restore(snapshot) {
+      return this.dispatch({ kind: "restore", snapshot, source: "workspace" });
+    },
+    dispose() {
+      disposed = true;
+      listeners.clear();
+    },
+  };
+}
+
+export function reduceSceneWorkspaceState(
+  state: SceneWorkspaceState,
+  intent: SceneWorkspaceIntent,
+): SceneWorkspaceState {
+  const base = applyIntent(state, intent);
+  return appendHistory(base, intent);
+}
+
+export function sceneWorkspaceIntentFromAdapterEvent(
+  event: SceneWorkspaceAdapterEvent,
+  source: SceneWorkspaceIntent["source"] = "scene",
+): SceneWorkspaceIntent {
+  switch (event.type) {
+    case "camera-change":
+      return { kind: "set-camera", camera: event.camera, source, historyLabel: "Scene camera changed" };
+    case "layer-visibility-change":
+      return {
+        kind: "set-layer-visibility",
+        layerId: event.layerId,
+        visible: event.visible,
+        source,
+        historyLabel: "Scene layer visibility changed",
+      };
+    case "selection-change":
+      return { kind: "set-selection", selection: event.selection, source, historyLabel: "Scene selection changed" };
+    case "timeline-change":
+      return { kind: "set-timeline", timeline: event.timeline, source, historyLabel: "Scene timeline changed" };
+    case "evidence-add":
+      if (!event.evidence) throw new Error("evidence-add adapter event requires evidence.");
+      return { kind: "add-evidence", evidence: event.evidence, source, historyLabel: "Scene evidence added" };
+    case "evidence-remove":
+      if (!event.id) throw new Error("evidence-remove adapter event requires id.");
+      return { kind: "remove-evidence", id: event.id, source, historyLabel: "Scene evidence removed" };
+    case "realtime-status":
+      return { kind: "set-realtime", realtime: event.realtime, source, historyLabel: "Scene realtime status changed" };
+  }
+}
+
+export function selectSceneVisibleLayers(state: SceneWorkspaceState): SceneLayerState[] {
+  return Object.values(state.layers).filter((layer) => layer.visible);
+}
+
+export function selectSceneEvidenceForFeature(
+  state: SceneWorkspaceState,
+  featureId: string | number | undefined,
+): SceneEvidenceReference[] {
+  if (featureId === undefined) return [];
+  return Object.values(state.evidence).filter((evidence) => evidence.featureId === featureId);
+}
+
+function applyIntent(state: SceneWorkspaceState, intent: SceneWorkspaceIntent): SceneWorkspaceState {
+  switch (intent.kind) {
+    case "set-scene":
+      return {
+        ...state,
+        sceneId: intent.sceneId,
+        title: intent.title,
+      };
+    case "set-layers":
+      return {
+        ...state,
+        layers: Object.fromEntries(intent.layers.map((layer) => [layer.id, { ...layer }])),
+      };
+    case "set-layer-visibility": {
+      const existing = state.layers[intent.layerId];
+      return {
+        ...state,
+        layers: {
+          ...state.layers,
+          [intent.layerId]: {
+            ...existing,
+            id: intent.layerId,
+            visible: intent.visible,
+          },
+        },
+      };
+    }
+    case "set-camera":
+      return {
+        ...state,
+        camera: intent.camera ? { ...intent.camera } : undefined,
+      };
+    case "apply-bookmark":
+      return {
+        ...state,
+        camera: { ...intent.bookmark.camera },
+        bookmarks: {
+          ...state.bookmarks,
+          [intent.bookmark.id]: { ...intent.bookmark, camera: { ...intent.bookmark.camera } },
+        },
+      };
+    case "set-selection":
+      return {
+        ...state,
+        selection: dedupeSelection(intent.selection),
+      };
+    case "clear-selection":
+      return {
+        ...state,
+        selection: [],
+      };
+    case "set-active-asset":
+      return {
+        ...state,
+        activeAssetId: intent.id,
+      };
+    case "set-timeline":
+      return {
+        ...state,
+        timeline: { ...intent.timeline },
+      };
+    case "add-evidence":
+      return {
+        ...state,
+        evidence: {
+          ...state.evidence,
+          [intent.evidence.id]: cloneEvidence(intent.evidence),
+        },
+      };
+    case "remove-evidence": {
+      const evidence = { ...state.evidence };
+      delete evidence[intent.id];
+      return { ...state, evidence };
+    }
+    case "set-realtime":
+      return {
+        ...state,
+        realtime: { ...intent.realtime },
+      };
+    case "restore":
+      return cloneSceneWorkspaceState(intent.snapshot.state);
+  }
+}
+
+function appendHistory(state: SceneWorkspaceState, intent: SceneWorkspaceIntent): SceneWorkspaceState {
+  if (intent.kind === "restore") return state;
+  const label = intent.historyLabel ?? intent.kind;
+  const at = intent.at ?? new Date().toISOString();
+  const entry = {
+    id: `${state.history.length + 1}:${intent.kind}`,
+    label,
+    at,
+    intentKind: intent.kind,
+  };
+  return {
+    ...state,
+    history: [...state.history, entry].slice(-50),
+  };
+}
+
+function changedSceneWorkspaceSlices(
+  previous: SceneWorkspaceState,
+  next: SceneWorkspaceState,
+): ReadonlySet<SceneWorkspaceSlice> {
+  const changed = new Set<SceneWorkspaceSlice>();
+  if (previous.sceneId !== next.sceneId || previous.title !== next.title) changed.add("scene");
+  if (previous.camera !== next.camera) changed.add("camera");
+  if (previous.layers !== next.layers) changed.add("layers");
+  if (previous.selection !== next.selection) changed.add("selection");
+  if (previous.timeline !== next.timeline) changed.add("timeline");
+  if (previous.evidence !== next.evidence) changed.add("evidence");
+  if (previous.realtime !== next.realtime) changed.add("realtime");
+  if (previous.history !== next.history) changed.add("history");
+  return changed;
+}
+
+function mergeState(base: SceneWorkspaceState, initial: Partial<SceneWorkspaceState>): SceneWorkspaceState {
+  return cloneSceneWorkspaceState({
+    ...base,
+    ...initial,
+    layers: {
+      ...base.layers,
+      ...Object.fromEntries(Object.entries(initial.layers ?? {}).map(([id, layer]) => [id, cloneLayer(layer)])),
+    },
+    bookmarks: {
+      ...base.bookmarks,
+      ...Object.fromEntries(
+        Object.entries(initial.bookmarks ?? {}).map(([id, bookmark]) => [id, cloneBookmark(bookmark)]),
+      ),
+    },
+    selection: initial.selection ? dedupeSelection(initial.selection) : base.selection,
+    timeline: { ...base.timeline, ...initial.timeline },
+    evidence: {
+      ...base.evidence,
+      ...Object.fromEntries(
+        Object.entries(initial.evidence ?? {}).map(([id, evidence]) => [id, cloneEvidence(evidence)]),
+      ),
+    },
+    realtime: { ...base.realtime, ...initial.realtime },
+    history: [...(initial.history ?? base.history)],
+  });
+}
+
+function cloneSceneWorkspaceState(state: SceneWorkspaceState): SceneWorkspaceState {
+  return {
+    ...state,
+    layers: Object.fromEntries(Object.entries(state.layers).map(([id, layer]) => [id, cloneLayer(layer)])),
+    bookmarks: Object.fromEntries(
+      Object.entries(state.bookmarks).map(([id, bookmark]) => [id, cloneBookmark(bookmark)]),
+    ),
+    camera: state.camera ? cloneCamera(state.camera) : undefined,
+    selection: dedupeSelection(state.selection),
+    timeline: { ...state.timeline },
+    evidence: Object.fromEntries(Object.entries(state.evidence).map(([id, evidence]) => [id, cloneEvidence(evidence)])),
+    realtime: { ...state.realtime },
+    history: state.history.map((entry) => ({ ...entry })),
+  };
+}
+
+function cloneLayer(layer: SceneLayerState): SceneLayerState {
+  return { ...layer };
+}
+
+function cloneCamera(camera: NonNullable<SceneWorkspaceState["camera"]>): NonNullable<SceneWorkspaceState["camera"]> {
+  return { ...camera };
+}
+
+function cloneBookmark(
+  bookmark: NonNullable<SceneWorkspaceState["bookmarks"][string]>,
+): NonNullable<SceneWorkspaceState["bookmarks"][string]> {
+  return {
+    ...bookmark,
+    camera: cloneCamera(bookmark.camera),
+  };
+}
+
+function cloneEvidence(evidence: SceneEvidenceReference): SceneEvidenceReference {
+  return {
+    ...evidence,
+    metadata: evidence.metadata ? cloneValue(evidence.metadata) : undefined,
+  };
+}
+
+function dedupeSelection(selection: ReadonlyArray<SceneWorkspaceState["selection"][number]>) {
+  const seen = new Set<string>();
+  const out: SceneWorkspaceState["selection"][number][] = [];
+  for (const target of selection) {
+    const key = featureSelectionKey(target);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(cloneSelectionTarget(target));
+  }
+  return out;
+}
+
+function cloneSelectionTarget(
+  target: SceneWorkspaceState["selection"][number],
+): SceneWorkspaceState["selection"][number] {
+  return typeof target === "object" && target !== null ? { ...target } : target;
+}
+
+function cloneValue<T>(value: T): T {
+  if (typeof structuredClone === "function") return structuredClone(value);
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/test/entrypoints.test.ts
+++ b/test/entrypoints.test.ts
@@ -133,6 +133,7 @@ import {
   createHonuaService,
   bindQueryProjectionToExploration as honuaBindQueryProjectionToExploration,
   createHonuaAppWorkspace as honuaCreateHonuaAppWorkspace,
+  createSceneWorkspace as honuaCreateSceneWorkspace,
   selectLinkedViewQueryProjection as honuaSelectLinkedViewQueryProjection,
   selectHonuaAppWorkspaceMetadataCacheModel as honuaSelectMetadataCacheModel,
   sourceFeatureSelectionTarget as honuaSourceFeatureSelectionTarget,
@@ -143,6 +144,7 @@ import {
   bindMapSelectionToExploration,
   bindQueryProjectionToExploration,
   createHonuaAppWorkspace,
+  createSceneWorkspace as rootCreateSceneWorkspace,
   selectLinkedViewQueryProjection as rootSelectLinkedViewQueryProjection,
   sourceFeatureSelectionTarget as rootSourceFeatureSelectionTarget,
   selectHonuaAppWorkspaceMetadataCacheModel,
@@ -166,6 +168,7 @@ import {
   emptyRealtimeFeatureState,
   reduceRealtimeFeatureState,
 } from "../src/realtime/index.js";
+import { createSceneWorkspace, sceneWorkspaceIntentFromAdapterEvent } from "../src/scene-workspace/index.js";
 
 describe("entrypoint modules", () => {
   it("exposes honua-first core entrypoint", () => {
@@ -345,5 +348,12 @@ describe("entrypoint modules", () => {
     expect(selectHonuaAppWorkspaceMetadataCacheModel).toBeTypeOf("function");
     expect(appWorkspaceSelectMetadataCacheModel).toBe(selectHonuaAppWorkspaceMetadataCacheModel);
     expect(honuaSelectMetadataCacheModel).toBe(selectHonuaAppWorkspaceMetadataCacheModel);
+  });
+
+  it("exposes the scene workspace entrypoint", () => {
+    expect(createSceneWorkspace).toBeTypeOf("function");
+    expect(sceneWorkspaceIntentFromAdapterEvent).toBeTypeOf("function");
+    expect(rootCreateSceneWorkspace).toBe(createSceneWorkspace);
+    expect(honuaCreateSceneWorkspace).toBe(createSceneWorkspace);
   });
 });

--- a/test/scene-workspace.test.ts
+++ b/test/scene-workspace.test.ts
@@ -1,0 +1,195 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+import { sourceFeatureSelectionTarget } from "../src/exploration/index.js";
+import {
+  createSceneWorkspace,
+  emptySceneWorkspaceState,
+  sceneWorkspaceIntentFromAdapterEvent,
+  selectSceneEvidenceForFeature,
+  selectSceneVisibleLayers,
+} from "../src/scene-workspace/index.js";
+
+describe("scene workspace", () => {
+  it("models scene layers, camera, timeline, evidence, realtime, and history without a renderer", () => {
+    const workspace = createSceneWorkspace();
+    const layerListener = vi.fn();
+    const allListener = vi.fn();
+    workspace.subscribe("layers", layerListener);
+    workspace.subscribe("all", allListener);
+
+    workspace.dispatch({
+      kind: "set-scene",
+      sceneId: "construction-yard",
+      title: "Construction Yard",
+      at: "2026-05-05T00:00:00.000Z",
+    });
+    workspace.dispatch({
+      kind: "set-layers",
+      layers: [
+        { id: "world-model", title: "World model", visible: true, kind: "scene" },
+        { id: "incidents", sourceId: "incidents", visible: false, kind: "feature" },
+      ],
+      at: "2026-05-05T00:00:01.000Z",
+    });
+    workspace.dispatch({
+      kind: "set-camera",
+      camera: { longitude: -157.8583, latitude: 21.3069, height: 700, heading: 45, pitch: -35 },
+      at: "2026-05-05T00:00:02.000Z",
+    });
+    workspace.dispatch({
+      kind: "set-timeline",
+      timeline: {
+        currentTime: "2026-05-05T00:05:00.000Z",
+        startTime: "2026-05-05T00:00:00.000Z",
+        endTime: "2026-05-05T00:10:00.000Z",
+        progress: 0.5,
+      },
+      at: "2026-05-05T00:00:03.000Z",
+    });
+    workspace.dispatch({
+      kind: "add-evidence",
+      evidence: {
+        id: "ev-1",
+        label: "Crane inspection still",
+        kind: "image",
+        sourceId: "incidents",
+        featureId: "INC-7",
+      },
+      at: "2026-05-05T00:00:04.000Z",
+    });
+    workspace.dispatch({
+      kind: "set-realtime",
+      realtime: { status: "stale", cursor: "c7", staleSince: 1_000 },
+      at: "2026-05-05T00:00:05.000Z",
+    });
+
+    expect(workspace.state.sceneId).toBe("construction-yard");
+    expect(selectSceneVisibleLayers(workspace.state).map((layer) => layer.id)).toEqual(["world-model"]);
+    expect(workspace.state.camera?.height).toBe(700);
+    expect(workspace.state.timeline.progress).toBe(0.5);
+    expect(selectSceneEvidenceForFeature(workspace.state, "INC-7")).toHaveLength(1);
+    expect(workspace.state.realtime.status).toBe("stale");
+    expect(workspace.state.history.map((entry) => entry.intentKind)).toEqual([
+      "set-scene",
+      "set-layers",
+      "set-camera",
+      "set-timeline",
+      "add-evidence",
+      "set-realtime",
+    ]);
+    expect(layerListener).toHaveBeenCalledTimes(1);
+    expect(allListener).toHaveBeenCalledTimes(6);
+  });
+
+  it("keeps scene, map, table, and detail selection targets source-qualified", () => {
+    const workspace = createSceneWorkspace();
+    const sceneTarget = sourceFeatureSelectionTarget("scene-assets", "asset-101");
+    const mapTarget = sourceFeatureSelectionTarget("work-orders", "asset-101");
+
+    workspace.dispatch({
+      kind: "set-selection",
+      selection: [sceneTarget, mapTarget, sceneTarget],
+      source: "scene",
+    });
+
+    expect(workspace.state.selection).toEqual([sceneTarget, mapTarget]);
+  });
+
+  it("translates renderer adapter events into workspace intents", () => {
+    const workspace = createSceneWorkspace();
+    const intent = sceneWorkspaceIntentFromAdapterEvent(
+      {
+        type: "selection-change",
+        selection: [sourceFeatureSelectionTarget("scene-assets", "asset-9")],
+      },
+      "map",
+    );
+
+    workspace.dispatch(intent);
+
+    expect(intent).toMatchObject({ kind: "set-selection", source: "map" });
+    expect(workspace.state.selection).toEqual([sourceFeatureSelectionTarget("scene-assets", "asset-9")]);
+  });
+
+  it("snapshots and restores serializable scene state", () => {
+    const workspace = createSceneWorkspace({
+      sceneId: "initial",
+      layers: { initial: { id: "initial", visible: true } },
+    });
+
+    const snapshot = workspace.snapshot();
+    workspace.dispatch({ kind: "set-scene", sceneId: "changed" });
+    workspace.dispatch({ kind: "set-layer-visibility", layerId: "initial", visible: false });
+
+    workspace.restore(snapshot);
+
+    expect(workspace.state.sceneId).toBe("initial");
+    expect(workspace.state.layers.initial?.visible).toBe(true);
+    expect(snapshot.state).not.toBe(workspace.state);
+  });
+
+  it("detaches initial state and snapshots from caller-owned nested objects", () => {
+    const selected = sourceFeatureSelectionTarget("scene-assets", "asset-1");
+    const initial = {
+      layers: { assets: { id: "assets", visible: true } },
+      selection: [selected],
+      evidence: {
+        ev1: {
+          id: "ev1",
+          label: "Inspection packet",
+          kind: "document" as const,
+          featureId: "asset-1",
+          metadata: { nested: { status: "original" } },
+        },
+      },
+    };
+    const workspace = createSceneWorkspace(initial);
+
+    initial.layers.assets.visible = false;
+    (selected as { id: string }).id = "mutated";
+    (initial.evidence.ev1.metadata.nested as { status: string }).status = "mutated";
+
+    expect(workspace.state.layers.assets?.visible).toBe(true);
+    expect(workspace.state.selection).toEqual([sourceFeatureSelectionTarget("scene-assets", "asset-1")]);
+    expect(workspace.state.evidence.ev1?.metadata).toEqual({ nested: { status: "original" } });
+
+    const snapshot = workspace.snapshot();
+    (snapshot.state.evidence.ev1?.metadata?.nested as { status: string }).status = "snapshot-mutated";
+    (snapshot.state.selection[0] as { id: string }).id = "snapshot-mutated";
+
+    expect(workspace.state.selection).toEqual([sourceFeatureSelectionTarget("scene-assets", "asset-1")]);
+    expect(workspace.state.evidence.ev1?.metadata).toEqual({ nested: { status: "original" } });
+  });
+
+  it("timestamps history with dispatch time when callers do not supply at", () => {
+    const workspace = createSceneWorkspace();
+    const before = Date.now();
+
+    workspace.dispatch({ kind: "set-scene", sceneId: "live-scene" });
+
+    const timestamp = Date.parse(workspace.state.history[0]?.at ?? "");
+    expect(timestamp).toBeGreaterThanOrEqual(before);
+    expect(timestamp).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("disposes subscriptions and rejects later dispatches", () => {
+    const workspace = createSceneWorkspace();
+    const listener = vi.fn();
+    workspace.subscribe("scene", listener);
+    workspace.dispose();
+
+    expect(() => workspace.dispatch({ kind: "set-scene", sceneId: "late" })).toThrow(/disposed/);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("does not introduce a Cesium runtime dependency in the core scene workspace", () => {
+    const sceneWorkspaceRoot = path.resolve(process.cwd(), "src", "scene-workspace");
+    const files = fs.readdirSync(sceneWorkspaceRoot).filter((file) => file.endsWith(".ts"));
+    const source = files.map((file) => fs.readFileSync(path.join(sceneWorkspaceRoot, file), "utf8")).join("\n");
+
+    expect(source).not.toMatch(/from "cesium"|from 'cesium'|maplibre-gl/);
+    expect(emptySceneWorkspaceState().realtime.status).toBe("idle");
+  });
+});


### PR DESCRIPTION
## Summary
- add renderer-neutral scene workspace contracts and reducer for scene, camera, layers, selection, timeline, evidence, realtime, history, snapshot, and adapter-event intents
- add scene workspace docs/sample adapter pattern plus feature-map status update
- publish @honua/sdk-js/scene-workspace and split @honua/sdk/scene-workspace entrypoints without adding Cesium/MapLibre runtime dependencies

## Validation
- npm test -- test/scene-workspace.test.ts test/entrypoints.test.ts
- npm run typecheck
- npm run check
- npm run verify:split-packages

Refs #75