### PR TITLE
[codex] Implement runtime style interaction helpers

### DIFF
--- a/docs/maplibre-runtime.md
+++ b/docs/maplibre-runtime.md
@@ -247,9 +247,20 @@ Theme application recurses into nested arrays / objects inside
 
 | Method | Behavior |
 | --- | --- |
+| `addSource(sourceId, source)` | Adds a Honua custom source or MapLibre-native source to `runtime.honuaMap`, `runtime.composedStyle`, and the host map via `map.addSource()` when available. Falls back to `setStyle(..., { diff: true })` for renderer adapters that only expose full style application. |
+| `updateSource(sourceId, source)` | Replaces a source spec and reapplies the composed style while preserving layer ids. Use for locator/data/source-option changes; paint/layout/filter-only updates should use layer helpers to avoid source reloads. |
+| `removeSource(sourceId)` | Removes the source and any dependent layers from the runtime style, `HonuaMap`, and host map. Returns the removed layer ids. |
+| `addLayer(layer, order?)` | Adds a typed layer spec, validates paint/layout/filter expressions first, and supports MapLibre `beforeId` as a string or `{ beforeId }`, `{ afterId }`, `{ position: "top" | "bottom" }`. |
+| `updateLayer(layerId, patch)` | Patches layer paint/layout/filter in place with `setPaintProperty` / `setLayoutProperty` / `setFilter` when the layer shape is stable. Structural layer changes or explicit reordering use a diffed `setStyle` path. |
+| `removeLayer(layerId)` / `moveLayer(layerId, order?)` | Removes or reorders runtime-owned layers while keeping `runtime.composedStyle` and `runtime.honuaMap` aligned with the renderer. |
+| `setLayerPaint(layerId, paint)` / `setLayerLayout(layerId, layout)` / `setLayerFilter(layerId, filter)` | Convenience wrappers around `updateLayer` for common Mapbox-style style changes. |
 | `setLayerVisibility(layerId, visible)` | `map.setLayoutProperty(layerId, "visibility", …)`. |
+| `validateStyleExpression(value)` / `validateFilterExpression(filter, layerId?)` | Runs Honua's lightweight expression validator and returns typed diagnostics with path, layer id, source id, protocol, and severity context. Mutating helpers throw `HonuaRuntimeDiagnosticError` before touching the renderer when diagnostics contain errors. |
 | `getLegend()` | Runs `buildLegend` against the current package and composed style; backfills missing swatches from the first `fill-color` / `circle-color` / `line-color` paint property when it is a string literal. |
 | `bindPopup(layerId, binding?)` | Requires `opts.popupFactory`. When `binding` is omitted the runtime looks up `pkg.popupBindings[]` by the layer's source id. The default renderer emits an unstyled `<dl>` of the first feature's properties (or a `{field}` template when `binding.template` is set). Returns a `{ remove() }` handle; re-binding on the same layer tears down the prior handle. |
+| `bindHover(layerId, options?)` / `bindClick(layerId, handler, options?)` / `bindSelect(layerId, options?)` | Infers source and source-layer from the runtime layer, binds MapLibre layer events, and manages hover/click/select feature-state without requiring app code to pass MapLibre types. `bindClick` emits a source-qualified selection target when a feature id is available. |
+| `bindSelectionToExploration(layerId, view, options?)` / `syncSelectionFromExploration(layerId, view, options?)` | Bridges runtime layer interactions to `ExplorationContext` selection and reflects source-qualified shared selection back into MapLibre feature-state. |
+| `layerSelectionTarget(layerId, id)` / `setFeatureStateForTarget(target, state)` / `getFeatureStateForTarget(target)` / `removeFeatureStateForTarget(target, key?)` | Converts layer + feature id pairs into source-qualified targets and applies feature-state using either runtime targets or `ExplorationContext` source-qualified targets. |
 | `setViewState(view)` | If `view.bbox` is supplied and `map.fitBounds` exists, fits the bounds (`animate: false` by default). Otherwise falls back to `map.jumpTo` for `center` / `zoom` / `pitch` / `bearing`. A final fallback applies `pkg.initialView.bbox` when no input is given. |
 | `updatePackage(next)` | See the Update lifecycle section. |
 | `on(listener)` | Subscribes to `HonuaRuntimeEvent`. Returns a `{ remove() }` handle. |
@@ -257,9 +268,10 @@ Theme application recurses into nested arrays / objects inside
 
 `runtime.map`, `runtime.honuaMap`, `runtime.dataset`,
 `runtime.mapPackage`, and `runtime.composedStyle` are readable at any
-time. Feature-state interactions continue to flow through
-`src/interactions/feature-state` — the runtime does not replicate
-them.
+time. The runtime helpers delegate to the lower-level
+`src/interactions/feature-state` and
+`src/interactions/exploration-bindings` modules, so apps can still use
+those lower-level primitives directly when they need custom behavior.
 
 ## Update lifecycle
 

--- a/src/map/honua-map.ts
+++ b/src/map/honua-map.ts
@@ -71,8 +71,10 @@ export interface LayerSnapshot extends HonuaLayerSpecification {
 /** Events emitted by HonuaMap. */
 export type HonuaMapEvent =
   | { type: "source-added"; sourceId: string }
+  | { type: "source-updated"; sourceId: string }
   | { type: "source-removed"; sourceId: string }
   | { type: "layer-added"; layerId: string }
+  | { type: "layer-updated"; layerId: string }
   | { type: "layer-removed"; layerId: string }
   | { type: "layer-moved"; layerId: string; beforeId: string | undefined };
 
@@ -194,6 +196,24 @@ export class HonuaMap {
     return this.#sources.get(name)?.spec;
   }
 
+  /**
+   * Replace a source specification while preserving layers that reference it.
+   *
+   * This updates the resolved SDK surface for Honua custom source types and
+   * leaves render layers in place so callers can decide how to patch the
+   * renderer.
+   *
+   * @throws If the source does not exist.
+   */
+  updateSource(name: string, spec: HonuaSourceSpecification | { type: string; [key: string]: unknown }): void {
+    if (!this.#sources.has(name)) {
+      throw new Error(`Source "${name}" not found.`);
+    }
+    const resolved = this.#resolveSource(spec);
+    this.#sources.set(name, { spec, resolved });
+    this.#emit({ type: "source-updated", sourceId: name });
+  }
+
   /** Check whether a source with the given name exists. */
   hasSource(name: string): boolean {
     return this.#sources.has(name);
@@ -253,6 +273,26 @@ export class HonuaMap {
   /** Get a layer specification by ID. */
   getLayer(id: string): HonuaLayerSpecification | undefined {
     return this.#layers.find((l) => l.id === id)?.spec;
+  }
+
+  /**
+   * Patch a layer specification by ID. The layer ID remains stable.
+   *
+   * @throws If the layer does not exist.
+   * @throws If the patched source does not exist.
+   */
+  updateLayer(id: string, patch: Partial<Omit<HonuaLayerSpecification, "id">>): HonuaLayerSpecification {
+    const entry = this.#layers.find((l) => l.id === id);
+    if (!entry) {
+      throw new Error(`Layer "${id}" not found.`);
+    }
+    const next: HonuaLayerSpecification = { ...entry.spec, ...patch, id };
+    if (next.source && !this.#sources.has(next.source)) {
+      throw new Error(`Cannot update layer "${id}": source "${next.source}" does not exist.`);
+    }
+    entry.spec = next;
+    this.#emit({ type: "layer-updated", layerId: id });
+    return next;
   }
 
   /** Check whether a layer with the given ID exists. */

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -85,3 +85,45 @@ export type { NativeMapLibreSourceEntry, SourceBridgeProjection } from "./source
 
 export { diffPackages } from "./diff.js";
 export type { MapPackageDiff } from "./diff.js";
+
+export {
+  HonuaRuntimeDiagnosticError,
+  featureStateTargetFromSelection,
+  featureStateTargetKey,
+  featureTargetForLayer,
+  materializeRuntimeLayer,
+  materializeRuntimeSource,
+  materializeStyleValue,
+  protocolForSource,
+  rendererRuntimeDiagnosticError,
+  resolveFeatureIdFromEventFeature,
+  resolveRuntimeBeforeId,
+  selectionTargetForLayer,
+  sourceContextForLayer,
+  throwRuntimeDiagnostics,
+  validateRuntimeFilterExpression,
+  validateRuntimeLayer,
+  validateRuntimeSource,
+  validateRuntimeStyleExpression,
+} from "./style-interactions.js";
+export type {
+  HonuaRuntimeDiagnostic,
+  HonuaRuntimeDiagnosticSeverity,
+  NativeMapLibreSourceSpecification,
+  RuntimeClickInteractionHandler,
+  RuntimeClickInteractionOptions,
+  RuntimeExplorationSelectionOptions,
+  RuntimeFeatureInteractionEvent,
+  RuntimeFeatureStateTarget,
+  RuntimeFilterExpression,
+  RuntimeHoverInteractionOptions,
+  RuntimeLayerOrder,
+  RuntimeLayerOrderOptions,
+  RuntimeLayerSpecification,
+  RuntimeLayerUpdate,
+  RuntimeLayoutSpecification,
+  RuntimePaintSpecification,
+  RuntimeSelectionInteractionOptions,
+  RuntimeSourceSpecification,
+  RuntimeStyleValue,
+} from "./style-interactions.js";

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -10,7 +10,19 @@
  */
 
 import type { Dataset } from "../contract/index.js";
-import type { FeatureStateMap, MapEventTarget } from "../interactions/feature-state.js";
+import type { FeatureId } from "../contract/types.js";
+import type { ExplorationViewController, SourceQualifiedFeatureSelectionTarget } from "../exploration/types.js";
+import {
+  bindMapSelectionToExploration,
+  syncFeatureStateSelection,
+} from "../interactions/exploration-bindings.js";
+import { createHoverHandler, createSelectionHandler } from "../interactions/feature-state.js";
+import type {
+  FeatureStateMap,
+  HoverHandle,
+  MapEventTarget,
+  SelectionHandle,
+} from "../interactions/feature-state.js";
 import type { HonuaMap } from "../map/honua-map.js";
 import type { HonuaStyleSpecification } from "../style/specification.js";
 import { type MapPackageDiff, diffPackages } from "./diff.js";
@@ -18,6 +30,38 @@ import { HonuaMapPackageError } from "./errors.js";
 import { type LegendEntry, buildLegend } from "./legend.js";
 import type { HonuaMapPackage, HonuaMapPackageInitialView, HonuaMapPackagePopupBinding } from "./map-package.js";
 import { type PopupBindingHandle, type PopupFactory, type PopupRenderer, bindPopup } from "./popups.js";
+import {
+  featureStateTargetFromSelection,
+  materializeRuntimeLayer,
+  materializeRuntimeSource,
+  materializeStyleValue,
+  rendererRuntimeDiagnosticError,
+  resolveFeatureIdFromEventFeature,
+  resolveRuntimeBeforeId,
+  selectionTargetForLayer,
+  sourceContextForLayer,
+  throwRuntimeDiagnostics,
+  validateRuntimeFilterExpression,
+  validateRuntimeLayer,
+  validateRuntimeSource,
+  validateRuntimeStyleExpression,
+} from "./style-interactions.js";
+import type {
+  HonuaRuntimeDiagnostic,
+  RuntimeClickInteractionHandler,
+  RuntimeClickInteractionOptions,
+  RuntimeExplorationSelectionOptions,
+  RuntimeFeatureStateTarget,
+  RuntimeFilterExpression,
+  RuntimeHoverInteractionOptions,
+  RuntimeLayerOrder,
+  RuntimeLayerSpecification,
+  RuntimeLayerUpdate,
+  RuntimeLayoutSpecification,
+  RuntimePaintSpecification,
+  RuntimeSelectionInteractionOptions,
+  RuntimeSourceSpecification,
+} from "./style-interactions.js";
 
 /**
  * Minimal subset of `maplibre-gl.Map` required by the runtime. Mirrors
@@ -32,6 +76,7 @@ export interface MaplibreMap extends FeatureStateMap, MapEventTarget {
   removeSource?(id: string): void;
   addLayer?(layer: unknown, beforeId?: string): void;
   removeLayer?(id: string): void;
+  moveLayer?(id: string, beforeId?: string): void;
   getLayer?(id: string): unknown;
   setLayoutProperty?(layerId: string, name: string, value: unknown): void;
   setPaintProperty?(layerId: string, name: string, value: unknown): void;
@@ -200,6 +245,516 @@ export class HonuaMapRuntime {
   public setLayerVisibility(layerId: string, visible: boolean): void {
     this.#assertLive();
     this.map.setLayoutProperty?.(layerId, "visibility", visible ? "visible" : "none");
+  }
+
+  public validateStyleExpression(value: unknown): HonuaRuntimeDiagnostic[] {
+    return validateRuntimeStyleExpression(value);
+  }
+
+  public validateFilterExpression(filter: unknown, layerId?: string): HonuaRuntimeDiagnostic[] {
+    const layerContext = layerId ? sourceContextForLayer(this.#composedStyle, this.#packageRef.current, layerId) : undefined;
+    return validateRuntimeFilterExpression(filter, {
+      ...(layerId ? { layerId, path: `layers.${layerId}.filter` } : {}),
+      ...(layerContext
+        ? {
+            sourceId: layerContext.sourceId,
+            protocol: layerContext.protocol,
+          }
+        : {}),
+    });
+  }
+
+  public addSource(sourceId: string, source: RuntimeSourceSpecification): void {
+    this.#assertLive();
+    const spec = materializeRuntimeSource(source);
+    const diagnostics = [
+      ...(Object.hasOwn(this.#composedStyle.sources, sourceId)
+        ? [
+            {
+              code: "source-duplicate",
+              severity: "error" as const,
+              message: `Source "${sourceId}" already exists.`,
+              path: `sources.${sourceId}`,
+              sourceId,
+              protocol: spec.type,
+            },
+          ]
+        : []),
+      ...validateRuntimeSource(sourceId, spec, {
+        style: this.#composedStyle,
+        mapPackage: this.#packageRef.current,
+        operation: "addSource",
+      }),
+    ];
+    throwRuntimeDiagnostics(diagnostics, `Cannot add source "${sourceId}".`);
+
+    const nextStyle = {
+      ...this.#composedStyle,
+      sources: { ...this.#composedStyle.sources, [sourceId]: spec },
+    };
+
+    try {
+      this.#honuaMap.addSource(sourceId, spec);
+      try {
+        this.#applyRendererSourceAdd(sourceId, spec, nextStyle);
+      } catch (error) {
+        this.#honuaMap.removeSource(sourceId);
+        throw error;
+      }
+      this.#composedStyle = nextStyle;
+    } catch (error) {
+      if (error instanceof Error && error.name === "HonuaRuntimeDiagnosticError") throw error;
+      throw rendererRuntimeDiagnosticError(
+        `addSource("${sourceId}") failed`,
+        {
+          code: "source-add-failed",
+          message: errorMessage(error),
+          path: `sources.${sourceId}`,
+          sourceId,
+          protocol: spec.type,
+        },
+        error,
+      );
+    }
+  }
+
+  public updateSource(sourceId: string, source: RuntimeSourceSpecification): void {
+    this.#assertLive();
+    const previous = this.#composedStyle.sources[sourceId];
+    const spec = materializeRuntimeSource(source);
+    const diagnostics = [
+      ...(!previous
+        ? [
+            {
+              code: "source-not-found",
+              severity: "error" as const,
+              message: `Source "${sourceId}" does not exist.`,
+              path: `sources.${sourceId}`,
+              sourceId,
+              protocol: spec.type,
+            },
+          ]
+        : []),
+      ...validateRuntimeSource(sourceId, spec, {
+        style: this.#composedStyle,
+        mapPackage: this.#packageRef.current,
+        operation: "updateSource",
+      }),
+    ];
+    throwRuntimeDiagnostics(diagnostics, `Cannot update source "${sourceId}".`);
+
+    const nextStyle = {
+      ...this.#composedStyle,
+      sources: { ...this.#composedStyle.sources, [sourceId]: spec },
+    };
+
+    try {
+      this.#honuaMap.updateSource(sourceId, spec);
+      try {
+        this.map.setStyle(nextStyle, { diff: true });
+      } catch (error) {
+        if (previous) this.#honuaMap.updateSource(sourceId, previous);
+        throw error;
+      }
+      this.#composedStyle = nextStyle;
+    } catch (error) {
+      throw rendererRuntimeDiagnosticError(
+        `updateSource("${sourceId}") failed`,
+        {
+          code: "source-update-failed",
+          message: errorMessage(error),
+          path: `sources.${sourceId}`,
+          sourceId,
+          protocol: spec.type,
+        },
+        error,
+      );
+    }
+  }
+
+  public removeSource(sourceId: string): string[] {
+    this.#assertLive();
+    if (!Object.hasOwn(this.#composedStyle.sources, sourceId)) {
+      return [];
+    }
+
+    const removedLayerIds = this.#composedStyle.layers
+      .filter((layer) => layer.source === sourceId)
+      .map((layer) => layer.id);
+    const nextSources = { ...this.#composedStyle.sources };
+    delete nextSources[sourceId];
+    const nextStyle = {
+      ...this.#composedStyle,
+      sources: nextSources,
+      layers: this.#composedStyle.layers.filter((layer) => layer.source !== sourceId),
+    };
+
+    try {
+      this.#applyRendererSourceRemove(sourceId, removedLayerIds, nextStyle);
+      this.#honuaMap.removeSource(sourceId);
+      this.#composedStyle = nextStyle;
+      return removedLayerIds;
+    } catch (error) {
+      throw rendererRuntimeDiagnosticError(
+        `removeSource("${sourceId}") failed`,
+        {
+          code: "source-remove-failed",
+          message: errorMessage(error),
+          path: `sources.${sourceId}`,
+          sourceId,
+        },
+        error,
+      );
+    }
+  }
+
+  public addLayer(layer: RuntimeLayerSpecification, order?: RuntimeLayerOrder): void {
+    this.#assertLive();
+    const spec = materializeRuntimeLayer(layer);
+    const orderResult = resolveRuntimeBeforeId(this.#composedStyle, order);
+    const diagnostics = [
+      ...(this.#composedStyle.layers.some((entry) => entry.id === spec.id)
+        ? [
+            {
+              code: "layer-duplicate",
+              severity: "error" as const,
+              message: `Layer "${spec.id}" already exists.`,
+              path: `layers.${spec.id}`,
+              layerId: spec.id,
+              sourceId: spec.source,
+            },
+          ]
+        : []),
+      ...orderResult.diagnostics,
+      ...validateRuntimeLayer(spec, {
+        style: this.#composedStyle,
+        mapPackage: this.#packageRef.current,
+        operation: "addLayer",
+      }),
+    ];
+    throwRuntimeDiagnostics(diagnostics, `Cannot add layer "${spec.id}".`);
+
+    const nextStyle = insertLayer(this.#composedStyle, spec, orderResult.beforeId);
+    try {
+      this.#honuaMap.addLayer(spec, orderResult.beforeId);
+      try {
+        this.#applyRendererLayerAdd(spec, orderResult.beforeId, nextStyle);
+      } catch (error) {
+        this.#honuaMap.removeLayer(spec.id);
+        throw error;
+      }
+      this.#composedStyle = nextStyle;
+    } catch (error) {
+      throw rendererRuntimeDiagnosticError(
+        `addLayer("${spec.id}") failed`,
+        {
+          code: "layer-add-failed",
+          message: errorMessage(error),
+          path: `layers.${spec.id}`,
+          sourceId: spec.source,
+          layerId: spec.id,
+          protocol: sourceContextForLayer(nextStyle, this.#packageRef.current, spec.id)?.protocol,
+        },
+        error,
+      );
+    }
+  }
+
+  public updateLayer(layerId: string, update: RuntimeLayerUpdate): void {
+    this.#assertLive();
+    const previous = this.#composedStyle.layers.find((layer) => layer.id === layerId);
+    if (!previous) {
+      throwRuntimeDiagnostics(
+        [
+          {
+            code: "layer-not-found",
+            severity: "error",
+            message: `Layer "${layerId}" does not exist.`,
+            path: `layers.${layerId}`,
+            layerId,
+          },
+        ],
+        `Cannot update layer "${layerId}".`,
+      );
+      return;
+    }
+
+    const { order, ...rawPatch } = update;
+    const patch = materializeStyleValue(rawPatch) as Partial<Omit<RuntimeLayerSpecification, "id">>;
+    const nextLayer: HonuaStyleSpecification["layers"][number] = { ...previous, ...patch, id: layerId };
+    const orderResult = resolveRuntimeBeforeId(this.#composedStyle, order, layerId);
+    const diagnostics = [
+      ...orderResult.diagnostics,
+      ...validateRuntimeLayer(nextLayer, {
+        style: this.#composedStyle,
+        mapPackage: this.#packageRef.current,
+        operation: "updateLayer",
+      }),
+    ];
+    throwRuntimeDiagnostics(diagnostics, `Cannot update layer "${layerId}".`);
+
+    const nextStyle = replaceLayer(
+      this.#composedStyle,
+      nextLayer,
+      order === undefined ? undefined : orderResult.beforeId,
+      order === undefined,
+    );
+    const incremental = order === undefined && canPatchLayerWithMap(this.map, previous, nextLayer);
+    try {
+      if (incremental) {
+        this.#patchLayer(layerId, previous, nextLayer);
+      } else {
+        this.map.setStyle(nextStyle, { diff: true });
+      }
+      this.#honuaMap.updateLayer(layerId, patch as Partial<Omit<HonuaStyleSpecification["layers"][number], "id">>);
+      if (order !== undefined) {
+        this.#honuaMap.moveLayer(layerId, orderResult.beforeId);
+      }
+      this.#composedStyle = nextStyle;
+    } catch (error) {
+      throw rendererRuntimeDiagnosticError(
+        `updateLayer("${layerId}") failed`,
+        {
+          code: "layer-update-failed",
+          message: errorMessage(error),
+          path: `layers.${layerId}`,
+          sourceId: nextLayer.source,
+          layerId,
+          protocol: sourceContextForLayer(nextStyle, this.#packageRef.current, layerId)?.protocol,
+        },
+        error,
+      );
+    }
+  }
+
+  public removeLayer(layerId: string): boolean {
+    this.#assertLive();
+    const existing = this.#composedStyle.layers.find((layer) => layer.id === layerId);
+    if (!existing) return false;
+
+    const nextStyle = {
+      ...this.#composedStyle,
+      layers: this.#composedStyle.layers.filter((layer) => layer.id !== layerId),
+    };
+    try {
+      if (this.map.removeLayer) {
+        this.map.removeLayer(layerId);
+      } else {
+        this.map.setStyle(nextStyle, { diff: true });
+      }
+      this.#honuaMap.removeLayer(layerId);
+      this.#composedStyle = nextStyle;
+      return true;
+    } catch (error) {
+      throw rendererRuntimeDiagnosticError(
+        `removeLayer("${layerId}") failed`,
+        {
+          code: "layer-remove-failed",
+          message: errorMessage(error),
+          path: `layers.${layerId}`,
+          sourceId: existing.source,
+          layerId,
+          protocol: sourceContextForLayer(this.#composedStyle, this.#packageRef.current, layerId)?.protocol,
+        },
+        error,
+      );
+    }
+  }
+
+  public moveLayer(layerId: string, order?: RuntimeLayerOrder): void {
+    this.#assertLive();
+    const existing = this.#composedStyle.layers.find((layer) => layer.id === layerId);
+    if (!existing) {
+      throwRuntimeDiagnostics(
+        [
+          {
+            code: "layer-not-found",
+            severity: "error",
+            message: `Layer "${layerId}" does not exist.`,
+            path: `layers.${layerId}`,
+            layerId,
+          },
+        ],
+        `Cannot move layer "${layerId}".`,
+      );
+      return;
+    }
+
+    const orderResult = resolveRuntimeBeforeId(this.#composedStyle, order, layerId);
+    throwRuntimeDiagnostics(orderResult.diagnostics, `Cannot move layer "${layerId}".`);
+    const nextStyle = replaceLayer(this.#composedStyle, existing, orderResult.beforeId, false);
+    try {
+      if (this.map.moveLayer) {
+        this.map.moveLayer(layerId, orderResult.beforeId);
+      } else {
+        this.map.setStyle(nextStyle, { diff: true });
+      }
+      this.#honuaMap.moveLayer(layerId, orderResult.beforeId);
+      this.#composedStyle = nextStyle;
+    } catch (error) {
+      throw rendererRuntimeDiagnosticError(
+        `moveLayer("${layerId}") failed`,
+        {
+          code: "layer-move-failed",
+          message: errorMessage(error),
+          path: `layers.${layerId}`,
+          sourceId: existing.source,
+          layerId,
+          protocol: sourceContextForLayer(this.#composedStyle, this.#packageRef.current, layerId)?.protocol,
+        },
+        error,
+      );
+    }
+  }
+
+  public setLayerPaint(layerId: string, paint: RuntimePaintSpecification): void {
+    this.updateLayer(layerId, { paint });
+  }
+
+  public setLayerLayout(layerId: string, layout: RuntimeLayoutSpecification): void {
+    this.updateLayer(layerId, { layout });
+  }
+
+  public setLayerFilter(layerId: string, filter: RuntimeFilterExpression | undefined): void {
+    this.updateLayer(layerId, { filter });
+  }
+
+  public layerSelectionTarget(layerId: string, id: FeatureId): SourceQualifiedFeatureSelectionTarget {
+    const target = selectionTargetForLayer(this.#composedStyle, layerId, id);
+    if (!target) {
+      throwRuntimeDiagnostics(
+        [
+          {
+            code: "layer-source-missing",
+            severity: "error",
+            message: `Layer "${layerId}" does not have a source for feature selection.`,
+            path: `layers.${layerId}.source`,
+            layerId,
+          },
+        ],
+        `Cannot build a source-qualified selection target for layer "${layerId}".`,
+      );
+      throw new Error("unreachable");
+    }
+    return target;
+  }
+
+  public setFeatureStateForTarget(
+    target: RuntimeFeatureStateTarget | SourceQualifiedFeatureSelectionTarget,
+    state: Record<string, unknown>,
+  ): void {
+    this.#assertLive();
+    this.map.setFeatureState(normalizeFeatureStateTarget(target), state);
+  }
+
+  public getFeatureStateForTarget(
+    target: RuntimeFeatureStateTarget | SourceQualifiedFeatureSelectionTarget,
+  ): Record<string, unknown> {
+    this.#assertLive();
+    return this.map.getFeatureState(normalizeFeatureStateTarget(target));
+  }
+
+  public removeFeatureStateForTarget(
+    target: RuntimeFeatureStateTarget | SourceQualifiedFeatureSelectionTarget,
+    key?: string,
+  ): void {
+    this.#assertLive();
+    this.map.removeFeatureState(normalizeFeatureStateTarget(target), key);
+  }
+
+  public bindHover(layerId: string, options: RuntimeHoverInteractionOptions = {}): HoverHandle {
+    this.#assertLive();
+    const context = this.#interactionContext(layerId, options.sourceId, options.sourceLayer);
+    return createHoverHandler(this.map, {
+      source: context.sourceId,
+      sourceLayer: context.sourceLayer,
+      layer: layerId,
+      stateKey: options.stateKey,
+    });
+  }
+
+  public bindClick(
+    layerId: string,
+    handler: RuntimeClickInteractionHandler,
+    options: RuntimeClickInteractionOptions = {},
+  ): { remove(): void } {
+    this.#assertLive();
+    const context = this.#interactionContext(layerId, options.sourceId, options.sourceLayer);
+
+    const onClick = (event: unknown): void => {
+      const feature = firstEventFeature(event);
+      const featureId = feature ? resolveFeatureIdFromEventFeature(feature, event, options) : undefined;
+      handler({
+        type: "click",
+        layerId,
+        sourceId: context.sourceId,
+        sourceLayer: context.sourceLayer,
+        feature,
+        featureId,
+        ...(featureId !== undefined
+          ? {
+              selectionTarget: {
+                sourceId: context.sourceId,
+                id: featureId,
+                ...(context.sourceLayer !== undefined ? { sourceLayer: context.sourceLayer } : {}),
+              },
+            }
+          : {}),
+        originalEvent: event,
+      });
+    };
+
+    this.map.on("click", layerId, onClick);
+    return {
+      remove: () => this.map.off("click", layerId, onClick),
+    };
+  }
+
+  public bindSelect(layerId: string, options: RuntimeSelectionInteractionOptions = {}): SelectionHandle {
+    this.#assertLive();
+    const context = this.#interactionContext(layerId, options.sourceId, options.sourceLayer);
+    return createSelectionHandler(this.map, {
+      source: context.sourceId,
+      sourceLayer: context.sourceLayer,
+      layer: layerId,
+      stateKey: options.stateKey,
+      multiSelect: options.multiSelect,
+      onChange: options.onChange,
+      onSelectionTargetsChange: options.onSelectionTargetsChange,
+    });
+  }
+
+  public bindSelectionToExploration(
+    layerId: string,
+    view: ExplorationViewController,
+    options: RuntimeExplorationSelectionOptions = {},
+  ): SelectionHandle {
+    this.#assertLive();
+    const context = this.#interactionContext(layerId, options.sourceId, options.sourceLayer);
+    return bindMapSelectionToExploration(this.map, view, {
+      source: context.sourceId,
+      sourceLayer: context.sourceLayer,
+      layer: layerId,
+      stateKey: options.stateKey,
+      multiSelect: options.multiSelect,
+      onChange: options.onChange,
+      onSelectionTargetsChange: options.onSelectionTargetsChange,
+      replaceSelection: options.replaceSelection,
+    });
+  }
+
+  public syncSelectionFromExploration(
+    layerId: string,
+    view: ExplorationViewController,
+    options: Omit<RuntimeExplorationSelectionOptions, "multiSelect" | "onChange" | "onSelectionTargetsChange"> = {},
+  ): { remove(): void } {
+    this.#assertLive();
+    const context = this.#interactionContext(layerId, options.sourceId, options.sourceLayer);
+    return syncFeatureStateSelection(this.map, view, {
+      source: context.sourceId,
+      sourceLayer: context.sourceLayer,
+      stateKey: options.stateKey,
+    });
   }
 
   public bindPopup(layerId: string, binding?: HonuaMapPackagePopupBinding): { remove(): void } {
@@ -420,6 +975,74 @@ export class HonuaMapRuntime {
 
   // ── Private helpers ─────────────────────────────────────────
 
+  #applyRendererSourceAdd(
+    sourceId: string,
+    source: RuntimeSourceSpecification,
+    nextStyle: HonuaStyleSpecification,
+  ): void {
+    if (this.map.addSource) {
+      this.map.addSource(sourceId, source);
+      return;
+    }
+    this.map.setStyle(nextStyle, { diff: true });
+  }
+
+  #applyRendererSourceRemove(
+    sourceId: string,
+    removedLayerIds: readonly string[],
+    nextStyle: HonuaStyleSpecification,
+  ): void {
+    if (!this.map.removeLayer || !this.map.removeSource) {
+      this.map.setStyle(nextStyle, { diff: true });
+      return;
+    }
+    for (const layerId of [...removedLayerIds].reverse()) {
+      this.map.removeLayer(layerId);
+    }
+    this.map.removeSource(sourceId);
+  }
+
+  #applyRendererLayerAdd(
+    layer: HonuaStyleSpecification["layers"][number],
+    beforeId: string | undefined,
+    nextStyle: HonuaStyleSpecification,
+  ): void {
+    if (this.map.addLayer) {
+      this.map.addLayer(layer, beforeId);
+      return;
+    }
+    this.map.setStyle(nextStyle, { diff: true });
+  }
+
+  #interactionContext(
+    layerId: string,
+    sourceIdOverride: string | undefined,
+    sourceLayerOverride: string | undefined,
+  ): { sourceId: string; sourceLayer: string | undefined; protocol: string | undefined } {
+    const context = sourceContextForLayer(this.#composedStyle, this.#packageRef.current, layerId);
+    const sourceId = sourceIdOverride ?? context?.sourceId;
+    if (!sourceId) {
+      throwRuntimeDiagnostics(
+        [
+          {
+            code: "layer-source-missing",
+            severity: "error",
+            message: `Layer "${layerId}" does not have a source for interactions.`,
+            path: `layers.${layerId}.source`,
+            layerId,
+          },
+        ],
+        `Cannot bind interactions for layer "${layerId}".`,
+      );
+      throw new Error("unreachable");
+    }
+    return {
+      sourceId,
+      sourceLayer: sourceLayerOverride ?? context?.sourceLayer,
+      protocol: context?.protocol,
+    };
+  }
+
   #applyIncremental(composed: HonuaStyleSpecification, diff: MapPackageDiff): void {
     const prevStyle = this.#composedStyle;
 
@@ -544,6 +1167,71 @@ export class HonuaMapRuntime {
 
 // ── Helpers ──────────────────────────────────────────────────
 
+function insertLayer(
+  style: HonuaStyleSpecification,
+  layer: HonuaStyleSpecification["layers"][number],
+  beforeId: string | undefined,
+): HonuaStyleSpecification {
+  const layers = [...style.layers];
+  if (beforeId) {
+    const index = layers.findIndex((entry) => entry.id === beforeId);
+    if (index >= 0) {
+      layers.splice(index, 0, layer);
+    } else {
+      layers.push(layer);
+    }
+  } else {
+    layers.push(layer);
+  }
+  return { ...style, layers };
+}
+
+function replaceLayer(
+  style: HonuaStyleSpecification,
+  layer: HonuaStyleSpecification["layers"][number],
+  beforeId: string | undefined,
+  preserveIndexWhenNoBefore = true,
+): HonuaStyleSpecification {
+  const layers = style.layers.filter((entry) => entry.id !== layer.id);
+  if (beforeId) {
+    const index = layers.findIndex((entry) => entry.id === beforeId);
+    if (index >= 0) {
+      layers.splice(index, 0, layer);
+    } else {
+      layers.push(layer);
+    }
+  } else {
+    const previousIndex = style.layers.findIndex((entry) => entry.id === layer.id);
+    if (preserveIndexWhenNoBefore && previousIndex >= 0 && previousIndex < layers.length) {
+      layers.splice(previousIndex, 0, layer);
+    } else {
+      layers.push(layer);
+    }
+  }
+  return { ...style, layers };
+}
+
+function normalizeFeatureStateTarget(
+  target: RuntimeFeatureStateTarget | SourceQualifiedFeatureSelectionTarget,
+): RuntimeFeatureStateTarget {
+  if ("sourceId" in target) {
+    return featureStateTargetFromSelection(target);
+  }
+  return target;
+}
+
+function firstEventFeature(event: unknown): unknown {
+  if (typeof event !== "object" || event === null || !("features" in event)) {
+    return undefined;
+  }
+  const features = (event as { features?: unknown }).features;
+  return Array.isArray(features) ? features[0] : undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 function layerIdToSource(style: HonuaStyleSpecification, layerId: string): string | undefined {
   return style.layers.find((l) => l.id === layerId)?.source;
 }
@@ -610,6 +1298,18 @@ function patchableLayerShapeEqual(
     a.maxzoom === b.maxzoom &&
     sameJson(a.metadata, b.metadata)
   );
+}
+
+function canPatchLayerWithMap(
+  map: MaplibreMap,
+  previous: HonuaStyleSpecification["layers"][number],
+  next: HonuaStyleSpecification["layers"][number],
+): boolean {
+  if (!patchableLayerShapeEqual(previous, next)) return false;
+  if (!sameJson(previous.paint ?? {}, next.paint ?? {}) && !map.setPaintProperty) return false;
+  if (!sameJson(previous.layout ?? {}, next.layout ?? {}) && !map.setLayoutProperty) return false;
+  if (!sameJson(previous.filter, next.filter) && !map.setFilter) return false;
+  return true;
 }
 
 function shallowPaintLayoutEqual(

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -12,17 +12,9 @@
 import type { Dataset } from "../contract/index.js";
 import type { FeatureId } from "../contract/types.js";
 import type { ExplorationViewController, SourceQualifiedFeatureSelectionTarget } from "../exploration/types.js";
-import {
-  bindMapSelectionToExploration,
-  syncFeatureStateSelection,
-} from "../interactions/exploration-bindings.js";
+import { bindMapSelectionToExploration, syncFeatureStateSelection } from "../interactions/exploration-bindings.js";
 import { createHoverHandler, createSelectionHandler } from "../interactions/feature-state.js";
-import type {
-  FeatureStateMap,
-  HoverHandle,
-  MapEventTarget,
-  SelectionHandle,
-} from "../interactions/feature-state.js";
+import type { FeatureStateMap, HoverHandle, MapEventTarget, SelectionHandle } from "../interactions/feature-state.js";
 import type { HonuaMap } from "../map/honua-map.js";
 import type { HonuaStyleSpecification } from "../style/specification.js";
 import { type MapPackageDiff, diffPackages } from "./diff.js";
@@ -252,7 +244,9 @@ export class HonuaMapRuntime {
   }
 
   public validateFilterExpression(filter: unknown, layerId?: string): HonuaRuntimeDiagnostic[] {
-    const layerContext = layerId ? sourceContextForLayer(this.#composedStyle, this.#packageRef.current, layerId) : undefined;
+    const layerContext = layerId
+      ? sourceContextForLayer(this.#composedStyle, this.#packageRef.current, layerId)
+      : undefined;
     return validateRuntimeFilterExpression(filter, {
       ...(layerId ? { layerId, path: `layers.${layerId}.filter` } : {}),
       ...(layerContext

--- a/src/runtime/style-interactions.ts
+++ b/src/runtime/style-interactions.ts
@@ -11,9 +11,9 @@
  */
 
 import type { FeatureId } from "../contract/types.js";
-import { Expr } from "../expr/index.js";
 import { sourceFeatureSelectionTarget } from "../exploration/selection.js";
 import type { SourceQualifiedFeatureSelectionTarget } from "../exploration/types.js";
+import { Expr } from "../expr/index.js";
 import type {
   HonuaLayerSpecification,
   HonuaSourceSpecification,
@@ -59,8 +59,7 @@ export type RuntimePaintSpecification = Record<string, RuntimeStyleValue>;
 export type RuntimeLayoutSpecification = Record<string, RuntimeStyleValue>;
 export type RuntimeFilterExpression = unknown;
 
-export interface RuntimeLayerSpecification
-  extends Omit<HonuaLayerSpecification, "paint" | "layout" | "filter"> {
+export interface RuntimeLayerSpecification extends Omit<HonuaLayerSpecification, "paint" | "layout" | "filter"> {
   readonly paint?: RuntimePaintSpecification;
   readonly layout?: RuntimeLayoutSpecification;
   readonly filter?: RuntimeFilterExpression;
@@ -647,7 +646,9 @@ function validateExpressionArray(
 
   const operator = expr[0];
   if (typeof operator !== "string") {
-    return [diagnostic("expression-operator-invalid", "Expression arrays must start with an operator string.", options)];
+    return [
+      diagnostic("expression-operator-invalid", "Expression arrays must start with an operator string.", options),
+    ];
   }
 
   const rule = EXPRESSION_OPERATORS[operator];

--- a/src/runtime/style-interactions.ts
+++ b/src/runtime/style-interactions.ts
@@ -1,0 +1,836 @@
+/**
+ * Mapbox-style runtime helpers for source/layer mutation, expression
+ * diagnostics, and source-qualified feature interaction targets.
+ *
+ * The types in this file intentionally stay structural instead of importing
+ * MapLibre GL JS declarations. App code can use common source, layer, paint,
+ * layout, filter, and interaction helpers without coupling to a specific
+ * renderer package version.
+ *
+ * @module
+ */
+
+import type { FeatureId } from "../contract/types.js";
+import { Expr } from "../expr/index.js";
+import { sourceFeatureSelectionTarget } from "../exploration/selection.js";
+import type { SourceQualifiedFeatureSelectionTarget } from "../exploration/types.js";
+import type {
+  HonuaLayerSpecification,
+  HonuaSourceSpecification,
+  HonuaStyleSpecification,
+} from "../style/specification.js";
+import { isHonuaSource } from "../style/specification.js";
+import type { HonuaMapPackage } from "./map-package.js";
+
+export type HonuaRuntimeDiagnosticSeverity = "error" | "warning";
+
+export interface HonuaRuntimeDiagnostic {
+  readonly code: string;
+  readonly severity: HonuaRuntimeDiagnosticSeverity;
+  readonly message: string;
+  readonly path?: string;
+  readonly sourceId?: string;
+  readonly layerId?: string;
+  readonly protocol?: string;
+  readonly capability?: string;
+  readonly context?: Readonly<Record<string, unknown>>;
+}
+
+export class HonuaRuntimeDiagnosticError extends Error {
+  public readonly diagnostics: readonly HonuaRuntimeDiagnostic[];
+  public override readonly cause: unknown;
+
+  public constructor(message: string, diagnostics: readonly HonuaRuntimeDiagnostic[], cause?: unknown) {
+    super(message);
+    this.name = "HonuaRuntimeDiagnosticError";
+    this.diagnostics = diagnostics;
+    this.cause = cause;
+  }
+}
+
+export interface NativeMapLibreSourceSpecification {
+  readonly type: string;
+  readonly [key: string]: unknown;
+}
+
+export type RuntimeSourceSpecification = HonuaSourceSpecification | NativeMapLibreSourceSpecification;
+export type RuntimeStyleValue = unknown;
+export type RuntimePaintSpecification = Record<string, RuntimeStyleValue>;
+export type RuntimeLayoutSpecification = Record<string, RuntimeStyleValue>;
+export type RuntimeFilterExpression = unknown;
+
+export interface RuntimeLayerSpecification
+  extends Omit<HonuaLayerSpecification, "paint" | "layout" | "filter"> {
+  readonly paint?: RuntimePaintSpecification;
+  readonly layout?: RuntimeLayoutSpecification;
+  readonly filter?: RuntimeFilterExpression;
+}
+
+export interface RuntimeLayerUpdate extends Partial<Omit<RuntimeLayerSpecification, "id">> {
+  readonly order?: RuntimeLayerOrder;
+}
+
+export interface RuntimeLayerOrderOptions {
+  readonly beforeId?: string;
+  readonly afterId?: string;
+  readonly position?: "top" | "bottom";
+}
+
+/**
+ * Layer order input. A string is treated as MapLibre's `beforeId`.
+ */
+export type RuntimeLayerOrder = string | RuntimeLayerOrderOptions | undefined;
+
+export interface RuntimeExpressionValidationOptions {
+  readonly kind?: "style" | "filter";
+  readonly path?: string;
+  readonly sourceId?: string;
+  readonly layerId?: string;
+  readonly protocol?: string;
+  readonly context?: Readonly<Record<string, unknown>>;
+  readonly requireExpression?: boolean;
+  readonly strictUnknownOperators?: boolean;
+}
+
+export interface RuntimeStyleValidationContext {
+  readonly style?: HonuaStyleSpecification;
+  readonly mapPackage?: HonuaMapPackage;
+  readonly operation?: string;
+}
+
+export interface RuntimeFeatureStateTarget {
+  readonly source: string;
+  readonly id: FeatureId;
+  readonly sourceLayer?: string;
+}
+
+export interface RuntimeFeatureInteractionEvent {
+  readonly type: string;
+  readonly layerId: string;
+  readonly sourceId: string;
+  readonly sourceLayer?: string;
+  readonly feature: unknown;
+  readonly featureId?: FeatureId;
+  readonly selectionTarget?: SourceQualifiedFeatureSelectionTarget;
+  readonly originalEvent: unknown;
+}
+
+export interface RuntimeClickInteractionOptions {
+  readonly sourceId?: string;
+  readonly sourceLayer?: string;
+  readonly featureIdProperty?: string;
+  readonly resolveFeatureId?: (feature: unknown, event: unknown) => FeatureId | undefined;
+}
+
+export type RuntimeClickInteractionHandler = (event: RuntimeFeatureInteractionEvent) => void;
+
+export interface RuntimeHoverInteractionOptions {
+  readonly sourceId?: string;
+  readonly sourceLayer?: string;
+  readonly stateKey?: string;
+}
+
+export interface RuntimeSelectionInteractionOptions {
+  readonly sourceId?: string;
+  readonly sourceLayer?: string;
+  readonly stateKey?: string;
+  readonly multiSelect?: boolean;
+  readonly onChange?: (selectedIds: ReadonlySet<string | number>) => void;
+  readonly onSelectionTargetsChange?: (selectedTargets: ReadonlyArray<SourceQualifiedFeatureSelectionTarget>) => void;
+}
+
+export interface RuntimeExplorationSelectionOptions extends RuntimeSelectionInteractionOptions {
+  readonly replaceSelection?: boolean;
+}
+
+interface OperatorRule {
+  readonly minArgs?: number;
+  readonly maxArgs?: number;
+  readonly custom?: (expr: readonly unknown[], options: RuntimeExpressionValidationOptions) => HonuaRuntimeDiagnostic[];
+}
+
+const EXPRESSION_OPERATORS: Readonly<Record<string, OperatorRule>> = {
+  "!": { minArgs: 1, maxArgs: 1 },
+  "!=": { minArgs: 2, maxArgs: 3 },
+  "<": { minArgs: 2, maxArgs: 3 },
+  "<=": { minArgs: 2, maxArgs: 3 },
+  "==": { minArgs: 2, maxArgs: 3 },
+  ">": { minArgs: 2, maxArgs: 3 },
+  ">=": { minArgs: 2, maxArgs: 3 },
+  "-": { minArgs: 1, maxArgs: 2 },
+  "+": { minArgs: 2 },
+  "*": { minArgs: 2 },
+  "/": { minArgs: 2, maxArgs: 2 },
+  "%": { minArgs: 2, maxArgs: 2 },
+  "^": { minArgs: 2, maxArgs: 2 },
+  abs: { minArgs: 1, maxArgs: 1 },
+  accumulated: { minArgs: 0, maxArgs: 0 },
+  acos: { minArgs: 1, maxArgs: 1 },
+  all: { minArgs: 1 },
+  any: { minArgs: 1 },
+  array: { minArgs: 1 },
+  asin: { minArgs: 1, maxArgs: 1 },
+  at: { minArgs: 2, maxArgs: 2 },
+  atan: { minArgs: 1, maxArgs: 1 },
+  boolean: { minArgs: 1 },
+  case: { custom: validateCaseExpression },
+  ceil: { minArgs: 1, maxArgs: 1 },
+  coalesce: { minArgs: 1 },
+  collator: { minArgs: 0, maxArgs: 1 },
+  concat: { minArgs: 1 },
+  cos: { minArgs: 1, maxArgs: 1 },
+  "cubic-bezier": { minArgs: 4, maxArgs: 4 },
+  "distance-from-center": { minArgs: 0, maxArgs: 0 },
+  downcase: { minArgs: 1, maxArgs: 1 },
+  distance: { minArgs: 1, maxArgs: 1 },
+  e: { minArgs: 0, maxArgs: 0 },
+  "feature-state": { minArgs: 1, maxArgs: 1 },
+  floor: { minArgs: 1, maxArgs: 1 },
+  format: { minArgs: 1 },
+  geometry: { minArgs: 0, maxArgs: 0 },
+  "geometry-type": { minArgs: 0, maxArgs: 0 },
+  get: { minArgs: 1, maxArgs: 2 },
+  has: { minArgs: 1, maxArgs: 2 },
+  "heatmap-density": { minArgs: 0, maxArgs: 0 },
+  hsl: { minArgs: 3, maxArgs: 3 },
+  hsla: { minArgs: 4, maxArgs: 4 },
+  id: { minArgs: 0, maxArgs: 0 },
+  image: { minArgs: 1, maxArgs: 1 },
+  in: { minArgs: 2, maxArgs: 2 },
+  index: { minArgs: 0, maxArgs: 0 },
+  "index-of": { minArgs: 2, maxArgs: 3 },
+  interpolate: { custom: validateInterpolateExpression },
+  "interpolate-hcl": { custom: validateInterpolateExpression },
+  "interpolate-lab": { custom: validateInterpolateExpression },
+  intersects: { minArgs: 1, maxArgs: 1 },
+  length: { minArgs: 1, maxArgs: 1 },
+  let: { minArgs: 3 },
+  "line-progress": { minArgs: 0, maxArgs: 0 },
+  literal: { minArgs: 1, maxArgs: 1 },
+  ln: { minArgs: 1, maxArgs: 1 },
+  ln2: { minArgs: 0, maxArgs: 0 },
+  log10: { minArgs: 1, maxArgs: 1 },
+  log2: { minArgs: 1, maxArgs: 1 },
+  match: { custom: validateMatchExpression },
+  max: { minArgs: 1 },
+  min: { minArgs: 1 },
+  "number-format": { minArgs: 1, maxArgs: 2 },
+  number: { minArgs: 1 },
+  object: { minArgs: 1 },
+  pi: { minArgs: 0, maxArgs: 0 },
+  pitch: { minArgs: 0, maxArgs: 0 },
+  properties: { minArgs: 0, maxArgs: 0 },
+  "resolved-locale": { minArgs: 1, maxArgs: 1 },
+  resolvedLocale: { minArgs: 1, maxArgs: 1 },
+  rgb: { minArgs: 3, maxArgs: 3 },
+  rgba: { minArgs: 4, maxArgs: 4 },
+  round: { minArgs: 1, maxArgs: 1 },
+  sin: { minArgs: 1, maxArgs: 1 },
+  slice: { minArgs: 2, maxArgs: 3 },
+  sqrt: { minArgs: 1, maxArgs: 1 },
+  step: { custom: validateStepExpression },
+  string: { minArgs: 1 },
+  tan: { minArgs: 1, maxArgs: 1 },
+  "to-boolean": { minArgs: 1, maxArgs: 1 },
+  "to-color": { minArgs: 1 },
+  "to-number": { minArgs: 1 },
+  "to-rgba": { minArgs: 1, maxArgs: 1 },
+  "to-string": { minArgs: 1, maxArgs: 1 },
+  typeof: { minArgs: 1, maxArgs: 1 },
+  upcase: { minArgs: 1, maxArgs: 1 },
+  var: { minArgs: 1, maxArgs: 1 },
+  within: { minArgs: 1, maxArgs: 1 },
+  zoom: { minArgs: 0, maxArgs: 0 },
+};
+
+export function materializeRuntimeSource(source: RuntimeSourceSpecification): RuntimeSourceSpecification {
+  return materializeStyleValue(source) as RuntimeSourceSpecification;
+}
+
+export function materializeRuntimeLayer(layer: RuntimeLayerSpecification): HonuaLayerSpecification {
+  return materializeStyleValue(layer) as HonuaLayerSpecification;
+}
+
+export function materializeStyleValue(value: unknown): unknown {
+  if (value instanceof Expr) {
+    return value.toJSON();
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => materializeStyleValue(entry));
+  }
+  if (isPlainObject(value)) {
+    const result: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      result[key] = materializeStyleValue(entry);
+    }
+    return result;
+  }
+  return value;
+}
+
+export function validateRuntimeSource(
+  sourceId: string,
+  source: RuntimeSourceSpecification,
+  context: RuntimeStyleValidationContext = {},
+): HonuaRuntimeDiagnostic[] {
+  const diagnostics: HonuaRuntimeDiagnostic[] = [];
+  const sourceContext = sourceDiagnosticContext(sourceId, source, context);
+
+  if (!sourceId.trim()) {
+    diagnostics.push({
+      code: "source-id-empty",
+      severity: "error",
+      message: "Source id must be a non-empty string.",
+      path: "sourceId",
+      ...sourceContext,
+    });
+  }
+
+  if (!isPlainObject(source)) {
+    diagnostics.push({
+      code: "source-invalid",
+      severity: "error",
+      message: "Source specification must be a non-null object.",
+      path: `sources.${sourceId}`,
+      ...sourceContext,
+    });
+    return diagnostics;
+  }
+
+  if (typeof source.type !== "string" || source.type.trim().length === 0) {
+    diagnostics.push({
+      code: "source-type-invalid",
+      severity: "error",
+      message: "Source specification must include a non-empty string type.",
+      path: `sources.${sourceId}.type`,
+      ...sourceContext,
+    });
+  }
+
+  if (isHonuaSource(source) && typeof source.url !== "string") {
+    diagnostics.push({
+      code: "source-url-missing",
+      severity: "error",
+      message: "Honua source specifications require a string url.",
+      path: `sources.${sourceId}.url`,
+      ...sourceContext,
+    });
+  }
+
+  return diagnostics;
+}
+
+export function validateRuntimeLayer(
+  layer: RuntimeLayerSpecification | HonuaLayerSpecification,
+  context: RuntimeStyleValidationContext = {},
+): HonuaRuntimeDiagnostic[] {
+  const materialized = materializeRuntimeLayer(layer as RuntimeLayerSpecification);
+  const diagnostics: HonuaRuntimeDiagnostic[] = [];
+  const sourceId = materialized.source;
+  const sourceContext = layerDiagnosticContext(materialized.id, sourceId, context);
+
+  if (typeof materialized.id !== "string" || materialized.id.trim().length === 0) {
+    diagnostics.push({
+      code: "layer-id-invalid",
+      severity: "error",
+      message: "Layer specification must include a non-empty string id.",
+      path: "layers[].id",
+      ...sourceContext,
+    });
+  }
+
+  if (typeof materialized.type !== "string" || materialized.type.trim().length === 0) {
+    diagnostics.push({
+      code: "layer-type-invalid",
+      severity: "error",
+      message: "Layer specification must include a non-empty string type.",
+      path: `layers.${materialized.id}.type`,
+      ...sourceContext,
+    });
+  }
+
+  if (sourceId && context.style && !Object.hasOwn(context.style.sources, sourceId)) {
+    diagnostics.push({
+      code: "layer-source-missing",
+      severity: "error",
+      message: `Layer "${materialized.id}" references missing source "${sourceId}".`,
+      path: `layers.${materialized.id}.source`,
+      ...sourceContext,
+    });
+  }
+
+  if (materialized.paint !== undefined && !isPlainObject(materialized.paint)) {
+    diagnostics.push({
+      code: "layer-paint-invalid",
+      severity: "error",
+      message: "Layer paint must be an object when provided.",
+      path: `layers.${materialized.id}.paint`,
+      ...sourceContext,
+    });
+  } else {
+    for (const [property, value] of Object.entries(materialized.paint ?? {})) {
+      diagnostics.push(
+        ...validateRuntimeStyleExpression(value, {
+          kind: "style",
+          path: `layers.${materialized.id}.paint.${property}`,
+          ...sourceContext,
+        }),
+      );
+    }
+  }
+
+  if (materialized.layout !== undefined && !isPlainObject(materialized.layout)) {
+    diagnostics.push({
+      code: "layer-layout-invalid",
+      severity: "error",
+      message: "Layer layout must be an object when provided.",
+      path: `layers.${materialized.id}.layout`,
+      ...sourceContext,
+    });
+  } else {
+    for (const [property, value] of Object.entries(materialized.layout ?? {})) {
+      diagnostics.push(
+        ...validateRuntimeStyleExpression(value, {
+          kind: "style",
+          path: `layers.${materialized.id}.layout.${property}`,
+          ...sourceContext,
+        }),
+      );
+    }
+  }
+
+  if (materialized.filter !== undefined) {
+    diagnostics.push(
+      ...validateRuntimeFilterExpression(materialized.filter, {
+        path: `layers.${materialized.id}.filter`,
+        ...sourceContext,
+      }),
+    );
+  }
+
+  return diagnostics;
+}
+
+export function validateRuntimeStyleExpression(
+  value: unknown,
+  options: RuntimeExpressionValidationOptions = {},
+): HonuaRuntimeDiagnostic[] {
+  const materialized = materializeStyleValue(value);
+  if (!Array.isArray(materialized)) {
+    return [];
+  }
+  if (!looksLikeExpressionArray(materialized)) {
+    return options.requireExpression
+      ? [
+          diagnostic("expression-operator-invalid", "Expression arrays must start with an operator string.", {
+            ...options,
+          }),
+        ]
+      : [];
+  }
+  return validateExpressionArray(materialized, options);
+}
+
+export function validateRuntimeFilterExpression(
+  filter: unknown,
+  options: Omit<RuntimeExpressionValidationOptions, "kind" | "requireExpression"> = {},
+): HonuaRuntimeDiagnostic[] {
+  const materialized = materializeStyleValue(filter);
+  if (!Array.isArray(materialized)) {
+    return [
+      diagnostic("filter-invalid", "Layer filter must be a MapLibre expression array.", {
+        kind: "filter",
+        requireExpression: true,
+        ...options,
+      }),
+    ];
+  }
+  return validateRuntimeStyleExpression(materialized, {
+    kind: "filter",
+    requireExpression: true,
+    ...options,
+  });
+}
+
+export function throwRuntimeDiagnostics(
+  diagnostics: readonly HonuaRuntimeDiagnostic[],
+  message = "Runtime style diagnostics failed.",
+): void {
+  const errors = diagnostics.filter((entry) => entry.severity === "error");
+  if (errors.length > 0) {
+    throw new HonuaRuntimeDiagnosticError(message, errors);
+  }
+}
+
+export function rendererRuntimeDiagnosticError(
+  message: string,
+  diagnostic: Omit<HonuaRuntimeDiagnostic, "severity"> & { readonly severity?: HonuaRuntimeDiagnosticSeverity },
+  cause: unknown,
+): HonuaRuntimeDiagnosticError {
+  return new HonuaRuntimeDiagnosticError(
+    message,
+    [
+      {
+        severity: "error",
+        ...diagnostic,
+      },
+    ],
+    cause,
+  );
+}
+
+export function resolveRuntimeBeforeId(
+  style: HonuaStyleSpecification,
+  order: RuntimeLayerOrder,
+  movingLayerId?: string,
+): { beforeId: string | undefined; diagnostics: HonuaRuntimeDiagnostic[] } {
+  const diagnostics: HonuaRuntimeDiagnostic[] = [];
+  const orderedLayers = style.layers.filter((layer) => layer.id !== movingLayerId);
+
+  if (order === undefined) {
+    return { beforeId: undefined, diagnostics };
+  }
+
+  if (typeof order === "string") {
+    if (order && !orderedLayers.some((layer) => layer.id === order)) {
+      diagnostics.push({
+        code: "layer-order-before-missing",
+        severity: "error",
+        message: `Cannot insert before missing layer "${order}".`,
+        layerId: movingLayerId,
+        path: "beforeId",
+      });
+    }
+    return { beforeId: order || undefined, diagnostics };
+  }
+
+  const requested = [order.beforeId, order.afterId, order.position].filter((value) => value !== undefined);
+  if (requested.length > 1) {
+    diagnostics.push({
+      code: "layer-order-conflict",
+      severity: "error",
+      message: "Specify only one of beforeId, afterId, or position.",
+      layerId: movingLayerId,
+      path: "order",
+    });
+    return { beforeId: undefined, diagnostics };
+  }
+
+  if (order.beforeId !== undefined) {
+    if (!orderedLayers.some((layer) => layer.id === order.beforeId)) {
+      diagnostics.push({
+        code: "layer-order-before-missing",
+        severity: "error",
+        message: `Cannot insert before missing layer "${order.beforeId}".`,
+        layerId: movingLayerId,
+        path: "order.beforeId",
+      });
+    }
+    return { beforeId: order.beforeId, diagnostics };
+  }
+
+  if (order.afterId !== undefined) {
+    const index = orderedLayers.findIndex((layer) => layer.id === order.afterId);
+    if (index === -1) {
+      diagnostics.push({
+        code: "layer-order-after-missing",
+        severity: "error",
+        message: `Cannot insert after missing layer "${order.afterId}".`,
+        layerId: movingLayerId,
+        path: "order.afterId",
+      });
+      return { beforeId: undefined, diagnostics };
+    }
+    return { beforeId: orderedLayers[index + 1]?.id, diagnostics };
+  }
+
+  if (order.position === "bottom") {
+    return { beforeId: orderedLayers[0]?.id, diagnostics };
+  }
+
+  return { beforeId: undefined, diagnostics };
+}
+
+export function sourceContextForLayer(
+  style: HonuaStyleSpecification,
+  mapPackage: HonuaMapPackage | undefined,
+  layerId: string,
+): { sourceId: string; sourceLayer: string | undefined; protocol: string | undefined } | undefined {
+  const layer = style.layers.find((entry) => entry.id === layerId);
+  if (!layer?.source) return undefined;
+  return {
+    sourceId: layer.source,
+    sourceLayer: layer["source-layer"],
+    protocol: protocolForSource(style, mapPackage, layer.source),
+  };
+}
+
+export function featureTargetForLayer(
+  style: HonuaStyleSpecification,
+  layerId: string,
+  id: FeatureId,
+): RuntimeFeatureStateTarget | undefined {
+  const layer = style.layers.find((entry) => entry.id === layerId);
+  if (!layer?.source) return undefined;
+  return {
+    source: layer.source,
+    id,
+    ...(layer["source-layer"] !== undefined ? { sourceLayer: layer["source-layer"] } : {}),
+  };
+}
+
+export function selectionTargetForLayer(
+  style: HonuaStyleSpecification,
+  layerId: string,
+  id: FeatureId,
+): SourceQualifiedFeatureSelectionTarget | undefined {
+  const target = featureTargetForLayer(style, layerId, id);
+  if (!target) return undefined;
+  return sourceFeatureSelectionTarget(target.source, target.id, { sourceLayer: target.sourceLayer });
+}
+
+export function featureStateTargetFromSelection(
+  target: SourceQualifiedFeatureSelectionTarget,
+): RuntimeFeatureStateTarget {
+  return {
+    source: target.sourceId,
+    id: target.id,
+    ...(target.sourceLayer !== undefined ? { sourceLayer: target.sourceLayer } : {}),
+  };
+}
+
+export function featureStateTargetKey(target: RuntimeFeatureStateTarget): string {
+  return `${target.source}\u0000${target.sourceLayer ?? ""}\u0000${typeof target.id}:${String(target.id)}`;
+}
+
+export function protocolForSource(
+  style: HonuaStyleSpecification,
+  mapPackage: HonuaMapPackage | undefined,
+  sourceId: string | undefined,
+): string | undefined {
+  if (!sourceId) return undefined;
+  const bindingProtocol = mapPackage?.sourceBindings.find((binding) => binding.sourceId === sourceId)?.protocol;
+  if (bindingProtocol) return bindingProtocol;
+  const source = style.sources[sourceId];
+  return typeof source?.type === "string" ? source.type : undefined;
+}
+
+export function resolveFeatureIdFromEventFeature(
+  feature: unknown,
+  event: unknown,
+  options: RuntimeClickInteractionOptions = {},
+): FeatureId | undefined {
+  const explicit = options.resolveFeatureId?.(feature, event);
+  if (explicit !== undefined) return explicit;
+
+  if (isPlainObject(feature)) {
+    const directId = feature.id;
+    if (typeof directId === "string" || typeof directId === "number") return directId;
+
+    if (options.featureIdProperty && isPlainObject(feature.properties)) {
+      const propertyId = feature.properties[options.featureIdProperty];
+      if (typeof propertyId === "string" || typeof propertyId === "number") return propertyId;
+    }
+  }
+
+  return undefined;
+}
+
+function validateExpressionArray(
+  expr: readonly unknown[],
+  options: RuntimeExpressionValidationOptions,
+): HonuaRuntimeDiagnostic[] {
+  const diagnostics: HonuaRuntimeDiagnostic[] = [];
+  if (expr.length === 0) {
+    return [diagnostic("expression-empty", "Expression array must not be empty.", options)];
+  }
+
+  const operator = expr[0];
+  if (typeof operator !== "string") {
+    return [diagnostic("expression-operator-invalid", "Expression arrays must start with an operator string.", options)];
+  }
+
+  const rule = EXPRESSION_OPERATORS[operator];
+  if (!rule) {
+    diagnostics.push(
+      diagnostic(
+        "expression-operator-unknown",
+        `Expression operator "${operator}" is not recognized by Honua's built-in validator.`,
+        {
+          ...options,
+          strictUnknownOperators: options.strictUnknownOperators,
+          context: { operator },
+        },
+        options.strictUnknownOperators ? "error" : "warning",
+      ),
+    );
+  } else {
+    const argCount = expr.length - 1;
+    if (rule.minArgs !== undefined && argCount < rule.minArgs) {
+      diagnostics.push(
+        diagnostic(
+          "expression-arity-too-small",
+          `Expression operator "${operator}" expects at least ${rule.minArgs} argument(s), received ${argCount}.`,
+          { ...options, context: { operator, expected: rule.minArgs, received: argCount } },
+        ),
+      );
+    }
+    if (rule.maxArgs !== undefined && argCount > rule.maxArgs) {
+      diagnostics.push(
+        diagnostic(
+          "expression-arity-too-large",
+          `Expression operator "${operator}" expects at most ${rule.maxArgs} argument(s), received ${argCount}.`,
+          { ...options, context: { operator, expected: rule.maxArgs, received: argCount } },
+        ),
+      );
+    }
+    diagnostics.push(...(rule.custom?.(expr, options) ?? []));
+  }
+
+  if (operator === "literal") {
+    return diagnostics;
+  }
+
+  for (let i = 1; i < expr.length; i++) {
+    const entry = expr[i];
+    if (Array.isArray(entry) && looksLikeExpressionArray(entry)) {
+      diagnostics.push(
+        ...validateExpressionArray(entry, {
+          ...options,
+          path: pathWithIndex(options.path, i),
+        }),
+      );
+    }
+  }
+
+  return diagnostics;
+}
+
+function validateCaseExpression(
+  expr: readonly unknown[],
+  options: RuntimeExpressionValidationOptions,
+): HonuaRuntimeDiagnostic[] {
+  const argCount = expr.length - 1;
+  if (argCount < 3 || argCount % 2 === 0) {
+    return [
+      diagnostic(
+        "expression-case-invalid",
+        'The "case" expression requires condition/output pairs followed by a fallback value.',
+        { ...options, context: { operator: "case", received: argCount } },
+      ),
+    ];
+  }
+  return [];
+}
+
+function validateMatchExpression(
+  expr: readonly unknown[],
+  options: RuntimeExpressionValidationOptions,
+): HonuaRuntimeDiagnostic[] {
+  const argCount = expr.length - 1;
+  if (argCount < 4 || argCount % 2 !== 0) {
+    return [
+      diagnostic(
+        "expression-match-invalid",
+        'The "match" expression requires an input, label/output pairs, and a fallback value.',
+        { ...options, context: { operator: "match", received: argCount } },
+      ),
+    ];
+  }
+  return [];
+}
+
+function validateStepExpression(
+  expr: readonly unknown[],
+  options: RuntimeExpressionValidationOptions,
+): HonuaRuntimeDiagnostic[] {
+  const argCount = expr.length - 1;
+  if (argCount < 4 || argCount % 2 !== 0) {
+    return [
+      diagnostic(
+        "expression-step-invalid",
+        'The "step" expression requires an input, base output, and stop/output pairs.',
+        { ...options, context: { operator: "step", received: argCount } },
+      ),
+    ];
+  }
+  return [];
+}
+
+function validateInterpolateExpression(
+  expr: readonly unknown[],
+  options: RuntimeExpressionValidationOptions,
+): HonuaRuntimeDiagnostic[] {
+  if (expr.length < 7 || (expr.length - 3) % 2 !== 0) {
+    return [
+      diagnostic(
+        "expression-interpolate-invalid",
+        'The "interpolate" expression requires an interpolation mode, input, and stop/output pairs.',
+        { ...options, context: { operator: String(expr[0]), received: expr.length - 1 } },
+      ),
+    ];
+  }
+  return [];
+}
+
+function sourceDiagnosticContext(
+  sourceId: string,
+  source: RuntimeSourceSpecification | undefined,
+  context: RuntimeStyleValidationContext,
+): Pick<HonuaRuntimeDiagnostic, "sourceId" | "protocol" | "context"> {
+  const protocol = source?.type ?? protocolForSource(context.style ?? emptyStyle(), context.mapPackage, sourceId);
+  return {
+    sourceId,
+    ...(protocol ? { protocol } : {}),
+    ...(context.operation ? { context: { operation: context.operation } } : {}),
+  };
+}
+
+function layerDiagnosticContext(
+  layerId: string | undefined,
+  sourceId: string | undefined,
+  context: RuntimeStyleValidationContext,
+): Pick<HonuaRuntimeDiagnostic, "sourceId" | "layerId" | "protocol" | "context"> {
+  return {
+    ...(sourceId ? { sourceId } : {}),
+    ...(layerId ? { layerId } : {}),
+    ...(protocolForSource(context.style ?? emptyStyle(), context.mapPackage, sourceId) !== undefined
+      ? { protocol: protocolForSource(context.style ?? emptyStyle(), context.mapPackage, sourceId) }
+      : {}),
+    ...(context.operation ? { context: { operation: context.operation } } : {}),
+  };
+}
+
+function diagnostic(
+  code: string,
+  message: string,
+  options: RuntimeExpressionValidationOptions,
+  severity: HonuaRuntimeDiagnosticSeverity = "error",
+): HonuaRuntimeDiagnostic {
+  return {
+    code,
+    severity,
+    message,
+    ...(options.path ? { path: options.path } : {}),
+    ...(options.sourceId ? { sourceId: options.sourceId } : {}),
+    ...(options.layerId ? { layerId: options.layerId } : {}),
+    ...(options.protocol ? { protocol: options.protocol } : {}),
+    ...(options.context ? { context: options.context } : {}),
+  };
+}
+
+function looksLikeExpressionArray(value: readonly unknown[]): boolean {
+  return value.length > 0 && typeof value[0] === "string";
+}
+
+function pathWithIndex(path: string | undefined, index: number): string {
+  return path ? `${path}[${index}]` : `[${index}]`;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function emptyStyle(): HonuaStyleSpecification {
+  return { version: 8, sources: {}, layers: [] };
+}

--- a/test/entrypoints.test.ts
+++ b/test/entrypoints.test.ts
@@ -181,6 +181,11 @@ import {
   emptyRealtimeFeatureState,
   reduceRealtimeFeatureState,
 } from "../src/realtime/index.js";
+import {
+  HonuaRuntimeDiagnosticError,
+  validateRuntimeFilterExpression,
+  validateRuntimeStyleExpression,
+} from "../src/runtime/index.js";
 import { createSceneWorkspace, sceneWorkspaceIntentFromAdapterEvent } from "../src/scene-workspace/index.js";
 
 describe("entrypoint modules", () => {
@@ -365,6 +370,12 @@ describe("entrypoint modules", () => {
     expect(emptyRealtimeFeatureState).toBeTypeOf("function");
     expect(reduceRealtimeFeatureState).toBeTypeOf("function");
     expect(createRealtimeFeatureStore).toBeTypeOf("function");
+  });
+
+  it("exposes the runtime style and interaction helper entrypoint", () => {
+    expect(HonuaRuntimeDiagnosticError).toBeTypeOf("function");
+    expect(validateRuntimeFilterExpression).toBeTypeOf("function");
+    expect(validateRuntimeStyleExpression).toBeTypeOf("function");
   });
 
   it("exposes the app workspace entrypoint", () => {

--- a/test/runtime-style-interactions.test.ts
+++ b/test/runtime-style-interactions.test.ts
@@ -4,8 +4,8 @@ import { HonuaClient } from "../src/core/client.js";
 import { createExplorationContext, sourceFeatureSelectionTarget } from "../src/exploration/index.js";
 import {
   HONUA_MAP_PACKAGE_FORMAT_V1,
-  HonuaRuntimeDiagnosticError,
   type HonuaMapPackage,
+  HonuaRuntimeDiagnosticError,
   type MaplibreMap,
   loadMapPackage,
   validateRuntimeFilterExpression,

--- a/test/runtime-style-interactions.test.ts
+++ b/test/runtime-style-interactions.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, test } from "vitest";
+
+import { HonuaClient } from "../src/core/client.js";
+import { createExplorationContext, sourceFeatureSelectionTarget } from "../src/exploration/index.js";
+import {
+  HONUA_MAP_PACKAGE_FORMAT_V1,
+  HonuaRuntimeDiagnosticError,
+  type HonuaMapPackage,
+  type MaplibreMap,
+  loadMapPackage,
+  validateRuntimeFilterExpression,
+} from "../src/runtime/index.js";
+
+interface MockCall {
+  method: string;
+  args: unknown[];
+}
+
+interface MockMap extends MaplibreMap {
+  _calls: MockCall[];
+  _style: unknown;
+  _listeners: Array<{ event: string; layer?: string; handler: (...args: unknown[]) => void }>;
+  _featureState: Map<string, Record<string, unknown>>;
+  _fire(event: string, layer: string, payload: unknown): void;
+}
+
+function makeMockMap(): MockMap {
+  const calls: MockCall[] = [];
+  const listeners: MockMap["_listeners"] = [];
+  const featureState = new Map<string, Record<string, unknown>>();
+  let style: unknown = {};
+
+  function record(method: string, args: unknown[]): void {
+    calls.push({ method, args });
+  }
+
+  function stateKey(target: { source: string; id: string | number; sourceLayer?: string }): string {
+    return `${target.source}:${target.sourceLayer ?? ""}:${String(target.id)}`;
+  }
+
+  const map: MockMap = {
+    _calls: calls,
+    _style: style,
+    _listeners: listeners,
+    _featureState: featureState,
+    setStyle(next, options) {
+      record("setStyle", [next, options]);
+      style = next;
+      map._style = next;
+    },
+    getStyle() {
+      return map._style;
+    },
+    addSource(id, source) {
+      record("addSource", [id, source]);
+    },
+    removeSource(id) {
+      record("removeSource", [id]);
+    },
+    addLayer(layer, beforeId) {
+      record("addLayer", [layer, beforeId]);
+    },
+    removeLayer(id) {
+      record("removeLayer", [id]);
+    },
+    moveLayer(id, beforeId) {
+      record("moveLayer", [id, beforeId]);
+    },
+    getLayer(id) {
+      record("getLayer", [id]);
+      return undefined;
+    },
+    setLayoutProperty(layerId, name, value) {
+      record("setLayoutProperty", [layerId, name, value]);
+    },
+    setPaintProperty(layerId, name, value) {
+      record("setPaintProperty", [layerId, name, value]);
+    },
+    setFilter(layerId, filter) {
+      record("setFilter", [layerId, filter]);
+    },
+    getSource(id) {
+      record("getSource", [id]);
+      return undefined;
+    },
+    fitBounds(bounds, options) {
+      record("fitBounds", [bounds, options]);
+    },
+    jumpTo(options) {
+      record("jumpTo", [options]);
+    },
+    easeTo(options) {
+      record("easeTo", [options]);
+    },
+    flyTo(options) {
+      record("flyTo", [options]);
+    },
+    setFeatureState(target, patch) {
+      const key = stateKey(target);
+      featureState.set(key, { ...(featureState.get(key) ?? {}), ...patch });
+    },
+    getFeatureState(target) {
+      return featureState.get(stateKey(target)) ?? {};
+    },
+    removeFeatureState(target, key) {
+      const stateTargetKey = stateKey(target);
+      if (!key) {
+        featureState.delete(stateTargetKey);
+        return;
+      }
+      const existing = featureState.get(stateTargetKey);
+      if (existing) delete existing[key];
+    },
+    on(event, layerOrHandler, handler) {
+      if (typeof layerOrHandler === "string" && handler) {
+        listeners.push({ event, layer: layerOrHandler, handler });
+      } else if (typeof layerOrHandler === "function") {
+        listeners.push({ event, handler: layerOrHandler });
+      }
+    },
+    off(event, layerOrHandler, handler) {
+      const target = typeof layerOrHandler === "function" ? layerOrHandler : handler;
+      const index = listeners.findIndex((entry) => entry.event === event && entry.handler === target);
+      if (index >= 0) listeners.splice(index, 1);
+    },
+    _fire(event, layer, payload) {
+      for (const listener of listeners.filter((entry) => entry.event === event && entry.layer === layer)) {
+        listener.handler(payload);
+      }
+    },
+  };
+
+  return map;
+}
+
+function makeClient(): HonuaClient {
+  return new HonuaClient({
+    baseUrl: "https://mock.honua.test",
+    fetchFn: async () => new Response("not used", { status: 200 }),
+  });
+}
+
+function makePackage(): HonuaMapPackage {
+  return {
+    mapPackageId: "pkg-style-interactions",
+    format: HONUA_MAP_PACKAGE_FORMAT_V1,
+    sourceBindings: [
+      {
+        sourceId: "parcels",
+        protocol: "geoservices_feature_service",
+        locator: { url: "https://server.example.com/rest/services/Parcels/FeatureServer/0" },
+      },
+    ],
+    mapSpec: {
+      version: 8,
+      sources: {},
+      layers: [
+        {
+          id: "parcels-fill",
+          type: "fill",
+          source: "parcels",
+          paint: { "fill-color": "#cccccc" },
+          layout: { visibility: "visible" },
+        },
+      ],
+    },
+  };
+}
+
+async function loadRuntime(map = makeMockMap()) {
+  const runtime = await loadMapPackage(makePackage(), map, {
+    client: makeClient(),
+    skipCompatibilityCheck: true,
+    applyInitialView: false,
+  });
+  map._calls.length = 0;
+  return { runtime, map };
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("runtime source/layer helpers", () => {
+  test("adds, updates, orders, and removes sources and layers without a style reload for paint/filter patches", async () => {
+    const { runtime, map } = await loadRuntime();
+
+    runtime.addSource("assets", {
+      type: "geojson",
+      data: { type: "FeatureCollection", features: [] },
+    });
+    expect(runtime.composedStyle.sources.assets).toMatchObject({ type: "geojson" });
+    expect(runtime.honuaMap.hasSource("assets")).toBe(true);
+    expect(map._calls.find((call) => call.method === "addSource")?.args[0]).toBe("assets");
+
+    runtime.updateSource("assets", {
+      type: "geojson",
+      data: { type: "FeatureCollection", features: [{ type: "Feature", properties: {}, geometry: null }] },
+    });
+    expect(runtime.composedStyle.sources.assets).toMatchObject({ type: "geojson" });
+    expect(map._calls.some((call) => call.method === "setStyle")).toBe(true);
+
+    runtime.addLayer(
+      {
+        id: "assets-points",
+        type: "circle",
+        source: "assets",
+        paint: { "circle-color": "#f00", "circle-radius": 5 },
+      },
+      { beforeId: "parcels-fill" },
+    );
+    expect(runtime.composedStyle.layers.map((layer) => layer.id)).toEqual(["assets-points", "parcels-fill"]);
+    expect(map._calls.find((call) => call.method === "addLayer")?.args[1]).toBe("parcels-fill");
+
+    map._calls.length = 0;
+    runtime.updateLayer("assets-points", {
+      paint: { "circle-color": "#0f0", "circle-radius": 5 },
+      filter: ["==", ["get", "status"], "open"],
+    });
+
+    expect(map._calls).toContainEqual({
+      method: "setPaintProperty",
+      args: ["assets-points", "circle-color", "#0f0"],
+    });
+    expect(map._calls).toContainEqual({
+      method: "setFilter",
+      args: ["assets-points", ["==", ["get", "status"], "open"]],
+    });
+    expect(map._calls.some((call) => call.method === "setStyle")).toBe(false);
+    expect(runtime.honuaMap.getLayer("assets-points")?.filter).toEqual(["==", ["get", "status"], "open"]);
+
+    runtime.moveLayer("assets-points", { afterId: "parcels-fill" });
+    expect(runtime.composedStyle.layers.map((layer) => layer.id)).toEqual(["parcels-fill", "assets-points"]);
+
+    expect(runtime.removeLayer("assets-points")).toBe(true);
+    expect(runtime.removeSource("assets")).toEqual([]);
+    expect(runtime.honuaMap.hasSource("assets")).toBe(false);
+  });
+
+  test("fails early with typed diagnostics for invalid expressions", async () => {
+    const { runtime } = await loadRuntime();
+
+    expect(() =>
+      runtime.addLayer({
+        id: "bad-fill",
+        type: "fill",
+        source: "parcels",
+        paint: { "fill-color": ["case", ["==", ["get", "status"], "open"] as unknown] },
+      }),
+    ).toThrow(HonuaRuntimeDiagnosticError);
+
+    try {
+      runtime.addLayer({
+        id: "bad-fill",
+        type: "fill",
+        source: "parcels",
+        paint: { "fill-color": ["case", ["==", ["get", "status"], "open"] as unknown] },
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(HonuaRuntimeDiagnosticError);
+      const diagnostics = (error as HonuaRuntimeDiagnosticError).diagnostics;
+      expect(diagnostics[0]).toMatchObject({
+        code: "expression-case-invalid",
+        layerId: "bad-fill",
+        sourceId: "parcels",
+        protocol: "geoservices_feature_service",
+      });
+    }
+
+    expect(validateRuntimeFilterExpression("status = 'open'")).toContainEqual(
+      expect.objectContaining({ code: "filter-invalid", severity: "error" }),
+    );
+  });
+});
+
+describe("runtime interaction helpers", () => {
+  test("infers source context for hover, click, select, and feature-state helpers", async () => {
+    const { runtime, map } = await loadRuntime();
+
+    const hover = runtime.bindHover("parcels-fill");
+    map._fire("mousemove", "parcels-fill", { features: [{ id: 3 }] });
+    expect(hover.hoveredId).toBe(3);
+    expect(map._featureState.get("parcels::3")).toEqual({ hover: true });
+
+    const clicks: unknown[] = [];
+    runtime.bindClick("parcels-fill", (event) => clicks.push(event));
+    map._fire("click", "parcels-fill", { features: [{ id: 4, properties: { name: "Parcel 4" } }] });
+    expect(clicks[0]).toMatchObject({
+      layerId: "parcels-fill",
+      sourceId: "parcels",
+      featureId: 4,
+      selectionTarget: { sourceId: "parcels", id: 4 },
+    });
+
+    const selection = runtime.bindSelect("parcels-fill");
+    map._fire("click", "parcels-fill", { features: [{ id: 5 }] });
+    expect(selection.selectedTargets).toEqual([sourceFeatureSelectionTarget("parcels", 5)]);
+
+    const target = runtime.layerSelectionTarget("parcels-fill", 6);
+    runtime.setFeatureStateForTarget(target, { selected: true });
+    expect(runtime.getFeatureStateForTarget(target)).toEqual({ selected: true });
+    runtime.removeFeatureStateForTarget(target, "selected");
+    expect(runtime.getFeatureStateForTarget(target)).toEqual({});
+  });
+
+  test("bridges layer selection to ExplorationContext and syncs source-qualified feature-state back", async () => {
+    const { runtime, map } = await loadRuntime();
+    const context = createExplorationContext({ datasetId: "d", sourceIds: ["parcels"] });
+    const mapView = context.connectView({ id: "map", role: "map" });
+    const tableView = context.connectView({ id: "table", role: "grid" });
+
+    runtime.bindSelectionToExploration("parcels-fill", mapView);
+    map._fire("click", "parcels-fill", { features: [{ id: 101 }] });
+    await flush();
+    expect(context.state.selection).toEqual([sourceFeatureSelectionTarget("parcels", 101)]);
+
+    runtime.syncSelectionFromExploration("parcels-fill", mapView);
+    tableView.select([sourceFeatureSelectionTarget("parcels", 202)], { replace: true });
+    await flush();
+    expect(map._featureState.get("parcels::202")).toEqual({ selected: true });
+
+    context.dispose();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Mapbox-style runtime helpers for add/update/remove source and layer workflows, layer ordering, style/filter expression diagnostics, and feature-state target conversion.
- Adds runtime interaction helpers for hover, click, select, ExplorationContext selection bridging, and feature-state synchronization using source-qualified targets.
- Documents the helper mapping in the MapLibre runtime guide and covers the runtime entrypoint exports.

Closes #150

## Validation

- `npm run typecheck`
- `npm test -- test/runtime-style-interactions.test.ts test/runtime/runtime.test.ts test/honua-map.test.ts test/entrypoints.test.ts`
- `npm run build`

## Follow-up Risks

- The expression validator is intentionally lightweight and structural; it catches common malformed expression/operator/arity cases, but it is not a full replacement for MapLibre's complete style-spec validator.
- Runtime source updates reapply the composed style because MapLibre source mutation support varies by source type; layer paint/layout/filter updates use granular setters when available.