### PR TITLE
feat(#139): add OGC API Records SDK surface

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -5,8 +5,8 @@ This repository owns the JavaScript/TypeScript SDK, browser runtime helpers, mig
 ## Current Capabilities
 
 - Honua-first `HonuaClient` for GeoServices FeatureServer/MapServer, catalog operations, request/auth interceptors, and compatibility checks.
-- Protocol-neutral Dataset/Source/Query/Result contract with built-in adapters for GeoServices, OGC API Features/Tiles/Maps/Processes, STAC, WMS, WMTS, WFS, and OData.
-- OGC client wrappers for Features, Tiles, Maps, Processes, STAC, WMS, WMTS, WFS, and OData.
+- Protocol-neutral Dataset/Source/Query/Result contract with built-in adapters for GeoServices, OGC API Features/Tiles/Maps/Records/Processes, STAC, WMS, WMTS, WFS, and OData.
+- OGC client wrappers for Features, Tiles, Maps, Records, Processes, STAC, WMS, WMTS, WFS, and OData.
 - MapLibre runtime helpers for `MapPackage`, source/layer style validation, WMS/WMTS source specs, web-map conversion, and warning contracts.
 - Generated-app manifest projection and operations-dashboard preview runtime under `@honua/sdk-js/generated-app`.
 - Esri compatibility layer for migration-critical layers, views, widgets, controls, routing helpers, search, popup, time slider, measurement, editor/sketch, graphics, groups, web maps, and basic scene-view compatibility.

--- a/docs/ogc-api.md
+++ b/docs/ogc-api.md
@@ -1,8 +1,8 @@
 # OGC API Client
 
 Status: implemented in `src/core/ogc-tiles.ts`, `src/core/ogc-maps.ts`,
-`src/core/ogc-processes.ts`, `src/core/stac.ts`, and (for OGC API
-Features) `src/core/surfaces.ts`.
+`src/core/ogc-processes.ts`, `src/core/ogc-records.ts`,
+`src/core/stac.ts`, and (for OGC API Features) `src/core/surfaces.ts`.
 
 This document is the developer reference for the first-party OGC API
 adapter. It complements the design notes in
@@ -17,6 +17,7 @@ capability matrix in [`protocol-capability-matrix.md`](./protocol-capability-mat
 | OGC API Tiles | `client.ogcTiles()` | `ogc-tiles` | tileset discovery, vector + raster tiles on the canonical `/collections/{id}/tiles/{tms}/…` route (styled tiles deferred — see below) |
 | OGC API Maps | `client.ogcMaps()` | `ogc-maps` | dataset / collection map renders, styled access |
 | OGC API Processes | `client.ogcProcesses()` | (none — job runner) | discovery, async execution, `IJobRun<T>` surface |
+| OGC API Records | `client.ogcRecords()` | `ogc-records` | metadata/catalog discovery, record search, record detail, raw response access |
 | STAC API | `client.stac()` | `stac` | landing, collections, items, cross-collection search |
 
 OGC conformance class identifiers (e.g.
@@ -187,6 +188,51 @@ token instead. `intersects` and `fields` are serialized onto the GET
 query (intersects as JSON; fields as `id,properties.datetime,-assets.thumbnail`)
 in addition to the POST body.
 
+### OGC API Records
+
+```ts
+const records = client.ogcRecords();
+
+// Discover available metadata catalogs.
+const catalogs = await records.collections();
+
+// Search one catalog. Records query parameters are catalog metadata
+// filters, not STAC item-search filters.
+const page = await records.collection("catalog").search({
+  q: ["roads", "parcels"],
+  type: ["service", "collection"],
+  externalIds: ["FeatureServer:transportation"],
+  bbox: [-158, 21, -157, 22],
+  datetime: "2025-01-01/2025-12-31",
+  limit: 25,
+  offset: 0,
+});
+
+const detail = await records.collection("catalog").record({ recordId: "service-transportation" });
+
+// Raw response access keeps the shared auth/interceptor/retry pipeline but
+// leaves body decoding to the caller.
+const html = await records.collection("catalog").rawRecord({
+  recordId: "service-transportation",
+  responseFormat: "html",
+  accept: "text/html",
+});
+```
+
+Records and STAC are intentionally separate surfaces. STAC describes
+spatiotemporal assets and collection/item search for imagery/data assets.
+Records describes metadata about resources: services, layers,
+collections, maps, scenes, styles, STAC collections, source descriptors,
+and other catalog entries. Honua admin metadata and migration inventory
+remain Honua-specific control-plane/read-model APIs; Records is the
+standards-facing public catalog view over stable metadata.
+
+`OgcRecordsSearchRequest` supports the Records core search parameters
+`bbox`, `datetime`, `limit`, `q`, `ids`, `type`, and `externalIds`, plus
+optional `filter` / `filter-lang` / `filter-crs` when the server
+advertises the Records filtering conformance class. `searchAll` and
+`searchStream` follow `rel=next` links that carry `?offset=N`.
+
 ## Canonical Source registration
 
 Source-shaped OGC adapters register through the shared client contract
@@ -224,13 +270,21 @@ const dataset = createDataset({
       locator: { url: baseUrl, collectionId: "parcels" },
       capabilities: PROTOCOL_DEFAULT_CAPABILITIES.stac,
     },
+    {
+      id: "catalog-records",
+      protocol: "ogc-records",
+      locator: { url: baseUrl, collectionId: "catalog" },
+      capabilities: PROTOCOL_DEFAULT_CAPABILITIES["ogc-records"],
+    },
   ],
 });
 
 const features = await dataset.source("parcels-ogc")!.query({ where: "STATUS = 'ACTIVE'" });
 const stacItems = await dataset.source("parcels-stac")!.query({ where: "cloud_cover < 10" });
+const catalogRecords = await dataset.source("catalog-records")!.query({ where: "type = 'service'" });
 const tileset = dataset.source("parcels-tiles")!.adapter("ogc-tiles"); // HonuaOgcTileset
 const map = dataset.source("parcels-map")!.adapter("ogc-maps"); // HonuaOgcCollectionMap
+const recordsCatalog = dataset.source("catalog-records")!.adapter("ogc-records"); // HonuaOgcRecordCollection
 ```
 
 OGC API Tiles and OGC API Maps are render-only; their `Source.query*`
@@ -269,6 +323,7 @@ The repo ships parametrized conformance suites under `test/contract/`:
 - `ogc-tiles.test.ts` — tileset discovery + tile fetch + Source adapter
 - `ogc-maps.test.ts` — dataset / collection / styled map renders
 - `ogc-processes.test.ts` — `IJobRun` lifecycle, cancel, error paths
+- `ogc-records.test.ts` — Records query params, paging, raw access, Source adapter
 - `stac.test.ts` — GET / POST search + Source adapter
 - `ogc-conformance.test.ts` — conformance-class negotiation
 

--- a/docs/protocol-capability-matrix.md
+++ b/docs/protocol-capability-matrix.md
@@ -28,26 +28,26 @@ without a canonical `Source` method today are negotiated for
 `◐` = supported only under `degraded` capability policy (client-side fallback).
 `—` = not supported.
 
-| Capability | gRPC | GS Feature | GS Map | GS Image | GS Geometry | GS GP | OGC Features | OGC Tiles | OGC Maps | STAC | WFS | WMS | WMTS | OData |
-| --- | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-| `query` | ✓ | ✓ | ✓ | ✓ | — | — | ✓ | — | — | ✓ | ✓ | ✓ | — | ✓ |
-| `queryAggregate` | ✓ | ✓ | ✓ | — | — | — | ◐ | — | — | — | — | — | — | — |
-| `spatialAggregate` | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| `queryExtent` | ✓ | ✓ | ✓ | ✓ | — | — | ◐ | — | — | — | ✓ | — | — | — |
-| `queryObjectIds` | ✓ | ✓ | ✓ | ✓ | — | — | ✓ | — | — | ✓ | ✓ | — | — | ✓ |
-| `queryRelated` | — | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — |
-| `applyEdits` | ✓ | ✓ | — | — | — | — | ✓ | — | — | — | ✓ | — | — | ✓ |
-| `attachments` | — | ✓ | — | — | — | — | — | — | — | — | — | — | — | — |
-| `render` | — | — | ✓ | ✓ | — | — | — | ✓ | ✓ | — | — | ✓ | ✓ | — |
-| `tiles` | — | ◐ | ✓ | ✓ | — | — | — | ✓ | — | — | — | ✓ | ✓ | — |
-| `sql` | — | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — |
-| `stream` | ✓ | ✓ | ✓ | — | — | — | ✓ | — | — | ✓ | ✓ | — | — | ✓ |
-| `pbf` | — | ✓ | — | — | — | — | — | — | — | — | — | — | — | — |
-| `connect` | — | ✓ | — | ✓ | ✓ | ✓ | — | — | — | — | — | — | — | — |
-| `image` | — | — | — | ✓ | — | — | — | — | — | — | — | — | — | — |
-| `geometry` | — | — | — | — | ✓ | — | — | — | — | — | — | — | — | — |
-| `geoprocess` | — | — | — | — | — | ✓ | — | — | — | — | — | — | — | — |
-| `processes` | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| Capability | gRPC | GS Feature | GS Map | GS Image | GS Geometry | GS GP | OGC Features | OGC Tiles | OGC Maps | OGC Records | STAC | WFS | WMS | WMTS | OData |
+| --- | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
+| `query` | ✓ | ✓ | ✓ | ✓ | — | — | ✓ | — | — | ✓ | ✓ | ✓ | ✓ | — | ✓ |
+| `queryAggregate` | ✓ | ✓ | ✓ | — | — | — | ◐ | — | — | — | — | — | — | — | — |
+| `spatialAggregate` | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `queryExtent` | ✓ | ✓ | ✓ | ✓ | — | — | ◐ | — | — | — | — | ✓ | — | — | — |
+| `queryObjectIds` | ✓ | ✓ | ✓ | ✓ | — | — | ✓ | — | — | ✓ | ✓ | ✓ | — | — | ✓ |
+| `queryRelated` | — | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — | — |
+| `applyEdits` | ✓ | ✓ | — | — | — | — | ✓ | — | — | — | — | ✓ | — | — | ✓ |
+| `attachments` | — | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `render` | — | — | ✓ | ✓ | — | — | — | ✓ | ✓ | — | — | — | ✓ | ✓ | — |
+| `tiles` | — | ◐ | ✓ | ✓ | — | — | — | ✓ | — | — | — | — | ✓ | ✓ | — |
+| `sql` | — | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — | — |
+| `stream` | ✓ | ✓ | ✓ | — | — | — | ✓ | — | — | ✓ | ✓ | ✓ | — | — | ✓ |
+| `pbf` | — | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `connect` | — | ✓ | — | ✓ | ✓ | ✓ | — | — | — | — | — | — | — | — | — |
+| `image` | — | — | — | ✓ | — | — | — | — | — | — | — | — | — | — | — |
+| `geometry` | — | — | — | — | ✓ | — | — | — | — | — | — | — | — | — | — |
+| `geoprocess` | — | — | — | — | — | ✓ | — | — | — | — | — | — | — | — | — |
+| `processes` | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 
 MapLibre-native sources (`maplibre-vector`, `maplibre-raster`,
 `maplibre-geojson`) are render-only and contribute `render` and (where
@@ -228,6 +228,18 @@ lacks dismissal capability) are rethrown verbatim. The canonical
 `negotiateOgcCapabilities("ogc-processes", conformance)`; it is
 intentionally absent from `PROTOCOL_DEFAULT_CAPABILITIES` because there
 is no `ogc-processes` `Source` protocol.
+
+### OGC API Records
+Metadata-catalog adapter. `query`, `queryObjectIds`, and `stream` are
+first-party capabilities over `/ogc/records/collections/{catalogId}/items`.
+The direct `client.ogcRecords()` surface exposes Records-specific query
+parameters (`q`, `type`, `externalIds`, `datetime`, `bbox`, `ids`,
+`profile`) and raw response access for HTML/JSON/profile negotiation.
+The canonical `Source.query` path maps `Query.where` to CQL2 `filter`
+and `spatialFilter` envelopes to Records `bbox`; aggregation, edits,
+attachments, related records, and extent-only queries are not advertised.
+Records describes metadata about resources and remains separate from STAC
+asset search and Honua admin/control-plane metadata APIs.
 
 ### STAC API
 STAC piggy-backs on OGC API Features for items but adds a

--- a/docs/shared-client-contract.md
+++ b/docs/shared-client-contract.md
@@ -62,7 +62,7 @@ unsupported-capability, and degraded-result scenarios.
 
 | Type | What it is |
 | --- | --- |
-| `Protocol` | One of seventeen identifiers — shared canonical gRPC FeatureService transport (`grpc`), five GeoServices service types (`geoservices-feature-service`, `geoservices-map-service`, `geoservices-image-service`, `geoservices-geometry-service`, `geoservices-gp-service`), four OGC API + STAC adapters (`ogc-features`, `ogc-tiles`, `ogc-maps`, `stac`), `wfs`, `wms`, `wmts`, `odata`, plus three MapLibre-native (`maplibre-vector`, `maplibre-raster`, `maplibre-geojson`). |
+| `Protocol` | One of eighteen identifiers — shared canonical gRPC FeatureService transport (`grpc`), five GeoServices service types (`geoservices-feature-service`, `geoservices-map-service`, `geoservices-image-service`, `geoservices-geometry-service`, `geoservices-gp-service`), OGC API + STAC adapters (`ogc-features`, `ogc-tiles`, `ogc-maps`, `ogc-records`, `stac`), `wfs`, `wms`, `wmts`, `odata`, plus three MapLibre-native (`maplibre-vector`, `maplibre-raster`, `maplibre-geojson`). |
 | `Capability` | A coarse-grained protocol capability (`query`, `queryAggregate`, `spatialAggregate`, `queryExtent`, `queryObjectIds`, `queryRelated`, `applyEdits`, `attachments`, `render`, `tiles`, `sql`, `stream`, `pbf`, `connect`, `image`, `geometry`, `geoprocess`, `processes`). The canonical `Source` surface standardizes the query / edit / related / attachment / object-id subset today; `spatialAggregate`, `image` / `geometry` / `geoprocess` / `processes` are negotiated for indexed analytics, `Source.protocol()` escape hatches, and for the `IJobRun`-based OGC API Processes runner because their request shapes are too protocol-specific to belong on the unified query envelope. |
 | `Capabilities` | `ReadonlySet<Capability>`. Set membership = first-party protocol support, whether the caller consumes it through a canonical `Source` method or the typed protocol escape hatch. Under `strict` (default) a missing capability throws `HonuaCapabilityNotSupportedError`. Under `degraded` only call sites with a defined fallback proceed (today: OGC `queryAggregate` and `queryExtent`); every other missing capability still throws. |
 | `SourceLocator` | Protocol-specific endpoint info (`url`, `serviceId`, `layerId`, `collectionId`, `tileMatrixSetId`, `styleId`, `typeName`, `entitySet`, `taskName`). Field-compatible with the server `SourceBinding.locator`; `tileMatrixSetId` / `styleId` carry OGC API Tiles / Maps route hints for downstream `SourceBinding` work tracked in [`source-binding-alignment.md`](./source-binding-alignment.md). |
@@ -180,6 +180,9 @@ The OGC API and STAC factories cover `docs/ogc-api.md`:
 - `ogcTilesSource` — OGC API Tiles (render-only; query family throws,
   `HonuaOgcTileset` / `HonuaOgcTiles` reachable via `protocol()`).
 - `ogcMapsSource` — OGC API Maps (render-only; same shape as Tiles).
+- `ogcRecordsSource` — OGC API Records metadata catalog search
+  (`/collections/{catalogId}/items`, queryObjectIds, stream; Records-specific
+  `q` / `type` / `externalIds` and raw response access via `protocol()`).
 - `stacSearchSource` — STAC API search (`/search` query, queryObjectIds,
   stream; cross-collection scope via `locator.collectionId`).
 
@@ -394,7 +397,7 @@ seeing a fabricated success. Submitted processes are typed as
 `IJobRun<T>`; `HonuaOgcProcessJobRun` is the implementation behind that
 interface and should not be the caller-facing contract.
 
-## OGC API Tiles / Maps / Processes / STAC
+## OGC API Tiles / Maps / Records / Processes / STAC
 
 The first-party OGC adapters live alongside `HonuaOgcFeatures`:
 
@@ -403,15 +406,16 @@ The first-party OGC adapters live alongside `HonuaOgcFeatures`:
 | OGC API Features | `client.ogcFeatures()` / `HonuaOgcFeatures` | `ogc-features` | `query`, `queryObjectIds`, `applyEdits`, `stream` |
 | OGC API Tiles | `client.ogcTiles()` / `HonuaOgcTiles`, `HonuaOgcTileset` | `ogc-tiles` | `render`, `tiles` (tileset-bound when locator includes `tileMatrixSetId`; root discovery handle otherwise) |
 | OGC API Maps | `client.ogcMaps()` / `HonuaOgcMaps`, `HonuaOgcCollectionMap` | `ogc-maps` | `render` |
+| OGC API Records | `client.ogcRecords()` / `HonuaOgcRecords`, `HonuaOgcRecordCollection` | `ogc-records` | `query`, `queryObjectIds`, `stream` |
 | OGC API Processes | `client.ogcProcesses()` / `HonuaOgcProcesses` | (no source — job runner) | `processes` from conformance negotiation, not `PROTOCOL_DEFAULT_CAPABILITIES` |
 | STAC API | `client.stac()` / `HonuaStacSearch` | `stac` | `query`, `queryObjectIds`, `stream` |
 
 OGC API Tiles and OGC API Maps are render-only — their `Source.query*`
 methods throw, and renderers reach the underlying class through
-`Source.adapter("ogc-tiles")` / `Source.adapter("ogc-maps")`. STAC
-search flows through the canonical `Source.query()` like every other
-tabular protocol. OGC API Processes does not register as a `Source`
-because its inputs are not queryable; it produces `IJobRun<T>` from
+`Source.adapter("ogc-tiles")` / `Source.adapter("ogc-maps")`. OGC API
+Records and STAC both flow through the canonical `Source.query()` path,
+but Records is metadata catalog search and STAC is asset/item search. OGC
+API Processes does not register as a `Source` because its inputs are not queryable; it produces `IJobRun<T>` from
 `execute(...)`.
 
 ## WMS / WMTS web-map services

--- a/docs/source-binding-alignment.md
+++ b/docs/source-binding-alignment.md
@@ -19,7 +19,7 @@ locator fields until the server schema exposes them explicitly.
 | `locator.url` | `locator.url` | Fully qualified endpoint URL. |
 | `locator.serviceId` | `locator.serviceId` | GeoServices service identifier (FeatureServer, MapServer, ImageServer, Geometry, GP). |
 | `locator.layerId` | `locator.layerId` | Numeric layer identifier within the service. |
-| `locator.collectionId` | `locator.collectionId` | OGC API Features / Tiles / Maps / STAC collection. |
+| `locator.collectionId` | `locator.collectionId` | OGC API Features / Tiles / Maps / STAC collection, or OGC API Records catalog id. |
 | `locator.tileMatrixSetId` | `locator.tileMatrixSetId` | OGC API Tiles tile-matrix-set identifier. When set, `Source.adapter("ogc-tiles")` returns a bound `HonuaOgcTileset`; when omitted, it returns the root `HonuaOgcTiles` handle for tile-matrix-set discovery. Preserved as an additive locator field when present. |
 | `locator.styleId` | `locator.styleId` | OGC API Maps styled-output identifier. Consumed by `Source.adapter("ogc-maps")` to build the `/styles/{styleId}/map` route. Not consumed by the OGC Tiles adapter today: honua-server does not expose a `/styles/{styleId}/tiles/...` route, so the SDK keeps the tile path canonical. Preserved as an additive locator field when present. |
 | `locator.typeName` | `locator.typeName` | WFS / WMS / WMTS layer name (the WMS `LAYERS=` value, the WMTS `Layer` identifier). |

--- a/src/contract/index.ts
+++ b/src/contract/index.ts
@@ -170,6 +170,7 @@ export {
   ogcFeaturesSource,
   ogcTilesSource,
   ogcMapsSource,
+  ogcRecordsSource,
   stacSearchSource,
   wfsSource,
   wmsSource,

--- a/src/contract/source.ts
+++ b/src/contract/source.ts
@@ -29,6 +29,7 @@ import {
 } from "../core/odata.js";
 import { HonuaOgcCollectionMap, HonuaOgcMaps } from "../core/ogc-maps.js";
 import type { HonuaOgcProcesses } from "../core/ogc-processes.js";
+import { HonuaOgcRecordCollection } from "../core/ogc-records.js";
 import { HonuaOgcTiles, HonuaOgcTileset } from "../core/ogc-tiles.js";
 import { HonuaStacSearch } from "../core/stac.js";
 import {
@@ -50,6 +51,7 @@ import type {
   HonuaStacItemResponse,
   HonuaTypedFeature,
   HonuaTypedQueryResponse,
+  OgcRecordsSearchRequest,
   StacSearchRequest,
 } from "../core/types.js";
 import {
@@ -183,6 +185,8 @@ function buildBuiltInSource<T>(
       return ogcTilesSource<T>(descriptor, client, policy);
     case "ogc-maps":
       return ogcMapsSource<T>(descriptor, client, policy);
+    case "ogc-records":
+      return ogcRecordsSource<T>(descriptor, client, policy);
     case "wms":
       return wmsSource<T>(descriptor, client, policy);
     case "wmts":
@@ -773,6 +777,107 @@ export function ogcMapsSource<T>(
   const caps = descriptor.capabilities ?? PROTOCOL_DEFAULT_CAPABILITIES["ogc-maps"];
 
   return makeSource<T>(descriptor, caps, policy, adapterRegistry, unsupportedFeatureSurface<T>(descriptor));
+}
+
+// ── OGC API Records ───────────────────────────────────────────
+
+/**
+ * Metadata-catalog Source adapter for OGC API Records. The canonical query
+ * family searches one catalog (`locator.collectionId`, the Records
+ * collection/catalog id) and returns record documents as typed features.
+ * Records-specific search affordances (`q`, `type`, `externalIds`,
+ * `profile`, raw HTML/JSON access) live on `Source.protocol("ogc-records")`.
+ */
+export function ogcRecordsSource<T>(
+  descriptor: SourceDescriptor,
+  client: HonuaClient,
+  policy: CapabilityPolicy,
+): Source<T> {
+  const { collectionId } = requireOgcRecordsLocator(descriptor);
+  const collection = new HonuaOgcRecordCollection({ client, collectionId });
+  const caps = descriptor.capabilities ?? PROTOCOL_DEFAULT_CAPABILITIES["ogc-records"];
+
+  const adapterRegistry: Partial<Record<AdapterKind, unknown>> = {
+    "ogc-records": collection,
+  };
+
+  return makeSource<T>(descriptor, caps, policy, adapterRegistry, {
+    async query(request) {
+      ensureCapability(descriptor, caps, "query");
+      if (request?.aggregation) {
+        throw new HonuaCapabilityNotSupportedError("queryAggregate", descriptor.protocol, descriptor.id);
+      }
+      const response = await collection.search(toOgcRecordsRequest(request));
+      const features = (response.features ?? []).map(toTypedFeatureFromOgcRecord<T>);
+      const totalCount = response.numberMatched;
+      return {
+        features,
+        exceededTransferLimit: totalCount !== undefined && features.length < totalCount,
+        ...(totalCount !== undefined ? { totalCount } : {}),
+      } satisfies Result<T>;
+    },
+    async queryAll(request) {
+      ensureCapability(descriptor, caps, "query");
+      const limit = request?.pagination?.limit;
+      const records = await collection.searchAll({
+        ...toOgcRecordsRequest(request),
+        ...withPagingBounds({}, limit),
+      });
+      const typed = records.map(toTypedFeatureFromOgcRecord<T>);
+      const { features, exceededTransferLimit } = applyQueryAllLimit(typed, limit);
+      return {
+        features,
+        exceededTransferLimit,
+        totalCount: features.length,
+      } satisfies Result<T>;
+    },
+    async queryAggregate() {
+      throw new HonuaCapabilityNotSupportedError("queryAggregate", descriptor.protocol, descriptor.id);
+    },
+    async queryExtent() {
+      throw new HonuaCapabilityNotSupportedError("queryExtent", descriptor.protocol, descriptor.id);
+    },
+    async *stream(request) {
+      ensureCapability(descriptor, caps, "stream");
+      const limit = request?.pagination?.limit;
+      const stream = collection.searchStream({
+        ...toOgcRecordsRequest(request),
+        pageSize: limit !== undefined ? Math.max(1, limit) : undefined,
+        maxPages: Number.MAX_SAFE_INTEGER,
+      });
+      for await (const page of stream) {
+        yield {
+          features: page.map(toTypedFeatureFromOgcRecord<T>),
+          exceededTransferLimit: false,
+        } satisfies Result<T>;
+      }
+    },
+    async queryObjectIds(request) {
+      ensureCapability(descriptor, caps, "queryObjectIds");
+      const limit = request?.pagination?.limit;
+      const records = await collection.searchAll({
+        ...toOgcRecordsRequest(request),
+        ...withPagingBounds({}, limit),
+      });
+      const ids: FeatureId[] = [];
+      for (const record of records) {
+        if (record.id !== undefined && record.id !== null) {
+          ids.push(record.id as FeatureId);
+        }
+      }
+      if (typeof limit === "number" && limit >= 0 && ids.length > limit) {
+        return ids.slice(0, limit);
+      }
+      return ids;
+    },
+    async applyEdits() {
+      throw new HonuaCapabilityNotSupportedError("applyEdits", descriptor.protocol, descriptor.id);
+    },
+    async queryRelated() {
+      throw new HonuaCapabilityNotSupportedError("queryRelated", descriptor.protocol, descriptor.id);
+    },
+    attachments: unsupportedAttachmentApi(descriptor),
+  });
 }
 
 // ── WMS 1.3 ───────────────────────────────────────────────────
@@ -2840,6 +2945,14 @@ function requireOgcLocator(descriptor: SourceDescriptor): { collectionId: string
   return { collectionId };
 }
 
+function requireOgcRecordsLocator(descriptor: SourceDescriptor): { collectionId: string | number } {
+  const { collectionId } = descriptor.locator;
+  if (collectionId === undefined || collectionId === null || collectionId === "") {
+    throw new Error(`createDataset: source "${descriptor.id}" (ogc-records) requires locator.collectionId`);
+  }
+  return { collectionId };
+}
+
 function requireImageServiceLocator(descriptor: SourceDescriptor): { serviceId: string } {
   const { serviceId } = descriptor.locator;
   if (typeof serviceId !== "string") {
@@ -3088,6 +3201,56 @@ function toStacRequest<T>(
 }
 
 function toTypedFeatureFromStac<T>(feature: HonuaStacItemResponse): HonuaTypedFeature<T> {
+  return {
+    attributes: (feature.properties ?? {}) as T,
+    geometry: feature.geometry as Record<string, unknown> | null,
+  };
+}
+
+function toOgcRecordsRequest<T>(request?: Query<T>): Omit<OgcRecordsSearchRequest, "collectionId"> {
+  if (!request) return {};
+  const out: Omit<OgcRecordsSearchRequest, "collectionId"> = {};
+  if (request.where !== undefined) {
+    out.filter = request.where;
+    out.filterLang = "cql2-text";
+  }
+  if (request.outFields && request.outFields.length > 0) out.properties = [...request.outFields];
+  if (request.pagination) {
+    if (request.pagination.limit !== undefined) out.limit = request.pagination.limit;
+    if (request.pagination.offset !== undefined) out.offset = request.pagination.offset;
+  }
+  if (request.orderBy && request.orderBy.length > 0) {
+    out.sortby = request.orderBy.map((s) => `${s.direction === "desc" ? "-" : ""}${s.field}`).join(",");
+  }
+  if (request.spatialFilter) {
+    if (request.spatialFilter.geometryType !== "esriGeometryEnvelope") {
+      throw new Error(
+        `ogc-records: spatialFilter.geometryType "${request.spatialFilter.geometryType}" is not supported; only "esriGeometryEnvelope" translates to Records bbox.`,
+      );
+    }
+    const rel = request.spatialFilter.spatialRel;
+    if (rel !== undefined && rel !== "esriSpatialRelIntersects" && rel !== "esriSpatialRelEnvelopeIntersects") {
+      throw new Error(
+        `ogc-records: spatialFilter.spatialRel "${rel}" is not supported; the Records bbox parameter only expresses envelope-intersects.`,
+      );
+    }
+    const env = request.spatialFilter.geometry as { xmin?: number; ymin?: number; xmax?: number; ymax?: number };
+    if (
+      typeof env.xmin === "number" &&
+      typeof env.ymin === "number" &&
+      typeof env.xmax === "number" &&
+      typeof env.ymax === "number"
+    ) {
+      out.bbox = [env.xmin, env.ymin, env.xmax, env.ymax];
+    }
+  }
+  if (request.signal) out.signal = request.signal;
+  return out;
+}
+
+function toTypedFeatureFromOgcRecord<T>(
+  feature: import("../core/types.js").HonuaOgcRecordResponse,
+): HonuaTypedFeature<T> {
   return {
     attributes: (feature.properties ?? {}) as T,
     geometry: feature.geometry as Record<string, unknown> | null,
@@ -3839,6 +4002,7 @@ declare module "./types.js" {
     "ogc-features": HonuaOgcFeatureCollection;
     "ogc-tiles": HonuaOgcTileset | HonuaOgcTiles;
     "ogc-maps": HonuaOgcMaps | HonuaOgcCollectionMap;
+    "ogc-records": HonuaOgcRecordCollection;
     "ogc-processes": HonuaOgcProcesses;
     stac: HonuaStacSearch;
     wfs: HonuaWfsFeatureType;
@@ -3866,6 +4030,7 @@ export const FIRST_PARTY_PROTOCOLS: ReadonlySet<Protocol> = new Set([
   "ogc-features",
   "ogc-tiles",
   "ogc-maps",
+  "ogc-records",
   "stac",
   "wfs",
   "wms",

--- a/src/contract/types.ts
+++ b/src/contract/types.ts
@@ -25,8 +25,9 @@ import type { HonuaExtent, HonuaFieldInfo, HonuaServerCompatibilityFeature, Honu
  * Canonical protocol identifiers. Spatial / tabular protocols served
  * behind a `Source` come first, with the shared canonical gRPC
  * FeatureService transport leading the list. Render-only OGC tile and map
- * adapters (reachable through `Source.protocol()`), then the STAC API
- * search adapter, the WFS / WMS / OData adapters, and finally the
+ * adapters (reachable through `Source.protocol()`), then OGC Records and
+ * STAC catalog/search adapters, the WFS / WMS / WMTS / OData adapters, and
+ * finally the
  * MapLibre-native sources composed alongside protocol sources by
  * `HonuaMap` and `MapBinding`.
  *
@@ -47,6 +48,7 @@ export type Protocol =
   | "ogc-features"
   | "ogc-tiles"
   | "ogc-maps"
+  | "ogc-records"
   | "stac"
   | "wfs"
   | "wms"
@@ -67,6 +69,7 @@ export const PROTOCOLS: readonly Protocol[] = [
   "ogc-features",
   "ogc-tiles",
   "ogc-maps",
+  "ogc-records",
   "stac",
   "wfs",
   "wms",
@@ -248,6 +251,7 @@ export const PROTOCOL_DEFAULT_CAPABILITIES: Readonly<Record<Protocol, Capabiliti
   "ogc-features": capabilities(["query", "queryObjectIds", "applyEdits", "stream"]),
   "ogc-tiles": capabilities(["render", "tiles"]),
   "ogc-maps": capabilities(["render"]),
+  "ogc-records": capabilities(["query", "queryObjectIds", "stream"]),
   stac: capabilities(["query", "queryObjectIds", "stream"]),
   wfs: capabilities(["query", "queryExtent", "queryObjectIds", "applyEdits", "stream"]),
   wms: capabilities(["render", "tiles", "query"]),
@@ -277,7 +281,7 @@ export interface SourceLocator {
   serviceId?: string;
   /** GeoServices layer identifier within the service. */
   layerId?: number;
-  /** OGC API Features / Tiles / Maps collection identifier. */
+  /** OGC API Features / Tiles / Maps collection identifier, or Records catalog id. */
   collectionId?: string | number;
   /** OGC API Tiles tile-matrix-set identifier (e.g. `WebMercatorQuad`). */
   tileMatrixSetId?: string;
@@ -606,6 +610,7 @@ export type AdapterKind =
   | "ogc-features"
   | "ogc-tiles"
   | "ogc-maps"
+  | "ogc-records"
   | "ogc-processes"
   | "stac"
   | "wfs"
@@ -745,9 +750,8 @@ export interface CreateDatasetOptions {
   skipCompatibilityCheck?: boolean;
   /**
    * Resolver invoked for descriptors the built-in resolvers do not know how
-   * to handle. Built-in coverage today is `geoservices-feature-service`,
-   * `geoservices-map-service`, `ogc-features`. Downstream WFS / WMS / OData
-   * tickets supply their adapter here.
+   * to handle. Built-in coverage includes GeoServices, OGC API
+   * Features/Tiles/Maps/Records, STAC, WFS, WMS, WMTS, and OData.
    */
   resolveSource?: SourceResolver;
 }

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -14,6 +14,7 @@ import { HonuaAbortError, HonuaHttpError, HonuaNetworkError, HonuaTimeoutError }
 import { HonuaOdataEntitySet } from "./odata.js";
 import { HonuaOgcMaps } from "./ogc-maps.js";
 import { HonuaOgcProcesses } from "./ogc-processes.js";
+import { HonuaOgcRecords } from "./ogc-records.js";
 import { HonuaOgcTiles } from "./ogc-tiles.js";
 import { decodePbfQueryResponse, isPbfResponse } from "./pbf-decoder.js";
 import {
@@ -67,6 +68,8 @@ import type {
   HonuaOgcProcessJobStatus,
   HonuaOgcProcessesResponse,
   HonuaOgcQueryablesResponse,
+  HonuaOgcRecordResponse,
+  HonuaOgcRecordsResponse,
   HonuaOgcTileMatrixSet,
   HonuaOgcTileMatrixSetsResponse,
   HonuaOgcTileResponse,
@@ -106,6 +109,10 @@ import type {
   OgcMetadataRequest,
   OgcPatchItemRequest,
   OgcProcessExecuteRequest,
+  OgcRecordItemRequest,
+  OgcRecordRawItemRequest,
+  OgcRecordsRawSearchRequest,
+  OgcRecordsSearchRequest,
   OgcReplaceItemRequest,
   OgcTileRequest,
   OgcTilesetRequest,
@@ -449,6 +456,10 @@ export class HonuaClient {
 
   public ogcMaps(): HonuaOgcMaps {
     return new HonuaOgcMaps({ client: this });
+  }
+
+  public ogcRecords(): HonuaOgcRecords {
+    return new HonuaOgcRecords({ client: this });
   }
 
   public wms(serviceId: string): HonuaWms {
@@ -1252,6 +1263,91 @@ export class HonuaClient {
     const accept = ogcMapAcceptHeader(request.format) ?? "image/png";
     const response = await this.requestBytes("GET", path, accept, undefined, request.signal);
     return { bytes: response.bytes, contentType: response.contentType };
+  }
+
+  // ── OGC API Records ────────────────────────────────────────
+
+  public async getOgcRecordsLanding(request: OgcMetadataRequest = {}): Promise<HonuaOgcLandingResponse> {
+    const params = createOgcMetadataParams(request);
+    return this.requestCachedMetadataJson<HonuaOgcLandingResponse>(
+      `ogc-records:landing:${params.toString()}`,
+      `/ogc/records?${params.toString()}`,
+      request,
+    );
+  }
+
+  public async getOgcRecordsConformance(request: OgcMetadataRequest = {}): Promise<HonuaOgcConformanceResponse> {
+    const params = createOgcMetadataParams(request);
+    return this.requestCachedMetadataJson<HonuaOgcConformanceResponse>(
+      `ogc-records:conformance:${params.toString()}`,
+      `/ogc/records/conformance?${params.toString()}`,
+      request,
+    );
+  }
+
+  public async listOgcRecordCollections(request: OgcMetadataRequest = {}): Promise<HonuaOgcCollectionsResponse> {
+    const params = createOgcMetadataParams(request);
+    return this.requestCachedMetadataJson<HonuaOgcCollectionsResponse>(
+      `ogc-records:collections:${params.toString()}`,
+      `/ogc/records/collections?${params.toString()}`,
+      request,
+    );
+  }
+
+  public async getOgcRecordCollection(request: OgcCollectionRequest): Promise<HonuaOgcCollectionMetadata> {
+    const params = createOgcMetadataParams(request);
+    const path = `/ogc/records/collections/${encodeURIComponent(String(request.collectionId))}`;
+    return this.requestCachedMetadataJson<HonuaOgcCollectionMetadata>(
+      `ogc-records:collection:${request.collectionId}:${params.toString()}`,
+      `${path}?${params.toString()}`,
+      request,
+    );
+  }
+
+  public async searchOgcRecords(request: OgcRecordsSearchRequest): Promise<HonuaOgcRecordsResponse> {
+    return this.requestJson(
+      "GET",
+      buildOgcRecordsSearchPath(request),
+      undefined,
+      request.signal,
+    ) as Promise<HonuaOgcRecordsResponse>;
+  }
+
+  public async getOgcRecord(request: OgcRecordItemRequest): Promise<HonuaOgcRecordResponse> {
+    return this.requestJson(
+      "GET",
+      buildOgcRecordPath(request),
+      undefined,
+      request.signal,
+    ) as Promise<HonuaOgcRecordResponse>;
+  }
+
+  public async fetchOgcRecordsRaw(request: OgcRecordsRawSearchRequest): Promise<Response> {
+    return this.pipelineFetch(
+      "GET",
+      buildOgcRecordsSearchPath(request),
+      {
+        headers: mergeHeaders(
+          { Accept: request.accept ?? "application/geo+json, application/json;q=0.9" },
+          request.headers,
+        ),
+      },
+      request.signal,
+    );
+  }
+
+  public async fetchOgcRecordRaw(request: OgcRecordRawItemRequest): Promise<Response> {
+    return this.pipelineFetch(
+      "GET",
+      buildOgcRecordPath(request),
+      {
+        headers: mergeHeaders(
+          { Accept: request.accept ?? "application/geo+json, application/json;q=0.9" },
+          request.headers,
+        ),
+      },
+      request.signal,
+    );
   }
 
   // ── WMS 1.3 ─────────────────────────────────────────────────
@@ -3197,6 +3293,47 @@ function normalizeCsv(value: string | readonly (string | number)[]): string {
     return value;
   }
   return Array.from(value).join(",");
+}
+
+function normalizeStringCsv(value: string | readonly string[]): string {
+  return typeof value === "string" ? value : value.join(",");
+}
+
+function normalizeRecordsBbox(value: OgcRecordsSearchRequest["bbox"]): string {
+  return Array.isArray(value) ? value.join(",") : String(value);
+}
+
+function buildOgcRecordsSearchPath(request: OgcRecordsSearchRequest): string {
+  const collection = encodeURIComponent(String(request.collectionId));
+  const params = serializeOgcRecordsSearchParams(request);
+  return `/ogc/records/collections/${collection}/items?${params.toString()}`;
+}
+
+function buildOgcRecordPath(request: OgcRecordItemRequest): string {
+  const collection = encodeURIComponent(String(request.collectionId));
+  const record = encodeURIComponent(String(request.recordId));
+  const params = createOgcMetadataParams(request);
+  if (request.profile !== undefined) params.set("profile", normalizeStringCsv(request.profile));
+  return `/ogc/records/collections/${collection}/items/${record}?${params.toString()}`;
+}
+
+function serializeOgcRecordsSearchParams(request: OgcRecordsSearchRequest): URLSearchParams {
+  const params = createOgcMetadataParams(request);
+  if (request.limit !== undefined) params.set("limit", String(request.limit));
+  if (request.offset !== undefined) params.set("offset", String(request.offset));
+  if (request.bbox !== undefined) params.set("bbox", normalizeRecordsBbox(request.bbox));
+  if (request.datetime !== undefined) params.set("datetime", request.datetime);
+  if (request.q !== undefined) params.set("q", normalizeStringCsv(request.q));
+  if (request.ids !== undefined) params.set("ids", normalizeCsv(request.ids));
+  if (request.type !== undefined) params.set("type", normalizeStringCsv(request.type));
+  if (request.externalIds !== undefined) params.set("externalIds", normalizeStringCsv(request.externalIds));
+  if (request.filter !== undefined) params.set("filter", request.filter);
+  if (request.filterLang !== undefined) params.set("filter-lang", request.filterLang);
+  if (request.filterCrs !== undefined) params.set("filter-crs", request.filterCrs);
+  if (request.properties !== undefined) params.set("properties", normalizeStringCsv(request.properties));
+  if (request.sortby !== undefined) params.set("sortby", request.sortby);
+  if (request.profile !== undefined) params.set("profile", normalizeStringCsv(request.profile));
+  return params;
 }
 
 function serializeOgcMapImageParams(request: OgcMapImageRequest): URLSearchParams {

--- a/src/core/ogc-conformance.ts
+++ b/src/core/ogc-conformance.ts
@@ -71,6 +71,19 @@ const PROCESS_CONFORMANCE_MAP: ReadonlyArray<readonly [string, readonly Capabili
   ["processes-1/1.0/conf/callback", ["processes"]],
 ];
 
+const RECORDS_CONFORMANCE_MAP: ReadonlyArray<readonly [string, readonly Capability[]]> = [
+  ["ogcapi-records-1/1.0/conf/records-api", ["query", "queryObjectIds"]],
+  ["ogcapi-records-1/1.0/conf/searchable-catalog", ["query", "queryObjectIds"]],
+  ["ogcapi-records-1/1.0/conf/record-core-query-parameters", ["query"]],
+  ["ogcapi-records-1/1.0/conf/cql-filter", ["query"]],
+  ["ogcapi-records-1/1.0/conf/searchable-catalog-filtering", ["query"]],
+  ["ogcapi-records-1/1.0/conf/sorting", ["query"]],
+  ["ogcapi-records-1/1.0/conf/searchable-catalog/sorting", ["query"]],
+  ["ogcapi-records-1/1.0/conf/json", []],
+  ["ogcapi-records-1/1.0/conf/html", []],
+  ["ogcapi-records-1/1.0/conf/oas30", []],
+];
+
 const STAC_CONFORMANCE_MAP: ReadonlyArray<readonly [string, readonly Capability[]]> = [
   ["stac-spec.org", ["query", "queryObjectIds"]],
   ["api.stacspec.org/v1.0.0/core", ["query"]],
@@ -88,12 +101,13 @@ const CONFORMANCE_TABLES: Record<OgcConformanceProtocol, ReadonlyArray<readonly 
   "ogc-tiles": TILE_CONFORMANCE_MAP,
   "ogc-maps": MAP_CONFORMANCE_MAP,
   "ogc-processes": PROCESS_CONFORMANCE_MAP,
+  "ogc-records": RECORDS_CONFORMANCE_MAP,
   stac: STAC_CONFORMANCE_MAP,
 };
 
 /** Subset of `Protocol` for which OGC-style conformance applies. */
 export type OgcConformanceProtocol =
-  | Extract<Protocol, "ogc-features" | "ogc-tiles" | "ogc-maps" | "stac">
+  | Extract<Protocol, "ogc-features" | "ogc-tiles" | "ogc-maps" | "ogc-records" | "stac">
   | "ogc-processes";
 
 /**

--- a/src/core/ogc-records.ts
+++ b/src/core/ogc-records.ts
@@ -1,0 +1,211 @@
+/**
+ * OGC API Records surface. Records are catalog metadata documents about
+ * resources (services, collections, maps, scenes, STAC collections, source
+ * descriptors), not STAC imagery items and not protocol-native service
+ * metadata. The wire calls live on `HonuaClient`; this class is the
+ * request-shaping layer on top.
+ *
+ * @module
+ */
+
+import type { HonuaClient } from "./client.js";
+import type {
+  HonuaOgcCollectionMetadata,
+  HonuaOgcCollectionsResponse,
+  HonuaOgcConformanceResponse,
+  HonuaOgcLandingResponse,
+  HonuaOgcRecordResponse,
+  HonuaOgcRecordsResponse,
+  OgcCollectionRequest,
+  OgcMetadataRequest,
+  OgcRecordItemRequest,
+  OgcRecordRawItemRequest,
+  OgcRecordsRawSearchRequest,
+  OgcRecordsSearchRequest,
+} from "./types.js";
+
+export interface HonuaOgcRecordsOptions {
+  client: HonuaClient;
+}
+
+export interface HonuaOgcRecordCollectionOptions {
+  client: HonuaClient;
+  collectionId: string | number;
+}
+
+export interface HonuaOgcRecordsSearchAllRequest extends OgcRecordsSearchRequest {
+  /** Maximum number of records to request per page. */
+  pageSize?: number;
+  /** Hard cap on the number of pages to fetch (defaults to 100). */
+  maxPages?: number;
+}
+
+export type HonuaOgcRecordCollectionSearchRequest = Omit<OgcRecordsSearchRequest, "collectionId">;
+export type HonuaOgcRecordCollectionSearchAllRequest = HonuaOgcRecordCollectionSearchRequest & {
+  pageSize?: number;
+  maxPages?: number;
+};
+export type HonuaOgcRecordCollectionItemRequest = Omit<OgcRecordItemRequest, "collectionId">;
+export type HonuaOgcRecordCollectionRawSearchRequest = Omit<OgcRecordsRawSearchRequest, "collectionId">;
+export type HonuaOgcRecordCollectionRawItemRequest = Omit<OgcRecordRawItemRequest, "collectionId">;
+
+const DEFAULT_RECORDS_PAGE_SIZE = 100;
+const DEFAULT_RECORDS_MAX_PAGES = 100;
+
+/** Top-level OGC API Records handle. */
+export class HonuaOgcRecords {
+  public readonly client: HonuaClient;
+
+  public constructor(options: HonuaOgcRecordsOptions) {
+    this.client = options.client;
+  }
+
+  public collection(collectionId: string | number): HonuaOgcRecordCollection {
+    return new HonuaOgcRecordCollection({ client: this.client, collectionId });
+  }
+
+  public async landing(request: OgcMetadataRequest = {}): Promise<HonuaOgcLandingResponse> {
+    return this.client.getOgcRecordsLanding(request);
+  }
+
+  public async conformance(request: OgcMetadataRequest = {}): Promise<HonuaOgcConformanceResponse> {
+    return this.client.getOgcRecordsConformance(request);
+  }
+
+  public async collections(request: OgcMetadataRequest = {}): Promise<HonuaOgcCollectionsResponse> {
+    return this.client.listOgcRecordCollections(request);
+  }
+
+  public async collectionMetadata(request: OgcCollectionRequest): Promise<HonuaOgcCollectionMetadata> {
+    return this.client.getOgcRecordCollection(request);
+  }
+
+  public async search(request: OgcRecordsSearchRequest): Promise<HonuaOgcRecordsResponse> {
+    return this.client.searchOgcRecords(request);
+  }
+
+  public async record(request: OgcRecordItemRequest): Promise<HonuaOgcRecordResponse> {
+    return this.client.getOgcRecord(request);
+  }
+
+  public async rawSearch(request: OgcRecordsRawSearchRequest): Promise<Response> {
+    return this.client.fetchOgcRecordsRaw(request);
+  }
+
+  public async rawRecord(request: OgcRecordRawItemRequest): Promise<Response> {
+    return this.client.fetchOgcRecordRaw(request);
+  }
+
+  public async searchAll(request: HonuaOgcRecordsSearchAllRequest): Promise<HonuaOgcRecordResponse[]> {
+    const pageSize = request.pageSize ?? request.limit ?? DEFAULT_RECORDS_PAGE_SIZE;
+    const maxPages = request.maxPages ?? DEFAULT_RECORDS_MAX_PAGES;
+    const records: HonuaOgcRecordResponse[] = [];
+    let cursor: RecordsPageCursor = { offset: request.offset };
+    for (let page = 0; page < maxPages; page += 1) {
+      const response = await this.client.searchOgcRecords({
+        ...request,
+        limit: pageSize,
+        offset: cursor.offset,
+      });
+      const pageRecords = response.features ?? [];
+      if (pageRecords.length === 0) break;
+      records.push(...pageRecords);
+      cursor = nextRecordsCursor(response.links);
+      if (cursor.offset === undefined) break;
+      if (pageRecords.length < pageSize) break;
+    }
+    return records;
+  }
+
+  public async *searchStream(
+    request: HonuaOgcRecordsSearchAllRequest,
+  ): AsyncGenerator<HonuaOgcRecordResponse[], void, undefined> {
+    const pageSize = request.pageSize ?? request.limit ?? DEFAULT_RECORDS_PAGE_SIZE;
+    const maxPages = request.maxPages ?? DEFAULT_RECORDS_MAX_PAGES;
+    let cursor: RecordsPageCursor = { offset: request.offset };
+    for (let page = 0; page < maxPages; page += 1) {
+      const response = await this.client.searchOgcRecords({
+        ...request,
+        limit: pageSize,
+        offset: cursor.offset,
+      });
+      const pageRecords = response.features ?? [];
+      if (pageRecords.length === 0) break;
+      yield pageRecords;
+      cursor = nextRecordsCursor(response.links);
+      if (cursor.offset === undefined) break;
+      if (pageRecords.length < pageSize) break;
+    }
+  }
+}
+
+/**
+ * Bound handle for one Records catalog (`/collections/{catalogId}`). Drops
+ * the routing discriminator from per-call requests.
+ */
+export class HonuaOgcRecordCollection {
+  public readonly client: HonuaClient;
+  public readonly collectionId: string | number;
+
+  public constructor(options: HonuaOgcRecordCollectionOptions) {
+    this.client = options.client;
+    this.collectionId = options.collectionId;
+  }
+
+  public async metadata(request: OgcMetadataRequest = {}): Promise<HonuaOgcCollectionMetadata> {
+    return this.client.getOgcRecordCollection({ ...request, collectionId: this.collectionId });
+  }
+
+  public async search(request: HonuaOgcRecordCollectionSearchRequest = {}): Promise<HonuaOgcRecordsResponse> {
+    return this.client.searchOgcRecords({ ...request, collectionId: this.collectionId });
+  }
+
+  public async record(request: HonuaOgcRecordCollectionItemRequest): Promise<HonuaOgcRecordResponse> {
+    return this.client.getOgcRecord({ ...request, collectionId: this.collectionId });
+  }
+
+  public async rawSearch(request: HonuaOgcRecordCollectionRawSearchRequest = {}): Promise<Response> {
+    return this.client.fetchOgcRecordsRaw({ ...request, collectionId: this.collectionId });
+  }
+
+  public async rawRecord(request: HonuaOgcRecordCollectionRawItemRequest): Promise<Response> {
+    return this.client.fetchOgcRecordRaw({ ...request, collectionId: this.collectionId });
+  }
+
+  public async searchAll(request: HonuaOgcRecordCollectionSearchAllRequest = {}): Promise<HonuaOgcRecordResponse[]> {
+    const root = new HonuaOgcRecords({ client: this.client });
+    return root.searchAll({ ...request, collectionId: this.collectionId });
+  }
+
+  public searchStream(
+    request: HonuaOgcRecordCollectionSearchAllRequest = {},
+  ): AsyncGenerator<HonuaOgcRecordResponse[], void, undefined> {
+    const root = new HonuaOgcRecords({ client: this.client });
+    return root.searchStream({ ...request, collectionId: this.collectionId });
+  }
+}
+
+interface RecordsPageCursor {
+  offset?: number;
+}
+
+function nextRecordsCursor(links: HonuaOgcRecordsResponse["links"] | undefined): RecordsPageCursor {
+  if (!links) return {};
+  for (const link of links) {
+    if (link.rel !== "next" || typeof link.href !== "string") continue;
+    try {
+      const url = new URL(link.href, "https://placeholder.test");
+      const offsetParam = url.searchParams.get("offset");
+      if (offsetParam === null) continue;
+      const offset = Number(offsetParam);
+      if (Number.isFinite(offset)) return { offset };
+    } catch {
+      // Ignore unparsable hrefs; keep scanning for a usable next link.
+    }
+  }
+  return {};
+}
+
+export function createHonuaOgcRecords(client: HonuaClient): HonuaOgcRecords {
+  return new HonuaOgcRecords({ client });
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -652,6 +652,48 @@ export interface OgcItemRequest extends OgcCollectionRequest {
   signal?: AbortSignal;
 }
 
+/** Query parameters for OGC API Records `/collections/{catalogId}/items`. */
+export interface OgcRecordsSearchRequest extends OgcCollectionRequest {
+  limit?: number;
+  offset?: number;
+  bbox?: string | readonly [number, number, number, number];
+  datetime?: string;
+  /** Free-text record search terms. Arrays serialize as OGC form-style CSV. */
+  q?: string | readonly string[];
+  ids?: string | readonly (string | number)[];
+  /** Record resource type filter, e.g. `dataset`, `service`, `map`, `collection`. */
+  type?: string | readonly string[];
+  /** External resource identifiers associated with the record. */
+  externalIds?: string | readonly string[];
+  /** Optional CQL2 filter when the server advertises the Records filtering class. */
+  filter?: string;
+  filterLang?: "cql2-text" | "cql2-json" | (string & {});
+  filterCrs?: string;
+  properties?: string | readonly string[];
+  sortby?: string;
+  profile?: string | readonly string[];
+  signal?: AbortSignal;
+}
+
+/** Request envelope for one OGC API Records record. */
+export interface OgcRecordItemRequest extends OgcCollectionRequest {
+  recordId: string | number;
+  profile?: string | readonly string[];
+  signal?: AbortSignal;
+}
+
+/** Raw response access for record searches. */
+export interface OgcRecordsRawSearchRequest extends OgcRecordsSearchRequest {
+  accept?: string;
+  headers?: HeadersInit;
+}
+
+/** Raw response access for one record. */
+export interface OgcRecordRawItemRequest extends OgcRecordItemRequest {
+  accept?: string;
+  headers?: HeadersInit;
+}
+
 export interface OgcCreateItemRequest extends OgcCollectionRequest {
   feature: GeoJsonFeature | Record<string, unknown>;
   headers?: HeadersInit;
@@ -1044,6 +1086,39 @@ export interface HonuaOgcFeatureResponse {
   geometry: import("../expr/expression.js").GeoJsonGeometry | null;
   properties: Record<string, unknown> | null;
   links?: HonuaOgcLink[];
+}
+
+/** Core record metadata carried in an OGC API Records GeoJSON feature. */
+export interface HonuaOgcRecordProperties extends Record<string, unknown> {
+  type?: string;
+  title?: string;
+  description?: string;
+  keywords?: readonly string[];
+  themes?: readonly unknown[];
+  language?: string;
+  languages?: readonly string[];
+  contacts?: readonly unknown[];
+  formats?: readonly string[];
+  license?: string;
+  created?: string;
+  updated?: string;
+  externalIds?: readonly string[];
+  links?: HonuaOgcLink[];
+}
+
+/** A single OGC API Records record (GeoJSON Feature with record metadata). */
+export interface HonuaOgcRecordResponse extends Omit<HonuaOgcFeatureResponse, "properties"> {
+  properties: HonuaOgcRecordProperties | null;
+}
+
+/** Response from OGC API Records `/collections/{catalogId}/items`. */
+export interface HonuaOgcRecordsResponse {
+  type: "FeatureCollection";
+  features: HonuaOgcRecordResponse[];
+  numberMatched?: number;
+  numberReturned?: number;
+  links?: HonuaOgcLink[];
+  timeStamp?: string;
 }
 
 /** A hypermedia link in an OGC API response. */

--- a/src/honua.ts
+++ b/src/honua.ts
@@ -289,6 +289,21 @@ export type {
   HonuaOgcMapsOptions,
 } from "./core/ogc-maps.js";
 export {
+  createHonuaOgcRecords,
+  HonuaOgcRecordCollection,
+  HonuaOgcRecords,
+} from "./core/ogc-records.js";
+export type {
+  HonuaOgcRecordCollectionItemRequest,
+  HonuaOgcRecordCollectionOptions,
+  HonuaOgcRecordCollectionRawItemRequest,
+  HonuaOgcRecordCollectionRawSearchRequest,
+  HonuaOgcRecordCollectionSearchAllRequest,
+  HonuaOgcRecordCollectionSearchRequest,
+  HonuaOgcRecordsOptions,
+  HonuaOgcRecordsSearchAllRequest,
+} from "./core/ogc-records.js";
+export {
   createGeoServicesGpAdapter,
   createGeospatialGrpcProcessAdapter,
   createHonuaProcessRunner,
@@ -429,6 +444,9 @@ export type {
   HonuaOgcCollectionMetadata,
   HonuaOgcQueryableProperty,
   HonuaOgcQueryablesResponse,
+  HonuaOgcRecordProperties,
+  HonuaOgcRecordResponse,
+  HonuaOgcRecordsResponse,
   HonuaStacItemCollectionResponse,
   HonuaStacItemResponse,
   HonuaStacLandingResponse,
@@ -517,6 +535,10 @@ export type {
   EsriGeometry,
   GeoJsonFeature,
   HonuaServicesResponse,
+  OgcRecordItemRequest,
+  OgcRecordRawItemRequest,
+  OgcRecordsRawSearchRequest,
+  OgcRecordsSearchRequest,
   StacSearchRequest,
 } from "./core/types.js";
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -342,6 +342,9 @@ export type {
   HonuaOgcCollectionMetadata,
   HonuaOgcQueryableProperty,
   HonuaOgcQueryablesResponse,
+  HonuaOgcRecordProperties,
+  HonuaOgcRecordResponse,
+  HonuaOgcRecordsResponse,
   HonuaErrorContext,
   HonuaRequestContext,
   HonuaRequestInterceptor,
@@ -989,6 +992,21 @@ export type {
   HonuaOgcMapsOptions,
 } from "./core/ogc-maps.js";
 export {
+  createHonuaOgcRecords,
+  HonuaOgcRecordCollection,
+  HonuaOgcRecords,
+} from "./core/ogc-records.js";
+export type {
+  HonuaOgcRecordCollectionItemRequest,
+  HonuaOgcRecordCollectionOptions,
+  HonuaOgcRecordCollectionRawItemRequest,
+  HonuaOgcRecordCollectionRawSearchRequest,
+  HonuaOgcRecordCollectionSearchAllRequest,
+  HonuaOgcRecordCollectionSearchRequest,
+  HonuaOgcRecordsOptions,
+  HonuaOgcRecordsSearchAllRequest,
+} from "./core/ogc-records.js";
+export {
   createGeoServicesGpAdapter,
   createGeospatialGrpcProcessAdapter,
   createHonuaProcessRunner,
@@ -1144,6 +1162,10 @@ export type {
   HonuaStacItemCollectionResponse,
   HonuaStacItemResponse,
   HonuaStacLandingResponse,
+  OgcRecordItemRequest,
+  OgcRecordRawItemRequest,
+  OgcRecordsRawSearchRequest,
+  OgcRecordsSearchRequest,
   OgcMapImageRequest,
   OgcMapFormat,
   OgcProcessExecuteRequest,

--- a/test/contract/conformance.test.ts
+++ b/test/contract/conformance.test.ts
@@ -215,7 +215,7 @@ const harnesses: Harness[] = [
 ];
 
 describe("contract / Protocol enum", () => {
-  it("includes all canonical protocols (gRPC, five GeoServices service types, OGC Features/Tiles/Maps, STAC, WFS/WMS/WMTS/OData, MapLibre-native)", () => {
+  it("includes all canonical protocols (gRPC, five GeoServices service types, OGC Features/Tiles/Maps/Records, STAC, WFS/WMS/WMTS/OData, MapLibre-native)", () => {
     expect(PROTOCOLS).toEqual([
       "grpc",
       "geoservices-feature-service",
@@ -226,6 +226,7 @@ describe("contract / Protocol enum", () => {
       "ogc-features",
       "ogc-tiles",
       "ogc-maps",
+      "ogc-records",
       "stac",
       "wfs",
       "wms",

--- a/test/contract/ogc-conformance.test.ts
+++ b/test/contract/ogc-conformance.test.ts
@@ -62,6 +62,21 @@ describe("ogc-conformance / negotiateOgcCapabilities", () => {
     expect(caps.has("processes")).toBe(true);
   });
 
+  it("translates OGC API Records searchable catalog classes to query capabilities", () => {
+    const caps = negotiateOgcCapabilities("ogc-records", {
+      conformsTo: [
+        "http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/records-api",
+        "http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/record-core-query-parameters",
+        "http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/cql-filter",
+        "http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/json",
+      ],
+    });
+    expect(caps.has("query")).toBe(true);
+    expect(caps.has("queryObjectIds")).toBe(true);
+    expect(caps.has("queryAggregate")).toBe(false);
+    expect(caps.has("applyEdits")).toBe(false);
+  });
+
   it("translates STAC item-search to query + queryObjectIds and does not advertise queryAggregate for filter", () => {
     // STAC's `filter` extension is CQL2 query-side filtering, not server-side
     // aggregation. The STAC source adapter has no aggregation implementation

--- a/test/contract/ogc-records.test.ts
+++ b/test/contract/ogc-records.test.ts
@@ -1,0 +1,327 @@
+/**
+ * OGC API Records catalog support. Records expose metadata about resources
+ * (services, collections, maps, STAC collections, source descriptors), so the
+ * SDK keeps them distinct from STAC item search and protocol-native metadata.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { PROTOCOL_DEFAULT_CAPABILITIES, type SourceDescriptor, createDataset } from "../../src/contract/index.js";
+import { HonuaClient } from "../../src/core/client.js";
+import { HonuaCapabilityNotSupportedError } from "../../src/core/errors.js";
+import type { HonuaHttpError } from "../../src/core/errors.js";
+import { HonuaOgcRecordCollection } from "../../src/core/ogc-records.js";
+import { envelope } from "../../src/core/spatial-filter.js";
+
+import { jsonResponse, makeMockClient } from "./shared.js";
+
+interface RecordAttrs {
+  type: string;
+  title: string;
+  externalIds?: readonly string[];
+}
+
+function recordsResponse(features = 2) {
+  return {
+    type: "FeatureCollection",
+    features: Array.from({ length: features }, (_, i) => ({
+      type: "Feature",
+      id: `record-${i + 1}`,
+      geometry: { type: "Point", coordinates: [-157.8 + i, 21.3] },
+      properties: {
+        type: i === 0 ? "service" : "collection",
+        title: `Catalog record ${i + 1}`,
+        description: "Metadata record",
+        externalIds: [`ext-${i + 1}`],
+        links: [{ rel: "item", href: `https://mock/resources/${i + 1}` }],
+      },
+    })),
+    numberMatched: features,
+    numberReturned: features,
+    links: [],
+  };
+}
+
+describe("ogc-records / wire", () => {
+  it("calls Records discovery, search, and detail endpoints with supported query parameters", async () => {
+    const requestedUrls: string[] = [];
+    const client = makeMockClient({
+      routes: [
+        [
+          "/ogc/records",
+          (url) => {
+            requestedUrls.push(url.href);
+            if (url.pathname.endsWith("/items/record-1")) {
+              return jsonResponse(recordsResponse(1).features[0]);
+            }
+            if (url.pathname.endsWith("/items")) {
+              return jsonResponse(recordsResponse());
+            }
+            if (url.pathname.endsWith("/collections/catalog")) {
+              return jsonResponse({ id: "catalog", itemType: "record" });
+            }
+            if (url.pathname.endsWith("/collections")) {
+              return jsonResponse({ collections: [{ id: "catalog", itemType: "record" }] });
+            }
+            if (url.pathname.endsWith("/conformance")) {
+              return jsonResponse({ conformsTo: [] });
+            }
+            return jsonResponse({ title: "Records" });
+          },
+        ],
+      ],
+    });
+
+    const records = client.ogcRecords();
+    await records.landing({ responseFormat: "json" });
+    await records.conformance({ responseFormat: "json" });
+    await records.collections({ responseFormat: "json" });
+    await records.collectionMetadata({ collectionId: "catalog", responseFormat: "json" });
+    await records.search({
+      collectionId: "catalog",
+      responseFormat: "geojson",
+      limit: 10,
+      offset: 20,
+      bbox: [-158, 21, -157, 22],
+      datetime: "2025-01-01/2025-12-31",
+      q: ["roads", "parcels"],
+      ids: ["record-1", "record-2"],
+      type: ["service", "collection"],
+      externalIds: ["svc-a", "svc-b"],
+      filter: "type = 'service'",
+      filterLang: "cql2-text",
+      filterCrs: "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+      properties: ["title", "type"],
+      sortby: "-updated",
+      profile: "record",
+    });
+    await records.record({ collectionId: "catalog", recordId: "record-1", responseFormat: "json" });
+
+    expect(requestedUrls[0]).toBe("https://mock.honua.test/ogc/records?f=json");
+    expect(requestedUrls[1]).toBe("https://mock.honua.test/ogc/records/conformance?f=json");
+    expect(requestedUrls[2]).toBe("https://mock.honua.test/ogc/records/collections?f=json");
+    expect(requestedUrls[3]).toBe("https://mock.honua.test/ogc/records/collections/catalog?f=json");
+
+    const search = new URL(requestedUrls[4]);
+    expect(search.pathname).toBe("/ogc/records/collections/catalog/items");
+    expect(search.searchParams.get("f")).toBe("geojson");
+    expect(search.searchParams.get("limit")).toBe("10");
+    expect(search.searchParams.get("offset")).toBe("20");
+    expect(search.searchParams.get("bbox")).toBe("-158,21,-157,22");
+    expect(search.searchParams.get("datetime")).toBe("2025-01-01/2025-12-31");
+    expect(search.searchParams.get("q")).toBe("roads,parcels");
+    expect(search.searchParams.get("ids")).toBe("record-1,record-2");
+    expect(search.searchParams.get("type")).toBe("service,collection");
+    expect(search.searchParams.get("externalIds")).toBe("svc-a,svc-b");
+    expect(search.searchParams.get("filter")).toBe("type = 'service'");
+    expect(search.searchParams.get("filter-lang")).toBe("cql2-text");
+    expect(search.searchParams.get("filter-crs")).toBe("http://www.opengis.net/def/crs/OGC/1.3/CRS84");
+    expect(search.searchParams.get("properties")).toBe("title,type");
+    expect(search.searchParams.get("sortby")).toBe("-updated");
+    expect(search.searchParams.get("profile")).toBe("record");
+    expect(requestedUrls[5]).toBe("https://mock.honua.test/ogc/records/collections/catalog/items/record-1?f=json");
+  });
+
+  it("returns raw Records responses through the shared auth/interceptor pipeline", async () => {
+    const seen: string[] = [];
+    let headers: HeadersInit | undefined;
+    const client = new HonuaClient({
+      baseUrl: "https://example.test",
+      apiKey: "key-1",
+      bearerToken: "token-1",
+      interceptors: [
+        {
+          before: () => {
+            seen.push("before");
+          },
+          after: () => {
+            seen.push("after");
+          },
+        },
+      ],
+      fetchFn: async (_input, init) => {
+        headers = init?.headers;
+        return new Response("<html>record catalog</html>", {
+          status: 200,
+          headers: { "Content-Type": "text/html" },
+        });
+      },
+    });
+
+    const response = await client.ogcRecords().collection("catalog").rawSearch({
+      responseFormat: "html",
+      accept: "text/html",
+    });
+
+    expect(await response.text()).toBe("<html>record catalog</html>");
+    expect(headers).toMatchObject({
+      Accept: "text/html",
+      "X-API-Key": "key-1",
+      Authorization: "Bearer token-1",
+    });
+    expect(seen).toEqual(["before", "after"]);
+  });
+
+  it("surfaces HTTP errors with normalized HonuaHttpError metadata", async () => {
+    const client = makeMockClient({
+      routes: [
+        [
+          "/ogc/records/collections/catalog/items",
+          () => jsonResponse({ error: { message: "records unavailable" } }, { status: 503 }),
+        ],
+      ],
+    });
+
+    await expect(client.ogcRecords().search({ collectionId: "catalog" })).rejects.toMatchObject({
+      name: "HonuaHttpError",
+      statusCode: 503,
+    } satisfies Partial<HonuaHttpError>);
+  });
+
+  it("searchAll() follows rel=next links with offset paging", async () => {
+    let calls = 0;
+    const observedOffsets: Array<string | null> = [];
+    const client = makeMockClient({
+      routes: [
+        [
+          "/ogc/records/collections/catalog/items",
+          (url) => {
+            calls += 1;
+            observedOffsets.push(url.searchParams.get("offset"));
+            const last = calls === 3;
+            return jsonResponse({
+              ...recordsResponse(2),
+              links: last
+                ? []
+                : [{ rel: "next", href: `https://mock/ogc/records/collections/catalog/items?offset=${calls * 2}` }],
+            });
+          },
+        ],
+      ],
+    });
+
+    const records = await client.ogcRecords().searchAll({ collectionId: "catalog", limit: 2 });
+
+    expect(records).toHaveLength(6);
+    expect(calls).toBe(3);
+    expect(observedOffsets).toEqual([null, "2", "4"]);
+  });
+});
+
+describe("ogc-records / Source adapter", () => {
+  it("maps canonical Query fields to Records search parameters and parses record properties", async () => {
+    let observed: URLSearchParams | undefined;
+    const client = makeMockClient({
+      routes: [
+        [
+          "/ogc/records/collections/catalog/items",
+          (url) => {
+            observed = url.searchParams;
+            return jsonResponse(recordsResponse(2));
+          },
+        ],
+      ],
+    });
+    const dataset = createDataset({
+      id: "catalog",
+      client,
+      skipCompatibilityCheck: true,
+      sources: [
+        {
+          id: "records",
+          protocol: "ogc-records",
+          locator: { url: "https://mock/", collectionId: "catalog" },
+          capabilities: PROTOCOL_DEFAULT_CAPABILITIES["ogc-records"],
+        } satisfies SourceDescriptor,
+      ],
+    });
+
+    const source = dataset.source<RecordAttrs>("records")!;
+    const result = await source.query({
+      where: "type = 'service'",
+      spatialFilter: envelope(-158, 21, -157, 22),
+      outFields: ["title", "type"],
+      orderBy: [{ field: "updated", direction: "desc" }],
+      pagination: { offset: 5, limit: 25 },
+    });
+
+    expect(observed?.get("filter")).toBe("type = 'service'");
+    expect(observed?.get("filter-lang")).toBe("cql2-text");
+    expect(observed?.get("bbox")).toBe("-158,21,-157,22");
+    expect(observed?.get("properties")).toBe("title,type");
+    expect(observed?.get("sortby")).toBe("-updated");
+    expect(observed?.get("offset")).toBe("5");
+    expect(observed?.get("limit")).toBe("25");
+    expect(result.features).toHaveLength(2);
+    expect(result.features[0].attributes.title).toBe("Catalog record 1");
+    expect(result.features[0].attributes.externalIds).toEqual(["ext-1"]);
+    expect(result.totalCount).toBe(2);
+    expect(source.protocol("ogc-records")).toBeInstanceOf(HonuaOgcRecordCollection);
+  });
+
+  it("queryObjectIds({ limit }) caps Records paging and slices IDs", async () => {
+    let calls = 0;
+    const client = makeMockClient({
+      routes: [
+        [
+          "/ogc/records/collections/catalog/items",
+          () => {
+            calls += 1;
+            return jsonResponse({
+              ...recordsResponse(1),
+              features: [
+                {
+                  ...recordsResponse(1).features[0],
+                  id: `record-${calls}`,
+                },
+              ],
+              numberMatched: 1000,
+              links: [{ rel: "next", href: `https://mock/ogc/records/collections/catalog/items?offset=${calls}` }],
+            });
+          },
+        ],
+      ],
+    });
+    const dataset = createDataset({
+      id: "catalog",
+      client,
+      skipCompatibilityCheck: true,
+      sources: [
+        {
+          id: "records",
+          protocol: "ogc-records",
+          locator: { url: "https://mock/", collectionId: "catalog" },
+          capabilities: PROTOCOL_DEFAULT_CAPABILITIES["ogc-records"],
+        } satisfies SourceDescriptor,
+      ],
+    });
+
+    const ids = await dataset.source("records")!.queryObjectIds({ pagination: { limit: 1 } });
+
+    expect(ids).toEqual(["record-1"]);
+    expect(calls).toBe(2);
+  });
+
+  it("rejects aggregation because Records search is catalog metadata, not analytics", async () => {
+    const client = makeMockClient({
+      routes: [["/ogc/records/collections/catalog/items", () => jsonResponse(recordsResponse())]],
+    });
+    const dataset = createDataset({
+      id: "catalog",
+      client,
+      skipCompatibilityCheck: true,
+      sources: [
+        {
+          id: "records",
+          protocol: "ogc-records",
+          locator: { url: "https://mock/", collectionId: "catalog" },
+          capabilities: PROTOCOL_DEFAULT_CAPABILITIES["ogc-records"],
+        } satisfies SourceDescriptor,
+      ],
+    });
+
+    await expect(
+      dataset.source("records")!.query({ aggregation: { metrics: [{ fn: "count", field: "type" }] } }),
+    ).rejects.toThrow(HonuaCapabilityNotSupportedError);
+  });
+});

--- a/test/entrypoints.test.ts
+++ b/test/entrypoints.test.ts
@@ -20,6 +20,7 @@ import {
   odataSource,
   ogcFeaturesSource,
   ogcMapsSource,
+  ogcRecordsSource,
   ogcTilesSource,
   stacSearchSource,
 } from "../src/contract/index.js";
@@ -129,11 +130,14 @@ import {
   HonuaMapService,
   HonuaOgcFeatureCollection,
   HonuaOgcFeatures,
+  HonuaOgcRecordCollection,
+  HonuaOgcRecords,
   HonuaProcessRunner,
   HonuaService,
   HonuaWfsExceptionError,
   createHonuaCacheState,
   createHonuaOgcFeatures,
+  createHonuaOgcRecords,
   createHonuaProcessRunner,
   createHonuaService,
   bindQueryProjectionToExploration as honuaBindQueryProjectionToExploration,
@@ -189,6 +193,8 @@ describe("entrypoint modules", () => {
     expect(HonuaMapService).toBeTypeOf("function");
     expect(HonuaOgcFeatures).toBeTypeOf("function");
     expect(HonuaOgcFeatureCollection).toBeTypeOf("function");
+    expect(HonuaOgcRecords).toBeTypeOf("function");
+    expect(HonuaOgcRecordCollection).toBeTypeOf("function");
     expect(HonuaImageService).toBeTypeOf("function");
     expect(HonuaGeometryService).toBeTypeOf("function");
     expect(HonuaGeoprocessingService).toBeTypeOf("function");
@@ -196,6 +202,7 @@ describe("entrypoint modules", () => {
     expect(createHonuaService).toBeTypeOf("function");
     expect(createHonuaProcessRunner).toBeTypeOf("function");
     expect(createHonuaOgcFeatures).toBeTypeOf("function");
+    expect(createHonuaOgcRecords).toBeTypeOf("function");
     expect(HonuaWfsExceptionError).toBeTypeOf("function");
     expect(HonuaWfsExceptionErrorRoot).toBe(HonuaWfsExceptionError);
     expect(createHonuaCacheState).toBeTypeOf("function");
@@ -297,11 +304,11 @@ describe("entrypoint modules", () => {
   });
 
   it("exposes the canonical contract entrypoint", () => {
-    // Seventeen canonical protocols: gRPC, five GeoServices service
+    // Eighteen canonical protocols: gRPC, five GeoServices service
     // types (FeatureServer, MapServer, ImageServer, Geometry, GP), OGC
-    // API Features / Tiles / Maps, STAC, WFS / WMS / WMTS / OData, and
-    // three MapLibre-native sources.
-    expect(PROTOCOLS).toHaveLength(17);
+    // API Features / Tiles / Maps / Records, STAC, WFS / WMS / WMTS /
+    // OData, and three MapLibre-native sources.
+    expect(PROTOCOLS).toHaveLength(18);
     expect(CAPABILITIES.length).toBeGreaterThan(0);
     expect(Object.keys(PROTOCOL_DEFAULT_CAPABILITIES)).toEqual([...PROTOCOLS]);
     expect(capabilities).toBeTypeOf("function");
@@ -318,6 +325,7 @@ describe("entrypoint modules", () => {
     expect(ogcFeaturesSource).toBeTypeOf("function");
     expect(ogcTilesSource).toBeTypeOf("function");
     expect(ogcMapsSource).toBeTypeOf("function");
+    expect(ogcRecordsSource).toBeTypeOf("function");
     expect(stacSearchSource).toBeTypeOf("function");
     expect(odataSource).toBeTypeOf("function");
   });

--- a/test/fixtures/sdk-contract/semantic-contract.v1.json
+++ b/test/fixtures/sdk-contract/semantic-contract.v1.json
@@ -69,6 +69,7 @@
     "ogc-features",
     "ogc-tiles",
     "ogc-maps",
+    "ogc-records",
     "stac",
     "wfs",
     "wms",
@@ -92,6 +93,7 @@
     "gp-server": "geoservices-gp-service",
     "gpserver": "geoservices-gp-service",
     "ogc-api-features": "ogc-features",
+    "ogc-api-records": "ogc-records",
     "ogc_features": "ogc-features",
     "odata-v4": "odata",
     "wfs-2.0": "wfs",
@@ -180,6 +182,11 @@
     ],
     "ogc-maps": [
       "render"
+    ],
+    "ogc-records": [
+      "query",
+      "queryObjectIds",
+      "stream"
     ],
     "stac": [
       "query",


### PR DESCRIPTION
## Summary

- Adds a first-class OGC API Records client surface, including discovery, search, item detail, raw access, pagination helpers, and `HonuaClient.ogcRecords()`.
- Registers `ogc-records` in protocol/capability metadata and the shared `Source` adapter path.
- Adds documentation and focused tests for request construction, paging, errors, auth/interceptors, and representative response parsing.

## Validation

Worker validation:
- `npm ci`
- `npm test -- --run test/contract/ogc-records.test.ts test/contract/ogc-conformance.test.ts test/contract/conformance.test.ts test/contract/sdk-contract-fixtures.test.ts test/entrypoints.test.ts`
- `npm run typecheck`
- `npx biome check <touched files>`
- `git diff --check`

## Remaining gaps

- Live server integration still depends on honua-server#952 finalizing Records routes/classes.
- Metadata/catalog parity is documented but not exhaustively enforced against every server metadata surface.
- Advanced Records operations such as create/update/delete, harvest, facets, and advanced sorting are intentionally out of this slice.

Closes #139 when accepted if the remaining live-server dependency is tracked server-side.