### PR TITLE
Guard incident dashboard live state authority

### DIFF
--- a/examples/realtime-incident-dashboard/README.md
+++ b/examples/realtime-incident-dashboard/README.md
@@ -4,6 +4,18 @@ Fixture-backed demo for the Honua JS SDK realtime feature store and linked explo
 
 The app starts from a deterministic incident snapshot, applies scripted realtime create/update/resolve/archive events, and keeps the map, filters, queue, summary metrics, event log, and detail panel synchronized through `@honua/sdk-js/exploration`.
 
+## Live State Authority
+
+Incident rows, geometry, counts, and detail actions are authoritative only when
+feature state comes from the realtime delta stream, cursor/watermark replay, or
+an explicit fresh snapshot. Metadata cache state for schemas, renderers,
+legends, and domains is shown separately and does not make incident feature
+state fresh.
+
+When the stream is stale, offline, or a feature-result cache is offered as the
+feature source, the dashboard keeps the last reconciled incidents visible for
+read-only context and disables actions that require authoritative live state.
+
 ## Run
 
 ```sh

--- a/examples/realtime-incident-dashboard/index.html
+++ b/examples/realtime-incident-dashboard/index.html
@@ -50,6 +50,9 @@
             <div><dt>Ignored</dt><dd id="stream-ignored">0</dd></div>
             <div><dt>Watermark</dt><dd id="stream-watermark">-</dd></div>
             <div><dt>Stale Since</dt><dd id="stream-stale-since">-</dd></div>
+            <div><dt>Authority</dt><dd id="live-authority" data-authoritative="false">Read-only</dd></div>
+            <div><dt>Feature Source</dt><dd id="feature-provenance">-</dd></div>
+            <div><dt>Metadata Cache</dt><dd id="metadata-cache">-</dd></div>
           </dl>
           <div class="button-row">
             <button id="step-event" type="button">Step Event</button>

--- a/examples/realtime-incident-dashboard/src/live-state.ts
+++ b/examples/realtime-incident-dashboard/src/live-state.ts
@@ -1,0 +1,204 @@
+import type { RealtimeConnectionStatus, RealtimeFeatureState, RealtimeResumeCheckpoint } from "@honua/sdk-js/realtime";
+
+export type IncidentMetadataCacheResource = "schemas" | "renderers" | "legends" | "domains";
+export type IncidentMetadataCacheStatus = "hit" | "miss" | "stale" | "refreshed" | "bypass";
+
+export interface IncidentMetadataCacheState {
+  readonly scope: "metadata";
+  readonly status: IncidentMetadataCacheStatus;
+  readonly resources: ReadonlyArray<IncidentMetadataCacheResource>;
+  readonly ageMs?: number;
+  readonly ttlMs?: number;
+}
+
+export type IncidentFeatureStateProvenance =
+  | {
+      readonly source: "realtime-delta";
+      readonly checkpoint?: RealtimeResumeCheckpoint;
+    }
+  | {
+      readonly source: "cursor-watermark-replay";
+      readonly checkpoint: RealtimeResumeCheckpoint;
+    }
+  | {
+      readonly source: "fresh-snapshot";
+      readonly fetchedAt: number;
+      readonly maxAgeMs: number;
+      readonly checkpoint?: RealtimeResumeCheckpoint;
+    }
+  | {
+      readonly source: "feature-result-cache";
+      readonly cacheStatus: "hit" | "stale" | "expired";
+      readonly ageMs?: number;
+      readonly ttlMs?: number;
+      readonly keyFingerprint?: string;
+    }
+  | {
+      readonly source: "unknown";
+      readonly reason?: string;
+    };
+
+export interface IncidentLiveStateAuthority {
+  readonly authoritative: boolean;
+  readonly actionsEnabled: boolean;
+  readonly liveStatus: RealtimeConnectionStatus;
+  readonly reason: string;
+  readonly featureProvenance: IncidentFeatureStateProvenance;
+  readonly metadataCache?: IncidentMetadataCacheState;
+}
+
+export interface IncidentLiveStateAuthorityOptions {
+  readonly featureProvenance?: IncidentFeatureStateProvenance;
+  readonly metadataCache?: IncidentMetadataCacheState;
+  readonly now?: number;
+}
+
+export const INCIDENT_METADATA_CACHE_STATE: IncidentMetadataCacheState = {
+  scope: "metadata",
+  status: "hit",
+  resources: ["schemas", "renderers", "legends", "domains"],
+  ageMs: 45_000,
+  ttlMs: 900_000,
+};
+
+const DEFAULT_FRESH_SNAPSHOT_MAX_AGE_MS = 15_000;
+
+export function inferIncidentFeatureProvenance<TFeature>(
+  state: RealtimeFeatureState<TFeature>,
+): IncidentFeatureStateProvenance {
+  const checkpoint = copyRealtimeResumeCheckpoint(state);
+  if (hasResumeCheckpoint(checkpoint)) {
+    return {
+      source: "realtime-delta",
+      checkpoint,
+    };
+  }
+  if (state.lastEventAt !== undefined && Object.keys(state.records).length > 0) {
+    return {
+      source: "fresh-snapshot",
+      fetchedAt: state.lastEventAt,
+      maxAgeMs: DEFAULT_FRESH_SNAPSHOT_MAX_AGE_MS,
+    };
+  }
+  return {
+    source: "unknown",
+    reason: "No realtime checkpoint or fresh snapshot has been received.",
+  };
+}
+
+export function evaluateIncidentLiveStateAuthority<TFeature>(
+  state: RealtimeFeatureState<TFeature>,
+  options: IncidentLiveStateAuthorityOptions = {},
+): IncidentLiveStateAuthority {
+  const featureProvenance = options.featureProvenance ?? inferIncidentFeatureProvenance(state);
+  const provenanceRejection = rejectNonAuthoritativeProvenance(featureProvenance, options.now ?? Date.now());
+  if (provenanceRejection) {
+    return {
+      authoritative: false,
+      actionsEnabled: false,
+      liveStatus: state.status,
+      reason: provenanceRejection,
+      featureProvenance,
+      metadataCache: options.metadataCache,
+    };
+  }
+
+  if (!isAuthoritativeConnectionStatus(state.status)) {
+    return {
+      authoritative: false,
+      actionsEnabled: false,
+      liveStatus: state.status,
+      reason: `Incident stream is ${state.status}; last incident state is read-only.`,
+      featureProvenance,
+      metadataCache: options.metadataCache,
+    };
+  }
+
+  return {
+    authoritative: true,
+    actionsEnabled: true,
+    liveStatus: state.status,
+    reason: "Incident feature state is sourced from the live stream.",
+    featureProvenance,
+    metadataCache: options.metadataCache,
+  };
+}
+
+export function formatIncidentAuthorityLabel(authority: IncidentLiveStateAuthority): string {
+  return authority.authoritative ? "Authoritative" : "Read-only";
+}
+
+export function formatIncidentFeatureProvenance(provenance: IncidentFeatureStateProvenance): string {
+  switch (provenance.source) {
+    case "realtime-delta":
+      return provenance.checkpoint ? `Realtime delta (${formatCheckpoint(provenance.checkpoint)})` : "Realtime delta";
+    case "cursor-watermark-replay":
+      return `Cursor/watermark replay (${formatCheckpoint(provenance.checkpoint)})`;
+    case "fresh-snapshot":
+      return `Fresh snapshot (${Math.round(provenance.maxAgeMs / 1_000)}s budget)`;
+    case "feature-result-cache":
+      return `Feature-result cache (${provenance.cacheStatus})`;
+    case "unknown":
+      return "Unknown feature provenance";
+  }
+}
+
+export function formatIncidentMetadataCacheState(cache: IncidentMetadataCacheState | undefined): string {
+  if (!cache) return "Metadata cache not used";
+  return `${titleCase(cache.status)} metadata (${cache.resources.join(", ")})`;
+}
+
+function copyRealtimeResumeCheckpoint<TFeature>(
+  state: RealtimeFeatureState<TFeature>,
+): RealtimeResumeCheckpoint | undefined {
+  return state.checkpoint ? { ...state.checkpoint } : undefined;
+}
+
+function rejectNonAuthoritativeProvenance(provenance: IncidentFeatureStateProvenance, now: number): string | undefined {
+  switch (provenance.source) {
+    case "feature-result-cache":
+      return provenance.cacheStatus === "stale" || provenance.cacheStatus === "expired"
+        ? "Stale feature-result cache cannot be authoritative incident state."
+        : "Feature-result cache provenance cannot be authoritative incident state.";
+    case "fresh-snapshot": {
+      const ageMs = Math.max(0, now - provenance.fetchedAt);
+      return ageMs > provenance.maxAgeMs ? "Explicit incident snapshot exceeded its freshness budget." : undefined;
+    }
+    case "cursor-watermark-replay":
+      return hasResumeCheckpoint(provenance.checkpoint)
+        ? undefined
+        : "Cursor/watermark replay is missing a resume checkpoint.";
+    case "realtime-delta":
+      return undefined;
+    case "unknown":
+      return provenance.reason ?? "Incident feature state provenance is unknown.";
+  }
+}
+
+function isAuthoritativeConnectionStatus(status: RealtimeConnectionStatus): boolean {
+  return status === "live";
+}
+
+function hasResumeCheckpoint(checkpoint: RealtimeResumeCheckpoint | undefined): checkpoint is RealtimeResumeCheckpoint {
+  return (
+    checkpoint !== undefined &&
+    (checkpoint.cursor !== undefined ||
+      checkpoint.watermark !== undefined ||
+      checkpoint.timestamp !== undefined ||
+      checkpoint.sequence !== undefined ||
+      checkpoint.deltaToken !== undefined)
+  );
+}
+
+function formatCheckpoint(checkpoint: RealtimeResumeCheckpoint): string {
+  if (checkpoint.cursor) return `cursor ${checkpoint.cursor}`;
+  if (checkpoint.watermark) return `watermark ${checkpoint.watermark}`;
+  if (checkpoint.deltaToken) return `delta ${checkpoint.deltaToken}`;
+  if (checkpoint.timestamp) return `timestamp ${checkpoint.timestamp}`;
+  if (checkpoint.sequence !== undefined) return `sequence ${checkpoint.sequence}`;
+  return "checkpoint pending";
+}
+
+function titleCase(value: string): string {
+  return value.replaceAll("-", " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}

--- a/examples/realtime-incident-dashboard/src/main.ts
+++ b/examples/realtime-incident-dashboard/src/main.ts
@@ -29,6 +29,14 @@ import {
 
 import { HONOLULU_CENTER, INCIDENT_LAYER_ID, INCIDENT_SOURCE_ID, INITIAL_INCIDENTS } from "./fixtures.js";
 import {
+  INCIDENT_METADATA_CACHE_STATE,
+  type IncidentLiveStateAuthority,
+  evaluateIncidentLiveStateAuthority,
+  formatIncidentAuthorityLabel,
+  formatIncidentFeatureProvenance,
+  formatIncidentMetadataCacheState,
+} from "./live-state.js";
+import {
   applyIncidentProjection,
   createIncidentLayerFilter,
   formatIncidentExtent,
@@ -55,6 +63,9 @@ interface IncidentRuntime {
   resume(): void;
   markStale(): void;
   refresh(): void;
+  authoritative: boolean;
+  featureProvenance: string;
+  metadataCacheStatus: string;
 }
 
 declare global {
@@ -237,10 +248,13 @@ function updateMapSource(map: maplibregl.Map, state: RealtimeFeatureState<Incide
   source?.setData(incidentFeatureCollection(incidentRecords(state)) as never);
 }
 
-function renderConnection(state: RealtimeFeatureState<IncidentFeature>): void {
+function renderConnection(state: RealtimeFeatureState<IncidentFeature>, authority: IncidentLiveStateAuthority): void {
   const badge = getElement<HTMLElement>("#connection-status");
   badge.dataset.status = state.status;
   badge.textContent = statusLabel(state.status);
+  const authorityBadge = getElement<HTMLElement>("#live-authority");
+  authorityBadge.dataset.authoritative = String(authority.authoritative);
+  authorityBadge.textContent = formatIncidentAuthorityLabel(authority);
   setText("#stream-cursor", state.cursor ?? "-");
   setText("#stream-ignored", String(state.ignoredEventCount));
   setText("#stream-records", String(Object.keys(state.records).length));
@@ -250,6 +264,8 @@ function renderConnection(state: RealtimeFeatureState<IncidentFeature>): void {
     state.watermark ?? formatTimestamp(new Date(state.lastEventAt ?? Date.now()).toISOString()),
   );
   setText("#stream-stale-since", state.staleSince ? formatTimestamp(new Date(state.staleSince).toISOString()) : "-");
+  setText("#feature-provenance", formatIncidentFeatureProvenance(authority.featureProvenance));
+  setText("#metadata-cache", formatIncidentMetadataCacheState(authority.metadataCache));
 }
 
 function renderSummary(summary: IncidentSummary, visibleCount: number): void {
@@ -271,6 +287,9 @@ function renderProjectionState(projection: LinkedViewQueryProjection, visibleCou
       spatialFilter: projection.spatialFilter,
       selection: projection.selection,
       cursor: window.__HONUA_INCIDENT_RUNTIME__?.cursor,
+      authoritative: window.__HONUA_INCIDENT_RUNTIME__?.authoritative,
+      featureProvenance: window.__HONUA_INCIDENT_RUNTIME__?.featureProvenance,
+      metadataCache: window.__HONUA_INCIDENT_RUNTIME__?.metadataCacheStatus,
     },
     null,
     2,
@@ -289,6 +308,7 @@ function readSelectedIncidentId(selection: ReadonlyArray<FeatureSelectionTarget>
 function renderIncidentList(
   incidents: readonly IncidentFeature[],
   selectedIncidentId: string | undefined,
+  authority: IncidentLiveStateAuthority,
   onSelect: (incident: IncidentFeature) => void,
 ): void {
   const list = getElement<HTMLElement>("#incident-list");
@@ -325,6 +345,8 @@ function renderIncidentList(
     button.textContent = "Open";
     button.dataset.testid = `select-${incident.id}`;
     button.setAttribute("aria-label", `Open ${incident.title}`);
+    button.disabled = !authority.actionsEnabled;
+    button.title = authority.actionsEnabled ? `Open ${incident.title}` : authority.reason;
     button.addEventListener("click", () => onSelect(incident));
     row.append(button);
     list.append(row);
@@ -503,6 +525,9 @@ async function bootstrap(): Promise<void> {
     resume: () => undefined,
     markStale: () => undefined,
     refresh: () => undefined,
+    authoritative: false,
+    featureProvenance: "Unknown feature provenance",
+    metadataCacheStatus: "Metadata cache not used",
   };
   window.__HONUA_INCIDENT_RUNTIME__ = runtime;
 
@@ -559,6 +584,9 @@ async function bootstrap(): Promise<void> {
     let latestProjection: LinkedViewQueryProjection | undefined;
     let selectedIncidentId: string | undefined;
     let activePopup: maplibregl.Popup | undefined;
+    let latestAuthority = evaluateIncidentLiveStateAuthority(store.state, {
+      metadataCache: INCIDENT_METADATA_CACHE_STATE,
+    });
 
     function currentIncidentById(id: string | undefined): IncidentFeature | undefined {
       if (!id) return undefined;
@@ -570,7 +598,7 @@ async function bootstrap(): Promise<void> {
       const projected = applyIncidentProjection(store.state, projection);
       renderSummary(projected.summary, projected.incidents.length);
       renderProjectionState(projection, projected.incidents.length);
-      renderIncidentList(projected.incidents, selectedIncidentId, (incident) => {
+      renderIncidentList(projected.incidents, selectedIncidentId, latestAuthority, (incident) => {
         tableSelection.select([sourceFeatureSelectionTarget(INCIDENT_SOURCE_ID, incident.id)], { replace: true });
       });
       runtime.visibleIncidentCount = projected.incidents.length;
@@ -598,13 +626,19 @@ async function bootstrap(): Promise<void> {
 
     store.subscribe(
       (state, event) => {
-        renderConnection(state);
+        latestAuthority = evaluateIncidentLiveStateAuthority(state, {
+          metadataCache: INCIDENT_METADATA_CACHE_STATE,
+        });
+        renderConnection(state, latestAuthority);
         updateMapSource(map, state);
         pushEventLog(event);
         renderEventLog();
         reconcileRealtimeSelection(tableView, state, { requireLiveRecord: false });
         runtime.status = state.status;
         runtime.cursor = state.cursor ?? null;
+        runtime.authoritative = latestAuthority.authoritative;
+        runtime.featureProvenance = formatIncidentFeatureProvenance(latestAuthority.featureProvenance);
+        runtime.metadataCacheStatus = formatIncidentMetadataCacheState(latestAuthority.metadataCache);
         if (latestProjection) renderProjectedIncidents(latestProjection);
         renderSelectedIncident(selectedIncidentId);
       },

--- a/examples/realtime-incident-dashboard/src/styles.css
+++ b/examples/realtime-incident-dashboard/src/styles.css
@@ -228,6 +228,15 @@ button:hover {
   background: rgba(15, 118, 110, 0.08);
 }
 
+button:disabled,
+button:disabled:hover {
+  border-color: var(--border);
+  background: #f3f5f7;
+  color: #6b7280;
+  cursor: not-allowed;
+  opacity: 0.68;
+}
+
 .filter-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -366,6 +375,14 @@ select {
 
 .map-overlay[data-state="error"] {
   background: rgba(185, 28, 28, 0.9);
+}
+
+#live-authority {
+  color: var(--red);
+}
+
+#live-authority[data-authoritative="true"] {
+  color: var(--green);
 }
 
 .detail-card p {

--- a/test/playwright/realtime-incident-dashboard.spec.mjs
+++ b/test/playwright/realtime-incident-dashboard.spec.mjs
@@ -20,6 +20,7 @@ test("realtime incident dashboard keeps map, queue, filters, and detail linked",
       .toBe(true);
 
     await expect(page.locator("#connection-status")).toHaveText("Live");
+    await expect(page.locator("#live-authority")).toHaveText("Authoritative");
     await expect(page.locator("#summary-active")).toHaveText("5");
     await expect(page.locator("#summary-critical")).toHaveText("1");
     await expect(page.locator("#projection-visible-count")).toHaveText("5");
@@ -50,14 +51,20 @@ test("realtime incident dashboard keeps map, queue, filters, and detail linked",
     await expect(page.locator("#detail-title")).toHaveText("No selected incident");
     await expect(page.locator("#stream-tombstones")).toHaveText("1");
 
+    await expect(page.getByRole("button", { name: "Open Harbor fuel sheen" })).toBeEnabled();
+
     await page.getByRole("button", { name: "Mark Stale" }).click();
     await expect(page.locator("#connection-status")).toHaveText("Stale");
+    await expect(page.locator("#live-authority")).toHaveText("Read-only");
+    await expect(page.getByRole("button", { name: "Open Harbor fuel sheen" })).toBeDisabled();
 
     await page.getByRole("button", { name: "Reconnect" }).click();
     await expect(page.locator("#connection-status")).toHaveText("Reconnecting");
 
     await page.getByRole("button", { name: "Resume" }).click();
     await expect(page.locator("#connection-status")).toHaveText("Live");
+    await expect(page.locator("#live-authority")).toHaveText("Authoritative");
+    await expect(page.getByRole("button", { name: "Open Harbor fuel sheen" })).toBeEnabled();
 
     const recordCount = await page.locator("#stream-records").textContent();
     await page.getByRole("button", { name: "Refresh" }).click();

--- a/test/realtime-incident-dashboard.test.ts
+++ b/test/realtime-incident-dashboard.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { INCIDENT_SOURCE_ID } from "../examples/realtime-incident-dashboard/src/fixtures.js";
+import { INCIDENT_SOURCE_ID, INITIAL_INCIDENTS } from "../examples/realtime-incident-dashboard/src/fixtures.js";
+import {
+  INCIDENT_METADATA_CACHE_STATE,
+  evaluateIncidentLiveStateAuthority,
+  formatIncidentMetadataCacheState,
+} from "../examples/realtime-incident-dashboard/src/live-state.js";
 import { applyIncidentProjection, incidentRecords } from "../examples/realtime-incident-dashboard/src/projection.js";
 import { createFixtureIncidentTransport } from "../examples/realtime-incident-dashboard/src/realtime-fixture.js";
 import type { IncidentFeature } from "../examples/realtime-incident-dashboard/src/types.js";
@@ -9,7 +14,13 @@ import {
   selectLinkedViewQueryProjection,
   sourceFeatureSelectionTarget,
 } from "../src/exploration/index.js";
-import { createRealtimeFeatureStore, realtimeFeatureKey, reconcileRealtimeSelection } from "../src/realtime/index.js";
+import {
+  createRealtimeFeatureStore,
+  emptyRealtimeFeatureState,
+  realtimeFeatureKey,
+  reconcileRealtimeSelection,
+  reduceRealtimeFeatureState,
+} from "../src/realtime/index.js";
 
 describe("realtime incident dashboard fixture", () => {
   it("projects live incident deltas through the linked exploration context", () => {
@@ -62,6 +73,145 @@ describe("realtime incident dashboard fixture", () => {
     expect(incidentRecords(store.state)).toHaveLength(6);
 
     context.dispose();
+  });
+
+  it("rejects stale feature-result cache provenance as authoritative live state", () => {
+    const store = createRealtimeFeatureStore<IncidentFeature>();
+    const transport = createFixtureIncidentTransport();
+    store.connect(transport, { sourceId: INCIDENT_SOURCE_ID });
+
+    const authority = evaluateIncidentLiveStateAuthority(store.state, {
+      featureProvenance: {
+        source: "feature-result-cache",
+        cacheStatus: "stale",
+        ageMs: 3_600_000,
+        ttlMs: 300_000,
+        keyFingerprint: "incident-query-cache",
+      },
+      metadataCache: INCIDENT_METADATA_CACHE_STATE,
+    });
+
+    expect(authority.authoritative).toBe(false);
+    expect(authority.actionsEnabled).toBe(false);
+    expect(authority.reason).toContain("feature-result cache");
+    expect(authority.metadataCache).toMatchObject({
+      scope: "metadata",
+      status: "hit",
+    });
+  });
+
+  it("allows metadata cache freshness without treating it as feature authority", () => {
+    const store = createRealtimeFeatureStore<IncidentFeature>();
+    const transport = createFixtureIncidentTransport();
+    store.connect(transport, { sourceId: INCIDENT_SOURCE_ID });
+
+    const metadataCache = {
+      ...INCIDENT_METADATA_CACHE_STATE,
+      status: "stale" as const,
+      ageMs: 1_200_000,
+    };
+    const authority = evaluateIncidentLiveStateAuthority(store.state, {
+      featureProvenance: {
+        source: "realtime-delta",
+        checkpoint: {
+          cursor: store.state.cursor ?? "fixture-cursor",
+        },
+      },
+      metadataCache,
+    });
+
+    expect(authority.authoritative).toBe(true);
+    expect(authority.actionsEnabled).toBe(true);
+    expect(authority.metadataCache?.status).toBe("stale");
+    expect(formatIncidentMetadataCacheState(authority.metadataCache)).toContain("Stale metadata");
+  });
+
+  it("accepts explicit fresh snapshots only inside the configured freshness budget", () => {
+    const state = reduceRealtimeFeatureState(emptyRealtimeFeatureState<IncidentFeature>(), {
+      type: "snapshot",
+      receivedAt: 1_000,
+      features: INITIAL_INCIDENTS.map((incident) => ({
+        sourceId: INCIDENT_SOURCE_ID,
+        id: incident.id,
+        feature: incident,
+      })),
+    });
+
+    const featureProvenance = {
+      source: "fresh-snapshot" as const,
+      fetchedAt: 1_000,
+      maxAgeMs: 1_000,
+    };
+
+    expect(
+      evaluateIncidentLiveStateAuthority(state, {
+        featureProvenance,
+        now: 1_500,
+      }).authoritative,
+    ).toBe(true);
+    expect(
+      evaluateIncidentLiveStateAuthority(state, {
+        featureProvenance,
+        now: 2_500,
+      }),
+    ).toMatchObject({
+      authoritative: false,
+      actionsEnabled: false,
+    });
+  });
+
+  it("represents stale and offline live state separately from metadata cache freshness", () => {
+    let clock = 20_000;
+    const store = createRealtimeFeatureStore<IncidentFeature>();
+    const transport = createFixtureIncidentTransport({ now: () => clock });
+    store.connect(transport, { sourceId: INCIDENT_SOURCE_ID });
+
+    const metadataCache = {
+      ...INCIDENT_METADATA_CACHE_STATE,
+      status: "hit" as const,
+      ageMs: 500,
+    };
+
+    clock += 2_000;
+    store.checkStale({ staleAfterMs: 1_000, now: clock });
+    const staleAuthority = evaluateIncidentLiveStateAuthority(store.state, {
+      metadataCache,
+      now: clock,
+    });
+
+    expect(staleAuthority).toMatchObject({
+      authoritative: false,
+      actionsEnabled: false,
+      liveStatus: "stale",
+      metadataCache: {
+        status: "hit",
+      },
+    });
+    expect(staleAuthority.reason).toContain("stale");
+
+    transport.resume();
+    expect(
+      evaluateIncidentLiveStateAuthority(store.state, {
+        metadataCache,
+        now: clock,
+      }).authoritative,
+    ).toBe(true);
+
+    transport.offline();
+    const offlineAuthority = evaluateIncidentLiveStateAuthority(store.state, {
+      metadataCache,
+      now: clock,
+    });
+
+    expect(offlineAuthority).toMatchObject({
+      authoritative: false,
+      actionsEnabled: false,
+      liveStatus: "offline",
+      metadataCache: {
+        status: "hit",
+      },
+    });
+    expect(offlineAuthority.reason).toContain("offline");
   });
 
   it("marks stale streams and reconciles archived selected incidents", () => {


### PR DESCRIPTION
Summary: Adds explicit live-state authority and provenance checks to the realtime incident dashboard, keeps metadata cache state visible but non-authoritative for feature state, and disables incident actions when the stream is stale or offline. Validation: npm test -- test/realtime-incident-dashboard.test.ts test/realtime.test.ts test/entrypoints.test.ts; npm run check; npm run build; npm run demo:incident:typecheck; npm run demo:incident:build; npm run test:playwright:incident. Closes #95.