### PR TITLE
Add unified ops field editing module

### DIFF
--- a/examples/edit-workflow-demo/src/model.ts
+++ b/examples/edit-workflow-demo/src/model.ts
@@ -498,6 +498,9 @@ export function createEditWorkflowDemoSession(
     metadataFields() {
       return EDIT_WORKFLOW_FIELDS;
     },
+    allFeatures() {
+      return source.features();
+    },
     draft() {
       return cloneDraft(draft);
     },

--- a/examples/edit-workflow-demo/src/types.ts
+++ b/examples/edit-workflow-demo/src/types.ts
@@ -144,6 +144,7 @@ export interface EditWorkflowDemoSession {
   activeProjection(): LinkedViewQueryProjection;
   capabilities(): EditWorkflowCapabilitySummary;
   metadataFields(): readonly EditWorkflowField[];
+  allFeatures(): readonly InspectionFeature[];
   draft(): EditWorkflowDraft;
   pendingAttachments(): readonly EditAttachmentMutation[];
   attachmentList(featureId?: FeatureId): Promise<readonly AttachmentInfo[]>;

--- a/examples/unified-ops-workspace/README.md
+++ b/examples/unified-ops-workspace/README.md
@@ -1,7 +1,7 @@
 # Unified Operational Intelligence Workspace
 
-Fixture-backed shell for issue `#73`. It composes an incident command module and
-an analysis review module over one `HonuaAppWorkspace` plus one linked
+Fixture-backed shell for issue `#73`. It composes incident command, analysis
+review, and field editing modules over one `HonuaAppWorkspace` plus one linked
 `ExplorationContext`.
 
 ## Commands
@@ -20,4 +20,6 @@ npm run test:playwright:unified-ops
 - Realtime fixture deltas reconciled into app workspace state.
 - AI/MCP proposals staged as reviewable drafts before applying linked-context
   changes.
+- Field inspection edits staged through the edit-workflow demo and reconciled
+  back into the shared realtime/detail context.
 - Saved workspace document round trip with snapshot diagnostics.

--- a/examples/unified-ops-workspace/index.html
+++ b/examples/unified-ops-workspace/index.html
@@ -16,6 +16,7 @@
         <nav class="module-switcher" aria-label="Workspace modules">
           <button type="button" data-module="incident-command" aria-pressed="true">Incident Command</button>
           <button type="button" data-module="analysis-review" aria-pressed="false">Analysis Review</button>
+          <button type="button" data-module="field-editing" aria-pressed="false">Field Editing</button>
         </nav>
 
         <section class="panel">
@@ -35,6 +36,13 @@
             <span>
               <strong>Response crews</strong>
               <em id="crew-source-status">ready</em>
+            </span>
+          </label>
+          <label class="source-toggle">
+            <input id="source-field-inspections" type="checkbox" checked />
+            <span>
+              <strong>Field inspections</strong>
+              <em id="field-source-status">ready</em>
             </span>
           </label>
         </section>
@@ -204,6 +212,76 @@
                 <span id="terminal-job-count">0 terminal</span>
               </div>
               <ul id="job-list" class="stack-list"></ul>
+            </section>
+          </div>
+        </section>
+
+        <section id="field-editing-module" class="module-view" data-active="false">
+          <div class="stage-heading">
+            <div>
+              <p class="eyebrow">Field Editing</p>
+              <h2>Shared Context Edit Workflow</h2>
+            </div>
+            <dl class="summary-strip">
+              <div>
+                <dt>Visible</dt>
+                <dd id="edit-visible-count">0</dd>
+              </div>
+              <div>
+                <dt>Pending</dt>
+                <dd id="edit-pending-count">0</dd>
+              </div>
+              <div>
+                <dt>Status</dt>
+                <dd id="edit-status-readout">Ready</dd>
+              </div>
+            </dl>
+          </div>
+
+          <div class="field-edit-grid">
+            <section class="panel">
+              <div class="panel-heading">
+                <h3>Editable Inspections</h3>
+                <span id="edit-form-source">-</span>
+              </div>
+              <ul id="editable-inspection-list" class="stack-list edit-list"></ul>
+            </section>
+
+            <section class="panel edit-form-panel">
+              <div class="panel-heading">
+                <h3>Feature Form</h3>
+                <span id="edit-feature-id">-</span>
+              </div>
+              <label class="field-label" for="edit-status-field">Status</label>
+              <select id="edit-status-field">
+                <option value="open">Open</option>
+                <option value="in-progress">In progress</option>
+                <option value="closed">Closed</option>
+              </select>
+              <label class="field-label" for="edit-priority-field">Priority</label>
+              <select id="edit-priority-field">
+                <option value="critical">Critical</option>
+                <option value="high">High</option>
+                <option value="medium">Medium</option>
+                <option value="low">Low</option>
+              </select>
+              <label class="field-label" for="edit-score-field">Inspection Score</label>
+              <input id="edit-score-field" type="number" min="0" max="100" step="1" />
+              <label class="field-label" for="edit-notes-field">Notes</label>
+              <textarea id="edit-notes-field" rows="5"></textarea>
+              <div class="button-row">
+                <button id="stage-edit-attachment" type="button">Stage Attachment</button>
+                <button id="force-edit-conflict" type="button">Force Conflict</button>
+                <button id="save-edit-workflow" type="button">Save Edit</button>
+              </div>
+            </section>
+
+            <section class="panel">
+              <div class="panel-heading">
+                <h3>Capability Readiness</h3>
+                <span id="edit-capability-state">-</span>
+              </div>
+              <ul id="edit-readiness-list" class="stack-list"></ul>
             </section>
           </div>
         </section>

--- a/examples/unified-ops-workspace/src/fixtures.ts
+++ b/examples/unified-ops-workspace/src/fixtures.ts
@@ -1,6 +1,8 @@
 import type { HonuaExtent } from "@honua/sdk-js/honua";
 
-import { CREW_SOURCE_ID, INCIDENT_SOURCE_ID } from "./types.js";
+import { createEditWorkflowDataset } from "../../edit-workflow-demo/src/fixtures.js";
+import type { InspectionFeature, InspectionPriority } from "../../edit-workflow-demo/src/types.js";
+import { CREW_SOURCE_ID, FIELD_INSPECTION_SOURCE_ID, INCIDENT_SOURCE_ID } from "./types.js";
 import type {
   UnifiedOpsFeature,
   UnifiedOpsMapPreset,
@@ -8,7 +10,7 @@ import type {
   UnifiedOpsSourceMetadata,
 } from "./types.js";
 
-export const OPS_SOURCE_IDS = [INCIDENT_SOURCE_ID, CREW_SOURCE_ID] as const;
+export const OPS_SOURCE_IDS = [INCIDENT_SOURCE_ID, CREW_SOURCE_ID, FIELD_INSPECTION_SOURCE_ID] as const;
 
 export const DEFAULT_WORKSPACE_EXTENT: HonuaExtent = {
   xmin: -157.93,
@@ -40,7 +42,9 @@ export const MAP_PRESETS: readonly UnifiedOpsMapPreset[] = [
   { id: "airport", label: "Airport", extent: AIRPORT_EXTENT },
 ];
 
-export const INITIAL_UNIFIED_OPS_FEATURES: readonly UnifiedOpsFeature[] = [
+const EDIT_WORKFLOW_DATASET = createEditWorkflowDataset();
+
+export const INITIAL_OPERATIONAL_FEATURES: readonly UnifiedOpsFeature[] = [
   {
     id: "INC-2001",
     sourceId: INCIDENT_SOURCE_ID,
@@ -165,6 +169,15 @@ export const INITIAL_UNIFIED_OPS_FEATURES: readonly UnifiedOpsFeature[] = [
   },
 ];
 
+export const INITIAL_EDIT_WORKFLOW_FEATURES: readonly UnifiedOpsFeature[] = EDIT_WORKFLOW_DATASET.features.map(
+  editWorkflowFeatureToUnifiedOpsFeature,
+);
+
+export const INITIAL_UNIFIED_OPS_FEATURES: readonly UnifiedOpsFeature[] = [
+  ...INITIAL_OPERATIONAL_FEATURES,
+  ...INITIAL_EDIT_WORKFLOW_FEATURES,
+];
+
 export const INITIAL_SOURCE_METADATA: Record<string, UnifiedOpsSourceMetadata> = {
   [INCIDENT_SOURCE_ID]: {
     title: "Incident operations",
@@ -187,6 +200,17 @@ export const INITIAL_SOURCE_METADATA: Record<string, UnifiedOpsSourceMetadata> =
       ttlMs: 900_000,
     },
     diagnostics: ["Layer metadata cache hit", "Domain cache hit", "Crew assignment index warmed"],
+  },
+  [FIELD_INSPECTION_SOURCE_ID]: {
+    title: "Field inspections",
+    protocol: "geoservices-feature-service",
+    active: true,
+    cache: {
+      status: "hit",
+      updatedAt: Date.parse("2026-05-06T18:00:00.000Z"),
+      ttlMs: 900_000,
+    },
+    diagnostics: ["Form metadata cache hit", "Domain cache hit", "Attachment capability supported"],
   },
 };
 
@@ -260,3 +284,37 @@ export const UNIFIED_OPS_SCENARIO_STEPS: readonly UnifiedOpsScenarioStep[] = [
     },
   },
 ];
+
+export function editWorkflowFeatureToUnifiedOpsFeature(feature: InspectionFeature): UnifiedOpsFeature {
+  return {
+    id: String(feature.id),
+    sourceId: FIELD_INSPECTION_SOURCE_ID,
+    kind: "inspection",
+    title: feature.title,
+    type: "Field Inspection",
+    severity: priorityToSeverity(feature.attributes.priority),
+    status: feature.attributes.status,
+    district: titleCase(feature.areaId),
+    coordinate: [feature.geometry.x, feature.geometry.y],
+    updatedAt: feature.attributes.last_edited_date,
+    impactScore: feature.attributes.inspection_score,
+    assignment: feature.attributes.assigned_to,
+    summary: feature.attributes.notes,
+    relatedIds: [feature.attributes.asset_id],
+    attachments:
+      EDIT_WORKFLOW_DATASET.attachments[String(feature.id)]?.map(
+        (attachment) => attachment.name ?? String(attachment.id),
+      ) ?? [],
+  };
+}
+
+function priorityToSeverity(priority: InspectionPriority): UnifiedOpsFeature["severity"] {
+  if (priority === "critical") return "critical";
+  if (priority === "high") return "high";
+  if (priority === "medium") return "medium";
+  return "low";
+}
+
+function titleCase(value: string): string {
+  return value.replaceAll("-", " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}

--- a/examples/unified-ops-workspace/src/main.ts
+++ b/examples/unified-ops-workspace/src/main.ts
@@ -12,16 +12,22 @@ import {
   applyUnifiedOpsProjection,
   createUnifiedOpsSnapshotDiagnostics,
   createUnifiedOpsWorkspace,
+  forceUnifiedOpsEditConflict,
   formatExtent,
   moveUnifiedOpsMap,
   restoreUnifiedOpsSnapshot,
   saveUnifiedOpsSnapshot,
+  selectUnifiedOpsEditFeature,
   selectedFeatureId,
   setUnifiedOpsActiveModule,
   setUnifiedOpsActiveSource,
   stageUnifiedOpsAiDraft,
+  stageUnifiedOpsEditAttachment,
+  submitUnifiedOpsEditDraft,
+  updateUnifiedOpsEditDraftValue,
+  visibleUnifiedOpsEditFeatures,
 } from "./model.js";
-import { CREW_SOURCE_ID, INCIDENT_SOURCE_ID, OPS_LAYER_ID } from "./types.js";
+import { CREW_SOURCE_ID, FIELD_INSPECTION_SOURCE_ID, INCIDENT_SOURCE_ID, OPS_LAYER_ID } from "./types.js";
 import type {
   UnifiedOpsFeature,
   UnifiedOpsModuleId,
@@ -41,6 +47,9 @@ interface UnifiedOpsRuntime {
   stagedDraftCount: number;
   appliedDraftCount: number;
   realtimeStatus: string;
+  editStatus: string;
+  editFeatureId: string | null;
+  pendingAttachmentCount: number;
   snapshotId: string | null;
   lastStep: string | null;
   step(): string | null;
@@ -71,6 +80,7 @@ let lastStep: string | null = null;
 let lastSavedDocument: unknown;
 let lastSnapshot: UnifiedOpsSavedSnapshot | undefined;
 let appliedDraftCount = 0;
+let lastEditStatus = "ready";
 
 const runtime: UnifiedOpsRuntime = {
   ready: false,
@@ -81,6 +91,9 @@ const runtime: UnifiedOpsRuntime = {
   stagedDraftCount: 0,
   appliedDraftCount: 0,
   realtimeStatus: "idle",
+  editStatus: lastEditStatus,
+  editFeatureId: null,
+  pendingAttachmentCount: 0,
   snapshotId: null,
   lastStep: null,
   step() {
@@ -120,6 +133,12 @@ function setText(selector: string, value: string): void {
   getElement<HTMLElement>(selector).textContent = value;
 }
 
+function setInputValue(selector: string, value: string): void {
+  const element = getElement<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>(selector);
+  if (document.activeElement === element) return;
+  element.value = value;
+}
+
 function escapeHtml(value: unknown): string {
   return String(value)
     .replaceAll("&", "&amp;")
@@ -151,6 +170,7 @@ function renderAll(): void {
   renderMap(mapResult);
   renderIncidentTable(incidentResult);
   renderChart(incidentResult);
+  renderFieldEditing();
   renderDetail();
   renderDrafts();
   renderJobs();
@@ -166,6 +186,7 @@ function renderModules(): void {
   });
   getElement<HTMLElement>("#incident-command-module").dataset.active = String(activeModule === "incident-command");
   getElement<HTMLElement>("#analysis-review-module").dataset.active = String(activeModule === "analysis-review");
+  getElement<HTMLElement>("#field-editing-module").dataset.active = String(activeModule === "field-editing");
   setText("#context-active-view", activeModule);
 }
 
@@ -175,10 +196,13 @@ function renderSourceToggles(): void {
   setText("#active-source-count", `${active.length} active`);
   const incidentEntry = state.sources.entries[INCIDENT_SOURCE_ID];
   const crewEntry = state.sources.entries[CREW_SOURCE_ID];
+  const fieldEntry = state.sources.entries[FIELD_INSPECTION_SOURCE_ID];
   getElement<HTMLInputElement>("#source-incident-ops").checked = incidentEntry?.metadata?.active !== false;
   getElement<HTMLInputElement>("#source-response-crews").checked = crewEntry?.metadata?.active !== false;
+  getElement<HTMLInputElement>("#source-field-inspections").checked = fieldEntry?.metadata?.active !== false;
   setText("#incident-source-status", incidentEntry?.status ?? "missing");
   setText("#crew-source-status", crewEntry?.status ?? "missing");
+  setText("#field-source-status", fieldEntry?.status ?? "missing");
 }
 
 function renderFilters(): void {
@@ -213,8 +237,14 @@ function renderMap(result: UnifiedOpsProjectionResult): void {
   `;
   map.querySelectorAll<HTMLButtonElement>(".map-pin").forEach((pin) => {
     pin.addEventListener("click", () => {
-      const sourceId = pin.dataset.sourceId === CREW_SOURCE_ID ? CREW_SOURCE_ID : INCIDENT_SOURCE_ID;
+      const sourceId = sourceIdFromPin(pin.dataset.sourceId);
       const id = pin.dataset.id ?? "";
+      if (sourceId === FIELD_INSPECTION_SOURCE_ID) {
+        selectUnifiedOpsEditFeature(shell, id);
+        lastEditStatus = "ready";
+        scheduleRender();
+        return;
+      }
       shell.controllers.table.select([sourceFeatureSelectionTarget(sourceId, id)], { replace: true });
       scheduleRender();
     });
@@ -239,7 +269,7 @@ function renderMapPin(feature: UnifiedOpsFeature, extent = latestProjection.exte
       aria-label="Open ${escapeHtml(feature.title)}"
       title="${escapeHtml(feature.title)}"
     >
-      <span>${feature.kind === "crew" ? "C" : "I"}</span>
+      <span>${pinLabel(feature)}</span>
     </button>
   `;
 }
@@ -317,6 +347,64 @@ function renderChart(result: UnifiedOpsProjectionResult): void {
       scheduleRender();
     });
   });
+}
+
+function renderFieldEditing(): void {
+  const draft = shell.editWorkflow.draft();
+  const visibleFeatures = visibleUnifiedOpsEditFeatures(shell);
+  const pendingAttachments = shell.editWorkflow.pendingAttachments();
+  const capability = shell.editWorkflow.capabilities();
+  const readiness = shell.editWorkflow.readiness();
+
+  setText("#edit-visible-count", String(visibleFeatures.length));
+  setText("#edit-pending-count", String(pendingAttachments.length));
+  setText("#edit-status-readout", titleCase(lastEditStatus));
+  setText("#edit-feature-id", draft.featureId === undefined ? "new" : String(draft.featureId));
+  setText(
+    "#edit-capability-state",
+    `Edits ${capability.applyEdits}; attachments ${capability.attachments}; conflicts ${capability.conflicts}`,
+  );
+  setText("#edit-form-source", FIELD_INSPECTION_SOURCE_ID);
+
+  setInputValue("#edit-status-field", String(draft.values.status));
+  setInputValue("#edit-priority-field", String(draft.values.priority));
+  setInputValue("#edit-score-field", String(draft.values.inspection_score));
+  setInputValue("#edit-notes-field", String(draft.values.notes));
+
+  const list = getElement<HTMLElement>("#editable-inspection-list");
+  list.innerHTML =
+    visibleFeatures.length === 0
+      ? "<li><strong>No inspections match the shared context</strong><span>-</span></li>"
+      : visibleFeatures
+          .map(
+            (feature) => `
+              <li data-active="${String(String(draft.featureId) === feature.id)}">
+                <button type="button" data-edit-feature="${escapeHtml(feature.id)}">
+                  <strong>${escapeHtml(feature.title)}</strong>
+                  <span>${escapeHtml(titleCase(feature.status))} / ${escapeHtml(titleCase(feature.severity))}</span>
+                </button>
+              </li>
+            `,
+          )
+          .join("");
+  list.querySelectorAll<HTMLButtonElement>("[data-edit-feature]").forEach((button) => {
+    button.addEventListener("click", () => {
+      selectUnifiedOpsEditFeature(shell, button.dataset.editFeature ?? "");
+      lastEditStatus = "ready";
+      scheduleRender();
+    });
+  });
+
+  getElement<HTMLElement>("#edit-readiness-list").innerHTML = readiness
+    .map(
+      (entry) => `
+        <li>
+          <strong>${escapeHtml(titleCase(entry.capability))}</strong>
+          <span>${escapeHtml(titleCase(entry.state))} / ${escapeHtml(entry.note)}</span>
+        </li>
+      `,
+    )
+    .join("");
 }
 
 function renderDetail(): void {
@@ -436,6 +524,11 @@ function renderContext(): void {
       selection: latestProjection.selection,
       jobs: Object.keys(state.jobs.entries),
       drafts: Object.keys(state.drafts.entries),
+      edit: {
+        featureId: shell.editWorkflow.draft().featureId ?? null,
+        pendingAttachments: shell.editWorkflow.pendingAttachments().length,
+        status: lastEditStatus,
+      },
       layerFilter: shell.mapLayerFilters.filters[OPS_LAYER_ID],
     },
     null,
@@ -453,6 +546,10 @@ function updateRuntime(result: UnifiedOpsProjectionResult): void {
   runtime.stagedDraftCount = Object.keys(state.drafts.entries).length;
   runtime.appliedDraftCount = appliedDraftCount;
   runtime.realtimeStatus = state.realtime.features.status;
+  runtime.editStatus = lastEditStatus;
+  runtime.editFeatureId =
+    shell.editWorkflow.draft().featureId === undefined ? null : String(shell.editWorkflow.draft().featureId);
+  runtime.pendingAttachmentCount = shell.editWorkflow.pendingAttachments().length;
   runtime.snapshotId = lastSnapshot?.id ?? null;
   runtime.lastStep = lastStep;
 }
@@ -470,6 +567,10 @@ function bindControls(): void {
   });
   getElement<HTMLInputElement>("#source-response-crews").addEventListener("change", (event) => {
     setUnifiedOpsActiveSource(shell, CREW_SOURCE_ID, (event.target as HTMLInputElement).checked);
+    scheduleRender();
+  });
+  getElement<HTMLInputElement>("#source-field-inspections").addEventListener("change", (event) => {
+    setUnifiedOpsActiveSource(shell, FIELD_INSPECTION_SOURCE_ID, (event.target as HTMLInputElement).checked);
     scheduleRender();
   });
   getElement<HTMLSelectElement>("#status-filter").addEventListener("change", (event) => {
@@ -504,6 +605,42 @@ function bindControls(): void {
   });
   getElement<HTMLButtonElement>("#restore-snapshot").addEventListener("click", () => {
     runtime.restoreSnapshot();
+  });
+  getElement<HTMLSelectElement>("#edit-status-field").addEventListener("change", (event) => {
+    updateUnifiedOpsEditDraftValue(shell, "status", (event.target as HTMLSelectElement).value);
+    lastEditStatus = "ready";
+    scheduleRender();
+  });
+  getElement<HTMLSelectElement>("#edit-priority-field").addEventListener("change", (event) => {
+    updateUnifiedOpsEditDraftValue(shell, "priority", (event.target as HTMLSelectElement).value);
+    lastEditStatus = "ready";
+    scheduleRender();
+  });
+  getElement<HTMLInputElement>("#edit-score-field").addEventListener("input", (event) => {
+    updateUnifiedOpsEditDraftValue(shell, "inspection_score", (event.target as HTMLInputElement).value);
+    lastEditStatus = "ready";
+    scheduleRender();
+  });
+  getElement<HTMLTextAreaElement>("#edit-notes-field").addEventListener("input", (event) => {
+    updateUnifiedOpsEditDraftValue(shell, "notes", (event.target as HTMLTextAreaElement).value);
+    lastEditStatus = "ready";
+    scheduleRender();
+  });
+  getElement<HTMLButtonElement>("#stage-edit-attachment").addEventListener("click", () => {
+    stageUnifiedOpsEditAttachment(shell);
+    lastEditStatus = "ready";
+    scheduleRender();
+  });
+  getElement<HTMLButtonElement>("#force-edit-conflict").addEventListener("click", () => {
+    forceUnifiedOpsEditConflict(shell);
+    lastEditStatus = "ready";
+    scheduleRender();
+  });
+  getElement<HTMLButtonElement>("#save-edit-workflow").addEventListener("click", () => {
+    void submitUnifiedOpsEditDraft(shell).then((result) => {
+      lastEditStatus = result.status;
+      scheduleRender();
+    });
   });
   renderMapPresetButtons();
 }
@@ -570,6 +707,18 @@ function sourceSelectionKey(selection: (typeof latestProjection.selection)[numbe
     return `${selection.sourceId}:${selection.id}`;
   }
   return `${INCIDENT_SOURCE_ID}:${selection}`;
+}
+
+function sourceIdFromPin(sourceId: string | undefined) {
+  if (sourceId === CREW_SOURCE_ID) return CREW_SOURCE_ID;
+  if (sourceId === FIELD_INSPECTION_SOURCE_ID) return FIELD_INSPECTION_SOURCE_ID;
+  return INCIDENT_SOURCE_ID;
+}
+
+function pinLabel(feature: UnifiedOpsFeature): string {
+  if (feature.kind === "crew") return "C";
+  if (feature.kind === "inspection") return "E";
+  return "I";
 }
 
 function titleCase(value: string): string {

--- a/examples/unified-ops-workspace/src/model.ts
+++ b/examples/unified-ops-workspace/src/model.ts
@@ -38,14 +38,17 @@ import {
   reconcileRealtimeSelection,
 } from "@honua/sdk-js/realtime";
 
+import { createEditWorkflowDemoSession } from "../../edit-workflow-demo/src/model.js";
+import type { EditWorkflowDemoSession, InspectionAttributes } from "../../edit-workflow-demo/src/types.js";
 import {
   DEFAULT_WORKSPACE_EXTENT,
   INITIAL_SOURCE_METADATA,
   INITIAL_UNIFIED_OPS_FEATURES,
   OPS_SOURCE_IDS,
   UNIFIED_OPS_SCENARIO_STEPS,
+  editWorkflowFeatureToUnifiedOpsFeature,
 } from "./fixtures.js";
-import { INCIDENT_SOURCE_ID, OPS_LAYER_ID } from "./types.js";
+import { FIELD_INSPECTION_SOURCE_ID, INCIDENT_SOURCE_ID, OPS_LAYER_ID } from "./types.js";
 import type {
   UnifiedOpsChartBucket,
   UnifiedOpsFeature,
@@ -91,6 +94,7 @@ export interface UnifiedOpsWorkspace {
   readonly controllers: UnifiedOpsWorkspaceControllers;
   readonly mapExtentSource: ManualMapExtentSource;
   readonly mapLayerFilters: MemoryMapLayerFilterTarget;
+  readonly editWorkflow: EditWorkflowDemoSession;
   readonly sourceIds: ReadonlyArray<UnifiedOpsSourceId>;
   readonly currentScenarioStepIndex: number;
   stepRealtimeScenario(): string | undefined;
@@ -132,10 +136,12 @@ const STATUS_RANK: Record<string, number> = {
   open: 0,
   assigned: 1,
   enroute: 2,
-  monitoring: 3,
-  staged: 4,
-  available: 5,
-  resolved: 6,
+  "in-progress": 3,
+  monitoring: 4,
+  staged: 5,
+  available: 6,
+  resolved: 7,
+  closed: 8,
 };
 
 export class ManualMapExtentSource implements MapExtentExplorationSource {
@@ -172,6 +178,7 @@ export class MemoryMapLayerFilterTarget {
 export function createUnifiedOpsWorkspace(options: CreateUnifiedOpsWorkspaceOptions = {}): UnifiedOpsWorkspace {
   const now = options.now ?? (() => Date.now());
   const workspace = createHonuaAppWorkspace<UnifiedOpsFeature, UnifiedOpsSourceMetadata, UnifiedOpsJobResult>();
+  const editWorkflow = createEditWorkflowDemoSession();
   const exploration = createExplorationContext({
     datasetId: "unified-operational-intelligence",
     sourceIds: OPS_SOURCE_IDS,
@@ -207,8 +214,9 @@ export function createUnifiedOpsWorkspace(options: CreateUnifiedOpsWorkspaceOpti
       panels: {
         "incident-command": { visible: true, order: 1, size: 620 },
         "analysis-review": { visible: false, order: 2, size: 520 },
-        "detail-panel": { visible: true, order: 3, size: 360 },
-        "diagnostics-panel": { visible: true, order: 4, size: 320 },
+        "field-editing": { visible: false, order: 3, size: 520 },
+        "detail-panel": { visible: true, order: 4, size: 360 },
+        "diagnostics-panel": { visible: true, order: 5, size: 320 },
       },
     },
   });
@@ -229,6 +237,7 @@ export function createUnifiedOpsWorkspace(options: CreateUnifiedOpsWorkspaceOpti
     },
     mapExtentSource,
     mapLayerFilters,
+    editWorkflow,
     sourceIds: OPS_SOURCE_IDS,
     get currentScenarioStepIndex() {
       return scenarioStepIndex;
@@ -241,6 +250,7 @@ export function createUnifiedOpsWorkspace(options: CreateUnifiedOpsWorkspaceOpti
     },
     dispose(): void {
       for (const handle of bindingHandles) handle.remove();
+      editWorkflow.dispose();
       workspace.dispose();
       exploration.dispose();
     },
@@ -259,6 +269,56 @@ export function setUnifiedOpsActiveModule(shell: UnifiedOpsWorkspace, moduleId: 
     panelId: "analysis-review",
     panel: { visible: moduleId === "analysis-review" },
   });
+  shell.workspace.dispatch({
+    kind: "update-panel",
+    panelId: "field-editing",
+    panel: { visible: moduleId === "field-editing" },
+  });
+}
+
+export function visibleUnifiedOpsEditFeatures(shell: UnifiedOpsWorkspace): readonly UnifiedOpsFeature[] {
+  const active = shell.workspace.state.sources.entries[FIELD_INSPECTION_SOURCE_ID]?.metadata?.active !== false;
+  if (!active) return [];
+  return applyUnifiedOpsProjection(shell.workspace.state, selectProjectionFromState(shell.workspace.state), {
+    sourceId: FIELD_INSPECTION_SOURCE_ID,
+  }).rows;
+}
+
+export function selectUnifiedOpsEditFeature(shell: UnifiedOpsWorkspace, featureId: string | number): void {
+  shell.editWorkflow.selectFeature(Number(featureId));
+  shell.views.table.select([sourceFeatureSelectionTarget(FIELD_INSPECTION_SOURCE_ID, String(featureId))], {
+    replace: true,
+  });
+  syncUnifiedOpsExplorationSnapshot(shell.workspace, shell.exploration);
+}
+
+export function updateUnifiedOpsEditDraftValue(
+  shell: UnifiedOpsWorkspace,
+  fieldName: keyof InspectionAttributes,
+  value: unknown,
+): void {
+  shell.editWorkflow.updateDraftValue(fieldName, value);
+}
+
+export function stageUnifiedOpsEditAttachment(shell: UnifiedOpsWorkspace, name = "workspace-after-action.png"): void {
+  shell.editWorkflow.stageAttachmentAdd(name);
+}
+
+export function forceUnifiedOpsEditConflict(shell: UnifiedOpsWorkspace): void {
+  shell.editWorkflow.forceNextConflict();
+}
+
+export async function submitUnifiedOpsEditDraft(shell: UnifiedOpsWorkspace) {
+  const result = await shell.editWorkflow.submitDraft();
+  syncUnifiedOpsEditWorkflowFeatures(shell);
+  const committedId = result.committedFeatureId ?? shell.editWorkflow.draft().featureId;
+  if (committedId !== undefined) {
+    shell.views.table.select([sourceFeatureSelectionTarget(FIELD_INSPECTION_SOURCE_ID, String(committedId))], {
+      replace: true,
+    });
+    syncUnifiedOpsExplorationSnapshot(shell.workspace, shell.exploration);
+  }
+  return result;
 }
 
 export function setUnifiedOpsActiveSource(
@@ -622,6 +682,20 @@ function seedUnifiedOpsRealtime(workspace: UnifiedOpsAppWorkspace, now: number):
       replace: true,
     },
   });
+}
+
+function syncUnifiedOpsEditWorkflowFeatures(shell: UnifiedOpsWorkspace): void {
+  for (const feature of shell.editWorkflow.allFeatures()) {
+    shell.workspace.dispatch({
+      kind: "apply-realtime-event",
+      event: {
+        type: "upsert",
+        eventId: `edit-workflow-sync-${String(feature.id)}-${String(feature.attributes.version)}`,
+        receivedAt: Date.parse(feature.attributes.last_edited_date),
+        feature: featureToPatch(editWorkflowFeatureToUnifiedOpsFeature(feature)),
+      },
+    });
+  }
 }
 
 function scenarioStepToRealtimeEvent(

--- a/examples/unified-ops-workspace/src/styles.css
+++ b/examples/unified-ops-workspace/src/styles.css
@@ -21,12 +21,15 @@ body {
 
 button,
 input,
-select {
+select,
+textarea {
   font: inherit;
 }
 
 button,
-select {
+input,
+select,
+textarea {
   min-height: 34px;
   border: 1px solid #a9b4ad;
   border-radius: 6px;
@@ -53,6 +56,16 @@ button:disabled {
 select {
   inline-size: 100%;
   padding: 0 10px;
+}
+
+input,
+textarea {
+  inline-size: 100%;
+  padding: 7px 10px;
+}
+
+textarea {
+  resize: vertical;
 }
 
 h1,
@@ -318,6 +331,10 @@ dd {
   background: #0f766e;
 }
 
+.map-pin[data-kind="inspection"] {
+  background: #7c3aed;
+}
+
 .map-pin[data-severity="critical"] {
   background: #b91c1c;
 }
@@ -378,6 +395,22 @@ td span {
   display: grid;
   grid-template-columns: repeat(2, minmax(260px, 1fr));
   gap: 14px;
+}
+
+.field-edit-grid {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.72fr) minmax(300px, 1fr) minmax(260px, 0.76fr);
+  gap: 14px;
+}
+
+.edit-form-panel {
+  display: grid;
+  align-content: start;
+}
+
+.edit-form-panel .button-row {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 12px;
 }
 
 .severity-chart {
@@ -444,6 +477,24 @@ td span {
   background: #fff8e6;
 }
 
+.edit-list li {
+  padding: 0;
+}
+
+.edit-list button {
+  display: grid;
+  gap: 3px;
+  inline-size: 100%;
+  min-height: 56px;
+  padding: 8px;
+  text-align: left;
+}
+
+.edit-list button span {
+  color: #596860;
+  font-size: 0.78rem;
+}
+
 .detail-panel {
   display: grid;
   gap: 10px;
@@ -469,7 +520,12 @@ td span {
   }
 
   .map-workspace,
-  .analysis-grid {
+  .analysis-grid,
+  .field-edit-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .edit-form-panel .button-row {
     grid-template-columns: 1fr;
   }
 

--- a/examples/unified-ops-workspace/src/types.ts
+++ b/examples/unified-ops-workspace/src/types.ts
@@ -3,13 +3,23 @@ import type { HonuaExtent } from "@honua/sdk-js/honua";
 
 export const INCIDENT_SOURCE_ID = "incident-ops";
 export const CREW_SOURCE_ID = "response-crews";
+export const FIELD_INSPECTION_SOURCE_ID = "honua-cloud:field-inspections";
 export const OPS_LAYER_ID = "unified-ops-features";
 
-export type UnifiedOpsSourceId = typeof INCIDENT_SOURCE_ID | typeof CREW_SOURCE_ID;
-export type UnifiedOpsModuleId = "incident-command" | "analysis-review";
-export type UnifiedOpsRecordKind = "incident" | "crew";
+export type UnifiedOpsSourceId = typeof INCIDENT_SOURCE_ID | typeof CREW_SOURCE_ID | typeof FIELD_INSPECTION_SOURCE_ID;
+export type UnifiedOpsModuleId = "incident-command" | "analysis-review" | "field-editing";
+export type UnifiedOpsRecordKind = "incident" | "crew" | "inspection";
 export type UnifiedOpsSeverity = "critical" | "high" | "medium" | "low";
-export type UnifiedOpsStatus = "open" | "assigned" | "monitoring" | "resolved" | "available" | "enroute" | "staged";
+export type UnifiedOpsStatus =
+  | "open"
+  | "assigned"
+  | "monitoring"
+  | "resolved"
+  | "available"
+  | "enroute"
+  | "staged"
+  | "in-progress"
+  | "closed";
 
 export interface UnifiedOpsFeature {
   readonly id: string;

--- a/examples/unified-ops-workspace/tsconfig.json
+++ b/examples/unified-ops-workspace/tsconfig.json
@@ -13,6 +13,7 @@
     "paths": {
       "@honua/sdk-js": ["../../src/index.ts"],
       "@honua/sdk-js/app-workspace": ["../../src/app-workspace/index.ts"],
+      "@honua/sdk-js/contract": ["../../src/contract/index.ts"],
       "@honua/sdk-js/exploration": ["../../src/exploration/index.ts"],
       "@honua/sdk-js/honua": ["../../src/honua.ts"],
       "@honua/sdk-js/interactions": ["../../src/interactions/index.ts"],

--- a/examples/unified-ops-workspace/vite.config.ts
+++ b/examples/unified-ops-workspace/vite.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
         replacement: path.resolve(repoRoot, "src/app-workspace/index.ts"),
       },
       {
+        find: "@honua/sdk-js/contract",
+        replacement: path.resolve(repoRoot, "src/contract/index.ts"),
+      },
+      {
         find: "@honua/sdk-js/exploration",
         replacement: path.resolve(repoRoot, "src/exploration/index.ts"),
       },

--- a/test/playwright/unified-ops-workspace.spec.mjs
+++ b/test/playwright/unified-ops-workspace.spec.mjs
@@ -67,6 +67,30 @@ test("unified ops workspace preserves linked context across modules, drafts, rea
     await expect(page.locator("#detail-title")).toHaveText("Harbor fuel sheen");
     await expect.poll(async () => page.evaluate(() => window.__HONUA_UNIFIED_OPS_RUNTIME__?.filterCount)).toBe(2);
 
+    await page.getByRole("button", { name: "Field Editing" }).click();
+    await expect(page.getByRole("button", { name: "Field Editing" })).toHaveAttribute("aria-pressed", "true");
+    await expect(page.locator("#filter-count")).toHaveText("2");
+    await expect(page.locator("#detail-title")).toHaveText("Harbor fuel sheen");
+    await expect(page.locator("#edit-visible-count")).toHaveText("3");
+
+    await page.getByRole("button", { name: /Pier 2 pump station/ }).click();
+    await expect(page.locator("#detail-title")).toHaveText("Pier 2 pump station");
+    await page.locator("#edit-status-field").selectOption("closed");
+    await page.locator("#edit-score-field").fill("95");
+    await page.getByRole("button", { name: "Stage Attachment" }).click();
+    await expect(page.locator("#edit-pending-count")).toHaveText("1");
+    await page.getByRole("button", { name: "Save Edit" }).click();
+    await expect(page.locator("#edit-status-readout")).toHaveText("Succeeded");
+    await expect(page.locator("#edit-pending-count")).toHaveText("0");
+    await expect(page.locator("#detail-attributes")).toContainText("Closed");
+
+    await page.getByRole("button", { name: "Analysis Review" }).click();
+    await expect(page.locator("#filter-count")).toHaveText("2");
+    await expect(page.locator("#detail-title")).toHaveText("Pier 2 pump station");
+    await expect.poll(async () => page.evaluate(() => window.__HONUA_UNIFIED_OPS_RUNTIME__?.editStatus)).toBe(
+      "succeeded",
+    );
+
     expect(pageErrors).toEqual([]);
   } finally {
     await fixtureServer.close();

--- a/test/unified-ops-workspace.test.ts
+++ b/test/unified-ops-workspace.test.ts
@@ -9,11 +9,16 @@ import {
   moveUnifiedOpsMap,
   restoreUnifiedOpsSnapshot,
   saveUnifiedOpsSnapshot,
+  selectUnifiedOpsEditFeature,
   setUnifiedOpsActiveModule,
   setUnifiedOpsActiveSource,
   stageUnifiedOpsAiDraft,
+  stageUnifiedOpsEditAttachment,
+  submitUnifiedOpsEditDraft,
+  updateUnifiedOpsEditDraftValue,
+  visibleUnifiedOpsEditFeatures,
 } from "../examples/unified-ops-workspace/src/model.js";
-import { INCIDENT_SOURCE_ID } from "../examples/unified-ops-workspace/src/types.js";
+import { FIELD_INSPECTION_SOURCE_ID, INCIDENT_SOURCE_ID } from "../examples/unified-ops-workspace/src/types.js";
 import { selectLinkedViewQueryProjection, sourceFeatureSelectionTarget } from "../src/exploration/index.js";
 import { selectHonuaAppWorkspaceDetailModel, selectHonuaAppWorkspaceFilterModel } from "../src/index.js";
 
@@ -156,6 +161,61 @@ describe("unified ops workspace", () => {
     shell.dispose();
   });
 
+  it("bridges field edit workflow saves into the shared linked context", async () => {
+    const shell = createUnifiedOpsWorkspace({ now: () => 4_800 });
+
+    shell.controllers.filters.setFilter("status", {
+      field: "status",
+      operator: "=",
+      value: "open",
+      appliesTo: [INCIDENT_SOURCE_ID],
+    });
+    moveUnifiedOpsMap(shell, URBAN_CORE_EXTENT);
+    shell.controllers.table.select([sourceFeatureSelectionTarget(INCIDENT_SOURCE_ID, "INC-2001")], { replace: true });
+    setUnifiedOpsActiveModule(shell, "field-editing");
+    await flush();
+
+    expect(shell.workspace.state.layout.activeViewId).toBe("field-editing");
+    expect(selectHonuaAppWorkspaceDetailModel(shell.workspace.state).selectedRecords[0]?.feature.id).toBe("INC-2001");
+    expect(visibleUnifiedOpsEditFeatures(shell).map((feature) => feature.id)).toEqual(["4101", "4103"]);
+
+    selectUnifiedOpsEditFeature(shell, 4101);
+    updateUnifiedOpsEditDraftValue(shell, "status", "closed");
+    updateUnifiedOpsEditDraftValue(shell, "inspection_score", 95);
+    stageUnifiedOpsEditAttachment(shell, "workspace-closeout.png");
+    await flush();
+
+    expect(shell.exploration.state.selection).toEqual([
+      sourceFeatureSelectionTarget(FIELD_INSPECTION_SOURCE_ID, "4101"),
+    ]);
+    expect(shell.editWorkflow.pendingAttachments()).toHaveLength(1);
+
+    const result = await submitUnifiedOpsEditDraft(shell);
+    await flush();
+
+    const projection = selectLinkedViewQueryProjection(shell.exploration.state);
+    const fieldRows = applyUnifiedOpsProjection(shell.workspace.state, projection, {
+      sourceId: FIELD_INSPECTION_SOURCE_ID,
+    }).rows;
+
+    expect(result.status).toBe("succeeded");
+    expect(shell.workspace.state.layout.activeViewId).toBe("field-editing");
+    expect(shell.exploration.state.filters.status?.value).toBe("open");
+    expect(shell.exploration.state.extent).toEqual(URBAN_CORE_EXTENT);
+    expect(fieldRows.find((feature) => feature.id === "4101")).toMatchObject({
+      status: "closed",
+      impactScore: 95,
+    });
+    expect(selectHonuaAppWorkspaceDetailModel(shell.workspace.state).selectedRecords[0]?.feature).toMatchObject({
+      id: "4101",
+      sourceId: FIELD_INSPECTION_SOURCE_ID,
+      status: "closed",
+    });
+    expect(shell.editWorkflow.pendingAttachments()).toHaveLength(0);
+
+    shell.dispose();
+  });
+
   it("saves and restores snapshots with diagnostics", async () => {
     const shell = createUnifiedOpsWorkspace({ now: () => 5_000 });
     setUnifiedOpsActiveModule(shell, "analysis-review");
@@ -174,7 +234,7 @@ describe("unified ops workspace", () => {
       savedAt: "2026-05-06T00:00:00.000Z",
     });
     expect(saved.diagnostics).toMatchObject({
-      activeSourceCount: 1,
+      activeSourceCount: 2,
       filterCount: 1,
       selectedFeatureCount: 1,
       activeViewId: "analysis-review",
@@ -194,8 +254,8 @@ describe("unified ops workspace", () => {
     expect(shell.exploration.state.filters.status?.value).toBe("open");
     expect(shell.exploration.state.selection).toEqual([sourceFeatureSelectionTarget(INCIDENT_SOURCE_ID, "INC-2001")]);
     expect(saved.document.metadata?.diagnostics).toMatchObject({
-      realtimeRecordCount: 7,
-      modulePanelCount: 4,
+      realtimeRecordCount: 10,
+      modulePanelCount: 5,
     });
 
     shell.dispose();


### PR DESCRIPTION
## Summary
- add field inspections as a third unified ops source backed by the edit-workflow demo dataset
- add a Field Editing module that shares map/filter/detail context and reconciles saved edits back into realtime records
- extend unified ops unit and Playwright coverage for module switching, context preservation, staged attachments, and save results

## Validation
- npm run check
- npm run demo:unified-ops:typecheck
- npm run typecheck
- npm run build
- npx vitest run test/unified-ops-workspace.test.ts test/edit-workflow-demo.test.ts
- npm run test:playwright:unified-ops
- npm test -- test/migration-cli-content-webmap.test.ts test/migration-real-sample-runtime.test.ts

Note: a full npm test pass completed once earlier in this worktree (158 files / 1704 tests). A final full-suite rerun later hit timeout limits in two unrelated long-running migration files under load; both failed files passed when rerun through npm test with explicit file arguments.

Refs #73