### PR TITLE
Add integration coverage for public API surfaces

### DIFF
--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -19,10 +19,13 @@ server routes, response shapes, errors, and capability negotiation.
   the server's admin auth — the harness passes
   `HONUA_INTEGRATION_API_KEY` as the `X-API-Key` header, and that value
   must match the server's `HONUA_ADMIN_PASSWORD`.
-- **Public API only.** Tests call methods on `HonuaClient` and its
+- **Public API only.** Tests call methods on `HonuaClient`, its
   factory-returned helpers (`featureLayer`, `mapService`,
-  `ogcFeatures`, `ogcTiles`, `ogcMaps`, `ogcProcesses`, `wms`, `wmts`).
-  Private HTTP helpers from `honua-server/tests/` are not used.
+  `imageService`, `geometryService`, `geoprocessing`, `ogcFeatures`,
+  `ogcTiles`, `ogcMaps`, `ogcProcesses`, `stac`, `wfs`, `wms`, `wmts`,
+  `odata`), and standalone public clients such as
+  `HonuaGeocodingClient`. Private HTTP helpers from
+  `honua-server/tests/` are not used.
 - **One file per protocol surface.** `test/integration/surfaces/`
   contains one `*.integration.ts` per surface; each file calls
   `integrationSuite("<friendly>", "<surface-tag>", () => …)` so the
@@ -77,6 +80,17 @@ HONUA_INTEGRATION_BASE_URL=http://localhost:8080 \
 | `HONUA_INTEGRATION_TIMEOUT_MS` | `30000` | Per-request timeout used by the harness `HonuaClient`. |
 | `HONUA_INTEGRATION_SERVER_IMAGE` | _(unset)_ | Recorded into `integration-meta.json` (CI uses the resolved image digest). |
 | `HONUA_INTEGRATION_SERVER_COMMIT` | _(unset)_ | Honua Server commit SHA, recorded into `integration-meta.json`. CI reads it from the workflow `server_commit` input or `vars.HONUA_INTEGRATION_SERVER_COMMIT`; it is never derived from `${{ github.sha }}` (which is the SDK repo commit). Leave blank when the server commit is unknown. |
+| `HONUA_INTEGRATION_STAC_COLLECTION_ID` | `HONUA_INTEGRATION_COLLECTION_ID` | STAC collection ID used for optional collection/item probes. |
+| `HONUA_INTEGRATION_ODATA_BASE_PATH` | `/odata` | OData service root path. |
+| `HONUA_INTEGRATION_ODATA_ENTITY_SET` | `Layers(<layerId>)/Features` | OData entity set or navigation path for the configured layer. |
+| `HONUA_INTEGRATION_IMAGE_SERVICE_ID` | _(unset)_ | Enables ImageServer live coverage against a seeded raster service. |
+| `HONUA_INTEGRATION_GP_SERVICE_ID` | _(unset)_ | Enables GPServer live coverage against a seeded job service. |
+| `HONUA_INTEGRATION_GP_TASK_NAME` | _(unset)_ | Optional GPServer task segment for task-scoped services. |
+| `HONUA_INTEGRATION_GP_PARAMETERS_JSON` | `{}` | JSON object submitted to the configured GPServer task. |
+| `HONUA_INTEGRATION_WFS_ENDPOINT_URL` | _(unset)_ | Enables WFS live coverage against a seeded WFS endpoint. |
+| `HONUA_INTEGRATION_WFS_TYPE_NAME` | _(unset)_ | WFS feature type used by the live WFS probe. |
+| `HONUA_INTEGRATION_GEOCODING_LOCATOR` | _(unset)_ | Enables GeocodeServer live coverage against a seeded locator. |
+| `HONUA_INTEGRATION_GEOCODING_PROBE_TEXT` | `Honolulu` | Forward-geocode text used when geocoding coverage is enabled. |
 
 ## Surface coverage
 
@@ -86,14 +100,19 @@ The lane exercises the following surfaces against the seed profile.
 | --- | --- | --- |
 | FeatureServer | Exercised | metadata, queryFeatures, queryFeatureCount, queryObjectIds |
 | MapServer | Exercised | metadata, mapLayer.queryFeatures, queryFeatureCount, exportMap |
+| ImageServer | Configured | `client.imageService().metadata` when `HONUA_INTEGRATION_IMAGE_SERVICE_ID` is set; otherwise recorded skipped because the default seed is vector-only |
+| GeometryServer | Exercised | `client.geometryService().project`, `buffer` |
+| GPServer | Configured | submitJob and jobStatus when `HONUA_INTEGRATION_GP_SERVICE_ID` is set; otherwise recorded skipped because the default seed has no runnable GP task |
 | OGC API Features | Exercised | landing, conformance, collections, items, item |
 | OGC API Tiles | Exercised | landing, conformance, tileMatrixSets (list + by id), tilesets, tile |
 | OGC API Maps | Exercised | landing, conformance, map render |
 | OGC API Processes | Exercised | landing, conformance, list, describe (when registered) |
+| STAC | Exercised | landing, collections, search, collection when advertised |
+| WFS | Configured | capabilities and bounded GetFeature when WFS endpoint/type env vars are set; otherwise recorded skipped |
 | WMS | Exercised | capabilities, GetMap |
 | WMTS | Exercised | capabilities, GetTile |
-| ImageServer | Skipped | No first-party `client.imageService(...)` entry yet (tracked by honua-sdk-js#39). |
-| GPServer | Skipped | No first-party `client.geoprocessing(...)` entry yet (tracked by honua-sdk-js#39). |
+| OData | Exercised | metadata, bounded entity query |
+| Geocoding | Configured | forwardGeocode when `HONUA_INTEGRATION_GEOCODING_LOCATOR` is set; otherwise recorded skipped |
 
 Skipped surfaces are recorded in `test-results/integration-meta.json`
 with a `reason` field so the gap is visible in CI artifacts; this keeps

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -11,12 +11,22 @@ import {
   withoutHonuaCacheState,
 } from "./cache-state.js";
 import { HonuaAbortError, HonuaHttpError, HonuaNetworkError, HonuaTimeoutError } from "./errors.js";
+import { HonuaOdataEntitySet } from "./odata.js";
 import { HonuaOgcMaps } from "./ogc-maps.js";
 import { HonuaOgcProcesses } from "./ogc-processes.js";
 import { HonuaOgcTiles } from "./ogc-tiles.js";
 import { decodePbfQueryResponse, isPbfResponse } from "./pbf-decoder.js";
 import { HonuaStacSearch } from "./stac.js";
-import { HonuaFeatureLayer, HonuaMapLayer, HonuaMapService, HonuaOgcFeatures, HonuaService } from "./surfaces.js";
+import {
+  HonuaFeatureLayer,
+  HonuaGeometryService,
+  HonuaGeoprocessingService,
+  HonuaImageService,
+  HonuaMapLayer,
+  HonuaMapService,
+  HonuaOgcFeatures,
+  HonuaService,
+} from "./surfaces.js";
 import type {
   ApplyEditsRequest,
   ExportMapRequest,
@@ -97,6 +107,7 @@ import type {
   QueryRelatedRecordsRequest,
   StacSearchRequest,
 } from "./types.js";
+import { HonuaWfs } from "./wfs.js";
 import { type WmsCapabilities, parseWmsCapabilities } from "./wms-capabilities.js";
 import {
   type HonuaWmsFeatureInfoResponse,
@@ -446,6 +457,26 @@ export class HonuaClient {
 
   public stac(): HonuaStacSearch {
     return new HonuaStacSearch({ client: this });
+  }
+
+  public imageService(serviceId: string): HonuaImageService {
+    return new HonuaImageService({ client: this, serviceId });
+  }
+
+  public geometryService(): HonuaGeometryService {
+    return new HonuaGeometryService({ client: this });
+  }
+
+  public geoprocessing(serviceId: string, taskName?: string): HonuaGeoprocessingService {
+    return new HonuaGeoprocessingService({ client: this, serviceId, taskName });
+  }
+
+  public wfs(endpointUrl = "/wfs", options: { version?: string } = {}): HonuaWfs {
+    return new HonuaWfs({ client: this, endpointUrl, version: options.version });
+  }
+
+  public odata(entitySet: string, options: { basePath?: string } = {}): HonuaOdataEntitySet {
+    return new HonuaOdataEntitySet({ client: this, entitySet, basePath: options.basePath });
   }
 
   public clearMetadataCache(options: { keyPrefix?: string } = {}): void {

--- a/src/honua.ts
+++ b/src/honua.ts
@@ -328,6 +328,16 @@ export type {
   OdataSpatialFilterContext,
 } from "./core/odata.js";
 export {
+  HonuaWfs,
+  HonuaWfsFeatureType,
+  HonuaWfsStoredQuery,
+  rethrowAsWfsExceptionIfPossible,
+} from "./core/wfs.js";
+export type {
+  HonuaWfsOptions,
+  OutputFormatChoice,
+} from "./core/wfs.js";
+export {
   hasOgcConformanceClass,
   negotiateOgcCapabilities,
 } from "./core/ogc-conformance.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1092,6 +1092,16 @@ export type {
   OdataSpatialFilterContext,
 } from "./core/odata.js";
 export {
+  HonuaWfs,
+  HonuaWfsFeatureType,
+  HonuaWfsStoredQuery,
+  rethrowAsWfsExceptionIfPossible,
+} from "./core/wfs.js";
+export type {
+  HonuaWfsOptions,
+  OutputFormatChoice,
+} from "./core/wfs.js";
+export {
   hasOgcConformanceClass,
   negotiateOgcCapabilities,
 } from "./core/ogc-conformance.js";

--- a/test/honua-surface.test.ts
+++ b/test/honua-surface.test.ts
@@ -3,11 +3,17 @@ import { describe, expect, it } from "vitest";
 import {
   HonuaClient,
   HonuaFeatureLayer,
+  HonuaGeometryService,
+  HonuaGeoprocessingService,
+  HonuaImageService,
   HonuaMapLayer,
   HonuaMapService,
+  HonuaOdataEntitySet,
   HonuaOgcFeatureCollection,
   HonuaOgcFeatures,
   HonuaService,
+  HonuaStacSearch,
+  HonuaWfs,
   createHonuaOgcFeatures,
   createHonuaService,
 } from "../src/index.js";
@@ -29,6 +35,12 @@ describe("Honua native API surfaces", () => {
     const ogc = client.ogcFeatures();
     const ogcViaFactory = createHonuaOgcFeatures(client);
     const ogcCollection = ogc.collection(0);
+    const stac = client.stac();
+    const image = client.imageService("imagery");
+    const geometry = client.geometryService();
+    const gp = client.geoprocessing("analysis", "buffer");
+    const wfs = client.wfs("/wfs");
+    const odata = client.odata("Layers(5)/Features");
     const helperService = createHonuaService(client, "transport");
 
     expect(service).toBeInstanceOf(HonuaService);
@@ -40,6 +52,12 @@ describe("Honua native API surfaces", () => {
     expect(ogc).toBeInstanceOf(HonuaOgcFeatures);
     expect(ogcViaFactory).toBeInstanceOf(HonuaOgcFeatures);
     expect(ogcCollection).toBeInstanceOf(HonuaOgcFeatureCollection);
+    expect(stac).toBeInstanceOf(HonuaStacSearch);
+    expect(image).toBeInstanceOf(HonuaImageService);
+    expect(geometry).toBeInstanceOf(HonuaGeometryService);
+    expect(gp).toBeInstanceOf(HonuaGeoprocessingService);
+    expect(wfs).toBeInstanceOf(HonuaWfs);
+    expect(odata).toBeInstanceOf(HonuaOdataEntitySet);
     expect(helperService).toBeInstanceOf(HonuaService);
     expect(layer.serviceId).toBe("transport");
     expect(layer.layerId).toBe(5);
@@ -49,6 +67,11 @@ describe("Honua native API surfaces", () => {
     expect(mapLayer.layerId).toBe(7);
     expect(mapLayerViaService.layerId).toBe(8);
     expect(ogcCollection.collectionId).toBe(0);
+    expect(image.serviceId).toBe("imagery");
+    expect(gp.serviceId).toBe("analysis");
+    expect(gp.taskName).toBe("buffer");
+    expect(wfs.endpointUrl).toBe("/wfs");
+    expect(odata.entitySet).toBe("Layers(5)/Features");
   });
 
   it("queries features and related records through fluent layer wrapper", async () => {

--- a/test/integration-surface-coverage.test.ts
+++ b/test/integration-surface-coverage.test.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const SURFACES_DIR = path.resolve(fileURLToPath(import.meta.url), "../integration/surfaces");
+
+const REQUIRED_SURFACES = [
+  "feature-server",
+  "map-server",
+  "image-server",
+  "geometry-server",
+  "gp-server",
+  "ogc-features",
+  "ogc-tiles",
+  "ogc-maps",
+  "ogc-processes",
+  "stac",
+  "wfs",
+  "wms",
+  "wmts",
+  "odata",
+  "geocoding",
+] as const;
+
+describe("integration API surface registry", () => {
+  it("has one integration surface entry for every public server-backed protocol API", () => {
+    const files = fs.readdirSync(SURFACES_DIR).filter((name) => name.endsWith(".integration.ts"));
+    const sourceByFile = new Map(files.map((name) => [name, fs.readFileSync(path.join(SURFACES_DIR, name), "utf8")]));
+    const joined = [...sourceByFile.values()].join("\n");
+
+    for (const surface of REQUIRED_SURFACES) {
+      const registration = new RegExp(
+        `(?:integrationSuite|skippedIntegrationSuite)\\([^\\n]*["']${escapeRegExp(surface)}["']`,
+      );
+      expect(joined, `missing integration registration for ${surface}`).toMatch(registration);
+    }
+  });
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/test/integration/harness.ts
+++ b/test/integration/harness.ts
@@ -55,6 +55,26 @@ export interface IntegrationConfig {
   collectionId: string;
   /** OGC Tiles tile-matrix-set used for sparse-tile reads. */
   tileMatrixSetId: string;
+  /** Optional ImageServer service ID for raster catalog / export coverage. */
+  imageServiceId: string | undefined;
+  /** Optional GPServer service ID for submit / job status coverage. */
+  gpServiceId: string | undefined;
+  /** Optional GPServer task name when the seed registers task-scoped jobs. */
+  gpTaskName: string | undefined;
+  /** STAC collection ID used for collection/item probes. Defaults to `collectionId`. */
+  stacCollectionId: string;
+  /** Optional WFS endpoint URL; set with `HONUA_INTEGRATION_WFS_ENDPOINT_URL`. */
+  wfsEndpointUrl: string | undefined;
+  /** Optional WFS feature type; set with `HONUA_INTEGRATION_WFS_TYPE_NAME`. */
+  wfsTypeName: string | undefined;
+  /** OData service root path. Defaults to Honua Server's `/odata`. */
+  odataBasePath: string;
+  /** OData entity set / navigation path. Defaults to the configured layer's features. */
+  odataEntitySet: string;
+  /** Optional GeocodeServer locator name; set when the seed exposes a locator. */
+  geocodingLocatorName: string | undefined;
+  /** Probe text used by geocoding coverage when a locator is configured. */
+  geocodingProbeText: string;
   /**
    * Free-form label tying the run to a server seed configuration.
    * Recorded into `integration-meta.json` for telemetry; not sent on
@@ -78,6 +98,8 @@ const DEFAULT_LAYER_ID = 1000;
 const DEFAULT_COLLECTION_ID = String(DEFAULT_LAYER_ID);
 const DEFAULT_TILE_MATRIX_SET = "WebMercatorQuad";
 const DEFAULT_SEED_PROFILE = "places-roads-v1";
+const DEFAULT_ODATA_BASE_PATH = "/odata";
+const DEFAULT_GEOCODING_PROBE_TEXT = "Honolulu";
 
 let cachedConfig: IntegrationConfig | undefined;
 
@@ -91,12 +113,24 @@ export function tryResolveIntegrationConfig(): IntegrationConfig | undefined {
   if (cachedConfig) return cachedConfig;
   const baseUrl = process.env[INTEGRATION_BASE_URL_ENV]?.trim();
   if (!baseUrl) return undefined;
+  const layerId = parseIntOrDefault(process.env.HONUA_INTEGRATION_LAYER_ID, DEFAULT_LAYER_ID);
+  const collectionId = process.env.HONUA_INTEGRATION_COLLECTION_ID?.trim() || DEFAULT_COLLECTION_ID;
   cachedConfig = {
     baseUrl,
     serviceId: process.env.HONUA_INTEGRATION_SERVICE_ID?.trim() || DEFAULT_SERVICE_ID,
-    layerId: parseIntOrDefault(process.env.HONUA_INTEGRATION_LAYER_ID, DEFAULT_LAYER_ID),
-    collectionId: process.env.HONUA_INTEGRATION_COLLECTION_ID?.trim() || DEFAULT_COLLECTION_ID,
+    layerId,
+    collectionId,
     tileMatrixSetId: process.env.HONUA_INTEGRATION_TILE_MATRIX_SET?.trim() || DEFAULT_TILE_MATRIX_SET,
+    imageServiceId: trimToUndefined(process.env.HONUA_INTEGRATION_IMAGE_SERVICE_ID),
+    gpServiceId: trimToUndefined(process.env.HONUA_INTEGRATION_GP_SERVICE_ID),
+    gpTaskName: trimToUndefined(process.env.HONUA_INTEGRATION_GP_TASK_NAME),
+    stacCollectionId: process.env.HONUA_INTEGRATION_STAC_COLLECTION_ID?.trim() || collectionId,
+    wfsEndpointUrl: trimToUndefined(process.env.HONUA_INTEGRATION_WFS_ENDPOINT_URL),
+    wfsTypeName: trimToUndefined(process.env.HONUA_INTEGRATION_WFS_TYPE_NAME),
+    odataBasePath: process.env.HONUA_INTEGRATION_ODATA_BASE_PATH?.trim() || DEFAULT_ODATA_BASE_PATH,
+    odataEntitySet: process.env.HONUA_INTEGRATION_ODATA_ENTITY_SET?.trim() || `Layers(${String(layerId)})/Features`,
+    geocodingLocatorName: trimToUndefined(process.env.HONUA_INTEGRATION_GEOCODING_LOCATOR),
+    geocodingProbeText: process.env.HONUA_INTEGRATION_GEOCODING_PROBE_TEXT?.trim() || DEFAULT_GEOCODING_PROBE_TEXT,
     seedProfile: process.env.HONUA_INTEGRATION_SEED_PROFILE?.trim() || DEFAULT_SEED_PROFILE,
     apiKey: trimToUndefined(process.env.HONUA_INTEGRATION_API_KEY),
     bearerToken: trimToUndefined(process.env.HONUA_INTEGRATION_BEARER_TOKEN),

--- a/test/integration/surfaces/geocoding.integration.ts
+++ b/test/integration/surfaces/geocoding.integration.ts
@@ -1,0 +1,44 @@
+/**
+ * GeocodeServer integration coverage. Exercises `HonuaGeocodingClient`
+ * when the target seed advertises a locator service.
+ *
+ * @module
+ */
+
+import { HonuaGeocodingClient } from "@honua/sdk-js";
+import { expect, it } from "vitest";
+import {
+  integrationSuite,
+  runWithDiagnostics,
+  skippedIntegrationSuite,
+  tryResolveIntegrationConfig,
+} from "../harness.js";
+
+const REASON = "HONUA_INTEGRATION_GEOCODING_LOCATOR unset; seeded GeocodeServer locator required";
+
+const config = tryResolveIntegrationConfig();
+
+if (config && !config.geocodingLocatorName) {
+  skippedIntegrationSuite("Geocoding", "geocoding", REASON, () => {
+    it.skip("forward geocodes against a seeded locator", () => {
+      expect(true).toBe(true);
+    });
+  });
+} else {
+  integrationSuite("Geocoding", "geocoding", ({ context, config }) => {
+    const geocoder = new HonuaGeocodingClient({
+      baseUrl: config.baseUrl,
+      locatorName: config.geocodingLocatorName,
+      apiKey: config.apiKey,
+      bearerToken: config.bearerToken,
+      timeoutMs: config.timeoutMs,
+    });
+
+    it("forward geocodes a configured probe string", async () => {
+      await runWithDiagnostics(context, "new HonuaGeocodingClient().forwardGeocode", async () => {
+        const results = await geocoder.forwardGeocode(config.geocodingProbeText, { maxResults: 1 });
+        expect(Array.isArray(results)).toBe(true);
+      });
+    });
+  });
+}

--- a/test/integration/surfaces/geometry-server.integration.ts
+++ b/test/integration/surfaces/geometry-server.integration.ts
@@ -1,0 +1,44 @@
+/**
+ * GeoServices GeometryServer integration coverage. Exercises the public
+ * `client.geometryService()` entry point against the shared Utilities
+ * GeometryServer route.
+ *
+ * @module
+ */
+
+import { expect, it } from "vitest";
+import { integrationSuite, runWithDiagnostics } from "../harness.js";
+
+const POINTS = {
+  geometryType: "esriGeometryPoint",
+  geometries: [{ x: -157.8583, y: 21.3069 }],
+};
+
+integrationSuite("GeometryServer", "geometry-server", ({ client, context }) => {
+  const geometry = client.geometryService();
+
+  it("projects point geometries through GeometryServer", async () => {
+    await runWithDiagnostics(context, "client.geometryService().project", async () => {
+      const result = await geometry.project({
+        geometries: POINTS,
+        inSr: 4326,
+        outSr: 3857,
+      });
+      expect(Array.isArray(result.geometries)).toBe(true);
+      expect(result.geometries?.length ?? 0).toBeGreaterThan(0);
+    });
+  });
+
+  it("buffers point geometries through GeometryServer", async () => {
+    await runWithDiagnostics(context, "client.geometryService().buffer", async () => {
+      const result = await geometry.buffer({
+        geometries: POINTS,
+        distances: [100],
+        unit: 9001,
+        inSr: 4326,
+        outSr: 4326,
+      });
+      expect(Array.isArray(result.geometries)).toBe(true);
+    });
+  });
+});

--- a/test/integration/surfaces/gp-server.integration.ts
+++ b/test/integration/surfaces/gp-server.integration.ts
@@ -1,25 +1,58 @@
 /**
  * GeoServices GPServer integration coverage.
  *
- * The Honua Server advertises GPServer routes, but the public
- * `HonuaClient` API does not expose a first-party
- * `client.geoprocessing(...)` entry point yet — `HonuaGeoprocessingService`
- * is registered for use by the canonical contract layer rather than as
- * a top-level client method like FeatureServer / MapServer have. The
- * integration lane scopes itself to public-API tests only, so this
- * file marks the surface as a documented gap until that dedicated
- * entry point lands. Track the gap in honua-sdk-js#39.
+ * Exercises the public `client.geoprocessing(...)` entry point when the
+ * target seed advertises a runnable GPServer service. Shared vector-only
+ * seeds usually do not include a job task, so the surface is recorded as
+ * skipped unless `HONUA_INTEGRATION_GP_SERVICE_ID` names a seeded GPServer.
  *
  * @module
  */
 
 import { expect, it } from "vitest";
-import { skippedIntegrationSuite } from "../harness.js";
+import {
+  integrationSuite,
+  runWithDiagnostics,
+  skippedIntegrationSuite,
+  tryResolveIntegrationConfig,
+} from "../harness.js";
 
-const REASON = "no first-party client.geoprocessing() entry point yet (tracked by honua-sdk-js#39)";
+const REASON = "HONUA_INTEGRATION_GP_SERVICE_ID unset; seeded GPServer task required for live job coverage";
 
-skippedIntegrationSuite("GPServer", "gp-server", REASON, () => {
-  it.skip("submits a GPServer job when the public surface lands", () => {
-    expect(true).toBe(true);
+const config = tryResolveIntegrationConfig();
+
+if (config && !config.gpServiceId) {
+  skippedIntegrationSuite("GPServer", "gp-server", REASON, () => {
+    it.skip("submits a GPServer job when a seeded task is configured", () => {
+      expect(true).toBe(true);
+    });
   });
-});
+} else {
+  integrationSuite("GPServer", "gp-server", ({ client, context, config }) => {
+    const gp = client.geoprocessing(config.gpServiceId ?? config.serviceId, config.gpTaskName);
+
+    it("submits a GPServer job and reads its status", async () => {
+      const job = await runWithDiagnostics(context, "client.geoprocessing().submitJob", async () => {
+        const parameters = parseJsonObject(process.env.HONUA_INTEGRATION_GP_PARAMETERS_JSON) ?? {};
+        const result = await gp.submitJob({ parameters });
+        expect(result.jobId).toBeTruthy();
+        expect(result.jobStatus).toBeTruthy();
+        return result;
+      });
+      await runWithDiagnostics(context, "client.geoprocessing().jobStatus", async () => {
+        const status = await gp.jobStatus(job.jobId);
+        expect(status.jobId).toBe(job.jobId);
+        expect(status.jobStatus).toBeTruthy();
+      });
+    });
+  });
+}
+
+function parseJsonObject(raw: string | undefined): Record<string, unknown> | undefined {
+  if (!raw?.trim()) return undefined;
+  const parsed = JSON.parse(raw) as unknown;
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("HONUA_INTEGRATION_GP_PARAMETERS_JSON must be a JSON object.");
+  }
+  return parsed as Record<string, unknown>;
+}

--- a/test/integration/surfaces/image-server.integration.ts
+++ b/test/integration/surfaces/image-server.integration.ts
@@ -1,25 +1,43 @@
 /**
  * GeoServices ImageServer integration coverage.
  *
- * The Honua Server exposes an ImageServer surface, but the public
- * `HonuaClient` API surfaces ImageServer through the lower-level
- * `client.request(...)` escape hatch and the
- * `HonuaImageService` runtime helper rather than through a first-party
- * `client.imageService(...)` method like FeatureServer / MapServer
- * have. The integration lane scopes itself to public-API tests only,
- * so this file marks the surface as a documented gap until that
- * dedicated entry point lands. Track the gap in honua-sdk-js#39.
+ * Exercises the public `client.imageService(...)` entry point when the
+ * target seed advertises a raster service. Most shared test seeds expose
+ * vector services only, so the surface is recorded as skipped unless
+ * `HONUA_INTEGRATION_IMAGE_SERVICE_ID` names a seeded ImageServer.
  *
  * @module
  */
 
 import { expect, it } from "vitest";
-import { skippedIntegrationSuite } from "../harness.js";
+import {
+  integrationSuite,
+  runWithDiagnostics,
+  skippedIntegrationSuite,
+  tryResolveIntegrationConfig,
+} from "../harness.js";
 
-const REASON = "no first-party client.imageService() entry point yet (tracked by honua-sdk-js#39)";
+const REASON = "HONUA_INTEGRATION_IMAGE_SERVICE_ID unset; seeded ImageServer required for live raster coverage";
 
-skippedIntegrationSuite("ImageServer", "image-server", REASON, () => {
-  it.skip("renders an ImageServer export when the public surface lands", () => {
-    expect(true).toBe(true);
+const config = tryResolveIntegrationConfig();
+
+if (config && !config.imageServiceId) {
+  skippedIntegrationSuite("ImageServer", "image-server", REASON, () => {
+    it.skip("reads ImageServer metadata when a seeded raster service is configured", () => {
+      expect(true).toBe(true);
+    });
   });
-});
+} else {
+  integrationSuite("ImageServer", "image-server", ({ client, context, config }) => {
+    const imageServiceId = config.imageServiceId ?? config.serviceId;
+    const image = client.imageService(imageServiceId);
+
+    it("returns ImageServer metadata", async () => {
+      await runWithDiagnostics(context, "client.imageService().metadata", async () => {
+        const metadata = await image.metadata();
+        expect(metadata).toBeDefined();
+        expect(metadata.serviceDescription ?? imageServiceId).toBeTruthy();
+      });
+    });
+  });
+}

--- a/test/integration/surfaces/odata.integration.ts
+++ b/test/integration/surfaces/odata.integration.ts
@@ -1,0 +1,29 @@
+/**
+ * OData v4 integration coverage. Exercises the public
+ * `client.odata(...)` entity-set adapter against the configured
+ * layer-scoped entity path.
+ *
+ * @module
+ */
+
+import { expect, it } from "vitest";
+import { integrationSuite, runWithDiagnostics } from "../harness.js";
+
+integrationSuite("OData", "odata", ({ client, context, config }) => {
+  const entitySet = client.odata(config.odataEntitySet, { basePath: config.odataBasePath });
+
+  it("reads OData metadata for the configured service root", async () => {
+    await runWithDiagnostics(context, "client.odata().metadata", async () => {
+      const metadata = await entitySet.metadata();
+      expect(metadata).toBeDefined();
+      expect(Object.keys(metadata.entitySets).length).toBeGreaterThan(0);
+    });
+  });
+
+  it("queries a bounded OData entity page", async () => {
+    await runWithDiagnostics(context, "client.odata().query", async () => {
+      const page = await entitySet.query({ top: 1, count: true });
+      expect(Array.isArray(page.rows)).toBe(true);
+    });
+  });
+});

--- a/test/integration/surfaces/stac.integration.ts
+++ b/test/integration/surfaces/stac.integration.ts
@@ -1,0 +1,48 @@
+/**
+ * STAC integration coverage. Walks the public `client.stac()` surface
+ * through catalog discovery and a bounded search probe.
+ *
+ * @module
+ */
+
+import { expect, it } from "vitest";
+import { integrationSuite, runWithDiagnostics } from "../harness.js";
+
+integrationSuite("STAC", "stac", ({ client, context, config }) => {
+  const stac = client.stac();
+
+  it("returns the STAC landing document", async () => {
+    await runWithDiagnostics(context, "client.stac().landing", async () => {
+      const landing = await stac.landing();
+      expect(landing).toBeDefined();
+      expect(Array.isArray(landing.links)).toBe(true);
+    });
+  });
+
+  it("lists STAC collections", async () => {
+    await runWithDiagnostics(context, "client.stac().collections", async () => {
+      const result = await stac.collections();
+      expect(Array.isArray(result.collections)).toBe(true);
+    });
+  });
+
+  it("fetches the configured STAC collection when it is advertised", async () => {
+    const collections = await runWithDiagnostics(context, "client.stac().collections", async () => stac.collections());
+    const ids = collections.collections.map((entry) => String(entry.id));
+    if (!ids.includes(String(config.stacCollectionId))) {
+      return;
+    }
+    await runWithDiagnostics(context, "client.stac().collection", async () => {
+      const collection = await stac.collection({ collectionId: config.stacCollectionId });
+      expect(String(collection.id)).toBe(String(config.stacCollectionId));
+    });
+  });
+
+  it("searches STAC items with a small page size", async () => {
+    await runWithDiagnostics(context, "client.stac().search", async () => {
+      const result = await stac.search({ limit: 1 });
+      expect(result.type).toBe("FeatureCollection");
+      expect(Array.isArray(result.features)).toBe(true);
+    });
+  });
+});

--- a/test/integration/surfaces/wfs.integration.ts
+++ b/test/integration/surfaces/wfs.integration.ts
@@ -1,0 +1,48 @@
+/**
+ * WFS 2.0 integration coverage. Exercises the public `client.wfs(...)`
+ * adapter when the target seed publishes a WFS endpoint and feature type.
+ *
+ * @module
+ */
+
+import { expect, it } from "vitest";
+import {
+  integrationSuite,
+  runWithDiagnostics,
+  skippedIntegrationSuite,
+  tryResolveIntegrationConfig,
+} from "../harness.js";
+
+const REASON =
+  "HONUA_INTEGRATION_WFS_ENDPOINT_URL or HONUA_INTEGRATION_WFS_TYPE_NAME unset; seeded WFS feature type required";
+
+const config = tryResolveIntegrationConfig();
+
+if (config && (!config.wfsEndpointUrl || !config.wfsTypeName)) {
+  skippedIntegrationSuite("WFS", "wfs", REASON, () => {
+    it.skip("reads WFS capabilities and fetches a feature page when a feature type is configured", () => {
+      expect(true).toBe(true);
+    });
+  });
+} else {
+  integrationSuite("WFS", "wfs", ({ client, context, config }) => {
+    const endpointUrl = config.wfsEndpointUrl ?? "/wfs";
+    const typeName = config.wfsTypeName ?? config.collectionId;
+    const wfs = client.wfs(endpointUrl);
+
+    it("returns WFS capabilities for the configured endpoint", async () => {
+      await runWithDiagnostics(context, "client.wfs().capabilities", async () => {
+        const capabilities = await wfs.capabilities();
+        expect(Array.isArray(capabilities.featureTypes)).toBe(true);
+        expect(capabilities.featureTypes.map((entry) => entry.name)).toContain(typeName);
+      });
+    });
+
+    it("fetches a bounded WFS feature page", async () => {
+      await runWithDiagnostics(context, "client.wfs().featureType().getFeature", async () => {
+        const result = await wfs.featureType(typeName).getFeature({ count: 1 });
+        expect(result.kind).toMatch(/json|raw/);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add first-party HonuaClient factories for ImageServer, GeometryServer, GPServer, WFS, and OData protocol handles
- add integration surface files for GeometryServer, STAC, WFS, OData, and Geocoding; promote ImageServer/GPServer to configurable live coverage with recorded skips when seed services are absent
- add a unit registry test so every public server-backed protocol surface has an integration registration
- document the expanded integration lane and optional seed env vars

## Validation
- npm run typecheck
- npm run lint
- npm run test:integration (no server configured; all 15 surface files skip via harness)
- npm test
- npm run build