### PR TITLE
[codex] Add hosted MapPackage fetch helpers

### DIFF
--- a/docs/maplibre-runtime.md
+++ b/docs/maplibre-runtime.md
@@ -24,6 +24,9 @@ through the contract's `Source` handles.
 src/runtime/
 ├── index.ts           # barrel — public surface
 ├── map-package.ts     # HonuaMapPackage type (mirrors honua-server#731)
+├── map-package-fetch.ts # hosted fetch + load-from-id helpers
+├── map-package-validation.ts # typed validation diagnostics
+├── map-package-watch.ts # disposable polling watcher
 ├── load-package.ts    # loadMapPackage(pkg, map, opts) → HonuaMapRuntime
 ├── runtime.ts         # HonuaMapRuntime class + event/telemetry types
 ├── source-bridge.ts   # SourceBinding[] → SourceDescriptor[] + native sources
@@ -55,7 +58,11 @@ runtime.dispose();
 
 | Export | Shape | Notes |
 | --- | --- | --- |
-| `loadMapPackage(pkg, map, opts)` | `Promise<HonuaMapRuntime>` | The only async entry point. Throws `HonuaMapPackageError` for binding failures under `sourceErrorPolicy: "fail-fast"`; under the default `"tolerant"` policy a single per-source binding failure does not abort the load — see *Tolerant binding* below. Query-time adapter failures surface on the per-`Source` promises from `runtime.dataset` and through the shared `HonuaClient` interceptor chain; consumers can broadcast them through `runtime.reportSourceError(sourceId, error)` to convert query-time rejections into the canonical `source-error` event. |
+| `loadMapPackage(pkg, map, opts)` | `Promise<HonuaMapRuntime>` | Inline-package load entry point. Throws `HonuaMapPackageError` for binding failures under `sourceErrorPolicy: "fail-fast"`; under the default `"tolerant"` policy a single per-source binding failure does not abort the load — see *Tolerant binding* below. Query-time adapter failures surface on the per-`Source` promises from `runtime.dataset` and through the shared `HonuaClient` interceptor chain; consumers can broadcast them through `runtime.reportSourceError(sourceId, error)` to convert query-time rejections into the canonical `source-error` event. |
+| `fetchMapPackage(idOrLocator, opts)` | `Promise<FetchMapPackageResult>` | Fetches a hosted package through `HonuaClient.pipelineFetch`, validates it, resolves style refs when a resolver is supplied, and uses ETag / Last-Modified validators from the server when available. |
+| `loadMapPackageFromId(idOrLocator, map, opts)` | `Promise<LoadMapPackageFromIdResult>` | Builder-style helper: fetches a hosted package, then delegates to `loadMapPackage`. The result includes the runtime plus fetch diagnostics/cache state. |
+| `watchMapPackage(idOrLocator, opts)` | `MapPackageWatchHandle` | Opt-in polling watcher with `dispose()` and `refresh()`. It reuses `fetchMapPackage`, reports structural updates that require full style reload, and can apply updates to an existing `HonuaMapRuntime`. |
+| `validateMapPackage(pkg, opts)` | `ValidateMapPackageResult` | Returns typed diagnostics for format/version, missing sources, unsupported protocols, stale/expired packages, and style-ref target mismatches. |
 | `HonuaMapRuntime` | class | `map`, `honuaMap`, `dataset`, `mapPackage`, `composedStyle`, `getLegend`, `setLayerVisibility`, `bindPopup`, `setViewState`, `updatePackage`, `on`, `reportSourceError`, `dispose`. |
 | `HonuaMapPackage` | type | v1 package shape. `format` is gated against `HONUA_MAP_PACKAGE_FORMAT_V1` (`"honua_map_package.v1"`). |
 | `HONUA_MAP_PACKAGE_FORMAT_V1` | const | Canonical format tag. |
@@ -100,6 +107,65 @@ observe the initial lifecycle without racing against `loadMapPackage`'s
 return must use this hook instead of calling `runtime.on(...)` after
 `await`. Subsequent events (`package-updated`, `disposed`, ...) also
 flow through the same listener.
+
+## Hosted MapPackage Fetch
+
+Builder-style usage starts from a package id instead of an inline
+`MapPackage`:
+
+```ts
+import { HonuaClient } from "@honua/sdk-js";
+import { loadMapPackageFromId, watchMapPackage } from "@honua/sdk-js/runtime";
+
+const client = new HonuaClient({ baseUrl: "https://honua.example.com" });
+const { runtime, diagnostics } = await loadMapPackageFromId("map_123", map, {
+  client,
+  popupFactory: () => new maplibregl.Popup(),
+  resolveStyleRef: (styleId, presetId) => fetchStyleBody(styleId, presetId),
+});
+
+for (const diagnostic of diagnostics) {
+  console.warn(diagnostic.code, diagnostic.message);
+}
+
+const watcher = watchMapPackage("map_123", {
+  client,
+  runtime,
+  intervalMs: 30_000,
+  onEvent: (event) => {
+    if (event.type === "reload-required") {
+      console.info(event.reason);
+    }
+  },
+});
+
+// Later, when the host tears down the map:
+watcher.dispose();
+```
+
+`fetchMapPackage` accepts either an id (`"map_123"`), a direct path or
+same-origin URL, a `honua://map-packages/{id}` locator, or an object with
+`id`, `packageId`, `path`, `url`, or `href`. Id locators default to
+`/api/v1/map-packages/{id}`; pass `resolvePath` when a deployment uses a
+different hosted package route.
+
+Fetch results include:
+
+- `mapPackage`: the validated package, with missing style-ref bodies
+  inlined when `resolveStyleRef` succeeds.
+- `diagnostics`: typed warnings/errors for unsupported formats,
+  missing source bindings, unsupported protocols, stale packages
+  (`maxAgeMs`), expired packages (`status: "Expired"` or `expiresAt`),
+  missing layer sources, and style-ref resolution failures.
+- `cache`: SDK fetch cache state. The helper stores validators in a
+  per-client in-memory cache by default. On later fetches it sends
+  `If-None-Match` / `If-Modified-Since` when the server supplied ETag or
+  Last-Modified. Pass `cache: false` to bypass the SDK cache, or pass a
+  `MapPackageFetchCache` to share cache state across clients/tests.
+
+Validation errors throw `HonuaMapPackageError { stage: "validate" }`
+with `{ diagnostics }` in `detail`. Pass `allowInvalid: true` when a
+host wants to display diagnostics without rejecting the fetch.
 
 ### Tolerant binding (`sourceErrorPolicy`)
 

--- a/src/runtime/errors.ts
+++ b/src/runtime/errors.ts
@@ -13,7 +13,9 @@
  * error class itself.
  */
 export type HonuaMapPackageErrorStage =
+  | "fetch"
   | "load"
+  | "validate"
   | "update"
   | "style-compose"
   | "source-bind"

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -24,6 +24,39 @@
 export { loadMapPackage } from "./load-package.js";
 export type { LoadMapPackageOptions, SourceErrorPolicy } from "./load-package.js";
 
+export {
+  DEFAULT_MAP_PACKAGE_PATH_PREFIX,
+  defaultMapPackagePath,
+  fetchMapPackage,
+  loadMapPackageFromId,
+  mapPackageFingerprint,
+  resolveMapPackagePath,
+} from "./map-package-fetch.js";
+export type {
+  FetchMapPackageOptions,
+  FetchMapPackageResult,
+  LoadMapPackageFromIdOptions,
+  LoadMapPackageFromIdResult,
+  MapPackageFetchCache,
+  MapPackageFetchCacheEntry,
+  MapPackageFetchCacheState,
+  MapPackageFetchCacheStatus,
+  MapPackageLocator,
+  MapPackagePathResolver,
+} from "./map-package-fetch.js";
+
+export { watchMapPackage } from "./map-package-watch.js";
+export type { MapPackageWatchEvent, MapPackageWatchHandle, WatchMapPackageOptions } from "./map-package-watch.js";
+
+export { hasMapPackageDiagnosticErrors, validateMapPackage } from "./map-package-validation.js";
+export type {
+  HonuaMapPackageDiagnostic,
+  HonuaMapPackageDiagnosticCode,
+  HonuaMapPackageDiagnosticSeverity,
+  ValidateMapPackageOptions,
+  ValidateMapPackageResult,
+} from "./map-package-validation.js";
+
 export { HonuaMapRuntime } from "./runtime.js";
 export type {
   HonuaMapRuntimeInternals,

--- a/src/runtime/map-package-fetch.ts
+++ b/src/runtime/map-package-fetch.ts
@@ -1,0 +1,418 @@
+import type { HonuaCacheValidator } from "../core/cache-state.js";
+import { honuaCacheValidatorFromHeaders } from "../core/cache-state.js";
+import type { HonuaClient } from "../core/client.js";
+import { HonuaMapPackageError } from "./errors.js";
+import { type LoadMapPackageOptions, loadMapPackage } from "./load-package.js";
+import {
+  type HonuaMapPackageDiagnostic,
+  hasMapPackageDiagnosticErrors,
+  validateMapPackage,
+} from "./map-package-validation.js";
+import type { HonuaMapPackage, HonuaMapPackageStyleRef, HonuaStyleRefBody } from "./map-package.js";
+import type { HonuaMapRuntime, MaplibreMap } from "./runtime.js";
+import type { StyleRefResolver } from "./style-compose.js";
+
+export const DEFAULT_MAP_PACKAGE_PATH_PREFIX = "/api/v1/map-packages";
+
+export type MapPackageLocator =
+  | string
+  | {
+      readonly id?: string;
+      readonly packageId?: string;
+      readonly path?: string;
+      readonly url?: string;
+      readonly href?: string;
+    };
+
+export type MapPackagePathResolver = (packageId: string) => string;
+
+export interface FetchMapPackageOptions {
+  readonly client: HonuaClient;
+  readonly signal?: AbortSignal;
+  readonly headers?: HeadersInit;
+  /**
+   * Override id-to-path resolution. The default is
+   * `/api/v1/map-packages/{encodeURIComponent(id)}`.
+   */
+  readonly resolvePath?: MapPackagePathResolver;
+  /** In-memory response cache. Omit for a per-client default; pass `false` to bypass SDK validators. */
+  readonly cache?: MapPackageFetchCache | false;
+  /** Resolve out-of-band style refs and inline successful bodies into the returned package. */
+  readonly resolveStyleRef?: StyleRefResolver;
+  /** Treat unresolved style refs as validation errors instead of warnings. */
+  readonly requireStyleRefResolution?: boolean;
+  /** Emit a stale-package warning when the package timestamp is older than this many ms. */
+  readonly maxAgeMs?: number;
+  readonly now?: number | Date;
+  /** Return invalid packages with diagnostics instead of throwing `HonuaMapPackageError`. */
+  readonly allowInvalid?: boolean;
+}
+
+export interface MapPackageFetchCacheEntry {
+  readonly mapPackage: HonuaMapPackage;
+  readonly validator?: HonuaCacheValidator;
+  readonly cachedAtMs: number;
+  readonly sourceUpdatedAt?: string;
+  readonly fingerprint: string;
+}
+
+export type MapPackageFetchCache = Map<string, MapPackageFetchCacheEntry>;
+
+export type MapPackageFetchCacheStatus = "miss" | "refreshed" | "not-modified" | "bypass";
+
+export interface MapPackageFetchCacheState {
+  readonly status: MapPackageFetchCacheStatus;
+  readonly key: string;
+  readonly validator?: HonuaCacheValidator;
+  readonly sourceUpdatedAt?: string;
+  readonly fetchedAt: string;
+  readonly revalidatedAt?: string;
+}
+
+export interface FetchMapPackageResult {
+  readonly mapPackage: HonuaMapPackage;
+  readonly diagnostics: readonly HonuaMapPackageDiagnostic[];
+  readonly cache: MapPackageFetchCacheState;
+}
+
+export interface LoadMapPackageFromIdOptions extends LoadMapPackageOptions {
+  readonly signal?: AbortSignal;
+  readonly headers?: HeadersInit;
+  readonly resolvePath?: MapPackagePathResolver;
+  readonly cache?: MapPackageFetchCache | false;
+  readonly requireStyleRefResolution?: boolean;
+  readonly maxAgeMs?: number;
+  readonly now?: number | Date;
+  readonly allowInvalid?: boolean;
+}
+
+export interface LoadMapPackageFromIdResult {
+  readonly runtime: HonuaMapRuntime;
+  readonly mapPackage: HonuaMapPackage;
+  readonly diagnostics: readonly HonuaMapPackageDiagnostic[];
+  readonly cache: MapPackageFetchCacheState;
+}
+
+const defaultCaches = new WeakMap<HonuaClient, MapPackageFetchCache>();
+
+export async function fetchMapPackage(
+  locator: MapPackageLocator,
+  options: FetchMapPackageOptions,
+): Promise<FetchMapPackageResult> {
+  const path = resolveMapPackagePath(locator, options.resolvePath);
+  const cache = resolveCache(options.client, options.cache);
+  const cached = cache?.get(path);
+  const headers = buildFetchHeaders(options.headers, cached?.validator);
+
+  const response = await options.client.pipelineFetch(
+    "GET",
+    path,
+    { headers },
+    options.signal,
+    cached ? { okStatuses: [304] } : {},
+  );
+
+  if (response.status === 304) {
+    if (!cached) {
+      throw new HonuaMapPackageError("MapPackage fetch returned 304 without an SDK cache entry", {
+        stage: "fetch",
+        detail: { path },
+      });
+    }
+    return buildFetchResult(cached.mapPackage, path, "not-modified", {
+      validator: honuaCacheValidatorFromHeaders(response.headers) ?? cached.validator,
+      sourceUpdatedAt: response.headers.get("last-modified") ?? cached.sourceUpdatedAt,
+      revalidatedAt: new Date().toISOString(),
+      options,
+    });
+  }
+
+  const body = await parseJsonBody(response, path);
+  const rawPackage = unwrapMapPackageEnvelope(body);
+  const resolved = await resolveMapPackageStyleRefs(rawPackage, {
+    resolveStyleRef: options.resolveStyleRef,
+    requireStyleRefResolution: options.requireStyleRefResolution === true,
+  });
+  const mapPackage = resolved.mapPackage;
+  const validation = validateMapPackage(mapPackage, {
+    maxAgeMs: options.maxAgeMs,
+    now: options.now,
+  });
+  const diagnostics = [...resolved.diagnostics, ...validation.diagnostics];
+
+  if (hasMapPackageDiagnosticErrors(diagnostics) && options.allowInvalid !== true) {
+    throw new HonuaMapPackageError("MapPackage validation failed", {
+      packageId: packageIdFromUnknown(mapPackage),
+      stage: "validate",
+      detail: { diagnostics, path },
+    });
+  }
+
+  const validator = honuaCacheValidatorFromHeaders(response.headers);
+  const sourceUpdatedAt = response.headers.get("last-modified") ?? undefined;
+  const status: MapPackageFetchCacheStatus = cache ? (cached ? "refreshed" : "miss") : "bypass";
+  const entry: MapPackageFetchCacheEntry = {
+    mapPackage: mapPackage as HonuaMapPackage,
+    cachedAtMs: Date.now(),
+    fingerprint: stableFingerprint(mapPackage),
+    ...(validator ? { validator } : {}),
+    ...(sourceUpdatedAt ? { sourceUpdatedAt } : {}),
+  };
+  if (cache) cache.set(path, entry);
+
+  return {
+    mapPackage: mapPackage as HonuaMapPackage,
+    diagnostics,
+    cache: {
+      status,
+      key: path,
+      ...(validator ? { validator } : {}),
+      ...(sourceUpdatedAt ? { sourceUpdatedAt } : {}),
+      fetchedAt: new Date(entry.cachedAtMs).toISOString(),
+    },
+  };
+}
+
+export async function loadMapPackageFromId(
+  locator: MapPackageLocator,
+  map: MaplibreMap,
+  options: LoadMapPackageFromIdOptions,
+): Promise<LoadMapPackageFromIdResult> {
+  const fetched = await fetchMapPackage(locator, {
+    client: options.client,
+    signal: options.signal,
+    headers: options.headers,
+    resolvePath: options.resolvePath,
+    cache: options.cache,
+    resolveStyleRef: options.resolveStyleRef,
+    requireStyleRefResolution: options.requireStyleRefResolution ?? true,
+    maxAgeMs: options.maxAgeMs,
+    now: options.now,
+    allowInvalid: options.allowInvalid,
+  });
+  const runtime = await loadMapPackage(fetched.mapPackage, map, options);
+  return {
+    runtime,
+    mapPackage: fetched.mapPackage,
+    diagnostics: fetched.diagnostics,
+    cache: fetched.cache,
+  };
+}
+
+export function resolveMapPackagePath(locator: MapPackageLocator, resolvePath?: MapPackagePathResolver): string {
+  if (typeof locator === "string") {
+    return resolveStringLocator(locator, resolvePath);
+  }
+  const direct = locator.path ?? locator.url ?? locator.href;
+  if (direct) return direct;
+  const id = locator.packageId ?? locator.id;
+  if (!id) {
+    throw new HonuaMapPackageError("MapPackage locator requires id, packageId, path, url, or href", {
+      stage: "fetch",
+      detail: { locator },
+    });
+  }
+  return (resolvePath ?? defaultMapPackagePath)(id);
+}
+
+export function defaultMapPackagePath(packageId: string): string {
+  return `${DEFAULT_MAP_PACKAGE_PATH_PREFIX}/${encodeURIComponent(packageId)}`;
+}
+
+export function mapPackageFingerprint(pkg: HonuaMapPackage): string {
+  return stableFingerprint(pkg);
+}
+
+async function resolveMapPackageStyleRefs(
+  value: unknown,
+  options: {
+    readonly resolveStyleRef?: StyleRefResolver;
+    readonly requireStyleRefResolution: boolean;
+  },
+): Promise<{ mapPackage: unknown; diagnostics: readonly HonuaMapPackageDiagnostic[] }> {
+  if (!isRecord(value) || !Array.isArray(value.styleRefs) || value.styleRefs.length === 0) {
+    return { mapPackage: value, diagnostics: [] };
+  }
+
+  const diagnostics: HonuaMapPackageDiagnostic[] = [];
+  const packageId = typeof value.mapPackageId === "string" ? value.mapPackageId : undefined;
+  const nextRefs: HonuaMapPackageStyleRef[] = [];
+  let changed = false;
+
+  for (let i = 0; i < value.styleRefs.length; i += 1) {
+    const ref = value.styleRefs[i];
+    if (!isRecord(ref)) {
+      nextRefs.push(ref as HonuaMapPackageStyleRef);
+      continue;
+    }
+    if (isRecord(ref.body)) {
+      nextRefs.push(ref as unknown as HonuaMapPackageStyleRef);
+      continue;
+    }
+
+    const styleId = typeof ref.styleId === "string" ? ref.styleId : "";
+    if (!options.resolveStyleRef) {
+      diagnostics.push({
+        code: "style-ref-unresolved",
+        severity: options.requireStyleRefResolution ? "error" : "warning",
+        message: `StyleRef "${styleId || i}" has no inline body and no resolver was provided.`,
+        ...(packageId ? { packageId } : {}),
+        path: `styleRefs[${i}].body`,
+        detail: { styleId: ref.styleId, presetId: ref.presetId },
+      });
+      nextRefs.push(ref as unknown as HonuaMapPackageStyleRef);
+      continue;
+    }
+
+    try {
+      const body = await options.resolveStyleRef(styleId, typeof ref.presetId === "string" ? ref.presetId : undefined);
+      if (!isRecord(body)) {
+        diagnostics.push({
+          code: "style-ref-resolution-failed",
+          severity: "error",
+          message: `StyleRef "${styleId || i}" resolver returned a non-object body.`,
+          ...(packageId ? { packageId } : {}),
+          path: `styleRefs[${i}].body`,
+          detail: { styleId, presetId: ref.presetId },
+        });
+        nextRefs.push(ref as unknown as HonuaMapPackageStyleRef);
+        continue;
+      }
+      changed = true;
+      nextRefs.push({
+        ...(ref as unknown as HonuaMapPackageStyleRef),
+        body: body as HonuaStyleRefBody,
+      });
+    } catch (cause) {
+      diagnostics.push({
+        code: "style-ref-resolution-failed",
+        severity: "error",
+        message: `StyleRef "${styleId || i}" could not be resolved.`,
+        ...(packageId ? { packageId } : {}),
+        path: `styleRefs[${i}].body`,
+        detail: { styleId, presetId: ref.presetId, error: errorMessage(cause) },
+      });
+      nextRefs.push(ref as unknown as HonuaMapPackageStyleRef);
+    }
+  }
+
+  return {
+    mapPackage: changed ? { ...value, styleRefs: nextRefs } : value,
+    diagnostics,
+  };
+}
+
+function buildFetchResult(
+  mapPackage: HonuaMapPackage,
+  path: string,
+  status: MapPackageFetchCacheStatus,
+  input: {
+    readonly validator?: HonuaCacheValidator;
+    readonly sourceUpdatedAt?: string;
+    readonly revalidatedAt?: string;
+    readonly options: FetchMapPackageOptions;
+  },
+): FetchMapPackageResult {
+  const validation = validateMapPackage(mapPackage, {
+    maxAgeMs: input.options.maxAgeMs,
+    now: input.options.now,
+  });
+  if (hasMapPackageDiagnosticErrors(validation.diagnostics) && input.options.allowInvalid !== true) {
+    throw new HonuaMapPackageError("MapPackage validation failed", {
+      packageId: mapPackage.mapPackageId,
+      stage: "validate",
+      detail: { diagnostics: validation.diagnostics, path },
+    });
+  }
+  return {
+    mapPackage,
+    diagnostics: validation.diagnostics,
+    cache: {
+      status,
+      key: path,
+      ...(input.validator ? { validator: input.validator } : {}),
+      ...(input.sourceUpdatedAt ? { sourceUpdatedAt: input.sourceUpdatedAt } : {}),
+      fetchedAt: new Date().toISOString(),
+      ...(input.revalidatedAt ? { revalidatedAt: input.revalidatedAt } : {}),
+    },
+  };
+}
+
+function buildFetchHeaders(headers: HeadersInit | undefined, validator: HonuaCacheValidator | undefined): Headers {
+  const out = new Headers(headers);
+  if (!out.has("Accept")) out.set("Accept", "application/json");
+  if (validator?.etag) out.set("If-None-Match", validator.etag);
+  if (validator?.lastModified) out.set("If-Modified-Since", validator.lastModified);
+  if (validator?.etag || validator?.lastModified) {
+    out.set("Cache-Control", "no-cache");
+  }
+  return out;
+}
+
+function resolveCache(
+  client: HonuaClient,
+  cache: MapPackageFetchCache | false | undefined,
+): MapPackageFetchCache | undefined {
+  if (cache === false) return undefined;
+  if (cache) return cache;
+  const existing = defaultCaches.get(client);
+  if (existing) return existing;
+  const next: MapPackageFetchCache = new Map();
+  defaultCaches.set(client, next);
+  return next;
+}
+
+function resolveStringLocator(locator: string, resolvePath: MapPackagePathResolver | undefined): string {
+  if (locator.startsWith("/") || locator.startsWith("http://") || locator.startsWith("https://")) return locator;
+  const honuaPackagePrefix = "honua://map-packages/";
+  if (locator.startsWith(honuaPackagePrefix)) {
+    return (resolvePath ?? defaultMapPackagePath)(decodeURIComponent(locator.slice(honuaPackagePrefix.length)));
+  }
+  return (resolvePath ?? defaultMapPackagePath)(locator);
+}
+
+async function parseJsonBody(response: Response, path: string): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch (cause) {
+    throw new HonuaMapPackageError("MapPackage fetch response was not valid JSON", {
+      stage: "fetch",
+      detail: { path },
+      cause,
+    });
+  }
+}
+
+function unwrapMapPackageEnvelope(body: unknown): unknown {
+  if (!isRecord(body)) return body;
+  if (typeof body.mapPackageId === "string" || typeof body.format === "string") return body;
+  const direct = body.mapPackage ?? body.package;
+  if (isRecord(direct)) return direct;
+  if (isRecord(body.data)) return unwrapMapPackageEnvelope(body.data);
+  return body;
+}
+
+function stableFingerprint(value: unknown): string {
+  return JSON.stringify(value, stableObjectKeys);
+}
+
+function stableObjectKeys(_key: string, value: unknown): unknown {
+  if (!isRecord(value)) return value;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort()) {
+    out[key] = value[key];
+  }
+  return out;
+}
+
+function packageIdFromUnknown(value: unknown): string | undefined {
+  return isRecord(value) && typeof value.mapPackageId === "string" ? value.mapPackageId : undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/runtime/map-package-validation.ts
+++ b/src/runtime/map-package-validation.ts
@@ -1,0 +1,319 @@
+import { HONUA_MAP_PACKAGE_FORMAT_V1, type HonuaMapPackage } from "./map-package.js";
+
+export type HonuaMapPackageDiagnosticSeverity = "error" | "warning";
+
+export type HonuaMapPackageDiagnosticCode =
+  | "invalid-package"
+  | "unsupported-format"
+  | "missing-map-package-id"
+  | "missing-source-bindings"
+  | "missing-map-spec"
+  | "invalid-map-spec"
+  | "duplicate-source"
+  | "missing-source-id"
+  | "missing-source-locator"
+  | "unsupported-protocol"
+  | "missing-source"
+  | "stale-package"
+  | "expired-package"
+  | "style-ref-missing-layer"
+  | "style-ref-unresolved"
+  | "style-ref-resolution-failed";
+
+export interface HonuaMapPackageDiagnostic {
+  readonly code: HonuaMapPackageDiagnosticCode;
+  readonly severity: HonuaMapPackageDiagnosticSeverity;
+  readonly message: string;
+  readonly packageId?: string;
+  readonly path?: string;
+  readonly detail?: unknown;
+}
+
+export interface ValidateMapPackageOptions {
+  /** Wall-clock used for stale / expired diagnostics. Defaults to `Date.now()`. */
+  readonly now?: number | Date;
+  /** Emit a `stale-package` warning when `updatedAt` / `createdAt` is older than this many ms. */
+  readonly maxAgeMs?: number;
+}
+
+export interface ValidateMapPackageResult {
+  readonly mapPackage: HonuaMapPackage | undefined;
+  readonly diagnostics: readonly HonuaMapPackageDiagnostic[];
+  readonly valid: boolean;
+}
+
+const SUPPORTED_SOURCE_PROTOCOLS = new Set([
+  "geoservices_feature_service",
+  "geoservices_map_service",
+  "ogc_features",
+  "ogc_maps",
+  "ogc_tiles",
+  "wfs",
+  "wms",
+  "wmts",
+  "odata",
+  "vector_tile",
+  "raster_tile",
+]);
+
+/**
+ * Validate the server-produced `MapPackage` wire shape and runtime binding
+ * assumptions without throwing raw JSON/type errors. Diagnostics are
+ * stable-enough for hosts to show or log directly.
+ */
+export function validateMapPackage(value: unknown, options: ValidateMapPackageOptions = {}): ValidateMapPackageResult {
+  const diagnostics: HonuaMapPackageDiagnostic[] = [];
+  if (!isRecord(value)) {
+    diagnostics.push({
+      code: "invalid-package",
+      severity: "error",
+      message: "MapPackage response must be a JSON object.",
+    });
+    return { mapPackage: undefined, diagnostics, valid: false };
+  }
+
+  const packageId = typeof value.mapPackageId === "string" ? value.mapPackageId : undefined;
+  const add = (diagnostic: Omit<HonuaMapPackageDiagnostic, "packageId">): void => {
+    diagnostics.push({ ...(packageId ? { packageId } : {}), ...diagnostic });
+  };
+
+  if (!packageId) {
+    add({
+      code: "missing-map-package-id",
+      severity: "error",
+      message: "MapPackage.mapPackageId must be a non-empty string.",
+      path: "mapPackageId",
+    });
+  }
+
+  if (value.format !== HONUA_MAP_PACKAGE_FORMAT_V1) {
+    add({
+      code: "unsupported-format",
+      severity: "error",
+      message: `MapPackage.format must be "${HONUA_MAP_PACKAGE_FORMAT_V1}".`,
+      path: "format",
+      detail: { expected: HONUA_MAP_PACKAGE_FORMAT_V1, received: value.format },
+    });
+  }
+
+  const sourceIds = new Set<string>();
+  const sourceBindings = value.sourceBindings;
+  if (!Array.isArray(sourceBindings)) {
+    add({
+      code: "missing-source-bindings",
+      severity: "error",
+      message: "MapPackage.sourceBindings must be an array.",
+      path: "sourceBindings",
+    });
+  } else {
+    for (let i = 0; i < sourceBindings.length; i += 1) {
+      const binding = sourceBindings[i];
+      const path = `sourceBindings[${i}]`;
+      if (!isRecord(binding)) {
+        add({
+          code: "invalid-package",
+          severity: "error",
+          message: "MapPackage.sourceBindings entries must be objects.",
+          path,
+        });
+        continue;
+      }
+
+      const sourceId = typeof binding.sourceId === "string" && binding.sourceId.length > 0 ? binding.sourceId : "";
+      if (!sourceId) {
+        add({
+          code: "missing-source-id",
+          severity: "error",
+          message: "SourceBinding.sourceId must be a non-empty string.",
+          path: `${path}.sourceId`,
+        });
+      } else if (sourceIds.has(sourceId)) {
+        add({
+          code: "duplicate-source",
+          severity: "error",
+          message: `SourceBinding sourceId "${sourceId}" is duplicated.`,
+          path: `${path}.sourceId`,
+          detail: { sourceId },
+        });
+      } else {
+        sourceIds.add(sourceId);
+      }
+
+      const protocol = typeof binding.protocol === "string" ? binding.protocol : undefined;
+      if (!protocol || !SUPPORTED_SOURCE_PROTOCOLS.has(protocol)) {
+        add({
+          code: "unsupported-protocol",
+          severity: "error",
+          message: `SourceBinding "${sourceId || i}" uses unsupported protocol "${String(binding.protocol)}".`,
+          path: `${path}.protocol`,
+          detail: { sourceId, protocol: binding.protocol },
+        });
+      }
+
+      const locator = binding.locator;
+      if (!isRecord(locator) || typeof locator.url !== "string" || locator.url.length === 0) {
+        add({
+          code: "missing-source-locator",
+          severity: "error",
+          message: `SourceBinding "${sourceId || i}" must include locator.url.`,
+          path: `${path}.locator.url`,
+          detail: { sourceId, protocol },
+        });
+      }
+    }
+  }
+
+  const mapSpec = value.mapSpec;
+  if (!isRecord(mapSpec)) {
+    add({
+      code: "missing-map-spec",
+      severity: "error",
+      message: "MapPackage.mapSpec must be a MapLibre style object.",
+      path: "mapSpec",
+    });
+  } else {
+    validateMapSpecSources(add, mapSpec, sourceIds);
+    validateStyleRefTargets(add, value, mapSpec);
+  }
+
+  validateLifecycle(add, value, options);
+
+  const valid = !hasMapPackageDiagnosticErrors(diagnostics);
+  return {
+    mapPackage: value as HonuaMapPackage,
+    diagnostics,
+    valid,
+  };
+}
+
+export function hasMapPackageDiagnosticErrors(diagnostics: readonly HonuaMapPackageDiagnostic[]): boolean {
+  return diagnostics.some((diagnostic) => diagnostic.severity === "error");
+}
+
+function validateMapSpecSources(
+  add: (diagnostic: Omit<HonuaMapPackageDiagnostic, "packageId">) => void,
+  mapSpec: Record<string, unknown>,
+  sourceIds: ReadonlySet<string>,
+): void {
+  const mapSpecSources = isRecord(mapSpec.sources) ? new Set(Object.keys(mapSpec.sources)) : new Set<string>();
+  const layers = mapSpec.layers;
+  if (!Array.isArray(layers)) {
+    add({
+      code: "invalid-map-spec",
+      severity: "error",
+      message: "MapPackage.mapSpec.layers must be an array.",
+      path: "mapSpec.layers",
+    });
+    return;
+  }
+
+  for (let i = 0; i < layers.length; i += 1) {
+    const layer = layers[i];
+    if (!isRecord(layer)) {
+      add({
+        code: "invalid-map-spec",
+        severity: "error",
+        message: "MapPackage.mapSpec.layers entries must be objects.",
+        path: `mapSpec.layers[${i}]`,
+      });
+      continue;
+    }
+    if (typeof layer.source !== "string") continue;
+    if (!sourceIds.has(layer.source) && !mapSpecSources.has(layer.source)) {
+      add({
+        code: "missing-source",
+        severity: "error",
+        message: `Layer "${String(layer.id ?? i)}" references missing source "${layer.source}".`,
+        path: `mapSpec.layers[${i}].source`,
+        detail: { layerId: layer.id, sourceId: layer.source },
+      });
+    }
+  }
+}
+
+function validateStyleRefTargets(
+  add: (diagnostic: Omit<HonuaMapPackageDiagnostic, "packageId">) => void,
+  pkg: Record<string, unknown>,
+  mapSpec: Record<string, unknown>,
+): void {
+  if (!Array.isArray(pkg.styleRefs)) return;
+  const layerIds = new Set<string>();
+  if (Array.isArray(mapSpec.layers)) {
+    for (const layer of mapSpec.layers) {
+      if (isRecord(layer) && typeof layer.id === "string") layerIds.add(layer.id);
+    }
+  }
+
+  for (let i = 0; i < pkg.styleRefs.length; i += 1) {
+    const ref = pkg.styleRefs[i];
+    if (!isRecord(ref) || !isRecord(ref.body)) continue;
+    for (const layerId of Object.keys(ref.body)) {
+      if (layerIds.has(layerId)) continue;
+      add({
+        code: "style-ref-missing-layer",
+        severity: "warning",
+        message: `StyleRef "${String(ref.styleId ?? i)}" targets missing layer "${layerId}".`,
+        path: `styleRefs[${i}].body.${layerId}`,
+        detail: { styleId: ref.styleId, layerId },
+      });
+    }
+  }
+}
+
+function validateLifecycle(
+  add: (diagnostic: Omit<HonuaMapPackageDiagnostic, "packageId">) => void,
+  pkg: Record<string, unknown>,
+  options: ValidateMapPackageOptions,
+): void {
+  const nowMs = normalizeNowMs(options.now);
+  if (pkg.status === "Expired") {
+    add({
+      code: "expired-package",
+      severity: "error",
+      message: "MapPackage status is Expired.",
+      path: "status",
+      detail: { status: pkg.status },
+    });
+  }
+
+  const expiresAt = parseTimestampMs(pkg.expiresAt);
+  if (expiresAt !== undefined && expiresAt <= nowMs) {
+    add({
+      code: "expired-package",
+      severity: "error",
+      message: "MapPackage expiresAt is in the past.",
+      path: "expiresAt",
+      detail: { expiresAt: pkg.expiresAt },
+    });
+  }
+
+  if (options.maxAgeMs === undefined) return;
+  const updatedAt = parseTimestampMs(pkg.updatedAt) ?? parseTimestampMs(pkg.createdAt);
+  if (updatedAt === undefined) return;
+  if (nowMs - updatedAt > Math.max(0, Math.trunc(options.maxAgeMs))) {
+    add({
+      code: "stale-package",
+      severity: "warning",
+      message: "MapPackage is older than the configured freshness budget.",
+      path: pkg.updatedAt ? "updatedAt" : "createdAt",
+      detail: { ageMs: nowMs - updatedAt, maxAgeMs: options.maxAgeMs },
+    });
+  }
+}
+
+function normalizeNowMs(now: number | Date | undefined): number {
+  if (now instanceof Date) return now.getTime();
+  if (typeof now === "number" && Number.isFinite(now)) return now;
+  return Date.now();
+}
+
+function parseTimestampMs(value: unknown): number | undefined {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value !== "string" && typeof value !== "number") return undefined;
+  const parsed = typeof value === "number" ? value : Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/runtime/map-package-watch.ts
+++ b/src/runtime/map-package-watch.ts
@@ -1,0 +1,198 @@
+import { type MapPackageDiff, diffPackages } from "./diff.js";
+import {
+  type FetchMapPackageOptions,
+  type FetchMapPackageResult,
+  type MapPackageLocator,
+  fetchMapPackage,
+  mapPackageFingerprint,
+} from "./map-package-fetch.js";
+import type { HonuaMapPackage } from "./map-package.js";
+import type { HonuaMapRuntime } from "./runtime.js";
+
+export type MapPackageWatchEvent =
+  | { readonly type: "fetched"; readonly result: FetchMapPackageResult }
+  | { readonly type: "unchanged"; readonly result: FetchMapPackageResult }
+  | {
+      readonly type: "updated";
+      readonly result: FetchMapPackageResult;
+      readonly diff: MapPackageDiff | undefined;
+      readonly applied: boolean;
+    }
+  | {
+      readonly type: "reload-required";
+      readonly result: FetchMapPackageResult;
+      readonly diff: MapPackageDiff;
+      readonly reason: string;
+    }
+  | { readonly type: "error"; readonly error: unknown }
+  | { readonly type: "disposed" };
+
+export interface WatchMapPackageOptions extends FetchMapPackageOptions {
+  /** Runtime to update after a changed package is fetched. */
+  readonly runtime?: HonuaMapRuntime;
+  /** Previous package snapshot for diffing when no runtime is supplied. */
+  readonly initialPackage?: HonuaMapPackage;
+  /** Defaults to true when `runtime` is supplied. */
+  readonly applyUpdates?: boolean;
+  /** Polling cadence. Defaults to 30 seconds. */
+  readonly intervalMs?: number;
+  /** Delay changed-package application to coalesce rapid fetches. Defaults to 0. */
+  readonly debounceMs?: number;
+  /** Fetch immediately on watcher creation. Defaults to true. */
+  readonly immediate?: boolean;
+  readonly onEvent?: (event: MapPackageWatchEvent) => void | Promise<void>;
+  readonly onUpdate?: (event: Extract<MapPackageWatchEvent, { type: "updated" }>) => void | Promise<void>;
+  readonly onError?: (error: unknown) => void | Promise<void>;
+}
+
+export interface MapPackageWatchHandle {
+  readonly disposed: boolean;
+  refresh(): Promise<void>;
+  dispose(): void;
+}
+
+const DEFAULT_WATCH_INTERVAL_MS = 30_000;
+
+export function watchMapPackage(locator: MapPackageLocator, options: WatchMapPackageOptions): MapPackageWatchHandle {
+  let disposed = false;
+  let inFlight = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  let pendingResult: FetchMapPackageResult | undefined;
+  let previousPackage = options.initialPackage ?? options.runtime?.mapPackage;
+  let previousFingerprint = previousPackage ? mapPackageFingerprint(previousPackage) : undefined;
+  let currentAbort: AbortController | undefined;
+
+  const intervalMs = normalizeDelay(options.intervalMs, DEFAULT_WATCH_INTERVAL_MS);
+  const debounceMs = normalizeDelay(options.debounceMs, 0);
+
+  const emit = (event: MapPackageWatchEvent): void => {
+    void options.onEvent?.(event);
+    if (event.type === "updated") void options.onUpdate?.(event);
+    if (event.type === "error") void options.onError?.(event.error);
+  };
+
+  const schedule = (): void => {
+    if (disposed) return;
+    timer = setTimeout(() => {
+      void poll();
+    }, intervalMs);
+  };
+
+  const clearScheduled = (): void => {
+    if (timer) clearTimeout(timer);
+    timer = undefined;
+  };
+
+  const queueApply = (result: FetchMapPackageResult): void => {
+    pendingResult = result;
+    if (debounceMs === 0) {
+      void applyPending();
+      return;
+    }
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = undefined;
+      void applyPending();
+    }, debounceMs);
+  };
+
+  const applyPending = async (): Promise<void> => {
+    try {
+      const result = pendingResult;
+      pendingResult = undefined;
+      if (!result || disposed) return;
+
+      const nextFingerprint = mapPackageFingerprint(result.mapPackage);
+      if (previousFingerprint === nextFingerprint) {
+        emit({ type: "unchanged", result });
+        return;
+      }
+
+      const diff = previousPackage ? diffPackages(previousPackage, result.mapPackage) : undefined;
+      if (diff && !diff.incremental) {
+        emit({
+          type: "reload-required",
+          result,
+          diff,
+          reason: diff.structuralReason ?? "MapPackage update requires a full style reload.",
+        });
+      }
+
+      const shouldApply = Boolean(options.runtime) && options.applyUpdates !== false;
+      if (shouldApply) {
+        await options.runtime?.updatePackage(result.mapPackage);
+      }
+      previousPackage = result.mapPackage;
+      previousFingerprint = nextFingerprint;
+      emit({ type: "updated", result, diff, applied: shouldApply });
+    } catch (error) {
+      if (!disposed) emit({ type: "error", error });
+    }
+  };
+
+  const poll = async (): Promise<void> => {
+    if (disposed || inFlight) return;
+    inFlight = true;
+    currentAbort = new AbortController();
+    try {
+      const result = await fetchMapPackage(locator, {
+        ...options,
+        signal: linkAbortSignals(options.signal, currentAbort.signal),
+      });
+      emit({ type: "fetched", result });
+      if (result.cache.status === "not-modified") {
+        emit({ type: "unchanged", result });
+        return;
+      }
+      queueApply(result);
+    } catch (error) {
+      if (!disposed) emit({ type: "error", error });
+    } finally {
+      inFlight = false;
+      currentAbort = undefined;
+      schedule();
+    }
+  };
+
+  const handle: MapPackageWatchHandle = {
+    get disposed() {
+      return disposed;
+    },
+    refresh: poll,
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      clearScheduled();
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = undefined;
+      pendingResult = undefined;
+      currentAbort?.abort();
+      emit({ type: "disposed" });
+    },
+  };
+
+  if (options.immediate !== false) {
+    void poll();
+  } else {
+    schedule();
+  }
+
+  return handle;
+}
+
+function normalizeDelay(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.max(0, Math.trunc(value));
+}
+
+function linkAbortSignals(a: AbortSignal | undefined, b: AbortSignal): AbortSignal {
+  if (!a) return b;
+  if (a.aborted) return a;
+  if (b.aborted) return b;
+  const controller = new AbortController();
+  const abort = (): void => controller.abort();
+  a.addEventListener("abort", abort, { once: true });
+  b.addEventListener("abort", abort, { once: true });
+  return controller.signal;
+}

--- a/src/runtime/map-package.ts
+++ b/src/runtime/map-package.ts
@@ -169,6 +169,8 @@ export interface HonuaMapPackage {
   status?: HonuaMapPackageStatus;
   createdAt?: string;
   updatedAt?: string;
+  /** Optional server retention / hosting expiry timestamp. */
+  expiresAt?: string;
 
   templateId?: string;
   themeId?: string;

--- a/test/runtime/map-package-fetch.test.ts
+++ b/test/runtime/map-package-fetch.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { HonuaClient } from "../../src/core/client.js";
+import {
+  HONUA_MAP_PACKAGE_FORMAT_V1,
+  type HonuaMapPackage,
+  HonuaMapPackageError,
+  type MaplibreMap,
+  fetchMapPackage,
+  loadMapPackageFromId,
+  validateMapPackage,
+  watchMapPackage,
+} from "../../src/runtime/index.js";
+
+interface RecordedRequest {
+  readonly url: string;
+  readonly headers: Headers;
+}
+
+interface MockMap extends MaplibreMap {
+  readonly calls: Array<{ method: string; args: unknown[] }>;
+  style: unknown;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("fetchMapPackage", () => {
+  test("fetches a hosted package and revalidates with ETag / Last-Modified", async () => {
+    const requests: RecordedRequest[] = [];
+    const pkg = makePackage();
+    const client = makeClient(async (url, init) => {
+      requests.push({ url: String(url), headers: new Headers(init?.headers) });
+      if (requests.length === 1) {
+        return jsonResponse(
+          { mapPackage: pkg },
+          { etag: '"pkg-v1"', "last-modified": "Mon, 11 May 2026 00:00:00 GMT" },
+        );
+      }
+      expect(new Headers(init?.headers).get("if-none-match")).toBe('"pkg-v1"');
+      expect(new Headers(init?.headers).get("if-modified-since")).toBe("Mon, 11 May 2026 00:00:00 GMT");
+      return new Response(null, { status: 304 });
+    });
+
+    const first = await fetchMapPackage("pkg-001", { client });
+    const second = await fetchMapPackage("pkg-001", { client });
+
+    expect(requests[0].url).toBe("https://mock.honua.test/api/v1/map-packages/pkg-001");
+    expect(first.mapPackage.mapPackageId).toBe("pkg-001");
+    expect(first.cache.status).toBe("miss");
+    expect(second.cache.status).toBe("not-modified");
+    expect(second.mapPackage).toEqual(first.mapPackage);
+  });
+
+  test("throws typed validation diagnostics instead of leaking raw package shape errors", async () => {
+    const client = makeClient(async () =>
+      jsonResponse({
+        mapPackageId: "bad",
+        format: "honua_map_package.v999",
+        sourceBindings: [],
+        mapSpec: { version: 8, sources: {}, layers: [] },
+      }),
+    );
+
+    await expect(fetchMapPackage("bad", { client })).rejects.toMatchObject({
+      name: "HonuaMapPackageError",
+      stage: "validate",
+      detail: {
+        diagnostics: expect.arrayContaining([
+          expect.objectContaining({ code: "unsupported-format", severity: "error" }),
+        ]),
+      },
+    });
+  });
+
+  test("returns style-ref resolution diagnostics and inlines resolved bodies", async () => {
+    const client = makeClient(async () =>
+      jsonResponse(
+        makePackage({
+          styleRefs: [{ styleId: "style-fill", body: undefined }],
+        }),
+      ),
+    );
+
+    const resolved = await fetchMapPackage("pkg-001", {
+      client,
+      resolveStyleRef: async () => ({ "parcels-fill": { paint: { "fill-color": "#ff0000" } } }),
+    });
+
+    expect(resolved.diagnostics).toEqual([]);
+    expect(resolved.mapPackage.styleRefs?.[0].body).toEqual({
+      "parcels-fill": { paint: { "fill-color": "#ff0000" } },
+    });
+  });
+
+  test("reports style-ref resolver failures as diagnostics", async () => {
+    const client = makeClient(async () =>
+      jsonResponse(
+        makePackage({
+          styleRefs: [{ styleId: "missing-style", body: undefined }],
+        }),
+      ),
+    );
+
+    const result = await fetchMapPackage("pkg-001", {
+      client,
+      allowInvalid: true,
+      requireStyleRefResolution: true,
+      resolveStyleRef: async () => {
+        throw new Error("not found");
+      },
+    });
+
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({ code: "style-ref-resolution-failed", severity: "error" }),
+    ]);
+  });
+});
+
+describe("validateMapPackage", () => {
+  test("reports stale, expired, missing-source, and unsupported-protocol diagnostics", () => {
+    const diagnostics = validateMapPackage(
+      makePackage({
+        status: "Expired",
+        updatedAt: "2026-05-10T00:00:00.000Z",
+        sourceBindings: [
+          {
+            sourceId: "draft",
+            protocol: "workspace_artifact",
+            locator: { url: "honua://workspace/artifact/1" },
+          },
+        ],
+        mapSpec: {
+          version: 8,
+          sources: {},
+          layers: [{ id: "missing", type: "fill", source: "not-bound" }],
+        },
+      }),
+      { now: Date.parse("2026-05-11T00:00:00.000Z"), maxAgeMs: 60_000 },
+    ).diagnostics;
+
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "expired-package", severity: "error" }),
+        expect.objectContaining({ code: "stale-package", severity: "warning" }),
+        expect.objectContaining({ code: "missing-source", severity: "error" }),
+        expect.objectContaining({ code: "unsupported-protocol", severity: "error" }),
+      ]),
+    );
+  });
+});
+
+describe("loadMapPackageFromId", () => {
+  test("fetches by package id and delegates to loadMapPackage", async () => {
+    const client = makeClient(async () => jsonResponse(makePackage({ sourceBindings: [], mapSpec: emptyStyle() })));
+    const map = makeMockMap();
+
+    const result = await loadMapPackageFromId("pkg-001", map, {
+      client,
+      skipCompatibilityCheck: true,
+      applyInitialView: false,
+    });
+
+    expect(result.runtime.mapPackage.mapPackageId).toBe("pkg-001");
+    expect(map.calls.some((call) => call.method === "setStyle")).toBe(true);
+  });
+});
+
+describe("watchMapPackage", () => {
+  test("does not poll after disposal", async () => {
+    vi.useFakeTimers();
+    const fetchFn = vi.fn(async () => jsonResponse(makePackage()));
+    const client = makeClient(fetchFn);
+    const events: string[] = [];
+
+    const handle = watchMapPackage("pkg-001", {
+      client,
+      immediate: false,
+      intervalMs: 25,
+      onEvent: (event) => {
+        events.push(event.type);
+      },
+    });
+    handle.dispose();
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(handle.disposed).toBe(true);
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(events).toEqual(["disposed"]);
+  });
+});
+
+function makePackage(overrides: Partial<HonuaMapPackage> = {}): HonuaMapPackage {
+  return {
+    mapPackageId: "pkg-001",
+    format: HONUA_MAP_PACKAGE_FORMAT_V1,
+    status: "Ready",
+    updatedAt: "2026-05-11T00:00:00.000Z",
+    sourceBindings: [
+      {
+        sourceId: "parcels",
+        protocol: "geoservices_feature_service",
+        locator: { url: "https://server.example.com/rest/services/Parcels/FeatureServer/0" },
+      },
+    ],
+    mapSpec: {
+      version: 8,
+      sources: {},
+      layers: [{ id: "parcels-fill", type: "fill", source: "parcels", paint: { "fill-color": "#cccccc" } }],
+    },
+    ...overrides,
+  };
+}
+
+function emptyStyle(): HonuaMapPackage["mapSpec"] {
+  return { version: 8, sources: {}, layers: [] };
+}
+
+function makeClient(fetchFn: typeof fetch): HonuaClient {
+  return new HonuaClient({ baseUrl: "https://mock.honua.test", fetchFn });
+}
+
+function jsonResponse(body: unknown, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+function makeMockMap(): MockMap {
+  const calls: MockMap["calls"] = [];
+  const map: MockMap = {
+    calls,
+    style: undefined,
+    setStyle(style) {
+      calls.push({ method: "setStyle", args: [style] });
+      map.style = style;
+    },
+    getStyle() {
+      return map.style;
+    },
+    addSource(id, source) {
+      calls.push({ method: "addSource", args: [id, source] });
+    },
+    removeSource(id) {
+      calls.push({ method: "removeSource", args: [id] });
+    },
+    addLayer(layer, beforeId) {
+      calls.push({ method: "addLayer", args: [layer, beforeId] });
+    },
+    removeLayer(id) {
+      calls.push({ method: "removeLayer", args: [id] });
+    },
+    getLayer() {
+      return undefined;
+    },
+    setLayoutProperty(layerId, name, value) {
+      calls.push({ method: "setLayoutProperty", args: [layerId, name, value] });
+    },
+    setPaintProperty(layerId, name, value) {
+      calls.push({ method: "setPaintProperty", args: [layerId, name, value] });
+    },
+    setFilter(layerId, filter) {
+      calls.push({ method: "setFilter", args: [layerId, filter] });
+    },
+    getSource() {
+      return undefined;
+    },
+    fitBounds(bounds, options) {
+      calls.push({ method: "fitBounds", args: [bounds, options] });
+    },
+    jumpTo(options) {
+      calls.push({ method: "jumpTo", args: [options] });
+    },
+    easeTo(options) {
+      calls.push({ method: "easeTo", args: [options] });
+    },
+    flyTo(options) {
+      calls.push({ method: "flyTo", args: [options] });
+    },
+    on() {},
+    off() {},
+    setFeatureState() {},
+    getFeatureState() {
+      return {};
+    },
+    removeFeatureState() {},
+  };
+  return map;
+}


### PR DESCRIPTION
## Summary

- Add `fetchMapPackage`, `loadMapPackageFromId`, validation diagnostics, and path/cache helpers to the runtime surface.
- Add ETag / Last-Modified validator reuse, style-ref resolution diagnostics, and stale / expired / missing-source / unsupported-protocol diagnostics.
- Add disposable `watchMapPackage` polling support that can update an existing runtime and reports full-reload requirements.
- Document the hosted MapPackage workflow and add focused runtime tests.

Closes #153.

## Validation

- `npx biome check src/runtime/map-package-fetch.ts src/runtime/map-package-validation.ts src/runtime/map-package-watch.ts src/runtime/index.ts src/runtime/errors.ts src/runtime/map-package.ts test/runtime/map-package-fetch.test.ts docs/maplibre-runtime.md`
- `npm run typecheck -- --pretty false`
- `npm test -- test/runtime/runtime.test.ts test/runtime/map-package-fetch.test.ts`
- `npm test`