### PR TITLE
Add realtime SSE transport path for incident dashboard

### DIFF
--- a/examples/realtime-incident-dashboard/README.md
+++ b/examples/realtime-incident-dashboard/README.md
@@ -22,6 +22,18 @@ read-only context and disables actions that require authoritative live state.
 npm run demo:incident
 ```
 
+The fixture transport is the default. To exercise a Honua cloud/server
+realtime endpoint that emits SDK `RealtimeFeatureEvent` JSON over SSE, start the
+demo with either:
+
+```sh
+VITE_HONUA_INCIDENT_TRANSPORT=cloud \
+VITE_HONUA_INCIDENT_STREAM_URL=https://honua.example/api/v1/realtime/events \
+npm run demo:incident
+```
+
+or append `?transport=cloud&streamUrl=<sse-url>` in the browser.
+
 ## Validate
 
 ```sh

--- a/examples/realtime-incident-dashboard/src/main.ts
+++ b/examples/realtime-incident-dashboard/src/main.ts
@@ -45,7 +45,7 @@ import {
   incidentRecords,
   statusLabel,
 } from "./projection.js";
-import { createFixtureIncidentTransport } from "./realtime-fixture.js";
+import { createIncidentDashboardTransport } from "./realtime-transport.js";
 import type { IncidentFeature, IncidentSummary } from "./types.js";
 
 import "./styles.css";
@@ -534,7 +534,7 @@ async function bootstrap(): Promise<void> {
   try {
     const { map, layerIds } = await createMap();
     const store = createRealtimeFeatureStore<IncidentFeature>();
-    const transport = createFixtureIncidentTransport();
+    const incidentTransport = createIncidentDashboardTransport();
     const context = createExplorationContext({
       datasetId: "honua-cloud-incident-operations",
       sourceIds: [INCIDENT_SOURCE_ID],
@@ -665,31 +665,31 @@ async function bootstrap(): Promise<void> {
       setFieldFilter(filterControls, "type", "type", typeFilter.value);
     });
     stepButton.addEventListener("click", () => {
-      const step = transport.step();
+      const step = incidentTransport.controls.step();
       runtime.lastStep = step?.label ?? null;
       setText("#last-scenario-step", step ? step.label : "No live step");
     });
-    reconnectButton.addEventListener("click", () => transport.reconnect());
-    resumeButton.addEventListener("click", () => transport.resume());
+    reconnectButton.addEventListener("click", () => incidentTransport.controls.reconnect());
+    resumeButton.addEventListener("click", () => incidentTransport.controls.resume());
     staleButton.addEventListener("click", () => {
       const lastLiveAt = store.state.lastHeartbeatAt ?? store.state.lastEventAt ?? Date.now();
       store.checkStale({ staleAfterMs: 1_000, now: lastLiveAt + 1_500 });
     });
-    refreshButton.addEventListener("click", () => transport.refresh());
+    refreshButton.addEventListener("click", () => incidentTransport.controls.refresh());
 
     runtime.step = () => {
-      const step = transport.step();
+      const step = incidentTransport.controls.step();
       runtime.lastStep = step?.label ?? null;
       setText("#last-scenario-step", step ? step.label : "No live step");
       return runtime.lastStep;
     };
-    runtime.reconnect = () => transport.reconnect();
-    runtime.resume = () => transport.resume();
+    runtime.reconnect = () => incidentTransport.controls.reconnect();
+    runtime.resume = () => incidentTransport.controls.resume();
     runtime.markStale = () => {
       const lastLiveAt = store.state.lastHeartbeatAt ?? store.state.lastEventAt ?? Date.now();
       store.checkStale({ staleAfterMs: 1_000, now: lastLiveAt + 1_500 });
     };
-    runtime.refresh = () => transport.refresh();
+    runtime.refresh = () => incidentTransport.controls.refresh();
 
     for (const layerId of layerIds) {
       map.on("mouseenter", layerId, () => {
@@ -700,14 +700,7 @@ async function bootstrap(): Promise<void> {
       });
     }
 
-    store.connect(transport, {
-      sourceId: INCIDENT_SOURCE_ID,
-      layerId: INCIDENT_LAYER_ID,
-      metadata: {
-        demo: "realtime-incident-dashboard",
-        channel: "fixture-backed-honua-cloud",
-      },
-    });
+    store.connect(incidentTransport.transport, incidentTransport.request);
 
     tableSelection.select([sourceFeatureSelectionTarget(INCIDENT_SOURCE_ID, INITIAL_INCIDENTS[0].id)], {
       replace: true,

--- a/examples/realtime-incident-dashboard/src/realtime-transport.ts
+++ b/examples/realtime-incident-dashboard/src/realtime-transport.ts
@@ -1,0 +1,94 @@
+import {
+  type RealtimeFeatureTransport,
+  type RealtimeSubscriptionRequest,
+  createRealtimeServerSentEventsTransport,
+} from "../../../src/realtime/index.js";
+
+import { INCIDENT_LAYER_ID, INCIDENT_SOURCE_ID } from "./fixtures.js";
+import { type FixtureIncidentTransport, createFixtureIncidentTransport } from "./realtime-fixture.js";
+import type { IncidentFeature, IncidentScenarioStep } from "./types.js";
+
+export type IncidentTransportMode = "fixture" | "cloud";
+
+export interface IncidentTransportControls {
+  readonly mode: IncidentTransportMode;
+  step(): IncidentScenarioStep | undefined;
+  reconnect(): void;
+  resume(): void;
+  refresh(): void;
+}
+
+export interface IncidentTransportConfig {
+  readonly mode: IncidentTransportMode;
+  readonly streamUrl?: string;
+}
+
+export interface IncidentDashboardTransport {
+  readonly transport: RealtimeFeatureTransport<IncidentFeature>;
+  readonly controls: IncidentTransportControls;
+  readonly request: RealtimeSubscriptionRequest;
+}
+
+export function createIncidentDashboardTransport(location: Location = window.location): IncidentDashboardTransport {
+  const config = readIncidentTransportConfig(location);
+  if (config.mode === "cloud" && config.streamUrl) {
+    return {
+      transport: createRealtimeServerSentEventsTransport<IncidentFeature>({
+        url: config.streamUrl,
+      }),
+      controls: createCloudIncidentTransportControls(),
+      request: createIncidentRealtimeRequest("cloud"),
+    };
+  }
+
+  const fixture = createFixtureIncidentTransport();
+  return {
+    transport: fixture,
+    controls: createFixtureIncidentTransportControls(fixture),
+    request: createIncidentRealtimeRequest("fixture"),
+  };
+}
+
+export function readIncidentTransportConfig(location: Location = window.location): IncidentTransportConfig {
+  const params = new URLSearchParams(location.search);
+  const env = (import.meta as ImportMeta & { readonly env?: Record<string, string | undefined> }).env;
+  const streamUrl = params.get("streamUrl") ?? env?.VITE_HONUA_INCIDENT_STREAM_URL;
+  const mode = params.get("transport") ?? env?.VITE_HONUA_INCIDENT_TRANSPORT;
+  return {
+    mode: mode === "cloud" && streamUrl ? "cloud" : "fixture",
+    streamUrl: streamUrl || undefined,
+  };
+}
+
+function createIncidentRealtimeRequest(channel: IncidentTransportMode): RealtimeSubscriptionRequest {
+  return {
+    requestId: "realtime-incident-dashboard",
+    sourceId: INCIDENT_SOURCE_ID,
+    layerId: INCIDENT_LAYER_ID,
+    mode: "snapshot-then-delta",
+    metadata: {
+      demo: "realtime-incident-dashboard",
+      channel,
+    },
+  };
+}
+
+function createFixtureIncidentTransportControls(fixture: FixtureIncidentTransport): IncidentTransportControls {
+  return {
+    mode: "fixture",
+    step: () => fixture.step(),
+    reconnect: () => fixture.reconnect(),
+    resume: () => fixture.resume(),
+    refresh: () => fixture.refresh(),
+  };
+}
+
+function createCloudIncidentTransportControls(): IncidentTransportControls {
+  return {
+    mode: "cloud",
+    step: () => undefined,
+    reconnect: () => undefined,
+    resume: () => undefined,
+    refresh: () => undefined,
+  };
+}

--- a/src/realtime/index.ts
+++ b/src/realtime/index.ts
@@ -1,4 +1,14 @@
 export {
+  createRealtimeServerSentEventsTransport,
+  decodeRealtimeServerSentEvent,
+  encodeDefaultRealtimeRequest,
+} from "./sse.js";
+export type {
+  RealtimeServerSentEventSource,
+  RealtimeServerSentEventSourceFactory,
+  RealtimeServerSentEventsTransportOptions,
+} from "./sse.js";
+export {
   emptyRealtimeFeatureState,
   reconcileRealtimeStaleness,
   reduceRealtimeFeatureState,

--- a/src/realtime/sse.ts
+++ b/src/realtime/sse.ts
@@ -1,0 +1,162 @@
+import type {
+  RealtimeFeatureEvent,
+  RealtimeFeatureObserver,
+  RealtimeFeatureTransport,
+  RealtimeSubscriptionHandle,
+  RealtimeSubscriptionRequest,
+} from "./types.js";
+
+export interface RealtimeServerSentEventSource {
+  readonly readyState?: number;
+  onopen: ((event: Event) => void) | null;
+  onmessage: ((event: MessageEvent<string>) => void) | null;
+  onerror: ((event: Event) => void) | null;
+  close(): void;
+  addEventListener?(type: string, listener: (event: MessageEvent<string>) => void): void;
+  removeEventListener?(type: string, listener: (event: MessageEvent<string>) => void): void;
+}
+
+export type RealtimeServerSentEventSourceFactory = (
+  url: string,
+  init?: EventSourceInit,
+) => RealtimeServerSentEventSource;
+
+export interface RealtimeServerSentEventsTransportOptions<TFeature = unknown> {
+  readonly url: string;
+  readonly eventSourceFactory?: RealtimeServerSentEventSourceFactory;
+  readonly withCredentials?: boolean;
+  readonly eventTypes?: ReadonlyArray<string>;
+  readonly encodeRequest?: (url: URL, request: RealtimeSubscriptionRequest) => void;
+  readonly decodeEvent?: (payload: unknown) => RealtimeFeatureEvent<TFeature>;
+}
+
+const DEFAULT_EVENT_TYPES = ["snapshot", "upsert", "delete", "delta", "heartbeat", "status", "error"] as const;
+
+export function createRealtimeServerSentEventsTransport<TFeature = unknown>(
+  options: RealtimeServerSentEventsTransportOptions<TFeature>,
+): RealtimeFeatureTransport<TFeature> {
+  return {
+    capabilities: {
+      kind: "sse",
+      resumeModes: ["cursor", "watermark", "timestamp", "sequence", "delta-token"],
+      emitsHeartbeats: true,
+      emitsWatermarks: true,
+    },
+    subscribe(request, observer): RealtimeSubscriptionHandle {
+      const url = new URL(options.url, "http://honua.local");
+      encodeDefaultRealtimeRequest(url, request);
+      options.encodeRequest?.(url, request);
+      const source = createEventSource(resolveEventSourceUrl(options.url, url), options);
+      let closed = false;
+      const listeners: Array<readonly [string, (event: MessageEvent<string>) => void]> = [];
+
+      const emitPayload = (payload: string): void => {
+        if (closed || payload.trim() === "") return;
+        try {
+          observer.next((options.decodeEvent ?? decodeRealtimeServerSentEvent<TFeature>)(JSON.parse(payload)));
+        } catch (error) {
+          observer.error(error);
+        }
+      };
+      const messageListener = (event: MessageEvent<string>) => emitPayload(event.data);
+
+      source.onopen = () => {
+        if (!closed) observer.next({ type: "status", status: "live", receivedAt: Date.now() });
+      };
+      source.onmessage = messageListener;
+      source.onerror = (event) => {
+        if (!closed)
+          observer.next({ type: "status", status: "reconnecting", reason: "sse-error", receivedAt: Date.now() });
+        if (isEventSourceClosed(source)) observer.error(event);
+      };
+
+      for (const type of options.eventTypes ?? DEFAULT_EVENT_TYPES) {
+        if (!source.addEventListener) break;
+        const listener = (event: MessageEvent<string>) => emitPayload(event.data);
+        source.addEventListener(type, listener);
+        listeners.push([type, listener]);
+      }
+
+      const abortListener = () => closeSource();
+      request.signal?.addEventListener("abort", abortListener, { once: true });
+
+      function closeSource(): void {
+        if (closed) return;
+        closed = true;
+        request.signal?.removeEventListener("abort", abortListener);
+        for (const [type, listener] of listeners) source.removeEventListener?.(type, listener);
+        source.onopen = null;
+        source.onmessage = null;
+        source.onerror = null;
+        source.close();
+        observer.complete();
+      }
+
+      return {
+        close: closeSource,
+      };
+    },
+  };
+}
+
+export function encodeDefaultRealtimeRequest(url: URL, request: RealtimeSubscriptionRequest): URL {
+  url.searchParams.set("sourceId", String(request.sourceId));
+  if (request.layerId !== undefined) url.searchParams.set("layerId", String(request.layerId));
+  if (request.requestId) url.searchParams.set("requestId", request.requestId);
+  if (request.mode) url.searchParams.set("mode", request.mode);
+  if (request.where) url.searchParams.set("where", request.where);
+  if (request.fields?.length) url.searchParams.set("fields", request.fields.join(","));
+  if (request.cursor ?? request.resumeFrom?.cursor)
+    url.searchParams.set("cursor", request.cursor ?? request.resumeFrom?.cursor ?? "");
+  if (request.watermark ?? request.resumeFrom?.watermark) {
+    url.searchParams.set("watermark", request.watermark ?? request.resumeFrom?.watermark ?? "");
+  }
+  if (request.timestamp ?? request.resumeFrom?.timestamp) {
+    url.searchParams.set("timestamp", request.timestamp ?? request.resumeFrom?.timestamp ?? "");
+  }
+  if (request.deltaToken ?? request.resumeFrom?.deltaToken) {
+    url.searchParams.set("deltaToken", request.deltaToken ?? request.resumeFrom?.deltaToken ?? "");
+  }
+  if (request.resumeFrom?.sequence !== undefined) url.searchParams.set("sequence", String(request.resumeFrom.sequence));
+  if (request.spatialFilter !== undefined) url.searchParams.set("spatialFilter", JSON.stringify(request.spatialFilter));
+  if (request.metadata !== undefined) url.searchParams.set("metadata", JSON.stringify(request.metadata));
+  return url;
+}
+
+export function decodeRealtimeServerSentEvent<TFeature = unknown>(payload: unknown): RealtimeFeatureEvent<TFeature> {
+  if (!isRecord(payload)) throw new Error("Realtime SSE payload must be a JSON object.");
+  if (typeof payload.type === "string") return payload as unknown as RealtimeFeatureEvent<TFeature>;
+  if (isRecord(payload.event) && typeof payload.event.type === "string") {
+    return payload.event as unknown as RealtimeFeatureEvent<TFeature>;
+  }
+  if (typeof payload.kind === "string") {
+    return { ...payload, type: payload.kind } as unknown as RealtimeFeatureEvent<TFeature>;
+  }
+  throw new Error("Realtime SSE payload is missing an event type.");
+}
+
+function createEventSource<TFeature>(
+  url: string,
+  options: RealtimeServerSentEventsTransportOptions<TFeature>,
+): RealtimeServerSentEventSource {
+  const factory =
+    options.eventSourceFactory ??
+    ((globalThis as unknown as { EventSource?: RealtimeServerSentEventSourceFactory }).EventSource as
+      | RealtimeServerSentEventSourceFactory
+      | undefined);
+  if (!factory) throw new Error("EventSource is not available; provide eventSourceFactory for this runtime.");
+  return factory(url, { withCredentials: options.withCredentials });
+}
+
+function resolveEventSourceUrl(input: string, url: URL): string {
+  if (input.startsWith("http://") || input.startsWith("https://")) return url.toString();
+  return `${url.pathname}${url.search}`;
+}
+
+function isEventSourceClosed(source: RealtimeServerSentEventSource): boolean {
+  return source.readyState === 2;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/test/realtime-incident-dashboard.test.ts
+++ b/test/realtime-incident-dashboard.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { INCIDENT_SOURCE_ID, INITIAL_INCIDENTS } from "../examples/realtime-incident-dashboard/src/fixtures.js";
+import {
+  INCIDENT_LAYER_ID,
+  INCIDENT_SOURCE_ID,
+  INITIAL_INCIDENTS,
+} from "../examples/realtime-incident-dashboard/src/fixtures.js";
 import {
   INCIDENT_METADATA_CACHE_STATE,
   evaluateIncidentLiveStateAuthority,
@@ -8,6 +12,10 @@ import {
 } from "../examples/realtime-incident-dashboard/src/live-state.js";
 import { applyIncidentProjection, incidentRecords } from "../examples/realtime-incident-dashboard/src/projection.js";
 import { createFixtureIncidentTransport } from "../examples/realtime-incident-dashboard/src/realtime-fixture.js";
+import {
+  createIncidentDashboardTransport,
+  readIncidentTransportConfig,
+} from "../examples/realtime-incident-dashboard/src/realtime-transport.js";
 import type { IncidentFeature } from "../examples/realtime-incident-dashboard/src/types.js";
 import {
   createExplorationContext,
@@ -23,6 +31,40 @@ import {
 } from "../src/realtime/index.js";
 
 describe("realtime incident dashboard fixture", () => {
+  it("keeps fixture transport as the default and opts into cloud SSE by config", () => {
+    const fixtureLocation = { search: "" } as Location;
+    const cloudLocation = {
+      search: "?transport=cloud&streamUrl=https%3A%2F%2Fhonua.example%2Fapi%2Fv1%2Frealtime%2Fevents",
+    } as Location;
+
+    expect(readIncidentTransportConfig(fixtureLocation)).toEqual({
+      mode: "fixture",
+      streamUrl: undefined,
+    });
+    expect(readIncidentTransportConfig(cloudLocation)).toEqual({
+      mode: "cloud",
+      streamUrl: "https://honua.example/api/v1/realtime/events",
+    });
+
+    const fixture = createIncidentDashboardTransport(fixtureLocation);
+    const cloud = createIncidentDashboardTransport(cloudLocation);
+
+    expect(fixture.controls.mode).toBe("fixture");
+    expect(fixture.transport.capabilities?.kind).toBeUndefined();
+    expect(fixture.request).toMatchObject({
+      requestId: "realtime-incident-dashboard",
+      sourceId: INCIDENT_SOURCE_ID,
+      layerId: INCIDENT_LAYER_ID,
+      mode: "snapshot-then-delta",
+      metadata: {
+        channel: "fixture",
+      },
+    });
+    expect(cloud.controls.mode).toBe("cloud");
+    expect(cloud.transport.capabilities?.kind).toBe("sse");
+    expect(cloud.request.metadata).toMatchObject({ channel: "cloud" });
+  });
+
   it("projects live incident deltas through the linked exploration context", () => {
     let clock = 1_000;
     const store = createRealtimeFeatureStore<IncidentFeature>();

--- a/test/realtime.test.ts
+++ b/test/realtime.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it, vi } from "vitest";
 import { createExplorationContext, sourceFeatureSelectionTarget } from "../src/exploration/index.js";
 import {
   createRealtimeFeatureStore,
+  createRealtimeServerSentEventsTransport,
+  decodeRealtimeServerSentEvent,
   emptyRealtimeFeatureState,
+  encodeDefaultRealtimeRequest,
   filterRealtimeSelection,
   realtimeFeatureKey,
   realtimeResumeCheckpoint,
@@ -20,8 +23,50 @@ import {
 import type {
   RealtimeFeatureObserver,
   RealtimeFeatureTransport,
+  RealtimeServerSentEventSource,
   RealtimeSubscriptionRequest,
 } from "../src/realtime/index.js";
+
+class MockRealtimeEventSource implements RealtimeServerSentEventSource {
+  public onopen: ((event: Event) => void) | null = null;
+  public onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  public onerror: ((event: Event) => void) | null = null;
+  public readyState = 0;
+  public closed = false;
+  private readonly listeners = new Map<string, Array<(event: MessageEvent<string>) => void>>();
+
+  public constructor(public readonly url: string) {}
+
+  public addEventListener(type: string, listener: (event: MessageEvent<string>) => void): void {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
+  }
+
+  public removeEventListener(type: string, listener: (event: MessageEvent<string>) => void): void {
+    this.listeners.set(
+      type,
+      (this.listeners.get(type) ?? []).filter((candidate) => candidate !== listener),
+    );
+  }
+
+  public close(): void {
+    this.closed = true;
+    this.readyState = 2;
+  }
+
+  public open(): void {
+    this.readyState = 1;
+    this.onopen?.(new Event("open"));
+  }
+
+  public message(payload: unknown): void {
+    this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(payload) }));
+  }
+
+  public namedMessage(type: string, payload: unknown): void {
+    const event = new MessageEvent(type, { data: JSON.stringify(payload) });
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+}
 
 describe("realtime feature state", () => {
   it("applies snapshot, upsert, delete, cursor, and heartbeat events", () => {
@@ -253,6 +298,110 @@ describe("realtime feature state", () => {
       mode: "snapshot-then-delta",
       resumeFrom,
     });
+  });
+
+  it("encodes server-sent event subscription requests for cloud realtime streams", () => {
+    const url = encodeDefaultRealtimeRequest(new URL("https://honua.example/realtime/events"), {
+      requestId: "incident-ops",
+      sourceId: "incidents",
+      layerId: "active",
+      fields: ["id", "status"],
+      where: "status <> 'resolved'",
+      mode: "snapshot-then-delta",
+      resumeFrom: {
+        cursor: "c7",
+        watermark: "w7",
+        timestamp: "2026-05-05T11:00:00.000Z",
+        sequence: 12,
+        deltaToken: "dt7",
+      },
+      spatialFilter: { relationship: "intersects", geometry: { x: -157.86, y: 21.31 } },
+      metadata: { demo: "incident-dashboard" },
+    });
+
+    expect(url.searchParams.get("requestId")).toBe("incident-ops");
+    expect(url.searchParams.get("sourceId")).toBe("incidents");
+    expect(url.searchParams.get("layerId")).toBe("active");
+    expect(url.searchParams.get("mode")).toBe("snapshot-then-delta");
+    expect(url.searchParams.get("cursor")).toBe("c7");
+    expect(url.searchParams.get("sequence")).toBe("12");
+    expect(JSON.parse(url.searchParams.get("spatialFilter") ?? "{}")).toEqual({
+      relationship: "intersects",
+      geometry: { x: -157.86, y: 21.31 },
+    });
+  });
+
+  it("decodes direct and enveloped server-sent event payloads", () => {
+    expect(
+      decodeRealtimeServerSentEvent<{ status: string }>({
+        type: "upsert",
+        feature: { sourceId: "incidents", id: 1, feature: { status: "open" } },
+      }),
+    ).toMatchObject({
+      type: "upsert",
+      feature: { id: 1 },
+    });
+    expect(
+      decodeRealtimeServerSentEvent<{ status: string }>({
+        event: {
+          type: "heartbeat",
+          cursor: "c9",
+        },
+      }),
+    ).toEqual({
+      type: "heartbeat",
+      cursor: "c9",
+    });
+    expect(() => decodeRealtimeServerSentEvent({ event: "missing-type" })).toThrow(/missing an event type/);
+  });
+
+  it("bridges server-sent events into the realtime store without live cloud calls", () => {
+    const sources: MockRealtimeEventSource[] = [];
+    const transport = createRealtimeServerSentEventsTransport<{ status: string }>({
+      url: "https://honua.example/api/v1/realtime/events",
+      eventSourceFactory(url) {
+        const source = new MockRealtimeEventSource(url);
+        sources.push(source);
+        return source;
+      },
+    });
+    const store = createRealtimeFeatureStore<{ status: string }>();
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    const handle = store.connect(transport, {
+      sourceId: "incidents",
+      layerId: "active",
+      mode: "snapshot-then-delta",
+      resumeFrom: { cursor: "c1" },
+    });
+    const [source] = sources;
+    expect(source?.url).toContain("/api/v1/realtime/events?");
+    expect(source?.url).toContain("sourceId=incidents");
+    expect(source?.url).toContain("cursor=c1");
+
+    source?.open();
+    source?.message({
+      type: "delta",
+      cursor: "c2",
+      sequence: 2,
+      upserts: [{ sourceId: "incidents", id: 7, feature: { status: "open" } }],
+    });
+    source?.namedMessage("heartbeat", {
+      type: "heartbeat",
+      cursor: "c3",
+      receivedAt: 500,
+    });
+
+    expect(store.state.status).toBe("live");
+    expect(store.state.cursor).toBe("c3");
+    expect(store.state.records[realtimeFeatureKey("incidents", 7)]?.feature.status).toBe("open");
+    expect(store.state.lastHeartbeatAt).toBe(500);
+
+    handle.close();
+    expect(source?.closed).toBe(true);
+    expect(store.state.status).toBe("closed");
+    expect(listener).toHaveBeenCalled();
   });
 
   it("projects realtime state for map, table, tombstone, and detail synchronization", () => {


### PR DESCRIPTION
## Summary
- Adds a protocol-neutral SSE realtime transport adapter for `@honua/sdk-js/realtime` with request encoding, EventSource injection, and event envelope decoding.
- Adds an opt-in cloud transport path for the realtime incident dashboard while keeping deterministic fixture mode as the default.
- Keeps dashboard updates flowing through the existing realtime store and linked map/table/filter/detail state.

## Validation
- npm test -- test/realtime.test.ts test/realtime-incident-dashboard.test.ts
- npm run demo:incident:typecheck
- npm run check
- npm run build
- npm run demo:incident:build

Closes #57
