### PR TITLE
Fix Kepler example audit

### DIFF
--- a/examples/kepler-analytics/package-lock.json
+++ b/examples/kepler-analytics/package-lock.json
@@ -9520,15 +9520,16 @@
       }
     },
     "node_modules/thrift": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.19.0.tgz",
-      "integrity": "sha512-FfAeToex47DYF5UiqFiLXc0dTOQ1Dt94hdT/p1WEM8HQGOvI32jGs235QUeOvYwb1bApsTfFCa+ACDyF0fVtrg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.23.0.tgz",
+      "integrity": "sha512-j7F1ls8JogClU88Ta/pwD/OzYuiFeD6Z5GoWw7ip+jcDhcNYFKgfXYEsyLXYpiNfJO94fbLnITGxyfZ19YzA6Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "browser-or-node": "^1.2.1",
         "isomorphic-ws": "^4.0.1",
         "node-int64": "^0.4.0",
         "q": "^1.5.0",
+        "uuid": "^13.0.0",
         "ws": "^5.2.3"
       },
       "engines": {

--- a/examples/kepler-analytics/package.json
+++ b/examples/kepler-analytics/package.json
@@ -46,6 +46,7 @@
     "postcss": "8.5.13",
     "react-vis": "1.12.1",
     "styled-components": "6.4.1",
+    "thrift": "0.23.0",
     "uuid": "14.0.0",
     "vite": "8.0.10"
   },


### PR DESCRIPTION
## Summary
- pins the Kepler analytics demo's transitive `thrift` package to `0.23.0`
- refreshes the Kepler demo lockfile so the CI audit no longer resolves `thrift@0.19.0`

## Validation
- `npm run demo:kepler:install`
- `npm audit --prefix examples/kepler-analytics`
- `npm run demo:kepler:build`

Fixes the post-merge trunk SDK CI audit failure from #114.
