### PR TITLE
Add SDK metadata cache state

### DIFF
--- a/docs/metadata-caching-strategy.md
+++ b/docs/metadata-caching-strategy.md
@@ -162,6 +162,30 @@ Cache-state visibility requirements:
 - A caller-forced bypass returns `status: "bypass"` and must not populate a
   shared cache unless the caller also opts into write-through.
 
+### JavaScript SDK Surface
+
+`@honua/sdk-js` exports the transport-neutral `HonuaCacheState`,
+`HonuaCacheStatus`, `HonuaCacheScope`, `HonuaCacheValidator`, and
+`HonuaMetadataRequestOptions` types from both the root and `/honua`
+entrypoints. Metadata and discovery helpers accept:
+
+```ts
+await client.getLayerMetadata("civic-services", 0);
+await client.getLayerMetadata("civic-services", 0, { refresh: true });
+await client.getLayerMetadata("civic-services", 0, { cache: "bypass" });
+```
+
+Default metadata reads reuse the SDK-local metadata entry when present and
+return `cache.status: "hit"`. `refresh: true` skips that fresh-cache shortcut,
+sends `ETag` / `Last-Modified` validators when the adapter has them, and
+reports `refreshed` for successful revalidation. `cache: "bypass"` skips cache
+lookup and write-through for that call.
+
+Feature rows, object ids, counts, statistics, spatial queries, STAC searches,
+tiles, and process/job results remain uncached by default. Those result reads
+should expose `scope: "materialized-result"` only when a separate
+materialization workflow explicitly owns the persisted result.
+
 ## Feature, Query, And Result Caching
 
 Feature/query/result caching is opt-in materialization only. Default SDK and

--- a/examples/service-explorer/src/data.ts
+++ b/examples/service-explorer/src/data.ts
@@ -1,5 +1,6 @@
-import { HonuaClient } from "@honua/sdk-js/honua";
+import { HonuaClient, createHonuaCacheState } from "@honua/sdk-js/honua";
 import type {
+  HonuaCacheState,
   HonuaFeature,
   HonuaLayerMetadata,
   HonuaServiceMetadata,
@@ -80,6 +81,10 @@ export function createFixtureServiceExplorerDataset(
     ...FIXTURE_SOURCE_METADATA,
     cache: {
       ...FIXTURE_SOURCE_METADATA.cache,
+      state: {
+        ...FIXTURE_SOURCE_METADATA.cache.state,
+        ageMs: Math.max(0, now - FIXTURE_SOURCE_METADATA.cache.updatedAt),
+      },
       updatedAt: FIXTURE_SOURCE_METADATA.cache.updatedAt || now,
     },
     diagnostics,
@@ -176,6 +181,11 @@ async function loadCloudServiceExplorerDataset(
     capabilities,
     cache: {
       status: "ready",
+      state:
+        layerMetadata.cache ??
+        serviceMetadata.cache ??
+        servicesResponse.cache ??
+        createServiceExplorerCacheState(sourceId),
       source: "cloud",
       updatedAt: now,
       revalidateAfterMs: FIXTURE_REVALIDATE_AFTER_MS,
@@ -201,6 +211,14 @@ async function loadCloudServiceExplorerDataset(
     diagnostics,
     queryDurationMs,
   };
+}
+
+function createServiceExplorerCacheState(sourceId: string): HonuaCacheState {
+  return createHonuaCacheState({
+    scope: "metadata",
+    status: "miss",
+    keyFingerprint: `metadata:service-explorer:${sourceId}`,
+  });
 }
 
 function servicesFromResponse(

--- a/examples/service-explorer/src/explorer-workspace.ts
+++ b/examples/service-explorer/src/explorer-workspace.ts
@@ -221,11 +221,25 @@ function withCacheStatus(
   status: HonuaSourceCacheStatus,
   now: number,
 ): ServiceExplorerSourceMetadata {
+  const cacheStateStatus =
+    status === "stale" || status === "error"
+      ? "stale"
+      : status === "loading"
+        ? metadata.cache.state.status
+        : metadata.cache.state.status === "hit"
+          ? "refreshed"
+          : metadata.cache.state.status;
   return {
     ...metadata,
     cache: {
       ...metadata.cache,
       status,
+      state: {
+        ...metadata.cache.state,
+        status: cacheStateStatus,
+        ageMs: Math.max(0, now - metadata.cache.updatedAt),
+        ...(status === "ready" ? { revalidatedAt: new Date(now).toISOString() } : {}),
+      },
       updatedAt: now,
       lastRevalidatedAt: status === "ready" ? now : metadata.cache.lastRevalidatedAt,
     },

--- a/examples/service-explorer/src/fixtures.ts
+++ b/examples/service-explorer/src/fixtures.ts
@@ -275,6 +275,14 @@ export const FIXTURE_SOURCE_METADATA: ServiceExplorerSourceMetadata = {
   capabilities: FIXTURE_CAPABILITIES,
   cache: {
     status: "ready",
+    state: {
+      scope: "metadata",
+      status: "hit",
+      keyFingerprint: `metadata:fixture:${FIXTURE_SOURCE_ID}`,
+      ageMs: 0,
+      ttlMs: FIXTURE_REVALIDATE_AFTER_MS,
+      sourceUpdatedAt: new Date(FIXTURE_UPDATED_AT).toISOString(),
+    },
     source: "fixture",
     updatedAt: FIXTURE_UPDATED_AT,
     revalidateAfterMs: FIXTURE_REVALIDATE_AFTER_MS,

--- a/examples/service-explorer/src/main.ts
+++ b/examples/service-explorer/src/main.ts
@@ -172,10 +172,14 @@ function renderCacheAndDiagnostics(
   const entry = cache.entries[dataset.sourceId];
   const metadata = entry?.metadata ?? dataset.metadata;
 
-  setText("#cache-status", entry?.status ?? metadata.cache.status);
+  const displayStatus = entry?.status === "loading" ? "loading" : metadata.cache.state.status;
+  setText("#cache-status", displayStatus);
   setText("#cache-updated", formatTimestamp(entry?.updatedAt ?? metadata.cache.updatedAt));
   setText("#cache-source", metadata.cache.source === "cloud" ? "Cloud Honua" : "Fixture");
-  setText("#cache-revalidate", `${Math.round(metadata.cache.revalidateAfterMs / 1000)} seconds`);
+  setText(
+    "#cache-revalidate",
+    `${Math.round((metadata.cache.state.ttlMs ?? metadata.cache.revalidateAfterMs) / 1000)} seconds`,
+  );
 
   const jobs = selectHonuaAppWorkspaceJobModel(workspace.workspace.state);
   setText("#job-status", jobs.entries["linked-query-projection"]?.snapshot.status ?? "waiting");

--- a/examples/service-explorer/src/types.ts
+++ b/examples/service-explorer/src/types.ts
@@ -1,6 +1,7 @@
 import type { HonuaSourceCacheStatus } from "@honua/sdk-js/app-workspace";
 import type {
   EsriGeometryType,
+  HonuaCacheState,
   HonuaExtent,
   HonuaFeature,
   HonuaFieldInfo,
@@ -66,6 +67,7 @@ export interface ServiceExplorerCatalog {
 
 export interface ServiceExplorerCacheInfo {
   readonly status: HonuaSourceCacheStatus;
+  readonly state: HonuaCacheState;
   readonly source: ServiceExplorerDataSource;
   readonly updatedAt: number;
   readonly revalidateAfterMs: number;

--- a/src/core/cache-state.ts
+++ b/src/core/cache-state.ts
@@ -1,0 +1,173 @@
+export type HonuaCacheScope = "metadata" | "materialized-result";
+
+export type HonuaCacheStatus = "hit" | "miss" | "stale" | "refreshed" | "bypass";
+
+export type HonuaCacheReadMode = "default" | "bypass";
+
+export interface HonuaCacheValidator {
+  readonly etag?: string;
+  readonly lastModified?: string;
+}
+
+export interface HonuaCacheState {
+  readonly scope: HonuaCacheScope;
+  readonly status: HonuaCacheStatus;
+  readonly keyFingerprint: string;
+  readonly ageMs?: number;
+  readonly ttlMs?: number;
+  readonly staleIfErrorMs?: number;
+  readonly revalidatedAt?: string;
+  readonly sourceUpdatedAt?: string;
+  readonly validator?: HonuaCacheValidator;
+  readonly invalidationReason?: string;
+  readonly refreshErrorId?: string;
+}
+
+export interface HonuaMetadataRequestOptions {
+  readonly signal?: AbortSignal;
+  /**
+   * Revalidate even when an SDK-local metadata entry is present. Adapters send
+   * conditional validators when available and report `refreshed` on success.
+   */
+  readonly refresh?: boolean;
+  /**
+   * `default` reads and writes the adapter metadata cache. `bypass` skips cache
+   * lookup and write-through for endpoints that support SDK-local caching.
+   */
+  readonly cache?: HonuaCacheReadMode;
+  /**
+   * Allow a cached metadata entry to be returned as `stale` when refresh fails.
+   * Defaults to `true`; ignored when no cached metadata entry exists.
+   */
+  readonly staleIfError?: boolean;
+  /** Optional freshness budget surfaced to callers in `HonuaCacheState`. */
+  readonly ttlMs?: number;
+  /** Optional stale fallback window surfaced to callers in `HonuaCacheState`. */
+  readonly staleIfErrorMs?: number;
+}
+
+export interface NormalizedHonuaMetadataRequestOptions {
+  readonly signal?: AbortSignal;
+  readonly refresh: boolean;
+  readonly cache: HonuaCacheReadMode;
+  readonly staleIfError: boolean;
+  readonly ttlMs?: number;
+  readonly staleIfErrorMs?: number;
+}
+
+export interface HonuaCacheStateInit {
+  readonly scope: HonuaCacheScope;
+  readonly status: HonuaCacheStatus;
+  readonly keyFingerprint: string;
+  readonly ageMs?: number;
+  readonly ttlMs?: number;
+  readonly staleIfErrorMs?: number;
+  readonly revalidatedAt?: string;
+  readonly sourceUpdatedAt?: string;
+  readonly validator?: HonuaCacheValidator;
+  readonly invalidationReason?: string;
+  readonly refreshErrorId?: string;
+}
+
+export function createHonuaCacheState(init: HonuaCacheStateInit): HonuaCacheState {
+  return {
+    scope: init.scope,
+    status: init.status,
+    keyFingerprint: init.keyFingerprint,
+    ...(init.ageMs !== undefined ? { ageMs: Math.max(0, Math.trunc(init.ageMs)) } : {}),
+    ...(init.ttlMs !== undefined ? { ttlMs: Math.max(0, Math.trunc(init.ttlMs)) } : {}),
+    ...(init.staleIfErrorMs !== undefined ? { staleIfErrorMs: Math.max(0, Math.trunc(init.staleIfErrorMs)) } : {}),
+    ...(init.revalidatedAt ? { revalidatedAt: init.revalidatedAt } : {}),
+    ...(init.sourceUpdatedAt ? { sourceUpdatedAt: init.sourceUpdatedAt } : {}),
+    ...(hasHonuaCacheValidator(init.validator) ? { validator: init.validator } : {}),
+    ...(init.invalidationReason ? { invalidationReason: init.invalidationReason } : {}),
+    ...(init.refreshErrorId ? { refreshErrorId: init.refreshErrorId } : {}),
+  };
+}
+
+export function normalizeHonuaMetadataRequestOptions(
+  options: HonuaMetadataRequestOptions = {},
+): NormalizedHonuaMetadataRequestOptions {
+  return {
+    ...(options.signal ? { signal: options.signal } : {}),
+    refresh: options.refresh === true,
+    cache: options.cache === "bypass" ? "bypass" : "default",
+    staleIfError: options.staleIfError !== false,
+    ...(normalizeNonNegativeInteger(options.ttlMs) !== undefined
+      ? { ttlMs: normalizeNonNegativeInteger(options.ttlMs) }
+      : {}),
+    ...(normalizeNonNegativeInteger(options.staleIfErrorMs) !== undefined
+      ? { staleIfErrorMs: normalizeNonNegativeInteger(options.staleIfErrorMs) }
+      : {}),
+  };
+}
+
+export function isHonuaCacheStatus(value: unknown): value is HonuaCacheStatus {
+  return value === "hit" || value === "miss" || value === "stale" || value === "refreshed" || value === "bypass";
+}
+
+export function honuaCacheValidatorFromHeaders(headers: Headers): HonuaCacheValidator | undefined {
+  const etag = headers.get("etag") ?? undefined;
+  const lastModified = headers.get("last-modified") ?? undefined;
+  return hasHonuaCacheValidator({ etag, lastModified })
+    ? { ...(etag ? { etag } : {}), ...(lastModified ? { lastModified } : {}) }
+    : undefined;
+}
+
+export function honuaMetadataRequestHeaders(options: {
+  readonly accept?: string;
+  readonly refresh?: boolean;
+  readonly bypass?: boolean;
+  readonly validator?: HonuaCacheValidator;
+}): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: options.accept ?? "application/json",
+  };
+
+  if (options.bypass) {
+    headers["Cache-Control"] = "no-store";
+    headers.Pragma = "no-cache";
+    return headers;
+  }
+
+  if (options.refresh) {
+    headers["Cache-Control"] = "no-cache";
+    if (options.validator?.etag) {
+      headers["If-None-Match"] = options.validator.etag;
+    }
+    if (options.validator?.lastModified) {
+      headers["If-Modified-Since"] = options.validator.lastModified;
+    }
+  }
+
+  return headers;
+}
+
+export function withHonuaCacheState<T>(value: T, cache: HonuaCacheState): T {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return value;
+  }
+  return {
+    ...(value as Record<string, unknown>),
+    cache,
+  } as T;
+}
+
+export function withoutHonuaCacheState<T>(value: T): T {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return value;
+  }
+  const { cache: _cache, ...rest } = value as Record<string, unknown>;
+  return rest as T;
+}
+
+function hasHonuaCacheValidator(value: HonuaCacheValidator | undefined): value is HonuaCacheValidator {
+  return Boolean(value?.etag || value?.lastModified);
+}
+
+function normalizeNonNegativeInteger(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  return Math.max(0, Math.trunc(value));
+}

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,5 +1,15 @@
 import type { Client } from "@connectrpc/connect";
 import type { FeatureService } from "../gen/honua/v1/feature_service_pb.js";
+import {
+  type HonuaCacheValidator,
+  type HonuaMetadataRequestOptions,
+  createHonuaCacheState,
+  honuaCacheValidatorFromHeaders,
+  honuaMetadataRequestHeaders,
+  normalizeHonuaMetadataRequestOptions,
+  withHonuaCacheState,
+  withoutHonuaCacheState,
+} from "./cache-state.js";
 import { HonuaAbortError, HonuaHttpError, HonuaNetworkError, HonuaTimeoutError } from "./errors.js";
 import { HonuaOgcMaps } from "./ogc-maps.js";
 import { HonuaOgcProcesses } from "./ogc-processes.js";
@@ -234,6 +244,14 @@ interface CachedAuthCredentials {
   expiresAtMs: number | undefined;
 }
 
+interface MetadataCacheEntry<T = unknown> {
+  body: T;
+  cachedAtMs: number;
+  keyFingerprint: string;
+  validator?: HonuaCacheValidator;
+  sourceUpdatedAt?: string;
+}
+
 export class HonuaClient {
   public static readonly minimumSupportedServerVersion = HONUA_MINIMUM_SUPPORTED_SERVER_VERSION;
   public static readonly minimumSupportedServerReleaseChannel = MINIMUM_SUPPORTED_SERVER_RELEASE_CHANNEL;
@@ -252,6 +270,7 @@ export class HonuaClient {
   private authCredentialsCache: CachedAuthCredentials | undefined;
   private authRefreshPromise: Promise<CachedAuthCredentials | undefined> | undefined;
   private connectClient: Client<typeof FeatureService> | undefined;
+  private readonly metadataCache = new Map<string, MetadataCacheEntry>();
 
   public constructor(options: HonuaClientOptions) {
     this.baseUrl = normalizeBaseUrl(options.baseUrl);
@@ -427,9 +446,32 @@ export class HonuaClient {
     return new HonuaStacSearch({ client: this });
   }
 
-  public async listServices(format: "json" | "pjson" = "json"): Promise<HonuaServicesResponse> {
+  public clearMetadataCache(options: { keyPrefix?: string } = {}): void {
+    if (!options.keyPrefix) {
+      this.metadataCache.clear();
+      return;
+    }
+    const prefix = `metadata:${options.keyPrefix}`;
+    for (const key of this.metadataCache.keys()) {
+      if (key.startsWith(prefix)) {
+        this.metadataCache.delete(key);
+      }
+    }
+  }
+
+  public async listServices(
+    formatOrOptions: "json" | "pjson" | HonuaMetadataRequestOptions = "json",
+    options: HonuaMetadataRequestOptions = {},
+  ): Promise<HonuaServicesResponse> {
+    const format = typeof formatOrOptions === "string" ? formatOrOptions : "json";
+    const metadataOptions = typeof formatOrOptions === "string" ? options : formatOrOptions;
     const query = new URLSearchParams({ f: format });
-    return this.requestJson("GET", `/rest/services?${query.toString()}`) as Promise<HonuaServicesResponse>;
+    const path = `/rest/services?${query.toString()}`;
+    return this.requestCachedMetadataJson<HonuaServicesResponse>(
+      `geoservices:services:${format}`,
+      path,
+      metadataOptions,
+    );
   }
 
   public async getCompatibility(options: HonuaCompatibilityRequest = {}): Promise<HonuaServerCompatibility> {
@@ -600,6 +642,7 @@ export class HonuaClient {
     path: string,
     init?: RequestInit,
     callerSignal?: AbortSignal,
+    options: { okStatuses?: readonly number[] } = {},
   ): Promise<Response> {
     let request: HonuaRequestContext = {
       url: resolveRequestUrl(this.baseUrl, path),
@@ -645,7 +688,7 @@ export class HonuaClient {
       }
       const durationMs = performance.now() - startTime;
 
-      if (!response.ok) {
+      if (!response.ok && !options.okStatuses?.includes(response.status)) {
         const body = await parseResponseBody(response.clone());
         const httpError = this.toHttpError(response.status, body);
         if (this.shouldRetryRequest(request.method, attempt, response.status, httpError)) {
@@ -667,53 +710,241 @@ export class HonuaClient {
     }
   }
 
-  public async getLayerMetadata(serviceId: string, layerId: number): Promise<HonuaLayerMetadata> {
-    const query = new URLSearchParams({ f: "json" });
-    return this.requestJson(
-      "GET",
-      `/rest/services/${encodeURIComponent(serviceId)}/FeatureServer/${layerId}?${query.toString()}`,
-    ) as Promise<HonuaLayerMetadata>;
+  private async requestCachedMetadataJson<T>(
+    cacheKey: string,
+    path: string,
+    options: HonuaMetadataRequestOptions = {},
+  ): Promise<T> {
+    const metadataOptions = normalizeHonuaMetadataRequestOptions(options);
+    const keyFingerprint = `metadata:${cacheKey}`;
+    const cached = this.metadataCache.get(keyFingerprint) as MetadataCacheEntry<T> | undefined;
+    const bypass = metadataOptions.cache === "bypass";
+
+    if (!bypass && !metadataOptions.refresh && cached) {
+      return withHonuaCacheState(
+        cached.body,
+        createMetadataCacheState(cached, "hit", {
+          now: Date.now(),
+          ttlMs: metadataOptions.ttlMs,
+          staleIfErrorMs: metadataOptions.staleIfErrorMs,
+        }),
+      );
+    }
+
+    let request: HonuaRequestContext = {
+      url: resolveRequestUrl(this.baseUrl, path),
+      path,
+      method: "GET",
+      init: {
+        method: "GET",
+        headers: await this.composeHeaders(
+          honuaMetadataRequestHeaders({
+            accept: "application/json",
+            refresh: metadataOptions.refresh,
+            bypass,
+            validator: cached?.validator,
+          }),
+        ),
+      },
+    };
+
+    request = await this.applyBeforeInterceptors(request);
+
+    for (let attempt = 0; ; attempt += 1) {
+      let response: Response;
+      const timeout = createTimeoutSignal(metadataOptions.signal ?? request.init.signal, this.timeoutMs);
+      const startTime = performance.now();
+      try {
+        response = await this.fetchFn(request.url, {
+          ...request.init,
+          method: request.method,
+          signal: timeout.signal,
+        });
+      } catch (error) {
+        const durationMs = performance.now() - startTime;
+        const normalizedError = timeout.didTimeout
+          ? new HonuaTimeoutError(this.timeoutMs ?? 0)
+          : normalizeNetworkError(error);
+        if (this.shouldRetryRequest(request.method, attempt, undefined, normalizedError)) {
+          await sleep(this.resolveRetryDelayMs(attempt));
+          continue;
+        }
+        const stale = this.staleMetadataFallback(cached, metadataOptions, normalizedError);
+        if (stale) return stale;
+        await this.applyErrorInterceptors({
+          request: cloneRequestContext(request),
+          error: normalizedError,
+          durationMs,
+        });
+        throw normalizedError;
+      } finally {
+        timeout.dispose();
+      }
+      const durationMs = performance.now() - startTime;
+
+      if (response.status === 304 && cached && !bypass) {
+        try {
+          await this.applyAfterInterceptors(cloneRequestContext(request), response, durationMs);
+        } catch (error) {
+          await this.applyErrorInterceptors({ request: cloneRequestContext(request), error, durationMs });
+          throw error;
+        }
+        const updatedEntry: MetadataCacheEntry<T> = {
+          ...cached,
+          cachedAtMs: Date.now(),
+          ...((honuaCacheValidatorFromHeaders(response.headers) ?? cached.validator)
+            ? { validator: honuaCacheValidatorFromHeaders(response.headers) ?? cached.validator }
+            : {}),
+        };
+        this.metadataCache.set(keyFingerprint, updatedEntry);
+        return withHonuaCacheState(
+          updatedEntry.body,
+          createMetadataCacheState(updatedEntry, "refreshed", {
+            now: Date.now(),
+            ttlMs: metadataOptions.ttlMs,
+            staleIfErrorMs: metadataOptions.staleIfErrorMs,
+            revalidatedAt: new Date().toISOString(),
+          }),
+        );
+      }
+
+      const body = await parseResponseBody(response.clone());
+      if (!response.ok) {
+        const httpError = this.toHttpError(response.status, body);
+        if (this.shouldRetryRequest(request.method, attempt, response.status, httpError)) {
+          await sleep(this.resolveRetryDelayMs(attempt, response));
+          continue;
+        }
+        const stale = this.staleMetadataFallback(cached, metadataOptions, httpError);
+        if (stale) return stale;
+        await this.applyErrorInterceptors({ request: cloneRequestContext(request), error: httpError, durationMs });
+        throw httpError;
+      }
+
+      try {
+        await this.applyAfterInterceptors(cloneRequestContext(request), response, durationMs);
+      } catch (error) {
+        await this.applyErrorInterceptors({ request: cloneRequestContext(request), error, durationMs });
+        throw error;
+      }
+
+      const cleanBody = withoutHonuaCacheState(body) as T;
+      const validator = honuaCacheValidatorFromHeaders(response.headers);
+      const sourceUpdatedAt = response.headers.get("last-modified") ?? undefined;
+      const entry: MetadataCacheEntry<T> = {
+        body: cleanBody,
+        cachedAtMs: Date.now(),
+        keyFingerprint,
+        ...(validator ? { validator } : {}),
+        ...(sourceUpdatedAt ? { sourceUpdatedAt } : {}),
+      };
+      const status = bypass ? "bypass" : cached ? "refreshed" : "miss";
+      if (!bypass) {
+        this.metadataCache.set(keyFingerprint, entry);
+      }
+      return withHonuaCacheState(
+        cleanBody,
+        createMetadataCacheState(entry, status, {
+          now: Date.now(),
+          ttlMs: metadataOptions.ttlMs,
+          staleIfErrorMs: metadataOptions.staleIfErrorMs,
+          ...(status === "refreshed" ? { revalidatedAt: new Date().toISOString() } : {}),
+        }),
+      );
+    }
   }
 
-  public async getFeatureServiceMetadata(serviceId: string): Promise<HonuaServiceMetadata> {
+  private staleMetadataFallback<T>(
+    cached: MetadataCacheEntry<T> | undefined,
+    options: ReturnType<typeof normalizeHonuaMetadataRequestOptions>,
+    error: unknown,
+  ): T | undefined {
+    if (!cached || options.cache === "bypass" || !options.staleIfError) {
+      return undefined;
+    }
+    return withHonuaCacheState(
+      cached.body,
+      createMetadataCacheState(cached, "stale", {
+        now: Date.now(),
+        ttlMs: options.ttlMs,
+        staleIfErrorMs: options.staleIfErrorMs,
+        refreshErrorId: metadataRefreshErrorId(error),
+      }),
+    );
+  }
+
+  public async getLayerMetadata(
+    serviceId: string,
+    layerId: number,
+    options: HonuaMetadataRequestOptions = {},
+  ): Promise<HonuaLayerMetadata> {
     const query = new URLSearchParams({ f: "json" });
-    return this.requestJson(
-      "GET",
-      `/rest/services/${encodeURIComponent(serviceId)}/FeatureServer?${query.toString()}`,
-    ) as Promise<HonuaServiceMetadata>;
+    const path = `/rest/services/${encodeURIComponent(serviceId)}/FeatureServer/${layerId}?${query.toString()}`;
+    return this.requestCachedMetadataJson<HonuaLayerMetadata>(
+      `geoservices-feature:${serviceId}:${layerId}`,
+      path,
+      options,
+    );
+  }
+
+  public async getFeatureServiceMetadata(
+    serviceId: string,
+    options: HonuaMetadataRequestOptions = {},
+  ): Promise<HonuaServiceMetadata> {
+    const query = new URLSearchParams({ f: "json" });
+    const path = `/rest/services/${encodeURIComponent(serviceId)}/FeatureServer?${query.toString()}`;
+    return this.requestCachedMetadataJson<HonuaServiceMetadata>(
+      `geoservices-feature:${serviceId}:service`,
+      path,
+      options,
+    );
   }
 
   public async getOgcFeaturesLanding(request: OgcMetadataRequest = {}): Promise<HonuaOgcLandingResponse> {
     const params = createOgcMetadataParams(request);
-    return this.requestJson("GET", `/ogc/features?${params.toString()}`) as Promise<HonuaOgcLandingResponse>;
+    return this.requestCachedMetadataJson<HonuaOgcLandingResponse>(
+      `ogc-features:landing:${params.toString()}`,
+      `/ogc/features?${params.toString()}`,
+      request,
+    );
   }
 
   public async getOgcFeaturesConformance(request: OgcMetadataRequest = {}): Promise<HonuaOgcConformanceResponse> {
     const params = createOgcMetadataParams(request);
-    return this.requestJson(
-      "GET",
+    return this.requestCachedMetadataJson<HonuaOgcConformanceResponse>(
+      `ogc-features:conformance:${params.toString()}`,
       `/ogc/features/conformance?${params.toString()}`,
-    ) as Promise<HonuaOgcConformanceResponse>;
+      request,
+    );
   }
 
   public async listOgcCollections(request: OgcMetadataRequest = {}): Promise<HonuaOgcCollectionsResponse> {
     const params = createOgcMetadataParams(request);
-    return this.requestJson(
-      "GET",
+    return this.requestCachedMetadataJson<HonuaOgcCollectionsResponse>(
+      `ogc-features:collections:${params.toString()}`,
       `/ogc/features/collections?${params.toString()}`,
-    ) as Promise<HonuaOgcCollectionsResponse>;
+      request,
+    );
   }
 
   public async getOgcCollection(request: OgcCollectionRequest): Promise<HonuaOgcCollectionMetadata> {
     const params = createOgcMetadataParams(request);
     const path = `/ogc/features/collections/${encodeURIComponent(String(request.collectionId))}`;
-    return this.requestJson("GET", `${path}?${params.toString()}`) as Promise<HonuaOgcCollectionMetadata>;
+    return this.requestCachedMetadataJson<HonuaOgcCollectionMetadata>(
+      `ogc-features:collection:${request.collectionId}:${params.toString()}`,
+      `${path}?${params.toString()}`,
+      request,
+    );
   }
 
   public async getOgcQueryables(request: OgcCollectionRequest): Promise<HonuaOgcQueryablesResponse> {
     const params = createOgcMetadataParams(request);
     const path = `/ogc/features/collections/${encodeURIComponent(String(request.collectionId))}/queryables`;
-    return this.requestJson("GET", `${path}?${params.toString()}`) as Promise<HonuaOgcQueryablesResponse>;
+    return this.requestCachedMetadataJson<HonuaOgcQueryablesResponse>(
+      `ogc-features:queryables:${request.collectionId}:${params.toString()}`,
+      `${path}?${params.toString()}`,
+      request,
+    );
   }
 
   public async listOgcItems(request: OgcItemsRequest): Promise<HonuaOgcFeatureCollectionResponse> {
@@ -837,41 +1068,54 @@ export class HonuaClient {
 
   public async getOgcTilesLanding(request: OgcMetadataRequest = {}): Promise<HonuaOgcLandingResponse> {
     const params = createOgcMetadataParams(request);
-    return this.requestJson("GET", `/ogc/tiles?${params.toString()}`) as Promise<HonuaOgcLandingResponse>;
+    return this.requestCachedMetadataJson<HonuaOgcLandingResponse>(
+      `ogc-tiles:landing:${params.toString()}`,
+      `/ogc/tiles?${params.toString()}`,
+      request,
+    );
   }
 
   public async getOgcTilesConformance(request: OgcMetadataRequest = {}): Promise<HonuaOgcConformanceResponse> {
     const params = createOgcMetadataParams(request);
-    return this.requestJson(
-      "GET",
+    return this.requestCachedMetadataJson<HonuaOgcConformanceResponse>(
+      `ogc-tiles:conformance:${params.toString()}`,
       `/ogc/tiles/conformance?${params.toString()}`,
-    ) as Promise<HonuaOgcConformanceResponse>;
+      request,
+    );
   }
 
   public async listOgcTileMatrixSets(request: OgcMetadataRequest = {}): Promise<HonuaOgcTileMatrixSetsResponse> {
     const params = createOgcMetadataParams(request);
-    return this.requestJson(
-      "GET",
+    return this.requestCachedMetadataJson<HonuaOgcTileMatrixSetsResponse>(
+      `ogc-tiles:tile-matrix-sets:${params.toString()}`,
       `/ogc/tiles/tileMatrixSets?${params.toString()}`,
-    ) as Promise<HonuaOgcTileMatrixSetsResponse>;
+      request,
+    );
   }
 
-  public async getOgcTileMatrixSet(request: {
-    tileMatrixSetId: string;
-    responseFormat?: string;
-    extraParams?: Record<string, string | number | boolean>;
-  }): Promise<HonuaOgcTileMatrixSet> {
+  public async getOgcTileMatrixSet(
+    request: {
+      tileMatrixSetId: string;
+      responseFormat?: string;
+      extraParams?: Record<string, string | number | boolean>;
+    } & HonuaMetadataRequestOptions,
+  ): Promise<HonuaOgcTileMatrixSet> {
     const params = createOgcMetadataParams(request);
-    return this.requestJson(
-      "GET",
+    return this.requestCachedMetadataJson<HonuaOgcTileMatrixSet>(
+      `ogc-tiles:tile-matrix-set:${request.tileMatrixSetId}:${params.toString()}`,
       `/ogc/tiles/tileMatrixSets/${encodeURIComponent(request.tileMatrixSetId)}?${params.toString()}`,
-    ) as Promise<HonuaOgcTileMatrixSet>;
+      request,
+    );
   }
 
   public async listOgcCollectionTilesets(request: OgcTilesetsRequest): Promise<HonuaOgcTilesetsResponse> {
     const params = createOgcMetadataParams(request);
     const path = `/ogc/tiles/collections/${encodeURIComponent(String(request.collectionId))}/tiles`;
-    return this.requestJson("GET", `${path}?${params.toString()}`) as Promise<HonuaOgcTilesetsResponse>;
+    return this.requestCachedMetadataJson<HonuaOgcTilesetsResponse>(
+      `ogc-tiles:tilesets:${request.collectionId}:${params.toString()}`,
+      `${path}?${params.toString()}`,
+      request,
+    );
   }
 
   public async getOgcCollectionTileset(request: OgcTilesetRequest): Promise<HonuaOgcTilesetMetadata> {
@@ -879,7 +1123,11 @@ export class HonuaClient {
     const path =
       `/ogc/tiles/collections/${encodeURIComponent(String(request.collectionId))}` +
       `/tiles/${encodeURIComponent(request.tileMatrixSetId)}`;
-    return this.requestJson("GET", `${path}?${params.toString()}`) as Promise<HonuaOgcTilesetMetadata>;
+    return this.requestCachedMetadataJson<HonuaOgcTilesetMetadata>(
+      `ogc-tiles:tileset:${request.collectionId}:${request.tileMatrixSetId}:${params.toString()}`,
+      `${path}?${params.toString()}`,
+      request,
+    );
   }
 
   public async fetchOgcTile(request: OgcTileRequest): Promise<HonuaOgcTileResponse> {
@@ -901,15 +1149,20 @@ export class HonuaClient {
 
   public async getOgcMapsLanding(request: OgcMetadataRequest = {}): Promise<HonuaOgcLandingResponse> {
     const params = createOgcMetadataParams(request);
-    return this.requestJson("GET", `/ogc/maps?${params.toString()}`) as Promise<HonuaOgcLandingResponse>;
+    return this.requestCachedMetadataJson<HonuaOgcLandingResponse>(
+      `ogc-maps:landing:${params.toString()}`,
+      `/ogc/maps?${params.toString()}`,
+      request,
+    );
   }
 
   public async getOgcMapsConformance(request: OgcMetadataRequest = {}): Promise<HonuaOgcConformanceResponse> {
     const params = createOgcMetadataParams(request);
-    return this.requestJson(
-      "GET",
+    return this.requestCachedMetadataJson<HonuaOgcConformanceResponse>(
+      `ogc-maps:conformance:${params.toString()}`,
       `/ogc/maps/conformance?${params.toString()}`,
-    ) as Promise<HonuaOgcConformanceResponse>;
+      request,
+    );
   }
 
   public async getOgcMapImage(request: OgcMapImageRequest): Promise<HonuaOgcMapImageResponse> {
@@ -1135,31 +1388,38 @@ export class HonuaClient {
 
   public async getOgcProcessesLanding(request: OgcMetadataRequest = {}): Promise<HonuaOgcLandingResponse> {
     const params = createOgcMetadataParams(request);
-    return this.requestJson("GET", `/ogc/processes?${params.toString()}`) as Promise<HonuaOgcLandingResponse>;
+    return this.requestCachedMetadataJson<HonuaOgcLandingResponse>(
+      `ogc-processes:landing:${params.toString()}`,
+      `/ogc/processes?${params.toString()}`,
+      request,
+    );
   }
 
   public async getOgcProcessesConformance(request: OgcMetadataRequest = {}): Promise<HonuaOgcConformanceResponse> {
     const params = createOgcMetadataParams(request);
-    return this.requestJson(
-      "GET",
+    return this.requestCachedMetadataJson<HonuaOgcConformanceResponse>(
+      `ogc-processes:conformance:${params.toString()}`,
       `/ogc/processes/conformance?${params.toString()}`,
-    ) as Promise<HonuaOgcConformanceResponse>;
+      request,
+    );
   }
 
   public async listOgcProcesses(request: OgcMetadataRequest = {}): Promise<HonuaOgcProcessesResponse> {
     const params = createOgcMetadataParams(request);
-    return this.requestJson(
-      "GET",
+    return this.requestCachedMetadataJson<HonuaOgcProcessesResponse>(
+      `ogc-processes:processes:${params.toString()}`,
       `/ogc/processes/processes?${params.toString()}`,
-    ) as Promise<HonuaOgcProcessesResponse>;
+      request,
+    );
   }
 
   public async getOgcProcess(request: { processId: string } & OgcMetadataRequest): Promise<HonuaOgcProcessDescription> {
     const params = createOgcMetadataParams(request);
-    return this.requestJson(
-      "GET",
+    return this.requestCachedMetadataJson<HonuaOgcProcessDescription>(
+      `ogc-processes:process:${request.processId}:${params.toString()}`,
       `/ogc/processes/processes/${encodeURIComponent(request.processId)}?${params.toString()}`,
-    ) as Promise<HonuaOgcProcessDescription>;
+      request,
+    );
   }
 
   public async executeOgcProcess(request: OgcProcessExecuteRequest): Promise<HonuaOgcProcessJobAccepted> {
@@ -1228,20 +1488,29 @@ export class HonuaClient {
 
   public async getStacLanding(request: OgcMetadataRequest = {}): Promise<HonuaStacLandingResponse> {
     const params = createOgcMetadataParams(request);
-    return this.requestJson("GET", `/stac?${params.toString()}`) as Promise<HonuaStacLandingResponse>;
+    return this.requestCachedMetadataJson<HonuaStacLandingResponse>(
+      `stac:landing:${params.toString()}`,
+      `/stac?${params.toString()}`,
+      request,
+    );
   }
 
   public async listStacCollections(request: OgcMetadataRequest = {}): Promise<HonuaOgcCollectionsResponse> {
     const params = createOgcMetadataParams(request);
-    return this.requestJson("GET", `/stac/collections?${params.toString()}`) as Promise<HonuaOgcCollectionsResponse>;
+    return this.requestCachedMetadataJson<HonuaOgcCollectionsResponse>(
+      `stac:collections:${params.toString()}`,
+      `/stac/collections?${params.toString()}`,
+      request,
+    );
   }
 
   public async getStacCollection(request: OgcCollectionRequest): Promise<HonuaOgcCollectionMetadata> {
     const params = createOgcMetadataParams(request);
-    return this.requestJson(
-      "GET",
+    return this.requestCachedMetadataJson<HonuaOgcCollectionMetadata>(
+      `stac:collection:${request.collectionId}:${params.toString()}`,
       `/stac/collections/${encodeURIComponent(String(request.collectionId))}?${params.toString()}`,
-    ) as Promise<HonuaOgcCollectionMetadata>;
+      request,
+    );
   }
 
   public async getStacItem(request: {
@@ -1284,12 +1553,23 @@ export class HonuaClient {
     ) as Promise<HonuaStacItemCollectionResponse>;
   }
 
-  public async getMapServiceMetadata(serviceId: string): Promise<HonuaServiceMetadata> {
+  public async getMapServiceMetadata(
+    serviceId: string,
+    options: HonuaMetadataRequestOptions = {},
+  ): Promise<HonuaServiceMetadata> {
     const query = new URLSearchParams({ f: "json" });
-    return this.requestJson(
-      "GET",
-      `/rest/services/${encodeURIComponent(serviceId)}/MapServer?${query.toString()}`,
-    ) as Promise<HonuaServiceMetadata>;
+    const path = `/rest/services/${encodeURIComponent(serviceId)}/MapServer?${query.toString()}`;
+    return this.requestCachedMetadataJson<HonuaServiceMetadata>(`geoservices-map:${serviceId}:service`, path, options);
+  }
+
+  public async getMapLayerMetadata(
+    serviceId: string,
+    layerId: number,
+    options: HonuaMetadataRequestOptions = {},
+  ): Promise<HonuaLayerMetadata> {
+    const query = new URLSearchParams({ f: "json" });
+    const path = `/rest/services/${encodeURIComponent(serviceId)}/MapServer/${layerId}?${query.toString()}`;
+    return this.requestCachedMetadataJson<HonuaLayerMetadata>(`geoservices-map:${serviceId}:${layerId}`, path, options);
   }
 
   public async queryFeatures(request: QueryFeaturesRequest): Promise<HonuaQueryResponse> {
@@ -2701,6 +2981,47 @@ function createOgcMetadataParams(request: OgcMetadataRequest): URLSearchParams {
     }
   }
   return params;
+}
+
+function createMetadataCacheState(
+  entry: MetadataCacheEntry,
+  status: "hit" | "miss" | "stale" | "refreshed" | "bypass",
+  options: {
+    now: number;
+    ttlMs?: number;
+    staleIfErrorMs?: number;
+    revalidatedAt?: string;
+    refreshErrorId?: string;
+  },
+) {
+  return createHonuaCacheState({
+    scope: "metadata",
+    status,
+    keyFingerprint: entry.keyFingerprint,
+    ageMs: Math.max(0, options.now - entry.cachedAtMs),
+    ...(options.ttlMs !== undefined ? { ttlMs: options.ttlMs } : {}),
+    ...(options.staleIfErrorMs !== undefined ? { staleIfErrorMs: options.staleIfErrorMs } : {}),
+    ...(options.revalidatedAt ? { revalidatedAt: options.revalidatedAt } : {}),
+    ...(entry.sourceUpdatedAt ? { sourceUpdatedAt: entry.sourceUpdatedAt } : {}),
+    ...(entry.validator ? { validator: entry.validator } : {}),
+    ...(options.refreshErrorId ? { refreshErrorId: options.refreshErrorId } : {}),
+  });
+}
+
+function metadataRefreshErrorId(error: unknown): string {
+  if (error instanceof HonuaHttpError) {
+    return `http-${error.statusCode}`;
+  }
+  if (error instanceof HonuaTimeoutError) {
+    return "timeout";
+  }
+  if (error instanceof HonuaNetworkError) {
+    return "network";
+  }
+  if (error instanceof Error && error.name) {
+    return error.name;
+  }
+  return "unknown";
 }
 
 function mergePathWithQueryParams(path: string, additionalParams: URLSearchParams): string {

--- a/src/core/odata.ts
+++ b/src/core/odata.ts
@@ -15,6 +15,17 @@
  * @module
  */
 
+import {
+  type HonuaCacheState,
+  type HonuaCacheValidator,
+  type HonuaMetadataRequestOptions,
+  createHonuaCacheState,
+  honuaCacheValidatorFromHeaders,
+  honuaMetadataRequestHeaders,
+  normalizeHonuaMetadataRequestOptions,
+  withHonuaCacheState,
+  withoutHonuaCacheState,
+} from "./cache-state.js";
 import type { HonuaClient } from "./client.js";
 import type { HonuaFieldInfo } from "./types.js";
 
@@ -119,6 +130,7 @@ export interface HonuaOdataMetadata {
   fields: Readonly<Record<string, readonly HonuaOdataFieldInfo[]>>;
   /** Entity-set name → coarse capability flags advertised by `Capabilities.*` annotations. */
   capabilities: Readonly<Record<string, HonuaOdataAdvertisedCapabilities>>;
+  cache?: HonuaCacheState;
 }
 
 /** Per-field metadata carried by {@link HonuaOdataMetadata.fields}. */
@@ -150,6 +162,15 @@ export interface HonuaOdataAdvertisedCapabilities {
   search?: boolean;
   delta?: boolean;
   count?: boolean;
+}
+
+interface OdataMetadataCacheEntry {
+  metadata: HonuaOdataMetadata;
+  cachedAtMs: number;
+  keyFingerprint: string;
+  status: "miss" | "refreshed" | "bypass";
+  validator?: HonuaCacheValidator;
+  sourceUpdatedAt?: string;
 }
 
 /** Single page of an OData `$apply` aggregation response. */
@@ -187,7 +208,7 @@ export class HonuaOdataEntitySet {
    */
   public readonly entitySetName: string;
   public readonly basePath: string;
-  private cachedMetadata: HonuaOdataMetadata | undefined;
+  private cachedMetadata: OdataMetadataCacheEntry | undefined;
   private inflightMetadata: Promise<HonuaOdataMetadata> | undefined;
 
   public constructor(options: HonuaOdataEntitySetOptions) {
@@ -202,17 +223,48 @@ export class HonuaOdataEntitySet {
    * `HonuaOdataEntitySet` instance so callers can pin a metadata snapshot
    * to a long-lived `Source` without re-parsing on every request.
    */
-  public async metadata(options: { signal?: AbortSignal; refresh?: boolean } = {}): Promise<HonuaOdataMetadata> {
-    if (!options.refresh && this.cachedMetadata) return this.cachedMetadata;
-    if (!options.refresh && this.inflightMetadata) return this.inflightMetadata;
-    const promise = this.fetchMetadata(options.signal).then((meta) => {
-      this.cachedMetadata = meta;
-      return meta;
+  public async metadata(options: HonuaMetadataRequestOptions = {}): Promise<HonuaOdataMetadata> {
+    const metadataOptions = normalizeHonuaMetadataRequestOptions(options);
+    const bypass = metadataOptions.cache === "bypass";
+    if (!bypass && !metadataOptions.refresh && this.cachedMetadata) {
+      return withOdataMetadataCacheState(this.cachedMetadata, "hit", {
+        now: Date.now(),
+        ttlMs: metadataOptions.ttlMs,
+        staleIfErrorMs: metadataOptions.staleIfErrorMs,
+      });
+    }
+    if (!bypass && !metadataOptions.refresh && this.inflightMetadata) return this.inflightMetadata;
+    const previous = this.cachedMetadata;
+    const promise = this.fetchMetadata(metadataOptions, previous).then((entry) => {
+      if (!bypass) {
+        this.cachedMetadata = entry;
+      }
+      const status = bypass ? "bypass" : entry.status;
+      return withOdataMetadataCacheState(entry, status, {
+        now: Date.now(),
+        ttlMs: metadataOptions.ttlMs,
+        staleIfErrorMs: metadataOptions.staleIfErrorMs,
+        ...(status === "refreshed" ? { revalidatedAt: new Date().toISOString() } : {}),
+      });
     });
-    this.inflightMetadata = promise.finally(() => {
-      if (this.inflightMetadata === promise) this.inflightMetadata = undefined;
-    });
-    return promise;
+    if (!bypass && !metadataOptions.refresh) {
+      this.inflightMetadata = promise.finally(() => {
+        if (this.inflightMetadata === promise) this.inflightMetadata = undefined;
+      });
+    }
+    try {
+      return await promise;
+    } catch (error) {
+      if (!bypass && metadataOptions.staleIfError && previous) {
+        return withOdataMetadataCacheState(previous, "stale", {
+          now: Date.now(),
+          ttlMs: metadataOptions.ttlMs,
+          staleIfErrorMs: metadataOptions.staleIfErrorMs,
+          refreshErrorId: odataMetadataRefreshErrorId(error),
+        });
+      }
+      throw error;
+    }
   }
 
   /** Fetch one page of the entity set. */
@@ -426,7 +478,10 @@ export class HonuaOdataEntitySet {
     return `${this.basePath}/${this.entitySet}`;
   }
 
-  private async fetchMetadata(signal?: AbortSignal): Promise<HonuaOdataMetadata> {
+  private async fetchMetadata(
+    options: ReturnType<typeof normalizeHonuaMetadataRequestOptions>,
+    cached: OdataMetadataCacheEntry | undefined,
+  ): Promise<OdataMetadataCacheEntry> {
     // Route through pipelineFetch so auth headers, interceptors, retry,
     // timeout, and normalized error handling all apply. The default
     // pipeline does not impose an `Accept` header — we ask for XML
@@ -434,11 +489,37 @@ export class HonuaOdataEntitySet {
     const response = await this.client.pipelineFetch(
       "GET",
       `${this.basePath}/$metadata`,
-      { headers: { Accept: "application/xml" } },
-      signal,
+      {
+        headers: honuaMetadataRequestHeaders({
+          accept: "application/xml",
+          refresh: options.refresh,
+          bypass: options.cache === "bypass",
+          validator: cached?.validator,
+        }),
+      },
+      options.signal,
+      { okStatuses: [304] },
     );
+    if (response.status === 304 && cached) {
+      const validator = honuaCacheValidatorFromHeaders(response.headers) ?? cached.validator;
+      return {
+        ...cached,
+        cachedAtMs: Date.now(),
+        ...(validator ? { validator } : {}),
+        status: "refreshed",
+      };
+    }
     const xml = await response.text();
-    return parseOdataMetadata(xml);
+    const validator = honuaCacheValidatorFromHeaders(response.headers);
+    const sourceUpdatedAt = response.headers.get("last-modified") ?? undefined;
+    return {
+      metadata: withoutHonuaCacheState(parseOdataMetadata(xml)),
+      cachedAtMs: Date.now(),
+      keyFingerprint: `metadata:odata:${this.basePath}:$metadata`,
+      status: options.cache === "bypass" ? "bypass" : cached ? "refreshed" : "miss",
+      ...(validator ? { validator } : {}),
+      ...(sourceUpdatedAt ? { sourceUpdatedAt } : {}),
+    };
   }
 
   private async followNextLink<T>(nextLink: string, signal?: AbortSignal): Promise<HonuaOdataPage<T>> {
@@ -491,6 +572,41 @@ export class HonuaOdataEntitySet {
 }
 
 // ── Helpers ───────────────────────────────────────────────────
+
+function withOdataMetadataCacheState(
+  entry: OdataMetadataCacheEntry,
+  status: "hit" | "miss" | "stale" | "refreshed" | "bypass",
+  options: {
+    now: number;
+    ttlMs?: number;
+    staleIfErrorMs?: number;
+    revalidatedAt?: string;
+    refreshErrorId?: string;
+  },
+): HonuaOdataMetadata {
+  return withHonuaCacheState(
+    entry.metadata,
+    createHonuaCacheState({
+      scope: "metadata",
+      status,
+      keyFingerprint: entry.keyFingerprint,
+      ageMs: Math.max(0, options.now - entry.cachedAtMs),
+      ...(options.ttlMs !== undefined ? { ttlMs: options.ttlMs } : {}),
+      ...(options.staleIfErrorMs !== undefined ? { staleIfErrorMs: options.staleIfErrorMs } : {}),
+      ...(options.revalidatedAt ? { revalidatedAt: options.revalidatedAt } : {}),
+      ...(entry.sourceUpdatedAt ? { sourceUpdatedAt: entry.sourceUpdatedAt } : {}),
+      ...(entry.validator ? { validator: entry.validator } : {}),
+      ...(options.refreshErrorId ? { refreshErrorId: options.refreshErrorId } : {}),
+    }),
+  );
+}
+
+function odataMetadataRefreshErrorId(error: unknown): string {
+  if (error instanceof Error && error.name) {
+    return error.name;
+  }
+  return "unknown";
+}
 
 interface OdataValueEnvelope<T> {
   value?: T[];

--- a/src/core/surfaces.ts
+++ b/src/core/surfaces.ts
@@ -1,3 +1,4 @@
+import type { HonuaMetadataRequestOptions } from "./cache-state.js";
 import type { HonuaClient } from "./client.js";
 import type {
   ApplyEditsRequest,
@@ -194,12 +195,12 @@ export class HonuaService {
     return this.featureLayer<T>(layerId);
   }
 
-  public async featureServiceMetadata(): Promise<HonuaServiceMetadata> {
-    return this.client.getFeatureServiceMetadata(this.serviceId);
+  public async featureServiceMetadata(options: HonuaMetadataRequestOptions = {}): Promise<HonuaServiceMetadata> {
+    return this.client.getFeatureServiceMetadata(this.serviceId, options);
   }
 
-  public async mapServiceMetadata(): Promise<HonuaServiceMetadata> {
-    return this.client.getMapServiceMetadata(this.serviceId);
+  public async mapServiceMetadata(options: HonuaMetadataRequestOptions = {}): Promise<HonuaServiceMetadata> {
+    return this.client.getMapServiceMetadata(this.serviceId, options);
   }
 
   public async featureLayerIds(): Promise<number[]> {
@@ -276,8 +277,8 @@ export class HonuaFeatureLayer<T = Record<string, unknown>> {
     this.layerId = options.layerId;
   }
 
-  public async metadata(): Promise<HonuaLayerMetadata> {
-    return this.client.getLayerMetadata(this.serviceId, this.layerId);
+  public async metadata(options: HonuaMetadataRequestOptions = {}): Promise<HonuaLayerMetadata> {
+    return this.client.getLayerMetadata(this.serviceId, this.layerId, options);
   }
 
   public createQuery(): HonuaFeatureLayerQueryRequest {
@@ -604,8 +605,8 @@ export class HonuaMapService {
     this.serviceId = options.serviceId;
   }
 
-  public async metadata(): Promise<HonuaServiceMetadata> {
-    return this.client.getMapServiceMetadata(this.serviceId);
+  public async metadata(options: HonuaMetadataRequestOptions = {}): Promise<HonuaServiceMetadata> {
+    return this.client.getMapServiceMetadata(this.serviceId, options);
   }
 
   public layer(layerId: number): HonuaMapLayer {
@@ -831,11 +832,8 @@ export class HonuaMapLayer {
     this.layerId = options.layerId;
   }
 
-  public async metadata(): Promise<HonuaLayerMetadata> {
-    return this.client.request({
-      method: "GET",
-      path: `/rest/services/${encodeURIComponent(this.serviceId)}` + `/MapServer/${this.layerId}`,
-    }) as Promise<HonuaLayerMetadata>;
+  public async metadata(options: HonuaMetadataRequestOptions = {}): Promise<HonuaLayerMetadata> {
+    return this.client.getMapLayerMetadata(this.serviceId, this.layerId, options);
   }
 
   public createQuery(): HonuaMapLayerQueryRequest {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,3 +1,5 @@
+import type { HonuaCacheState, HonuaMetadataRequestOptions } from "./cache-state.js";
+
 export type QueryMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 
 export interface HonuaRequestContext {
@@ -341,7 +343,7 @@ export interface HonuaServerCompatibilityStatus {
 
 export type OgcResponseFormat = "json" | "html" | "geojson" | "gml" | "csv" | "schemajson" | "schema+json";
 
-export interface OgcMetadataRequest {
+export interface OgcMetadataRequest extends HonuaMetadataRequestOptions {
   responseFormat?: OgcResponseFormat | string;
   extraParams?: Record<string, string | number | boolean>;
 }
@@ -721,6 +723,7 @@ export interface HonuaLayerMetadata {
   maxRecordCount?: number;
   supportsAttachments?: boolean;
   relationships?: HonuaRelationshipInfo[];
+  cache?: HonuaCacheState;
 }
 
 /** Top-level metadata for a FeatureServer or MapServer service. */
@@ -731,6 +734,7 @@ export interface HonuaServiceMetadata {
   spatialReference?: HonuaSpatialReference;
   fullExtent?: HonuaExtent;
   maxRecordCount?: number;
+  cache?: HonuaCacheState;
 }
 
 /** Response from `listServices()` — the REST services directory. */
@@ -738,6 +742,7 @@ export interface HonuaServicesResponse {
   currentVersion?: number;
   folders?: string[];
   services?: Array<{ name: string; type: string }>;
+  cache?: HonuaCacheState;
 }
 
 // ── OGC Responses ─────────────────────────────
@@ -775,11 +780,13 @@ export interface HonuaOgcLandingResponse {
   title?: string;
   description?: string;
   links?: HonuaOgcLink[];
+  cache?: HonuaCacheState;
 }
 
 /** Response from OGC API conformance (`/ogc/features/conformance`). */
 export interface HonuaOgcConformanceResponse {
   conformsTo: string[];
+  cache?: HonuaCacheState;
 }
 
 /** A single collection summary in an OGC collections listing. */
@@ -800,10 +807,13 @@ export interface HonuaOgcCollectionSummary {
 export interface HonuaOgcCollectionsResponse {
   collections: HonuaOgcCollectionSummary[];
   links?: HonuaOgcLink[];
+  cache?: HonuaCacheState;
 }
 
 /** Response from a single OGC API collection (`/ogc/features/collections/{id}`). */
-export interface HonuaOgcCollectionMetadata extends HonuaOgcCollectionSummary {}
+export interface HonuaOgcCollectionMetadata extends HonuaOgcCollectionSummary {
+  cache?: HonuaCacheState;
+}
 
 /** A single queryable property definition. */
 export interface HonuaOgcQueryableProperty {
@@ -819,6 +829,7 @@ export interface HonuaOgcQueryablesResponse {
   title?: string;
   description?: string;
   properties?: Record<string, HonuaOgcQueryableProperty>;
+  cache?: HonuaCacheState;
 }
 
 // ── OGC API Tiles ─────────────────────────────
@@ -852,12 +863,14 @@ export interface HonuaOgcTileMatrixSet {
   orderedAxes?: readonly string[];
   tileMatrices?: readonly HonuaOgcTileMatrix[];
   links?: HonuaOgcLink[];
+  cache?: HonuaCacheState;
 }
 
 /** Response from `/tileMatrixSets`. */
 export interface HonuaOgcTileMatrixSetsResponse {
   tileMatrixSets: HonuaOgcTileMatrixSet[];
   links?: HonuaOgcLink[];
+  cache?: HonuaCacheState;
 }
 
 /** Metadata for a single tileset (a tile-matrix-set bound to a collection). */
@@ -871,12 +884,14 @@ export interface HonuaOgcTilesetMetadata {
   boundingBox?: { lowerLeft?: readonly number[]; upperRight?: readonly number[]; crs?: string };
   /** Pre-baked styles available on the tileset (for styled-tile access). */
   styles?: Array<{ id: string; title?: string }>;
+  cache?: HonuaCacheState;
 }
 
 /** Response from `/collections/{id}/tiles` (list of tilesets). */
 export interface HonuaOgcTilesetsResponse {
   tilesets: HonuaOgcTilesetMetadata[];
   links?: HonuaOgcLink[];
+  cache?: HonuaCacheState;
 }
 
 /** Request envelope for tileset-discovery operations. */
@@ -983,12 +998,14 @@ export interface HonuaOgcProcessSummary {
 export interface HonuaOgcProcessDescription extends HonuaOgcProcessSummary {
   inputs?: Record<string, Record<string, unknown>>;
   outputs?: Record<string, Record<string, unknown>>;
+  cache?: HonuaCacheState;
 }
 
 /** Response from `/processes`. */
 export interface HonuaOgcProcessesResponse {
   processes: HonuaOgcProcessSummary[];
   links?: HonuaOgcLink[];
+  cache?: HonuaCacheState;
 }
 
 /** OGC API Processes 1.0 status values. */

--- a/src/honua.ts
+++ b/src/honua.ts
@@ -1,4 +1,21 @@
 export { HonuaClient, HONUA_MINIMUM_SUPPORTED_SERVER_VERSION } from "./core/client.js";
+export {
+  createHonuaCacheState,
+  honuaCacheValidatorFromHeaders,
+  honuaMetadataRequestHeaders,
+  isHonuaCacheStatus,
+  normalizeHonuaMetadataRequestOptions,
+} from "./core/cache-state.js";
+export type {
+  HonuaCacheReadMode,
+  HonuaCacheScope,
+  HonuaCacheState,
+  HonuaCacheStateInit,
+  HonuaCacheStatus,
+  HonuaCacheValidator,
+  HonuaMetadataRequestOptions,
+  NormalizedHonuaMetadataRequestOptions,
+} from "./core/cache-state.js";
 export { parseWebMap } from "./webmap/index.js";
 export type { ParseWebMapOptions, ParseWebMapResult } from "./webmap/index.js";
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,23 @@ export { batchQuery } from "./core/batch.js";
 export type { BatchQueryItem, BatchQueryOptions, BatchQueryResult } from "./core/batch.js";
 export { decodePbfQueryResponse, isPbfResponse } from "./core/pbf-decoder.js";
 export {
+  createHonuaCacheState,
+  honuaCacheValidatorFromHeaders,
+  honuaMetadataRequestHeaders,
+  isHonuaCacheStatus,
+  normalizeHonuaMetadataRequestOptions,
+} from "./core/cache-state.js";
+export type {
+  HonuaCacheReadMode,
+  HonuaCacheScope,
+  HonuaCacheState,
+  HonuaCacheStateInit,
+  HonuaCacheStatus,
+  HonuaCacheValidator,
+  HonuaMetadataRequestOptions,
+  NormalizedHonuaMetadataRequestOptions,
+} from "./core/cache-state.js";
+export {
   isHonuaSource,
   isFeatureServiceSource,
   isMapServiceSource,

--- a/test/cache-state.test.ts
+++ b/test/cache-state.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { HonuaClient, createHonuaCacheState, isHonuaCacheStatus } from "../src/index.js";
+
+const layerFixture = {
+  id: 0,
+  name: "Service Requests",
+  geometryType: "esriGeometryPoint",
+  fields: [{ name: "OBJECTID", type: "esriFieldTypeOID" }],
+};
+
+describe("Honua cache state", () => {
+  it("serializes public cache-state values", () => {
+    const state = createHonuaCacheState({
+      scope: "metadata",
+      status: "hit",
+      keyFingerprint: "metadata:fixture:layer:0",
+      ageMs: 10.8,
+      ttlMs: 300_000,
+      validator: { etag: '"v1"' },
+    });
+
+    expect(JSON.parse(JSON.stringify(state))).toEqual({
+      scope: "metadata",
+      status: "hit",
+      keyFingerprint: "metadata:fixture:layer:0",
+      ageMs: 10,
+      ttlMs: 300000,
+      validator: { etag: '"v1"' },
+    });
+    expect(isHonuaCacheStatus("refreshed")).toBe(true);
+    expect(isHonuaCacheStatus("loading")).toBe(false);
+  });
+
+  it("reports metadata cache miss, hit, refreshed, stale, and bypass states", async () => {
+    const requestedHeaders: HeadersInit[] = [];
+    let requestCount = 0;
+    const client = new HonuaClient({
+      baseUrl: "https://example.test",
+      fetchFn: async (_input, init) => {
+        requestCount += 1;
+        requestedHeaders.push(init?.headers ?? {});
+
+        if (requestCount === 1) {
+          return json(layerFixture, 200, { etag: '"v1"', "last-modified": "Tue, 05 May 2026 19:30:00 GMT" });
+        }
+        if (requestCount === 2) {
+          expect(init?.headers).toMatchObject({ "If-None-Match": '"v1"' });
+          return new Response(null, { status: 304, headers: { etag: '"v1"' } });
+        }
+        if (requestCount === 3) {
+          return json({ error: { message: "upstream unavailable" } }, 503);
+        }
+        return json({ ...layerFixture, name: "Bypassed Layer" }, 200, { etag: '"v2"' });
+      },
+    });
+
+    const miss = await client.getLayerMetadata("civic", 0);
+    const hit = await client.getLayerMetadata("civic", 0);
+    const refreshed = await client.getLayerMetadata("civic", 0, { refresh: true });
+    const stale = await client.getLayerMetadata("civic", 0, { refresh: true });
+    const bypass = await client.getLayerMetadata("civic", 0, { cache: "bypass" });
+    const postBypassHit = await client.getLayerMetadata("civic", 0);
+
+    expect(miss.cache?.status).toBe("miss");
+    expect(hit.cache?.status).toBe("hit");
+    expect(refreshed.cache?.status).toBe("refreshed");
+    expect(stale.cache).toMatchObject({ status: "stale", refreshErrorId: "http-503" });
+    expect(bypass.cache?.status).toBe("bypass");
+    expect(bypass.name).toBe("Bypassed Layer");
+    expect(postBypassHit.name).toBe("Service Requests");
+    expect(postBypassHit.cache?.status).toBe("hit");
+    expect(requestCount).toBe(4);
+    expect(requestedHeaders[3]).toMatchObject({ "Cache-Control": "no-store", Pragma: "no-cache" });
+  });
+});
+
+function json(body: unknown, status: number, headers: HeadersInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+  });
+}

--- a/test/core-client.test.ts
+++ b/test/core-client.test.ts
@@ -25,7 +25,7 @@ describe("HonuaClient", () => {
     });
 
     await client.listServices();
-    await client.listServices();
+    await client.listServices({ refresh: true });
 
     expect(requestedHeaders[0]).toMatchObject({
       "X-API-Key": "key-1",
@@ -66,16 +66,16 @@ describe("HonuaClient", () => {
     });
 
     await client.listServices();
-    await client.listServices();
+    await client.listServices({ refresh: true });
     expect(issue).toBe(1);
     expect(requestedHeaders[1]).toMatchObject({ Authorization: "Bearer token-1" });
 
     await client.refreshAuthCredentials();
-    await client.listServices();
+    await client.listServices({ refresh: true });
     expect(requestedHeaders[2]).toMatchObject({ Authorization: "Bearer token-2" });
 
     await client.revokeAuthCredentials();
-    await client.listServices();
+    await client.listServices({ refresh: true });
 
     expect(revoked).toEqual([{ token: "token-2", reason: "manual" }]);
     expect(requestedHeaders[3]).toMatchObject({ Authorization: "Bearer token-3" });
@@ -240,7 +240,13 @@ describe("HonuaClient", () => {
     });
 
     const response = await client.getMapServiceMetadata("default");
-    expect(response).toEqual({ mapName: "default" });
+    expect(response).toMatchObject({
+      mapName: "default",
+      cache: {
+        scope: "metadata",
+        status: "miss",
+      },
+    });
     expect(requestedUrl).toContain("/rest/services/default/MapServer?f=json");
   });
 
@@ -744,8 +750,19 @@ describe("HonuaClient", () => {
       },
     });
 
-    await expect(client.listServices()).resolves.toEqual({});
-    await expect(client.listServices()).resolves.toEqual({ raw: "plain text" });
+    await expect(client.listServices({ cache: "bypass" })).resolves.toMatchObject({
+      cache: {
+        scope: "metadata",
+        status: "bypass",
+      },
+    });
+    await expect(client.listServices({ cache: "bypass" })).resolves.toMatchObject({
+      raw: "plain text",
+      cache: {
+        scope: "metadata",
+        status: "bypass",
+      },
+    });
   });
 
   it("uses fallback HTTP error message for array response bodies", async () => {
@@ -801,7 +818,7 @@ describe("HonuaClient", () => {
       },
     });
 
-    await expect(client.listServices()).resolves.toEqual({ services: [] });
+    await expect(client.listServices()).resolves.toMatchObject({ services: [] });
     expect(attempts).toBe(3);
   });
 
@@ -824,7 +841,7 @@ describe("HonuaClient", () => {
       },
     });
 
-    await expect(client.listServices()).resolves.toEqual({ services: [{ id: "ok" }] });
+    await expect(client.listServices()).resolves.toMatchObject({ services: [{ id: "ok" }] });
     expect(attempts).toBe(3);
   });
 
@@ -987,7 +1004,7 @@ describe("HonuaClient", () => {
 
     const response = await client.listServices();
     expect(afterPayload).toEqual({ services: [{ id: "default" }] });
-    expect(response).toEqual({ services: [{ id: "default" }] });
+    expect(response).toMatchObject({ services: [{ id: "default" }] });
   });
 
   it("invokes only error interceptors for HTTP error responses", async () => {

--- a/test/entrypoints.test.ts
+++ b/test/entrypoints.test.ts
@@ -129,6 +129,7 @@ import {
   HonuaOgcFeatures,
   HonuaService,
   HonuaWfsExceptionError,
+  createHonuaCacheState,
   createHonuaOgcFeatures,
   createHonuaService,
   bindQueryProjectionToExploration as honuaBindQueryProjectionToExploration,
@@ -189,6 +190,7 @@ describe("entrypoint modules", () => {
     expect(createHonuaOgcFeatures).toBeTypeOf("function");
     expect(HonuaWfsExceptionError).toBeTypeOf("function");
     expect(HonuaWfsExceptionErrorRoot).toBe(HonuaWfsExceptionError);
+    expect(createHonuaCacheState).toBeTypeOf("function");
   });
 
   it("exposes esri-compat entrypoint", () => {

--- a/test/honua-surface.test.ts
+++ b/test/honua-surface.test.ts
@@ -446,7 +446,14 @@ describe("Honua native API surfaces", () => {
     await mapLayer.request({ path: "queryDomains" });
 
     expect(query).toEqual({ where: "1=1", outFields: ["*"], returnGeometry: true });
-    expect(metadata).toEqual({ id: 4, name: "Roads" });
+    expect(metadata).toMatchObject({
+      id: 4,
+      name: "Roads",
+      cache: {
+        scope: "metadata",
+        status: "miss",
+      },
+    });
     expect(features).toEqual({ features: [{ id: 1 }] });
     expect(count).toBe(9);
     expect(objectIds).toEqual([10, 11]);
@@ -649,8 +656,8 @@ describe("Honua native API surfaces", () => {
     expect(calls[8]).toMatchObject({ method: "PUT" });
     expect(calls[9]).toMatchObject({ method: "PATCH" });
     expect(calls[10]).toMatchObject({ method: "DELETE" });
-    expect(calls[11]?.url).toContain("/ogc/features/collections/3?f=json");
-    expect(calls[18]).toMatchObject({ method: "DELETE" });
+    expect(calls[11]?.url).toContain("/ogc/features/collections/3/queryables?f=json");
+    expect(calls[17]).toMatchObject({ method: "DELETE" });
   });
 
   it("supports OGC itemsAll pagination helpers", async () => {

--- a/test/request-interceptors.test.ts
+++ b/test/request-interceptors.test.ts
@@ -39,7 +39,13 @@ describe("HonuaClient request interceptors", () => {
     });
 
     const response = await client.listServices();
-    expect(response).toEqual({ services: [] });
+    expect(response).toMatchObject({
+      services: [],
+      cache: {
+        scope: "metadata",
+        status: "miss",
+      },
+    });
     expect(requestedUrl).toContain("/rest/services?f=json&traceId=abc123");
     expect(requestedHeaders).toMatchObject({
       Accept: "application/json",
@@ -118,7 +124,7 @@ describe("HonuaClient request interceptors", () => {
 
     const response = await client.listServices();
     expect(afterBodies).toEqual([{ services: [{ name: "demo" }] }]);
-    expect(response).toEqual({ services: [{ name: "demo" }] });
+    expect(response).toMatchObject({ services: [{ name: "demo" }] });
   });
 
   it("clones responses so multiple after interceptors can read body streams", async () => {
@@ -147,7 +153,7 @@ describe("HonuaClient request interceptors", () => {
 
     const response = await client.listServices();
     expect(afterTexts).toEqual(['{"services":[]}', '{"services":[]}']);
-    expect(response).toEqual({ services: [] });
+    expect(response).toMatchObject({ services: [] });
   });
 });
 


### PR DESCRIPTION
Summary: Exports HonuaCacheState and metadata request options, adds SDK-local metadata cache status for GeoServices/OGC/STAC/OData discovery calls, keeps feature/query reads uncached by default, and updates Service Explorer plus docs to display cache state. Validation: npm test -- test/cache-state.test.ts test/service-explorer-workspace.test.ts test/entrypoints.test.ts; npm test -- test/contract/odata-conformance.test.ts; npm run typecheck; npm run check; npm run build. Closes #94.