### PR TITLE
Add gRPC to the shared canonical contract

### DIFF
--- a/docs/protocol-capability-matrix.md
+++ b/docs/protocol-capability-matrix.md
@@ -7,7 +7,8 @@ The matrix below is the **default** capability set per protocol. Callers
 that need a narrower surface for a specific source (for example a Feature
 Service whose metadata reports `supportsStatistics: false`) must intersect
 the default set themselves and pass the result on
-`SourceDescriptor.capabilities`. The GeoServices, OGC, STAC, WFS, and WMS
+`SourceDescriptor.capabilities`. The gRPC default is shared by the canonical
+FeatureService transport, and the GeoServices, OGC, STAC, WFS, and WMS
 adapter constructors do not read service metadata today, so per-source
 downgrades for those protocols stay caller-side. **OData is the
 exception**: the `odataSource` adapter lazily fetches `$metadata` on the
@@ -27,26 +28,26 @@ without a canonical `Source` method today are negotiated for
 `◐` = supported only under `degraded` capability policy (client-side fallback).
 `—` = not supported.
 
-| Capability | GS Feature | GS Map | GS Image | GS Geometry | GS GP | OGC Features | OGC Tiles | OGC Maps | STAC | WFS | WMS | WMTS | OData |
-| --- | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-| `query` | ✓ | ✓ | ✓ | — | — | ✓ | — | — | ✓ | ✓ | ✓ | — | ✓ |
-| `queryAggregate` | ✓ | ✓ | — | — | — | ◐ | — | — | — | — | — | — | — |
-| `spatialAggregate` | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| `queryExtent` | ✓ | ✓ | ✓ | — | — | ◐ | — | — | — | ✓ | — | — | — |
-| `queryObjectIds` | ✓ | ✓ | ✓ | — | — | ✓ | — | — | ✓ | ✓ | — | — | ✓ |
-| `queryRelated` | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — |
-| `applyEdits` | ✓ | — | — | — | — | ✓ | — | — | — | ✓ | — | — | ✓ |
-| `attachments` | ✓ | — | — | — | — | — | — | — | — | — | — | — | — |
-| `render` | — | ✓ | ✓ | — | — | — | ✓ | ✓ | — | — | ✓ | ✓ | — |
-| `tiles` | ◐ | ✓ | ✓ | — | — | — | ✓ | — | — | — | ✓ | ✓ | — |
-| `sql` | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — |
-| `stream` | ✓ | ✓ | — | — | — | ✓ | — | — | ✓ | ✓ | — | — | ✓ |
-| `pbf` | ✓ | — | — | — | — | — | — | — | — | — | — | — | — |
-| `connect` | ✓ | — | ✓ | ✓ | ✓ | — | — | — | — | — | — | — | — |
-| `image` | — | — | ✓ | — | — | — | — | — | — | — | — | — | — |
-| `geometry` | — | — | — | ✓ | — | — | — | — | — | — | — | — | — |
-| `geoprocess` | — | — | — | — | ✓ | — | — | — | — | — | — | — | — |
-| `processes` | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| Capability | gRPC | GS Feature | GS Map | GS Image | GS Geometry | GS GP | OGC Features | OGC Tiles | OGC Maps | STAC | WFS | WMS | WMTS | OData |
+| --- | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
+| `query` | ✓ | ✓ | ✓ | ✓ | — | — | ✓ | — | — | ✓ | ✓ | ✓ | — | ✓ |
+| `queryAggregate` | ✓ | ✓ | ✓ | — | — | — | ◐ | — | — | — | — | — | — | — |
+| `spatialAggregate` | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `queryExtent` | ✓ | ✓ | ✓ | ✓ | — | — | ◐ | — | — | — | ✓ | — | — | — |
+| `queryObjectIds` | ✓ | ✓ | ✓ | ✓ | — | — | ✓ | — | — | ✓ | ✓ | — | — | ✓ |
+| `queryRelated` | — | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — |
+| `applyEdits` | ✓ | ✓ | — | — | — | — | ✓ | — | — | — | ✓ | — | — | ✓ |
+| `attachments` | — | ✓ | — | — | — | — | — | — | — | — | — | — | — | — |
+| `render` | — | — | ✓ | ✓ | — | — | — | ✓ | ✓ | — | — | ✓ | ✓ | — |
+| `tiles` | — | ◐ | ✓ | ✓ | — | — | — | ✓ | — | — | — | ✓ | ✓ | — |
+| `sql` | — | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — |
+| `stream` | ✓ | ✓ | ✓ | — | — | — | ✓ | — | — | ✓ | ✓ | — | — | ✓ |
+| `pbf` | — | ✓ | — | — | — | — | — | — | — | — | — | — | — | — |
+| `connect` | — | ✓ | — | ✓ | ✓ | ✓ | — | — | — | — | — | — | — | — |
+| `image` | — | — | — | ✓ | — | — | — | — | — | — | — | — | — | — |
+| `geometry` | — | — | — | — | ✓ | — | — | — | — | — | — | — | — | — |
+| `geoprocess` | — | — | — | — | — | ✓ | — | — | — | — | — | — | — | — |
+| `processes` | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 
 MapLibre-native sources (`maplibre-vector`, `maplibre-raster`,
 `maplibre-geojson`) are render-only and contribute `render` and (where
@@ -63,6 +64,14 @@ keep the index model opaque so H3, Quadbin, or provider-specific grids
 can all satisfy the same app contract.
 
 ## Notes by protocol
+
+### gRPC FeatureService
+Canonical transport shared across the SDKs and generated from the
+`geospatial-grpc` FeatureService definitions. The default capability set is
+`query`, `queryAggregate`, `queryExtent`, `queryObjectIds`, `applyEdits`, and
+`stream`. In JS, gRPC-Web is selected on `HonuaClient` with
+`transport: "grpc-web"`; it is not exposed as a `Source.protocol("grpc")`
+adapter handle.
 
 ### GeoServices Feature Service
 First-class. Aggregations set `outStatistics`, `groupByFieldsForStatistics`,

--- a/docs/sdk-surface-alignment.md
+++ b/docs/sdk-surface-alignment.md
@@ -60,6 +60,7 @@ prefer the canonical identifiers; SDKs may accept short or legacy aliases for
 already-shipped public names by normalizing on read through the
 `protocolAliases` map in the fixture pack:
 
+- `grpc`
 - `geoservices-feature-service`
 - `geoservices-map-service`
 - `geoservices-image-service`

--- a/docs/shared-client-contract.md
+++ b/docs/shared-client-contract.md
@@ -62,7 +62,7 @@ unsupported-capability, and degraded-result scenarios.
 
 | Type | What it is |
 | --- | --- |
-| `Protocol` | One of sixteen identifiers — five GeoServices service types (`geoservices-feature-service`, `geoservices-map-service`, `geoservices-image-service`, `geoservices-geometry-service`, `geoservices-gp-service`), four OGC API + STAC adapters (`ogc-features`, `ogc-tiles`, `ogc-maps`, `stac`), `wfs`, `wms`, `wmts`, `odata`, plus three MapLibre-native (`maplibre-vector`, `maplibre-raster`, `maplibre-geojson`). |
+| `Protocol` | One of seventeen identifiers — shared canonical gRPC FeatureService transport (`grpc`), five GeoServices service types (`geoservices-feature-service`, `geoservices-map-service`, `geoservices-image-service`, `geoservices-geometry-service`, `geoservices-gp-service`), four OGC API + STAC adapters (`ogc-features`, `ogc-tiles`, `ogc-maps`, `stac`), `wfs`, `wms`, `wmts`, `odata`, plus three MapLibre-native (`maplibre-vector`, `maplibre-raster`, `maplibre-geojson`). |
 | `Capability` | A coarse-grained protocol capability (`query`, `queryAggregate`, `spatialAggregate`, `queryExtent`, `queryObjectIds`, `queryRelated`, `applyEdits`, `attachments`, `render`, `tiles`, `sql`, `stream`, `pbf`, `connect`, `image`, `geometry`, `geoprocess`, `processes`). The canonical `Source` surface standardizes the query / edit / related / attachment / object-id subset today; `spatialAggregate`, `image` / `geometry` / `geoprocess` / `processes` are negotiated for indexed analytics, `Source.protocol()` escape hatches, and for the `IJobRun`-based OGC API Processes runner because their request shapes are too protocol-specific to belong on the unified query envelope. |
 | `Capabilities` | `ReadonlySet<Capability>`. Set membership = first-party protocol support, whether the caller consumes it through a canonical `Source` method or the typed protocol escape hatch. Under `strict` (default) a missing capability throws `HonuaCapabilityNotSupportedError`. Under `degraded` only call sites with a defined fallback proceed (today: OGC `queryAggregate` and `queryExtent`); every other missing capability still throws. |
 | `SourceLocator` | Protocol-specific endpoint info (`url`, `serviceId`, `layerId`, `collectionId`, `tileMatrixSetId`, `styleId`, `typeName`, `entitySet`, `taskName`). Field-compatible with the server `SourceBinding.locator`; `tileMatrixSetId` / `styleId` carry OGC API Tiles / Maps route hints for downstream `SourceBinding` work tracked in [`source-binding-alignment.md`](./source-binding-alignment.md). |
@@ -279,6 +279,9 @@ against the original ticket-23 surface; it returns the same instance.
 The `AdapterTypeMap` interface uses TypeScript declaration merging so
 adapter tickets can plug in their own kind → instance type mapping
 without touching this file.
+`grpc` is a canonical protocol id for the shared FeatureService transport
+and fixture pack; it is consumed through the client gRPC-Web transport
+rather than a `Source.protocol("grpc")` adapter handle in this package.
 
 ```ts
 declare module "@honua/sdk-js/contract" {

--- a/src/contract/types.ts
+++ b/src/contract/types.ts
@@ -23,7 +23,8 @@ import type { HonuaExtent, HonuaFieldInfo, HonuaServerCompatibilityFeature, Honu
 
 /**
  * Canonical protocol identifiers. Spatial / tabular protocols served
- * behind a `Source` come first, then the render-only OGC tile and map
+ * behind a `Source` come first, with the shared canonical gRPC
+ * FeatureService transport leading the list. Render-only OGC tile and map
  * adapters (reachable through `Source.protocol()`), then the STAC API
  * search adapter, the WFS / WMS / OData adapters, and finally the
  * MapLibre-native sources composed alongside protocol sources by
@@ -37,6 +38,7 @@ import type { HonuaExtent, HonuaFieldInfo, HonuaServerCompatibilityFeature, Honu
  * vocabulary even when the underlying protocol is utility-only.
  */
 export type Protocol =
+  | "grpc"
   | "geoservices-feature-service"
   | "geoservices-map-service"
   | "geoservices-image-service"
@@ -56,6 +58,7 @@ export type Protocol =
 
 /** All protocol identifiers, in declaration order. */
 export const PROTOCOLS: readonly Protocol[] = [
+  "grpc",
   "geoservices-feature-service",
   "geoservices-map-service",
   "geoservices-image-service",
@@ -206,6 +209,7 @@ export function unionCapabilities(participants: ReadonlyArray<{ readonly capabil
  * Update both together.
  */
 export const PROTOCOL_DEFAULT_CAPABILITIES: Readonly<Record<Protocol, Capabilities>> = {
+  grpc: capabilities(["query", "queryAggregate", "queryExtent", "queryObjectIds", "applyEdits", "stream"]),
   "geoservices-feature-service": capabilities([
     "query",
     "queryAggregate",

--- a/test/contract/conformance.test.ts
+++ b/test/contract/conformance.test.ts
@@ -215,8 +215,9 @@ const harnesses: Harness[] = [
 ];
 
 describe("contract / Protocol enum", () => {
-  it("includes all canonical protocols (five GeoServices service types, OGC Features/Tiles/Maps, STAC, WFS/WMS/WMTS/OData, MapLibre-native)", () => {
+  it("includes all canonical protocols (gRPC, five GeoServices service types, OGC Features/Tiles/Maps, STAC, WFS/WMS/WMTS/OData, MapLibre-native)", () => {
     expect(PROTOCOLS).toEqual([
+      "grpc",
       "geoservices-feature-service",
       "geoservices-map-service",
       "geoservices-image-service",

--- a/test/entrypoints.test.ts
+++ b/test/entrypoints.test.ts
@@ -293,11 +293,11 @@ describe("entrypoint modules", () => {
   });
 
   it("exposes the canonical contract entrypoint", () => {
-    // Sixteen canonical protocols: five GeoServices service types
-    // (FeatureServer, MapServer, ImageServer, Geometry, GP), OGC API
-    // Features / Tiles / Maps, STAC, WFS / WMS / WMTS / OData, and three
-    // MapLibre-native sources.
-    expect(PROTOCOLS).toHaveLength(16);
+    // Seventeen canonical protocols: gRPC, five GeoServices service
+    // types (FeatureServer, MapServer, ImageServer, Geometry, GP), OGC
+    // API Features / Tiles / Maps, STAC, WFS / WMS / WMTS / OData, and
+    // three MapLibre-native sources.
+    expect(PROTOCOLS).toHaveLength(17);
     expect(CAPABILITIES.length).toBeGreaterThan(0);
     expect(Object.keys(PROTOCOL_DEFAULT_CAPABILITIES)).toEqual([...PROTOCOLS]);
     expect(capabilities).toBeTypeOf("function");

--- a/test/fixtures/sdk-contract/semantic-contract.v1.json
+++ b/test/fixtures/sdk-contract/semantic-contract.v1.json
@@ -60,6 +60,7 @@
     }
   ],
   "protocols": [
+    "grpc",
     "geoservices-feature-service",
     "geoservices-map-service",
     "geoservices-image-service",
@@ -118,6 +119,14 @@
     "processes"
   ],
   "defaultCapabilities": {
+    "grpc": [
+      "query",
+      "queryAggregate",
+      "queryExtent",
+      "queryObjectIds",
+      "applyEdits",
+      "stream"
+    ],
     "geoservices-feature-service": [
       "query",
       "queryAggregate",


### PR DESCRIPTION
Closes #135.\n\n## Summary\n- adds grpc to the canonical Protocol union, PROTOCOLS list, and semantic contract fixture\n- mirrors the shared default capability set from honua-io/honua-sdk-dotnet#145\n- updates pinned protocol tests and protocol docs\n\n## Tests\n- npm test -- test/contract/sdk-contract-fixtures.test.ts test/contract/conformance.test.ts test/entrypoints.test.ts\n- npm run typecheck