### PR TITLE
Add interaction detail and share state helpers

### DIFF
--- a/src/honua.ts
+++ b/src/honua.ts
@@ -117,6 +117,13 @@ export {
   selectLinkedViewQueryProjection,
   subscribeExplorationSelector,
   bindTableSelectionToExploration,
+  interactionQueryParamNames,
+  parseInteractionQueryState,
+  parseSelection,
+  preparePrimaryDetailModel,
+  prepareSelectionDetailModels,
+  serializeInteractionQueryState,
+  serializeSelection,
   syncMapLayerFilterToExploration,
   syncFeatureStateSelection,
 } from "./interactions/index.js";
@@ -149,6 +156,14 @@ export type {
   MapSelectionExplorationBindingOptions,
   SelectionDetailListener,
   TableSelectionExplorationBinding,
+  DetailFeatureLike,
+  DetailFieldDefinition,
+  DetailFieldModel,
+  DetailModel,
+  DetailModelOptions,
+  DetailSelectionStatus,
+  ShareableInteractionQueryParams,
+  ShareableInteractionQueryState,
 } from "./interactions/index.js";
 export {
   createSceneWorkspace,

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,6 +178,13 @@ export {
   selectLinkedViewQueryProjection,
   subscribeExplorationSelector,
   bindTableSelectionToExploration,
+  interactionQueryParamNames,
+  parseInteractionQueryState,
+  parseSelection,
+  preparePrimaryDetailModel,
+  prepareSelectionDetailModels,
+  serializeInteractionQueryState,
+  serializeSelection,
   syncMapLayerFilterToExploration,
   syncFeatureStateSelection,
 } from "./interactions/index.js";
@@ -210,6 +217,14 @@ export type {
   MapSelectionExplorationBindingOptions,
   SelectionDetailListener,
   TableSelectionExplorationBinding,
+  DetailFeatureLike,
+  DetailFieldDefinition,
+  DetailFieldModel,
+  DetailModel,
+  DetailModelOptions,
+  DetailSelectionStatus,
+  ShareableInteractionQueryParams,
+  ShareableInteractionQueryState,
 } from "./interactions/index.js";
 export {
   createSceneWorkspace,

--- a/src/interactions/detail-model.ts
+++ b/src/interactions/detail-model.ts
@@ -1,0 +1,176 @@
+/**
+ * Framework-neutral popup/detail data preparation helpers.
+ *
+ * These helpers consume selection targets and query results from the existing
+ * exploration surfaces. They do not own interaction state.
+ *
+ * @module
+ */
+
+import type { FeatureId, SourceId } from "../contract/types.js";
+import {
+  featureSelectionKey,
+  isSourceQualifiedSelectionTarget,
+  sourceFeatureSelectionTarget,
+} from "../exploration/selection.js";
+import type { FeatureSelectionTarget } from "../exploration/types.js";
+
+export interface DetailFeatureLike {
+  readonly id?: FeatureId;
+  readonly sourceId?: SourceId;
+  readonly sourceLayer?: string;
+  readonly attributes?: Readonly<Record<string, unknown>>;
+  readonly properties?: Readonly<Record<string, unknown>>;
+  readonly geometry?: unknown;
+}
+
+export interface DetailFieldDefinition {
+  readonly name: string;
+  readonly label?: string;
+  readonly visible?: boolean;
+  readonly formatter?: (value: unknown, feature: DetailFeatureLike) => unknown;
+}
+
+export interface DetailModelOptions {
+  readonly selection: ReadonlyArray<FeatureSelectionTarget>;
+  readonly features?: ReadonlyArray<DetailFeatureLike>;
+  readonly sourceId?: SourceId;
+  readonly sourceLayer?: string;
+  readonly objectIdField?: string;
+  readonly titleField?: string;
+  readonly fields?: ReadonlyArray<DetailFieldDefinition | string>;
+  readonly includeHiddenFields?: boolean;
+}
+
+export type DetailSelectionStatus = "empty" | "ready" | "stale";
+
+export interface DetailFieldModel {
+  readonly name: string;
+  readonly label: string;
+  readonly value: unknown;
+}
+
+export interface DetailModel {
+  readonly status: DetailSelectionStatus;
+  readonly target?: FeatureSelectionTarget;
+  readonly feature?: DetailFeatureLike;
+  readonly title?: string;
+  readonly attributes: Readonly<Record<string, unknown>>;
+  readonly fields: ReadonlyArray<DetailFieldModel>;
+  readonly geometry?: unknown;
+}
+
+/** Build one detail model per selected target. */
+export function prepareSelectionDetailModels(options: DetailModelOptions): DetailModel[] {
+  const selection = options.selection;
+  if (selection.length === 0) return [emptyDetailModel()];
+
+  const features = options.features ?? [];
+  const bySelectionKey = new Map<string, DetailFeatureLike>();
+  for (const feature of features) {
+    const target = featureToSelectionTarget(feature, options);
+    if (target) bySelectionKey.set(featureSelectionKey(target), feature);
+  }
+
+  return selection.map((target) => {
+    const feature = bySelectionKey.get(featureSelectionKey(target));
+    if (!feature) return staleDetailModel(target);
+    return readyDetailModel(target, feature, options);
+  });
+}
+
+/** Build the primary popup/detail model for the first selected target. */
+export function preparePrimaryDetailModel(options: DetailModelOptions): DetailModel {
+  return prepareSelectionDetailModels(options)[0] ?? emptyDetailModel();
+}
+
+function readyDetailModel(
+  target: FeatureSelectionTarget,
+  feature: DetailFeatureLike,
+  options: DetailModelOptions,
+): DetailModel {
+  const attributes = featureAttributes(feature);
+  return {
+    status: "ready",
+    target,
+    feature,
+    title: detailTitle(attributes, options.titleField, target),
+    attributes,
+    fields: detailFields(feature, attributes, options),
+    geometry: feature.geometry,
+  };
+}
+
+function emptyDetailModel(): DetailModel {
+  return {
+    status: "empty",
+    attributes: {},
+    fields: [],
+  };
+}
+
+function staleDetailModel(target: FeatureSelectionTarget): DetailModel {
+  return {
+    status: "stale",
+    target,
+    attributes: {},
+    fields: [],
+  };
+}
+
+function featureToSelectionTarget(
+  feature: DetailFeatureLike,
+  options: Pick<DetailModelOptions, "objectIdField" | "sourceId" | "sourceLayer">,
+): FeatureSelectionTarget | undefined {
+  const id = featureId(feature, options.objectIdField);
+  if (id === undefined) return undefined;
+  const sourceId = feature.sourceId ?? options.sourceId;
+  if (!sourceId) return id;
+  return sourceFeatureSelectionTarget(sourceId, id, { sourceLayer: feature.sourceLayer ?? options.sourceLayer });
+}
+
+function featureId(feature: DetailFeatureLike, objectIdField: string | undefined): FeatureId | undefined {
+  if (feature.id !== undefined) return feature.id;
+  const attributes = featureAttributes(feature);
+  const value =
+    (objectIdField ? attributes[objectIdField] : undefined) ??
+    attributes.OBJECTID ??
+    attributes.objectid ??
+    attributes.ObjectID ??
+    attributes.id;
+  return typeof value === "string" || typeof value === "number" ? value : undefined;
+}
+
+function featureAttributes(feature: DetailFeatureLike): Readonly<Record<string, unknown>> {
+  return feature.attributes ?? feature.properties ?? {};
+}
+
+function detailTitle(
+  attributes: Readonly<Record<string, unknown>>,
+  titleField: string | undefined,
+  target: FeatureSelectionTarget,
+): string {
+  const title = titleField ? attributes[titleField] : undefined;
+  if (title !== undefined && title !== null && String(title).length > 0) return String(title);
+  if (isSourceQualifiedSelectionTarget(target)) return `${target.sourceId} ${String(target.id)}`;
+  return String(target);
+}
+
+function detailFields(
+  feature: DetailFeatureLike,
+  attributes: Readonly<Record<string, unknown>>,
+  options: DetailModelOptions,
+): DetailFieldModel[] {
+  const definitions = options.fields ?? Object.keys(attributes);
+  const out: DetailFieldModel[] = [];
+  for (const definition of definitions) {
+    const field = typeof definition === "string" ? { name: definition } : definition;
+    if (field.visible === false && !options.includeHiddenFields) continue;
+    out.push({
+      name: field.name,
+      label: field.label ?? field.name,
+      value: field.formatter ? field.formatter(attributes[field.name], feature) : attributes[field.name],
+    });
+  }
+  return out;
+}

--- a/src/interactions/index.ts
+++ b/src/interactions/index.ts
@@ -21,6 +21,14 @@ export {
   syncMapLayerFilterToExploration,
   syncFeatureStateSelection,
 } from "./exploration-bindings.js";
+export { preparePrimaryDetailModel, prepareSelectionDetailModels } from "./detail-model.js";
+export {
+  interactionQueryParamNames,
+  parseInteractionQueryState,
+  parseSelection,
+  serializeInteractionQueryState,
+  serializeSelection,
+} from "./share-state.js";
 export type {
   FeatureStateMap,
   MapEventTarget,
@@ -55,3 +63,12 @@ export type {
   SelectionDetailListener,
   TableSelectionExplorationBinding,
 } from "./exploration-bindings.js";
+export type {
+  DetailFeatureLike,
+  DetailFieldDefinition,
+  DetailFieldModel,
+  DetailModel,
+  DetailModelOptions,
+  DetailSelectionStatus,
+} from "./detail-model.js";
+export type { ShareableInteractionQueryParams, ShareableInteractionQueryState } from "./share-state.js";

--- a/src/interactions/share-state.ts
+++ b/src/interactions/share-state.ts
@@ -1,0 +1,149 @@
+/**
+ * Shareable serialization helpers for map/table/detail interaction state.
+ *
+ * The encoded query string is intended for URLs and bookmarks. It carries the
+ * query projection and selection but leaves state ownership with
+ * `ExplorationContext`.
+ *
+ * @module
+ */
+
+import type { LinkedViewQueryProjection } from "../exploration/selectors.js";
+import type { FeatureSelectionTarget } from "../exploration/types.js";
+
+export type ShareableInteractionQueryState = Partial<LinkedViewQueryProjection> & {
+  readonly selection?: ReadonlyArray<FeatureSelectionTarget>;
+};
+
+export interface ShareableInteractionQueryParams {
+  readonly filters: string;
+  readonly spatialFilter: string;
+  readonly extent: string;
+  readonly orderBy: string;
+  readonly pagination: string;
+  readonly outFields: string;
+  readonly grouping: string;
+  readonly aggregation: string;
+  readonly selection: string;
+}
+
+const PARAMS: ShareableInteractionQueryParams = {
+  filters: "f",
+  spatialFilter: "sf",
+  extent: "ext",
+  orderBy: "sort",
+  pagination: "page",
+  outFields: "fields",
+  grouping: "group",
+  aggregation: "agg",
+  selection: "sel",
+};
+
+/** Encode selection targets as a stable JSON value suitable for a URL param. */
+export function serializeSelection(selection: ReadonlyArray<FeatureSelectionTarget>): string {
+  return stableStringify(selection);
+}
+
+/** Decode a selection value produced by {@link serializeSelection}. */
+export function parseSelection(value: string | null | undefined): FeatureSelectionTarget[] {
+  if (!value) return [];
+  const parsed = parseJson(value);
+  return Array.isArray(parsed) ? (parsed.filter(isSelectionTarget) as FeatureSelectionTarget[]) : [];
+}
+
+/** Encode query projection state into URL query parameters. */
+export function serializeInteractionQueryState(state: ShareableInteractionQueryState): string {
+  const params = new URLSearchParams();
+  setJsonParam(params, PARAMS.filters, emptyObjectToUndefined(state.filters));
+  setJsonParam(params, PARAMS.spatialFilter, state.spatialFilter);
+  setJsonParam(params, PARAMS.extent, state.extent);
+  setJsonParam(params, PARAMS.orderBy, emptyArrayToUndefined(state.orderBy));
+  setJsonParam(params, PARAMS.pagination, emptyObjectToUndefined(state.pagination));
+  setJsonParam(params, PARAMS.outFields, emptyArrayToUndefined(state.outFields));
+  setJsonParam(params, PARAMS.grouping, emptyArrayToUndefined(state.grouping));
+  setJsonParam(params, PARAMS.aggregation, state.aggregation);
+  setJsonParam(params, PARAMS.selection, emptyArrayToUndefined(state.selection));
+  return params.toString();
+}
+
+/** Decode URL query parameters produced by {@link serializeInteractionQueryState}. */
+export function parseInteractionQueryState(search: string | URLSearchParams): ShareableInteractionQueryState {
+  const params =
+    typeof search === "string" ? new URLSearchParams(search.startsWith("?") ? search.slice(1) : search) : search;
+  return {
+    filters: parseRecordParam<LinkedViewQueryProjection["filters"]>(params.get(PARAMS.filters)),
+    spatialFilter: parseRecordParam<LinkedViewQueryProjection["spatialFilter"]>(params.get(PARAMS.spatialFilter)),
+    extent: parseRecordParam<LinkedViewQueryProjection["extent"]>(params.get(PARAMS.extent)),
+    orderBy: parseArrayParam<LinkedViewQueryProjection["orderBy"][number]>(params.get(PARAMS.orderBy)),
+    pagination: parseRecordParam<LinkedViewQueryProjection["pagination"]>(params.get(PARAMS.pagination)),
+    outFields: parseStringArrayParam(params.get(PARAMS.outFields)),
+    grouping: parseStringArrayParam(params.get(PARAMS.grouping)),
+    aggregation: parseRecordParam<LinkedViewQueryProjection["aggregation"]>(params.get(PARAMS.aggregation)),
+    selection: parseSelection(params.get(PARAMS.selection)),
+  };
+}
+
+/** Return the query parameter names used by the shareable serializer. */
+export function interactionQueryParamNames(): ShareableInteractionQueryParams {
+  return { ...PARAMS };
+}
+
+function setJsonParam(params: URLSearchParams, name: string, value: unknown): void {
+  if (value === undefined) return;
+  params.set(name, stableStringify(value));
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortJsonValue(value));
+}
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJsonValue);
+  if (!value || typeof value !== "object") return value;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort()) {
+    out[key] = sortJsonValue((value as Record<string, unknown>)[key]);
+  }
+  return out;
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseRecordParam<T extends object | undefined>(value: string | null): T | undefined {
+  if (!value) return undefined;
+  const parsed = parseJson(value);
+  return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as T) : undefined;
+}
+
+function parseArrayParam<T>(value: string | null): T[] | undefined {
+  if (!value) return undefined;
+  const parsed = parseJson(value);
+  return Array.isArray(parsed) ? (parsed as T[]) : undefined;
+}
+
+function parseStringArrayParam(value: string | null): string[] | undefined {
+  const parsed = parseArrayParam(value);
+  if (!parsed) return undefined;
+  return parsed.filter((entry): entry is string => typeof entry === "string");
+}
+
+function emptyArrayToUndefined<T>(value: ReadonlyArray<T> | undefined): ReadonlyArray<T> | undefined {
+  return value && value.length > 0 ? value : undefined;
+}
+
+function emptyObjectToUndefined<T extends object>(value: T | undefined): T | undefined {
+  return value && Object.keys(value).length > 0 ? value : undefined;
+}
+
+function isSelectionTarget(value: unknown): boolean {
+  if (typeof value === "string" || typeof value === "number") return true;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.sourceId === "string" && (typeof record.id === "string" || typeof record.id === "number");
+}

--- a/test/entrypoints.test.ts
+++ b/test/entrypoints.test.ts
@@ -134,6 +134,7 @@ import {
   bindQueryProjectionToExploration as honuaBindQueryProjectionToExploration,
   createHonuaAppWorkspace as honuaCreateHonuaAppWorkspace,
   createSceneWorkspace as honuaCreateSceneWorkspace,
+  preparePrimaryDetailModel as honuaPreparePrimaryDetailModel,
   selectLinkedViewQueryProjection as honuaSelectLinkedViewQueryProjection,
   selectHonuaAppWorkspaceMetadataCacheModel as honuaSelectMetadataCacheModel,
   sourceFeatureSelectionTarget as honuaSourceFeatureSelectionTarget,
@@ -144,6 +145,7 @@ import {
   bindMapSelectionToExploration,
   bindQueryProjectionToExploration,
   createHonuaAppWorkspace,
+  preparePrimaryDetailModel,
   createSceneWorkspace as rootCreateSceneWorkspace,
   selectLinkedViewQueryProjection as rootSelectLinkedViewQueryProjection,
   sourceFeatureSelectionTarget as rootSourceFeatureSelectionTarget,
@@ -324,6 +326,8 @@ describe("entrypoint modules", () => {
     expect(interactionsSelectLinkedViewQueryProjection).toBe(selectLinkedViewQueryProjection);
     expect(bindQueryProjectionToExploration).toBeTypeOf("function");
     expect(honuaBindQueryProjectionToExploration).toBe(bindQueryProjectionToExploration);
+    expect(preparePrimaryDetailModel).toBeTypeOf("function");
+    expect(honuaPreparePrimaryDetailModel).toBe(preparePrimaryDetailModel);
     expect(bindChartToExploration).toBeTypeOf("function");
     expect(interactionsBindChartToExploration).toBe(bindChartToExploration);
     expect(Object.keys(LINKED_VIEW_PRESETS)).toEqual([

--- a/test/interaction-detail-share-state.test.ts
+++ b/test/interaction-detail-share-state.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  interactionQueryParamNames,
+  parseInteractionQueryState,
+  parseSelection,
+  preparePrimaryDetailModel,
+  prepareSelectionDetailModels,
+  serializeInteractionQueryState,
+  serializeSelection,
+  sourceFeatureSelectionTarget,
+} from "../src/index.js";
+
+describe("interaction detail model helpers", () => {
+  it("prepares popup/detail data for selected features", () => {
+    const target = sourceFeatureSelectionTarget("incidents", 10);
+    const detail = preparePrimaryDetailModel({
+      selection: [target],
+      sourceId: "incidents",
+      objectIdField: "OBJECTID",
+      titleField: "name",
+      fields: [
+        { name: "name", label: "Name" },
+        { name: "status", label: "Status", formatter: (value) => String(value).toUpperCase() },
+        { name: "internal", visible: false },
+      ],
+      features: [
+        {
+          attributes: { OBJECTID: 10, name: "Station 10", status: "open", internal: "hidden" },
+          geometry: { x: -157.8, y: 21.3 },
+        },
+      ],
+    });
+
+    expect(detail).toMatchObject({
+      status: "ready",
+      target,
+      title: "Station 10",
+      attributes: { OBJECTID: 10, name: "Station 10", status: "open", internal: "hidden" },
+      geometry: { x: -157.8, y: 21.3 },
+    });
+    expect(detail.fields).toEqual([
+      { name: "name", label: "Name", value: "Station 10" },
+      { name: "status", label: "Status", value: "OPEN" },
+    ]);
+  });
+
+  it("returns empty detail state when selection is cleared", () => {
+    expect(preparePrimaryDetailModel({ selection: [], features: [] })).toEqual({
+      status: "empty",
+      attributes: {},
+      fields: [],
+    });
+  });
+
+  it("marks selected features as stale when filtered or deleted from current results", () => {
+    const selected = [
+      sourceFeatureSelectionTarget("incidents", 10),
+      sourceFeatureSelectionTarget("incidents", 20),
+      sourceFeatureSelectionTarget("assets", 10),
+    ];
+
+    const details = prepareSelectionDetailModels({
+      selection: selected,
+      sourceId: "incidents",
+      features: [
+        { attributes: { OBJECTID: 20, name: "Current incident" } },
+        { sourceId: "assets", attributes: { OBJECTID: 10, name: "Same object id, other source" } },
+      ],
+      titleField: "name",
+    });
+
+    expect(details.map((detail) => detail.status)).toEqual(["stale", "ready", "ready"]);
+    expect(details[0].target).toEqual(sourceFeatureSelectionTarget("incidents", 10));
+    expect(details[1]).toMatchObject({ title: "Current incident" });
+    expect(details[2]).toMatchObject({ title: "Same object id, other source" });
+  });
+});
+
+describe("interaction share-state helpers", () => {
+  it("serializes and parses mixed raw and source-qualified selection", () => {
+    const selection = [1, "2", sourceFeatureSelectionTarget("incidents", 3, { sourceLayer: "points" })];
+    const encoded = serializeSelection(selection);
+
+    expect(parseSelection(encoded)).toEqual(selection);
+    expect(parseSelection("not json")).toEqual([]);
+  });
+
+  it("omits cleared filters, pages, and selection from shareable query state", () => {
+    expect(
+      serializeInteractionQueryState({
+        filters: {},
+        pagination: {},
+        grouping: [],
+        orderBy: [],
+        selection: [],
+      }),
+    ).toBe("");
+  });
+
+  it("round-trips linked query projection state through URL query params", () => {
+    const selection = [sourceFeatureSelectionTarget("incidents", 7)];
+    const encoded = serializeInteractionQueryState({
+      filters: {
+        status: { field: "STATUS", operator: "=", value: "open", appliesTo: ["incidents"] },
+      },
+      spatialFilter: {
+        geometry: { xmin: 0, ymin: 1, xmax: 2, ymax: 3 },
+        geometryType: "esriGeometryEnvelope",
+        spatialRel: "esriSpatialRelIntersects",
+      },
+      extent: { xmin: 0, ymin: 1, xmax: 2, ymax: 3 },
+      orderBy: [{ field: "UPDATED_AT", direction: "desc" }],
+      pagination: { offset: 20, limit: 10 },
+      outFields: ["OBJECTID", "STATUS"],
+      grouping: ["STATUS"],
+      aggregation: { metrics: [{ field: "*", fn: "count" }] },
+      selection,
+    });
+
+    const names = interactionQueryParamNames();
+    const params = new URLSearchParams(encoded);
+    expect(params.has(names.filters)).toBe(true);
+    expect(params.has(names.selection)).toBe(true);
+    expect(parseInteractionQueryState(`?${encoded}`)).toEqual({
+      filters: {
+        status: { appliesTo: ["incidents"], field: "STATUS", operator: "=", value: "open" },
+      },
+      spatialFilter: {
+        geometry: { xmax: 2, xmin: 0, ymax: 3, ymin: 1 },
+        geometryType: "esriGeometryEnvelope",
+        spatialRel: "esriSpatialRelIntersects",
+      },
+      extent: { xmax: 2, xmin: 0, ymax: 3, ymin: 1 },
+      orderBy: [{ direction: "desc", field: "UPDATED_AT" }],
+      pagination: { limit: 10, offset: 20 },
+      outFields: ["OBJECTID", "STATUS"],
+      grouping: ["STATUS"],
+      aggregation: { metrics: [{ field: "*", fn: "count" }] },
+      selection,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add framework-neutral popup/detail model helpers for selected features, empty selection, and stale/deleted selected feature states
- add shareable interaction query and selection URL serialization helpers for map/table/detail workflows and MCP handoff
- export the helpers through interactions, root, and honua-first entrypoints

## Validation
- npm test -- test/feature-state.test.ts test/interaction-exploration-bindings.test.ts test/interaction-detail-share-state.test.ts test/entrypoints.test.ts
- npm run typecheck
- npm run check

Refs #67