### PR TITLE
fix: dispatch release publish workflows with explicit repo

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,5 +30,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           release_ref="${GITHUB_SHA}"
-          gh workflow run publish-js-sdk.yml --ref "${release_ref}" -f dry_run=false
-          gh workflow run publish-mcp-server.yml --ref "${release_ref}" -f dry_run=false
+          gh workflow run publish-js-sdk.yml --repo "${GITHUB_REPOSITORY}" --ref "${release_ref}" -f dry_run=false
+          gh workflow run publish-mcp-server.yml --repo "${GITHUB_REPOSITORY}" --ref "${release_ref}" -f dry_run=false


### PR DESCRIPTION
## Summary

- pass `--repo "${GITHUB_REPOSITORY}"` when Release Please dispatches JS SDK and MCP publish workflows
- keeps publish dispatch independent of local git repository discovery inside the workflow step

Closes #126

## Validation

- rebased onto current `origin/trunk`
- inspected workflow diff