### PR TITLE
[codex] Add Honua web components subpath

### DIFF
--- a/docs/web-components.md
+++ b/docs/web-components.md
@@ -1,0 +1,63 @@
+# Honua Web Components
+
+`@honua/sdk-js/web-components` registers framework-neutral custom elements for
+plain TypeScript applications:
+
+- `honua-map`
+- `honua-layer-list`
+- `honua-legend`
+- `honua-feature-table`
+- `honua-search`
+- `honua-editor`
+- `honua-chart`
+
+Import the subpath once in a browser module. The module auto-registers the
+elements when `customElements` is available and also exports
+`defineHonuaWebComponents()` for scoped registries.
+
+```ts
+import {
+  createHonuaWebComponentController,
+  defineHonuaWebComponents,
+} from "@honua/sdk-js/web-components";
+
+defineHonuaWebComponents();
+
+const controller = createHonuaWebComponentController({
+  mapPackage,
+  featuresBySource: {
+    incidents: incidentFeatures,
+  },
+});
+
+document.querySelector("honua-map")!.controller = controller;
+```
+
+Sibling controls bind to the same controller with `for="<map-id>"`.
+
+```html
+<honua-map id="map"></honua-map>
+<honua-layer-list for="map"></honua-layer-list>
+<honua-legend for="map"></honua-legend>
+<honua-feature-table for="map" source="incidents"></honua-feature-table>
+<honua-search for="map" source="incidents"></honua-search>
+```
+
+The controller contract is intentionally small so this package can integrate
+with the runtime today and a richer `HonuaController` later. Use
+`createHonuaWebComponentControllerFromRuntime(runtime)` when a
+`HonuaMapRuntime` already owns the MapPackage and layer operations.
+
+Components dispatch typed custom events:
+
+- `honua-controller-ready`
+- `honua-layer-visibility-change`
+- `honua-selection-change`
+- `honua-viewport-change`
+- `honua-filter-change`
+- `honua-search`
+- `honua-edit-change`
+
+Styling is scoped to each component's shadow root and can be themed with CSS
+custom properties such as `--honua-ui-bg`, `--honua-ui-fg`,
+`--honua-ui-border`, and `--honua-ui-accent`.

--- a/examples/web-components-basic/README.md
+++ b/examples/web-components-basic/README.md
@@ -1,0 +1,11 @@
+# Honua Web Components Basic
+
+Plain TypeScript sample for `@honua/sdk-js/web-components`.
+
+The sample registers Honua custom elements, shares one controller across map,
+layer list, legend, table, search, editor, and chart widgets, and demonstrates
+read-only editor capability state without React or another framework.
+
+```bash
+npm run demo:web-components
+```

--- a/examples/web-components-basic/index.html
+++ b/examples/web-components-basic/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Honua Web Components</title>
+    <script type="module" src="/src/main.ts"></script>
+  </head>
+  <body>
+    <main class="app-shell">
+      <section class="workspace">
+        <honua-map id="ops-map" label="Response map"></honua-map>
+        <div class="side-panel">
+          <honua-search for="ops-map" source="incidents" placeholder="Find incidents"></honua-search>
+          <honua-layer-list for="ops-map"></honua-layer-list>
+          <honua-legend for="ops-map"></honua-legend>
+        </div>
+      </section>
+      <section class="bottom-panel">
+        <honua-feature-table
+          for="ops-map"
+          source="incidents"
+          fields="name,status,priority"
+          page-size="6"
+          label="Incident features"
+        ></honua-feature-table>
+        <honua-editor for="ops-map" source="incidents" label="Incident editor"></honua-editor>
+        <honua-chart for="ops-map" label="Priority summary"></honua-chart>
+      </section>
+      <output id="event-log" aria-live="polite"></output>
+    </main>
+  </body>
+</html>

--- a/examples/web-components-basic/mock-server.mjs
+++ b/examples/web-components-basic/mock-server.mjs
@@ -1,0 +1,76 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const exampleRoot = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(exampleRoot, "../..");
+const distRoot = path.resolve(exampleRoot, "dist");
+
+const MIME_TYPES = {
+  ".css": "text/css; charset=utf-8",
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".map": "application/json; charset=utf-8",
+};
+
+function buildDemoIfNeeded() {
+  const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+  const result = spawnSync(npmCommand, ["run", "demo:web-components:build", "--silent"], {
+    cwd: projectRoot,
+    stdio: "inherit",
+    env: process.env,
+  });
+  if (result.status !== 0) throw new Error("Failed to build the web components sample.");
+}
+
+function serve(res, filePath) {
+  res.writeHead(200, {
+    "content-type": MIME_TYPES[path.extname(filePath)] ?? "application/octet-stream",
+    "cache-control": "no-store",
+  });
+  res.end(fs.readFileSync(filePath));
+}
+
+export async function startWebComponentsFixtureServer({ build = true } = {}) {
+  if (build) buildDemoIfNeeded();
+
+  const server = http.createServer((req, res) => {
+    const requestUrl = new URL(req.url ?? "/", "http://127.0.0.1");
+    const requestedPath = requestUrl.pathname === "/" ? "/index.html" : requestUrl.pathname;
+    const staticPath = path.join(distRoot, requestedPath);
+
+    if (staticPath.startsWith(distRoot) && fs.existsSync(staticPath) && fs.statSync(staticPath).isFile()) {
+      serve(res, staticPath);
+      return;
+    }
+
+    const indexPath = path.join(distRoot, "index.html");
+    if (!path.extname(requestUrl.pathname) && fs.existsSync(indexPath)) {
+      serve(res, indexPath);
+      return;
+    }
+
+    res.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+    res.end("Not found");
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to bind web components fixture server.");
+  }
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    async close() {
+      await new Promise((resolve) => server.close(resolve));
+    },
+  };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const server = await startWebComponentsFixtureServer();
+  process.stdout.write(`webComponentsUrl=${server.url}\n`);
+}

--- a/examples/web-components-basic/src/main.ts
+++ b/examples/web-components-basic/src/main.ts
@@ -1,0 +1,164 @@
+import {
+  type HonuaChartModel,
+  type HonuaFeatureRecord,
+  createHonuaWebComponentController,
+} from "@honua/sdk-js/web-components";
+
+import "./styles.css";
+
+declare global {
+  interface Window {
+    __HONUA_WEB_COMPONENTS_DEMO__?: {
+      ready: boolean;
+      events: string[];
+      selectedFeatureId?: string | number;
+      layerVisible(layerId: string): boolean;
+    };
+  }
+}
+
+const INCIDENT_SOURCE_ID = "incidents";
+
+const features: HonuaFeatureRecord[] = [
+  {
+    id: 101,
+    sourceId: INCIDENT_SOURCE_ID,
+    title: "Harbor response district",
+    attributes: { name: "Harbor response district", status: "Open", priority: "High" },
+    geometry: { x: -157.87, y: 21.31 },
+  },
+  {
+    id: 102,
+    sourceId: INCIDENT_SOURCE_ID,
+    title: "Kakaako utility corridor",
+    attributes: { name: "Kakaako utility corridor", status: "Monitoring", priority: "Medium" },
+    geometry: { x: -157.86, y: 21.29 },
+  },
+  {
+    id: 103,
+    sourceId: INCIDENT_SOURCE_ID,
+    title: "Ala Moana shelter route",
+    attributes: { name: "Ala Moana shelter route", status: "Closed", priority: "Low" },
+    geometry: { x: -157.84, y: 21.3 },
+  },
+];
+
+const chart: HonuaChartModel = {
+  id: "priority-summary",
+  title: "Priority summary",
+  kind: "bar",
+  status: "ready",
+  sourceId: INCIDENT_SOURCE_ID,
+  data: [
+    { label: "High", value: 1, color: "#dc2626" },
+    { label: "Medium", value: 1, color: "#d97706" },
+    { label: "Low", value: 1, color: "#16a34a" },
+  ],
+};
+
+const controller = createHonuaWebComponentController({
+  mapPackage: {
+    mapPackageId: "web-components-demo",
+    format: "honua_map_package.v1",
+    status: "Ready",
+    sourceBindings: [],
+    initialView: { center: [-157.86, 21.3], zoom: 11 },
+    legend: [
+      { label: "High priority", color: "#dc2626" },
+      { label: "Medium priority", color: "#d97706" },
+      { label: "Low priority", color: "#16a34a" },
+    ],
+    mapSpec: {
+      version: 8,
+      sources: {
+        [INCIDENT_SOURCE_ID]: {
+          type: "geojson",
+          data: { type: "FeatureCollection", features: [] },
+        },
+      },
+      layers: [
+        {
+          id: "incident-points",
+          source: INCIDENT_SOURCE_ID,
+          type: "circle",
+          metadata: { title: "Public safety incidents" },
+          paint: { "circle-color": "#dc2626" },
+        },
+        {
+          id: "incident-labels",
+          source: INCIDENT_SOURCE_ID,
+          type: "symbol",
+          metadata: { title: "Incident labels" },
+          paint: { "text-color": "#172033" },
+        },
+      ],
+    },
+  },
+  featuresBySource: {
+    [INCIDENT_SOURCE_ID]: features,
+  },
+  fieldsBySource: {
+    [INCIDENT_SOURCE_ID]: ["name", "status", "priority"],
+  },
+  editor: {
+    sourceId: INCIDENT_SOURCE_ID,
+    status: "idle",
+    capabilities: {
+      canCreate: false,
+      canUpdate: false,
+      canDelete: false,
+      readOnly: true,
+      reason: "Source metadata marks incidents read-only.",
+    },
+  },
+  chart,
+  searchFields: ["name", "status", "priority"],
+});
+
+const eventLog: string[] = [];
+const runtime = {
+  ready: false,
+  events: eventLog,
+  selectedFeatureId: undefined as string | number | undefined,
+  layerVisible(layerId: string): boolean {
+    return controller.getState().layers.find((layer) => layer.id === layerId)?.visible ?? false;
+  },
+};
+
+window.__HONUA_WEB_COMPONENTS_DEMO__ = runtime;
+
+const map = document.querySelector("honua-map");
+if (!map) throw new Error("Missing honua-map");
+map.controller = controller;
+
+document.addEventListener("honua-layer-visibility-change", (event) => {
+  const detail = (event as CustomEvent<{ layerId: string; visible: boolean }>).detail;
+  eventLog.push(`layer:${detail.layerId}:${String(detail.visible)}`);
+  writeEventLog();
+});
+
+document.addEventListener("honua-selection-change", (event) => {
+  const detail = (event as CustomEvent<{ featureId?: string | number }>).detail;
+  runtime.selectedFeatureId = detail.featureId;
+  eventLog.push(`select:${String(detail.featureId)}`);
+  writeEventLog();
+});
+
+document.addEventListener("honua-search", (event) => {
+  const detail = (event as CustomEvent<{ query: string; results: readonly unknown[] }>).detail;
+  eventLog.push(`search:${detail.query}:${detail.results.length}`);
+  writeEventLog();
+});
+
+document.addEventListener("honua-filter-change", (event) => {
+  const detail = (event as CustomEvent<{ sourceId?: string; text?: string }>).detail;
+  eventLog.push(`filter:${detail.sourceId ?? ""}:${detail.text ?? ""}`);
+  writeEventLog();
+});
+
+function writeEventLog(): void {
+  const target = document.querySelector("#event-log");
+  if (target) target.textContent = eventLog.at(-1) ?? "";
+}
+
+runtime.ready = true;

--- a/examples/web-components-basic/src/styles.css
+++ b/examples/web-components-basic/src/styles.css
@@ -1,0 +1,46 @@
+body {
+  background: #eef2f7;
+  color: #172033;
+  margin: 0;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.app-shell {
+  display: grid;
+  gap: 16px;
+  min-height: 100vh;
+  padding: 16px;
+}
+
+.workspace {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(360px, 1fr) minmax(260px, 340px);
+}
+
+.side-panel,
+.bottom-panel {
+  display: grid;
+  gap: 12px;
+}
+
+.bottom-panel {
+  align-items: start;
+  grid-template-columns: minmax(420px, 1fr) minmax(220px, 280px) minmax(220px, 280px);
+}
+
+honua-map {
+  min-height: 420px;
+}
+
+#event-log {
+  color: #475467;
+  min-height: 20px;
+}
+
+@media (max-width: 820px) {
+  .workspace,
+  .bottom-panel {
+    grid-template-columns: 1fr;
+  }
+}

--- a/examples/web-components-basic/tsconfig.json
+++ b/examples/web-components-basic/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "types": ["vite/client"],
+    "paths": {
+      "@honua/sdk-js": ["../../src/index.ts"],
+      "@honua/sdk-js/runtime": ["../../src/runtime/index.ts"],
+      "@honua/sdk-js/web-components": ["../../src/web-components/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "vite.config.ts"]
+}

--- a/examples/web-components-basic/vite.config.ts
+++ b/examples/web-components-basic/vite.config.ts
@@ -1,0 +1,41 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vite";
+
+const exampleRoot = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(exampleRoot, "../..");
+
+export default defineConfig({
+  root: exampleRoot,
+  envDir: exampleRoot,
+  resolve: {
+    alias: [
+      {
+        find: "@honua/sdk-js/web-components",
+        replacement: path.resolve(repoRoot, "src/web-components/index.ts"),
+      },
+      {
+        find: "@honua/sdk-js/runtime",
+        replacement: path.resolve(repoRoot, "src/runtime/index.ts"),
+      },
+      {
+        find: "@honua/sdk-js",
+        replacement: path.resolve(repoRoot, "src/index.ts"),
+      },
+    ],
+  },
+  server: {
+    host: "127.0.0.1",
+    fs: {
+      allow: [repoRoot],
+    },
+  },
+  preview: {
+    host: "127.0.0.1",
+  },
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -79,6 +79,10 @@
       "types": "./dist/src/runtime/index.d.ts",
       "default": "./dist/src/runtime/index.js"
     },
+    "./web-components": {
+      "types": "./dist/src/web-components/index.d.ts",
+      "default": "./dist/src/web-components/index.js"
+    },
     "./generated-app": {
       "types": "./dist/src/generated-app/index.d.ts",
       "default": "./dist/src/generated-app/index.js"
@@ -186,8 +190,13 @@
     "demo:edit-workflow:preview": "vite preview --config examples/edit-workflow-demo/vite.config.ts --host 127.0.0.1",
     "demo:edit-workflow:mock": "node examples/edit-workflow-demo/mock-server.mjs",
     "demo:edit-workflow:typecheck": "tsc -p examples/edit-workflow-demo/tsconfig.json --noEmit",
-    "demo:examples:typecheck": "npm run demo:quickstart:typecheck && npm run demo:incident:typecheck && npm run demo:unified-ops:typecheck && npm run demo:25d:typecheck && npm run demo:service-explorer:typecheck && npm run demo:migration-workbench:typecheck && npm run demo:mcp-gis-assistant:typecheck && npm run demo:ai-spatial-builder:typecheck && npm run demo:spatial-analytics:typecheck && npm run demo:gp-runner:typecheck && npm run demo:stac-browser:typecheck && npm run demo:imagery-cog:typecheck && npm run demo:geocoding:typecheck && npm run demo:node-backend:typecheck && npm run demo:terrain-elevation:typecheck && npm run demo:edit-workflow:typecheck && node scripts/ensure-kepler-demo-deps.mjs && npm --prefix examples/kepler-analytics run typecheck",
-    "demo:examples:build": "node scripts/ensure-kepler-demo-deps.mjs && npm run demo:quickstart:build && npm run demo:incident:build && npm run demo:unified-ops:build && npm run demo:25d:build && npm run demo:service-explorer:build && npm run demo:migration-workbench:build && npm run demo:mcp-gis-assistant:build && npm run demo:ai-spatial-builder:build && npm run demo:spatial-analytics:build && npm run demo:gp-runner:build && npm run demo:stac-browser:build && npm run demo:imagery-cog:build && npm run demo:geocoding:build && npm run demo:node-backend:build && npm run demo:terrain-elevation:build && npm run demo:edit-workflow:build && npm run demo:kepler:build",
+    "demo:web-components": "vite --config examples/web-components-basic/vite.config.ts",
+    "demo:web-components:build": "vite build --config examples/web-components-basic/vite.config.ts",
+    "demo:web-components:preview": "vite preview --config examples/web-components-basic/vite.config.ts --host 127.0.0.1",
+    "demo:web-components:mock": "node examples/web-components-basic/mock-server.mjs",
+    "demo:web-components:typecheck": "tsc -p examples/web-components-basic/tsconfig.json --noEmit",
+    "demo:examples:typecheck": "npm run demo:quickstart:typecheck && npm run demo:incident:typecheck && npm run demo:unified-ops:typecheck && npm run demo:25d:typecheck && npm run demo:service-explorer:typecheck && npm run demo:migration-workbench:typecheck && npm run demo:mcp-gis-assistant:typecheck && npm run demo:ai-spatial-builder:typecheck && npm run demo:spatial-analytics:typecheck && npm run demo:gp-runner:typecheck && npm run demo:stac-browser:typecheck && npm run demo:imagery-cog:typecheck && npm run demo:geocoding:typecheck && npm run demo:node-backend:typecheck && npm run demo:terrain-elevation:typecheck && npm run demo:edit-workflow:typecheck && npm run demo:web-components:typecheck && node scripts/ensure-kepler-demo-deps.mjs && npm --prefix examples/kepler-analytics run typecheck",
+    "demo:examples:build": "node scripts/ensure-kepler-demo-deps.mjs && npm run demo:quickstart:build && npm run demo:incident:build && npm run demo:unified-ops:build && npm run demo:25d:build && npm run demo:service-explorer:build && npm run demo:migration-workbench:build && npm run demo:mcp-gis-assistant:build && npm run demo:ai-spatial-builder:build && npm run demo:spatial-analytics:build && npm run demo:gp-runner:build && npm run demo:stac-browser:build && npm run demo:imagery-cog:build && npm run demo:geocoding:build && npm run demo:node-backend:build && npm run demo:terrain-elevation:build && npm run demo:edit-workflow:build && npm run demo:web-components:build && npm run demo:kepler:build",
     "test": "vitest run",
     "test:cloud-demo:config": "vitest run test/cloud-demo-services.test.ts test/demo-capability-matrix.test.ts",
     "test:cloud-demo:staging": "vitest run --config vitest.cloud-demo.config.ts",
@@ -204,6 +213,7 @@
     "test:playwright:geocoding": "playwright test test/playwright/geocoding-quickstart.spec.mjs",
     "test:playwright:terrain-elevation": "playwright test test/playwright/terrain-rgb-elevation.spec.mjs",
     "test:playwright:edit-workflow": "playwright test test/playwright/edit-workflow-demo.spec.mjs",
+    "test:playwright:web-components": "playwright test test/playwright/web-components-basic.spec.mjs",
     "test:quickstart:staging": "vitest run --config vitest.staging.config.ts",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:migration:real-samples": "vitest run test/migration-real-sample-runtime.test.ts test/migration-feature-table-demo-runtime.test.ts",
@@ -269,7 +279,12 @@
       "optional": true
     }
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/web-components/index.ts",
+    "./src/web-components/elements.ts",
+    "./dist/src/web-components/index.js",
+    "./dist/src/web-components/elements.js"
+  ],
   "engines": {
     "node": ">=20.0.0"
   }

--- a/src/web-components/controller.ts
+++ b/src/web-components/controller.ts
@@ -1,0 +1,585 @@
+import type { FeatureId, Query } from "../contract/index.js";
+import type { HonuaTypedFeature } from "../core/types.js";
+import type { HonuaLayerSpecification } from "../style/index.js";
+import type {
+  CreateHonuaWebComponentControllerOptions,
+  HonuaChartModel,
+  HonuaComponentStatus,
+  HonuaControllerStateListener,
+  HonuaEditorModel,
+  HonuaFeatureRecord,
+  HonuaFeatureTableModel,
+  HonuaFilterState,
+  HonuaLayerModel,
+  HonuaLegendItem,
+  HonuaQueryFeaturesOptions,
+  HonuaSearchOptions,
+  HonuaSearchResult,
+  HonuaSelectionState,
+  HonuaViewportState,
+  HonuaWebComponentController,
+  HonuaWebComponentRuntimeLike,
+  HonuaWebComponentState,
+} from "./types.js";
+
+export class HonuaInMemoryWebComponentController<T = Record<string, unknown>>
+  implements HonuaWebComponentController<T>
+{
+  readonly #listeners = new Set<HonuaControllerStateListener<T>>();
+  readonly #fieldsBySource = new Map<string, readonly string[]>();
+  readonly #searchFields: readonly string[] | undefined;
+  readonly #runtime: HonuaWebComponentRuntimeLike<T> | undefined;
+  #runtimeHandle: { remove(): void } | undefined;
+  #state: HonuaWebComponentState<T>;
+
+  public constructor(
+    options: CreateHonuaWebComponentControllerOptions<T> & {
+      runtime?: HonuaWebComponentRuntimeLike<T>;
+    } = {},
+  ) {
+    this.#runtime = options.runtime;
+    this.#searchFields = options.searchFields;
+    for (const [sourceId, fields] of Object.entries(options.fieldsBySource ?? {})) {
+      this.#fieldsBySource.set(sourceId, [...fields]);
+    }
+
+    const layers = options.layers
+      ? options.layers.map(copyLayerModel)
+      : options.mapPackage
+        ? layersFromMapPackage(options.mapPackage.mapSpec.layers)
+        : [];
+    const legend = options.legend
+      ? options.legend.map(copyLegendItem)
+      : options.mapPackage
+        ? legendFromMapPackage(options.mapPackage.legend, layers, options.mapPackage.mapSpec.layers)
+        : [];
+    const featuresBySource = normalizeFeaturesBySource(options.featuresBySource ?? {});
+    this.#state = {
+      packageId: options.mapPackage?.mapPackageId,
+      status: options.status ?? "ready",
+      ...(options.mapPackage ? { mapPackage: options.mapPackage } : {}),
+      layers,
+      legend,
+      viewport: { ...(options.viewport ?? options.mapPackage?.initialView ?? {}) },
+      featuresBySource,
+      filters: {},
+      ...(options.editor || options.mapPackage
+        ? { editor: normalizeEditor(options.editor, firstSourceId(featuresBySource, layers)) }
+        : {}),
+      ...(options.chart ? { chart: copyChartModel(options.chart) } : {}),
+      refreshedAt: new Date().toISOString(),
+    };
+
+    this.#runtimeHandle = this.#runtime?.on?.((event) => {
+      if (event.type === "source-error" && event.sourceId) {
+        this.#state = { ...this.#state, status: "error" };
+        this.#notify();
+      }
+    });
+  }
+
+  public getState(): HonuaWebComponentState<T> {
+    return copyState(this.#state);
+  }
+
+  public subscribe(listener: HonuaControllerStateListener<T>): { remove(): void } {
+    this.#listeners.add(listener);
+    listener(this.getState());
+    return {
+      remove: () => {
+        this.#listeners.delete(listener);
+      },
+    };
+  }
+
+  public setLayerVisibility(layerId: string, visible: boolean): void {
+    this.#runtime?.setLayerVisibility(layerId, visible);
+    this.#state = {
+      ...this.#state,
+      layers: this.#state.layers.map((layer) => (layer.id === layerId ? { ...layer, visible } : layer)),
+    };
+    this.#notify();
+  }
+
+  public setViewport(viewport: HonuaViewportState): void {
+    this.#runtime?.setViewState(viewport);
+    this.#state = {
+      ...this.#state,
+      viewport: { ...this.#state.viewport, ...viewport },
+    };
+    this.#notify();
+  }
+
+  public setFilter(filter: HonuaFilterState): void {
+    const sourceId = filter.sourceId ?? firstSourceId(this.#state.featuresBySource, this.#state.layers);
+    if (!sourceId) return;
+    this.#state = {
+      ...this.#state,
+      filters: {
+        ...this.#state.filters,
+        [sourceId]: { ...filter, sourceId },
+      },
+    };
+    this.#notify();
+  }
+
+  public selectFeature(selection: HonuaSelectionState<T>): void {
+    const sourceId = selection.sourceId;
+    const featureId = selection.featureId;
+    const feature =
+      selection.feature ??
+      (sourceId !== undefined && featureId !== undefined
+        ? this.#state.featuresBySource[sourceId]?.find((row) => String(row.id) === String(featureId))
+        : undefined);
+    this.#state = {
+      ...this.#state,
+      selection: {
+        ...(sourceId !== undefined ? { sourceId } : {}),
+        ...(featureId !== undefined ? { featureId } : {}),
+        ...(feature ? { feature: copyFeature(feature) } : {}),
+      },
+      ...(this.#state.editor
+        ? {
+            editor: {
+              ...this.#state.editor,
+              ...(featureId !== undefined ? { selectedFeatureId: featureId } : {}),
+            },
+          }
+        : {}),
+    };
+    this.#notify();
+  }
+
+  public clearSelection(): void {
+    this.#state = {
+      ...this.#state,
+      selection: undefined,
+      ...(this.#state.editor
+        ? {
+            editor: {
+              ...this.#state.editor,
+              selectedFeatureId: undefined,
+            },
+          }
+        : {}),
+    };
+    this.#notify();
+  }
+
+  public async queryFeatures(
+    sourceId = firstSourceId(this.#state.featuresBySource, this.#state.layers),
+    options: HonuaQueryFeaturesOptions = {},
+  ): Promise<HonuaFeatureTableModel<T>> {
+    const resolvedSourceId = options.sourceId ?? sourceId;
+    if (!resolvedSourceId) {
+      return {
+        sourceId: undefined,
+        status: "ready",
+        fields: [],
+        rows: [],
+        totalCount: 0,
+      };
+    }
+
+    const inMemoryRows = this.#state.featuresBySource[resolvedSourceId] ?? [];
+    if (inMemoryRows.length > 0 || !this.#runtime?.dataset) {
+      return this.#queryInMemory(resolvedSourceId, options);
+    }
+
+    const source = this.#runtime.dataset.source(resolvedSourceId);
+    if (!source) return this.#queryInMemory(resolvedSourceId, options);
+
+    try {
+      const request = queryOptionsToRuntimeQuery(this.#state.filters[resolvedSourceId], options);
+      const result = await source.query(request);
+      const rows = result.features.map((feature, index) => normalizeFeature(resolvedSourceId, feature, index));
+      const fields = result.fields?.map((field) => field.name) ?? options.fields ?? inferFields(rows);
+      return {
+        sourceId: resolvedSourceId,
+        status: "ready",
+        fields,
+        rows,
+        totalCount: result.totalCount ?? rows.length,
+        exceededTransferLimit: result.exceededTransferLimit,
+      };
+    } catch (error) {
+      return {
+        sourceId: resolvedSourceId,
+        status: "error",
+        fields: options.fields ?? this.#fieldsBySource.get(resolvedSourceId) ?? [],
+        rows: [],
+        totalCount: 0,
+        error,
+      };
+    }
+  }
+
+  public async search(query: string, options: HonuaSearchOptions = {}): Promise<readonly HonuaSearchResult<T>[]> {
+    const trimmed = query.trim();
+    if (!trimmed) return [];
+    const needle = trimmed.toLowerCase();
+    const limit = Math.max(1, options.limit ?? 10);
+    const sourceIds = options.sourceId
+      ? [options.sourceId]
+      : Object.keys(this.#state.featuresBySource).filter((sourceId) => sourceId.trim().length > 0);
+    const fields = options.fields ?? this.#searchFields;
+    const results: HonuaSearchResult<T>[] = [];
+
+    for (const sourceId of sourceIds) {
+      const rows = this.#state.featuresBySource[sourceId] ?? [];
+      for (const row of rows) {
+        if (!featureMatches(row, needle, fields)) continue;
+        results.push({
+          id: `${sourceId}:${String(row.id)}`,
+          label: row.title ?? String(row.id),
+          sourceId,
+          featureId: row.id,
+          feature: copyFeature(row),
+          subtitle: sourceId,
+          score: featureScore(row, needle, fields),
+        });
+        if (results.length >= limit) return results;
+      }
+    }
+
+    return results;
+  }
+
+  public async applyEdit(): Promise<HonuaEditorModel> {
+    const editor = this.#state.editor ?? normalizeEditor(undefined, firstSourceId(this.#state.featuresBySource, []));
+    const next: HonuaEditorModel = editor.capabilities.readOnly
+      ? {
+          ...editor,
+          status: "unsupported",
+          message: editor.capabilities.reason ?? "Source is read-only.",
+        }
+      : {
+          ...editor,
+          status: "unsupported",
+          message: "Editing is reserved for the HonuaController integration path.",
+        };
+    this.#state = { ...this.#state, editor: next };
+    this.#notify();
+    return next;
+  }
+
+  public updateFeatures(sourceId: string, features: readonly HonuaFeatureRecord<T>[]): void {
+    this.#state = {
+      ...this.#state,
+      featuresBySource: {
+        ...this.#state.featuresBySource,
+        [sourceId]: features.map((feature, index) => normalizeFeature(sourceId, feature, index)),
+      },
+    };
+    this.#notify();
+  }
+
+  public destroy(): void {
+    this.#runtimeHandle?.remove();
+    this.#runtimeHandle = undefined;
+    this.#listeners.clear();
+  }
+
+  #queryInMemory(sourceId: string, options: HonuaQueryFeaturesOptions): HonuaFeatureTableModel<T> {
+    const filter = options.filter ?? this.#state.filters[sourceId];
+    const allRows = this.#state.featuresBySource[sourceId] ?? [];
+    const rows = filterRows(allRows, filter);
+    const offset = Math.max(0, options.pagination?.offset ?? 0);
+    const limit = options.pagination?.limit;
+    const pagedRows = limit !== undefined ? rows.slice(offset, offset + Math.max(0, limit)) : rows.slice(offset);
+    const fields = options.fields ?? this.#fieldsBySource.get(sourceId) ?? inferFields(rows);
+    return {
+      sourceId,
+      status: "ready",
+      fields,
+      rows: pagedRows.map(copyFeature),
+      totalCount: rows.length,
+    };
+  }
+
+  #notify(): void {
+    this.#state = {
+      ...this.#state,
+      refreshedAt: new Date().toISOString(),
+    };
+    const snapshot = this.getState();
+    for (const listener of this.#listeners) listener(snapshot);
+  }
+}
+
+export function createHonuaWebComponentController<T = Record<string, unknown>>(
+  options: CreateHonuaWebComponentControllerOptions<T> = {},
+): HonuaWebComponentController<T> {
+  return new HonuaInMemoryWebComponentController(options);
+}
+
+export function createHonuaWebComponentControllerFromRuntime<T = Record<string, unknown>>(
+  runtime: HonuaWebComponentRuntimeLike<T>,
+  options: Omit<CreateHonuaWebComponentControllerOptions<T>, "mapPackage" | "layers" | "legend" | "viewport"> = {},
+): HonuaWebComponentController<T> {
+  return new HonuaInMemoryWebComponentController({
+    ...options,
+    runtime,
+    mapPackage: runtime.mapPackage,
+    layers: layersFromMapPackage(runtime.composedStyle.layers),
+    legend: runtime.getLegend().map((entry, index) => ({
+      id: "id" in entry && typeof entry.id === "string" ? entry.id : legendId(entry.label, index),
+      label: entry.label,
+      ...(entry.color !== undefined ? { color: entry.color } : {}),
+      ...(entry.iconUrl !== undefined ? { iconUrl: entry.iconUrl } : {}),
+      ...(entry.minValue !== undefined ? { minValue: entry.minValue } : {}),
+      ...(entry.maxValue !== undefined ? { maxValue: entry.maxValue } : {}),
+    })),
+    viewport: runtime.mapPackage.initialView,
+  });
+}
+
+export function layersFromMapPackage(layers: readonly HonuaLayerSpecification[]): HonuaLayerModel[] {
+  return layers.map((layer) => ({
+    id: layer.id,
+    title: layerTitle(layer),
+    ...(layer.source ? { sourceId: layer.source } : {}),
+    type: layer.type,
+    visible: layer.layout?.visibility !== "none",
+    ...(layer.metadata ? { metadata: layer.metadata } : {}),
+  }));
+}
+
+export function legendFromMapPackage(
+  entries:
+    | readonly { label: string; color?: string; iconUrl?: string; minValue?: number; maxValue?: number }[]
+    | undefined,
+  layers: readonly HonuaLayerModel[],
+  styleLayers: readonly HonuaLayerSpecification[],
+): HonuaLegendItem[] {
+  if (entries && entries.length > 0) {
+    return entries.map((entry, index) => ({
+      id: legendId(entry.label, index),
+      label: entry.label,
+      ...(entry.color !== undefined ? { color: entry.color } : {}),
+      ...(entry.iconUrl !== undefined ? { iconUrl: entry.iconUrl } : {}),
+      ...(entry.minValue !== undefined ? { minValue: entry.minValue } : {}),
+      ...(entry.maxValue !== undefined ? { maxValue: entry.maxValue } : {}),
+    }));
+  }
+
+  return styleLayers.map((layer, index) => ({
+    id: legendId(layer.id, index),
+    label: layers.find((candidate) => candidate.id === layer.id)?.title ?? layer.id,
+    layerId: layer.id,
+    ...(layerColor(layer) ? { color: layerColor(layer) } : {}),
+  }));
+}
+
+function queryOptionsToRuntimeQuery<T>(
+  filter: HonuaFilterState | undefined,
+  options: HonuaQueryFeaturesOptions,
+): Query<T> {
+  const query: Query<T> = {
+    ...(filter?.expression ? { where: filter.expression } : {}),
+    ...(options.fields ? { outFields: options.fields } : {}),
+    ...(options.pagination ? { pagination: options.pagination } : {}),
+    ...(options.signal ? { signal: options.signal } : {}),
+  };
+  return query;
+}
+
+function normalizeFeaturesBySource<T>(
+  featuresBySource: Readonly<Record<string, readonly HonuaFeatureRecord<T>[]>>,
+): Record<string, HonuaFeatureRecord<T>[]> {
+  const out: Record<string, HonuaFeatureRecord<T>[]> = {};
+  for (const [sourceId, rows] of Object.entries(featuresBySource)) {
+    out[sourceId] = rows.map((row, index) => normalizeFeature(sourceId, row, index));
+  }
+  return out;
+}
+
+function normalizeFeature<T>(
+  sourceId: string,
+  feature: HonuaFeatureRecord<T> | HonuaTypedFeature<T>,
+  index: number,
+): HonuaFeatureRecord<T> {
+  const attributes = "attributes" in feature ? feature.attributes : ({} as T);
+  const existingId = "id" in feature ? feature.id : undefined;
+  const id = existingId ?? featureIdFromAttributes(attributes, sourceId, index);
+  return {
+    id,
+    sourceId,
+    attributes,
+    ...("geometry" in feature && feature.geometry !== undefined ? { geometry: feature.geometry } : {}),
+    title: "title" in feature && feature.title ? feature.title : featureTitle(attributes, id),
+  };
+}
+
+function featureIdFromAttributes<T>(attributes: T, sourceId: string, index: number): FeatureId {
+  const values = attributes && typeof attributes === "object" ? (attributes as Record<string, unknown>) : {};
+  for (const key of ["OBJECTID", "objectid", "objectId", "id", "globalid", "GlobalID", "GLOBALID"]) {
+    const value = values[key];
+    if (typeof value === "string" || typeof value === "number") return value;
+  }
+  return `${sourceId}:${index}`;
+}
+
+function featureTitle<T>(attributes: T, id: FeatureId): string {
+  const values = attributes && typeof attributes === "object" ? (attributes as Record<string, unknown>) : {};
+  for (const key of ["name", "Name", "NAME", "title", "Title", "TITLE", "label", "Label", "LABEL"]) {
+    const value = values[key];
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  const firstString = Object.values(values).find((value) => typeof value === "string" && value.trim());
+  return typeof firstString === "string" ? firstString : String(id);
+}
+
+function normalizeEditor(
+  editor: Partial<HonuaEditorModel> | undefined,
+  sourceId: string | undefined,
+): HonuaEditorModel {
+  return {
+    sourceId: editor?.sourceId ?? sourceId,
+    status: editor?.status ?? "idle",
+    capabilities: {
+      canCreate: editor?.capabilities?.canCreate ?? false,
+      canUpdate: editor?.capabilities?.canUpdate ?? false,
+      canDelete: editor?.capabilities?.canDelete ?? false,
+      readOnly: editor?.capabilities?.readOnly ?? true,
+      reason: editor?.capabilities?.reason ?? "Editing is not enabled for this source.",
+    },
+    ...(editor?.selectedFeatureId !== undefined ? { selectedFeatureId: editor.selectedFeatureId } : {}),
+    ...(editor?.fields ? { fields: [...editor.fields] } : {}),
+    ...(editor?.message ? { message: editor.message } : {}),
+  };
+}
+
+function copyState<T>(state: HonuaWebComponentState<T>): HonuaWebComponentState<T> {
+  const featuresBySource: Record<string, HonuaFeatureRecord<T>[]> = {};
+  for (const [sourceId, rows] of Object.entries(state.featuresBySource)) {
+    featuresBySource[sourceId] = rows.map(copyFeature);
+  }
+  return {
+    ...state,
+    layers: state.layers.map(copyLayerModel),
+    legend: state.legend.map(copyLegendItem),
+    viewport: { ...state.viewport },
+    featuresBySource,
+    filters: Object.fromEntries(Object.entries(state.filters).map(([sourceId, filter]) => [sourceId, { ...filter }])),
+    ...(state.selection ? { selection: copySelection(state.selection) } : { selection: undefined }),
+    ...(state.editor ? { editor: copyEditorModel(state.editor) } : {}),
+    ...(state.chart ? { chart: copyChartModel(state.chart) } : {}),
+  };
+}
+
+function copySelection<T>(selection: HonuaSelectionState<T>): HonuaSelectionState<T> {
+  return {
+    ...(selection.sourceId !== undefined ? { sourceId: selection.sourceId } : {}),
+    ...(selection.featureId !== undefined ? { featureId: selection.featureId } : {}),
+    ...(selection.feature ? { feature: copyFeature(selection.feature) } : {}),
+  };
+}
+
+function copyLayerModel(layer: HonuaLayerModel): HonuaLayerModel {
+  return {
+    ...layer,
+    ...(layer.metadata ? { metadata: { ...layer.metadata } } : {}),
+  };
+}
+
+function copyLegendItem(item: HonuaLegendItem): HonuaLegendItem {
+  return { ...item };
+}
+
+function copyFeature<T>(feature: HonuaFeatureRecord<T>): HonuaFeatureRecord<T> {
+  return {
+    ...feature,
+    attributes:
+      feature.attributes && typeof feature.attributes === "object"
+        ? ({ ...(feature.attributes as Record<string, unknown>) } as T)
+        : feature.attributes,
+  };
+}
+
+function copyEditorModel(editor: HonuaEditorModel): HonuaEditorModel {
+  return {
+    ...editor,
+    capabilities: { ...editor.capabilities },
+    ...(editor.fields ? { fields: [...editor.fields] } : {}),
+  };
+}
+
+function copyChartModel(chart: HonuaChartModel): HonuaChartModel {
+  return {
+    ...chart,
+    ...(chart.data ? { data: chart.data.map((datum) => ({ ...datum })) } : {}),
+  };
+}
+
+function firstSourceId<T>(
+  featuresBySource: Readonly<Record<string, readonly HonuaFeatureRecord<T>[]>>,
+  layers: readonly HonuaLayerModel[],
+): string | undefined {
+  const featureSource = Object.keys(featuresBySource)[0];
+  if (featureSource) return featureSource;
+  return layers.find((layer) => layer.sourceId)?.sourceId;
+}
+
+function filterRows<T>(
+  rows: readonly HonuaFeatureRecord<T>[],
+  filter: HonuaFilterState | undefined,
+): HonuaFeatureRecord<T>[] {
+  if (!filter?.text?.trim()) return rows.map(copyFeature);
+  const needle = filter.text.trim().toLowerCase();
+  return rows.filter((row) => featureMatches(row, needle)).map(copyFeature);
+}
+
+function featureMatches<T>(row: HonuaFeatureRecord<T>, needle: string, fields?: readonly string[]): boolean {
+  if (String(row.id).toLowerCase().includes(needle)) return true;
+  if (row.title?.toLowerCase().includes(needle)) return true;
+  const attrs = row.attributes as Record<string, unknown>;
+  const keys = fields && fields.length > 0 ? fields : Object.keys(attrs);
+  return keys.some((key) =>
+    String(attrs[key] ?? "")
+      .toLowerCase()
+      .includes(needle),
+  );
+}
+
+function featureScore<T>(row: HonuaFeatureRecord<T>, needle: string, fields?: readonly string[]): number {
+  if (row.title?.toLowerCase() === needle) return 1;
+  if (row.title?.toLowerCase().startsWith(needle)) return 0.9;
+  const attrs = row.attributes as Record<string, unknown>;
+  const keys = fields && fields.length > 0 ? fields : Object.keys(attrs);
+  return keys.some((key) =>
+    String(attrs[key] ?? "")
+      .toLowerCase()
+      .startsWith(needle),
+  )
+    ? 0.8
+    : 0.5;
+}
+
+function inferFields<T>(rows: readonly HonuaFeatureRecord<T>[]): string[] {
+  const fields = new Set<string>();
+  for (const row of rows) {
+    const attrs = row.attributes as Record<string, unknown>;
+    for (const key of Object.keys(attrs)) fields.add(key);
+  }
+  return [...fields];
+}
+
+function layerTitle(layer: HonuaLayerSpecification): string {
+  const metadataTitle = layer.metadata?.title ?? layer.metadata?.name ?? layer.metadata?.label;
+  return typeof metadataTitle === "string" && metadataTitle.trim() ? metadataTitle : layer.id;
+}
+
+function layerColor(layer: HonuaLayerSpecification): string | undefined {
+  const value = layer.paint?.["fill-color"] ?? layer.paint?.["circle-color"] ?? layer.paint?.["line-color"];
+  return typeof value === "string" ? value : undefined;
+}
+
+function legendId(label: string, index: number): string {
+  const slug = label
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug ? `${slug}-${index}` : `legend-${index}`;
+}

--- a/src/web-components/elements.ts
+++ b/src/web-components/elements.ts
@@ -1,0 +1,950 @@
+import { createHonuaWebComponentController } from "./controller.js";
+import type {
+  CreateHonuaWebComponentControllerOptions,
+  HonuaChartModel,
+  HonuaControllerReadyDetail,
+  HonuaEditChangeDetail,
+  HonuaEditorModel,
+  HonuaFeatureRecord,
+  HonuaFeatureTableModel,
+  HonuaFilterChangeDetail,
+  HonuaLayerVisibilityChangeDetail,
+  HonuaSearchDetail,
+  HonuaSearchResult,
+  HonuaSelectionChangeDetail,
+  HonuaViewportChangeDetail,
+  HonuaWebComponentController,
+  HonuaWebComponentState,
+} from "./types.js";
+
+const globalDom = globalThis as typeof globalThis & {
+  HTMLElement?: typeof HTMLElement;
+  CustomEvent?: typeof CustomEvent;
+  customElements?: CustomElementRegistry;
+};
+
+const HTMLElementBase: typeof HTMLElement = globalDom.HTMLElement ?? (class {} as unknown as typeof HTMLElement);
+
+abstract class HonuaElementBase<T = Record<string, unknown>> extends HTMLElementBase {
+  #controller: HonuaWebComponentController<T> | undefined;
+  #unsubscribe: { remove(): void } | undefined;
+  #controllerReadyListener: ((event: Event) => void) | undefined;
+  protected state: HonuaWebComponentState<T> | undefined;
+
+  public get controller(): HonuaWebComponentController<T> | undefined {
+    return this.#controller;
+  }
+
+  public set controller(controller: HonuaWebComponentController<T> | undefined) {
+    if (this.#controller === controller) return;
+    this.#unsubscribe?.remove();
+    this.#unsubscribe = undefined;
+    this.#controller = controller;
+    this.state = controller?.getState();
+    if (controller) {
+      this.#unsubscribe = controller.subscribe((state) => {
+        this.state = state;
+        this.stateChanged(state);
+        this.render();
+      });
+    }
+    this.controllerChanged(controller);
+    this.render();
+  }
+
+  public connectedCallback(): void {
+    this.ensureShadowRoot();
+    this.listenForControllerReady();
+    this.resolveControllerFromContext();
+    this.render();
+  }
+
+  public disconnectedCallback(): void {
+    this.#unsubscribe?.remove();
+    this.#unsubscribe = undefined;
+    if (this.#controllerReadyListener) {
+      this.getRootEventTarget()?.removeEventListener("honua-controller-ready", this.#controllerReadyListener);
+      this.#controllerReadyListener = undefined;
+    }
+  }
+
+  protected controllerChanged(_controller: HonuaWebComponentController<T> | undefined): void {}
+
+  protected stateChanged(_state: HonuaWebComponentState<T>): void {}
+
+  protected ensureShadowRoot(): void {
+    if (!this.shadowRoot && typeof this.attachShadow === "function") {
+      this.attachShadow({ mode: "open" });
+    }
+  }
+
+  protected setShadowHtml(html: string): void {
+    this.ensureShadowRoot();
+    const root = this.shadowRoot ?? this;
+    root.innerHTML = html;
+  }
+
+  protected resolveControllerFromContext(): void {
+    if (this.controller) return;
+    const mapId = this.getAttribute("for");
+    const root = this.getRootNode?.() as (Document | ShadowRoot) | undefined;
+    const map = mapId
+      ? getElementById(root, mapId)
+      : typeof root?.querySelector === "function"
+        ? root.querySelector("honua-map")
+        : undefined;
+    const controller = (map as { controller?: HonuaWebComponentController<T> } | undefined)?.controller;
+    if (controller) this.controller = controller;
+  }
+
+  protected listenForControllerReady(): void {
+    if (this.#controllerReadyListener) return;
+    const target = this.getRootEventTarget();
+    if (!target) return;
+    this.#controllerReadyListener = (event: Event) => {
+      const detail = (event as CustomEvent<HonuaControllerReadyDetail<T>>).detail;
+      if (!detail?.controller) return;
+      const mapId = this.getAttribute("for");
+      if (mapId && (event.target as Element | null)?.id !== mapId) return;
+      if (!mapId && this.controller) return;
+      this.controller = detail.controller;
+    };
+    target.addEventListener("honua-controller-ready", this.#controllerReadyListener as EventListener);
+  }
+
+  protected dispatchTypedEvent<D>(name: string, detail: D): void {
+    if (!globalDom.CustomEvent || typeof this.dispatchEvent !== "function") return;
+    this.dispatchEvent(new globalDom.CustomEvent(name, { bubbles: true, composed: true, detail }));
+  }
+
+  protected getRootEventTarget(): EventTarget | undefined {
+    const root = this.getRootNode?.();
+    if (root && "addEventListener" in root) return root as EventTarget;
+    return typeof document !== "undefined" ? document : undefined;
+  }
+
+  protected abstract render(): void;
+}
+
+export class HonuaMapElement<T = Record<string, unknown>> extends HonuaElementBase<T> {
+  static get observedAttributes(): string[] {
+    return ["map-package", "label"];
+  }
+
+  #options: CreateHonuaWebComponentControllerOptions<T> = {};
+
+  public get mapPackage(): CreateHonuaWebComponentControllerOptions<T>["mapPackage"] {
+    return this.#options.mapPackage;
+  }
+
+  public set mapPackage(mapPackage: CreateHonuaWebComponentControllerOptions<T>["mapPackage"]) {
+    this.#options = { ...this.#options, ...(mapPackage ? { mapPackage } : { mapPackage: undefined }) };
+    if (!this.controller) this.ensureController();
+    this.render();
+  }
+
+  public get featuresBySource(): CreateHonuaWebComponentControllerOptions<T>["featuresBySource"] {
+    return this.#options.featuresBySource;
+  }
+
+  public set featuresBySource(featuresBySource: CreateHonuaWebComponentControllerOptions<T>["featuresBySource"]) {
+    this.#options = {
+      ...this.#options,
+      ...(featuresBySource ? { featuresBySource } : { featuresBySource: undefined }),
+    };
+    if (this.controller?.updateFeatures && featuresBySource) {
+      for (const [sourceId, features] of Object.entries(featuresBySource)) {
+        this.controller.updateFeatures(sourceId, features as readonly HonuaFeatureRecord<T>[]);
+      }
+    } else if (!this.controller) {
+      this.ensureController();
+    }
+    this.render();
+  }
+
+  public attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null): void {
+    if (name === "map-package" && newValue) {
+      try {
+        this.mapPackage = JSON.parse(newValue) as CreateHonuaWebComponentControllerOptions<T>["mapPackage"];
+      } catch {
+        // Invalid inline JSON is surfaced visually by the empty component state.
+      }
+    }
+    this.render();
+  }
+
+  public connectedCallback(): void {
+    super.connectedCallback();
+    this.ensureController();
+  }
+
+  protected controllerChanged(controller: HonuaWebComponentController<T> | undefined): void {
+    if (controller) {
+      this.dispatchTypedEvent<HonuaControllerReadyDetail<T>>("honua-controller-ready", { controller });
+    }
+  }
+
+  protected render(): void {
+    const state = this.state ?? this.controller?.getState();
+    const layers = state?.layers ?? [];
+    const viewport = state?.viewport ?? {};
+    const visibleLayers = layers.filter((layer) => layer.visible);
+    const label = this.getAttribute("label") ?? state?.mapPackage?.mapPackageId ?? "Honua map";
+    this.setShadowHtml(`
+      <style>${baseStyles()}${mapStyles()}</style>
+      <section part="map" class="map" role="region" aria-label="${escapeHtml(label)}" tabindex="0">
+        <div class="map__chrome">
+          <div class="map__title">${escapeHtml(label)}</div>
+          <div class="map__controls" aria-label="Map controls">
+            <button type="button" class="icon-button" data-zoom="out" aria-label="Zoom out">-</button>
+            <output class="zoom" aria-label="Zoom">${escapeHtml(String(viewport.zoom ?? 0))}</output>
+            <button type="button" class="icon-button" data-zoom="in" aria-label="Zoom in">+</button>
+          </div>
+        </div>
+        <div class="map__canvas" part="canvas">
+          ${visibleLayers.map((layer, index) => layerBackdrop(layer.title, index, visibleLayers.length)).join("")}
+        </div>
+        <div class="map__footer">
+          <span>${escapeHtml(String(visibleLayers.length))} visible</span>
+          <span>${viewport.center ? escapeHtml(viewport.center.join(", ")) : "No center"}</span>
+        </div>
+      </section>
+    `);
+    this.shadowRoot?.querySelectorAll<HTMLButtonElement>("[data-zoom]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const direction = button.dataset.zoom === "in" ? 1 : -1;
+        const nextZoom = (this.controller?.getState().viewport.zoom ?? 0) + direction;
+        this.controller?.setViewport({ zoom: nextZoom });
+        this.dispatchTypedEvent<HonuaViewportChangeDetail>("honua-viewport-change", { zoom: nextZoom });
+      });
+    });
+  }
+
+  private ensureController(): void {
+    if (this.controller) return;
+    this.controller = createHonuaWebComponentController(this.#options);
+  }
+}
+
+export class HonuaLayerListElement<T = Record<string, unknown>> extends HonuaElementBase<T> {
+  static get observedAttributes(): string[] {
+    return ["for", "label"];
+  }
+
+  public attributeChangedCallback(): void {
+    this.resolveControllerFromContext();
+    this.render();
+  }
+
+  protected render(): void {
+    const layers = this.state?.layers ?? [];
+    const label = this.getAttribute("label") ?? "Layers";
+    this.setShadowHtml(`
+      <style>${baseStyles()}${listStyles()}</style>
+      <fieldset class="panel" part="panel">
+        <legend>${escapeHtml(label)}</legend>
+        <div class="stack" role="list">
+          ${
+            layers.length === 0
+              ? `<p class="empty">No layers</p>`
+              : layers
+                  .map(
+                    (layer) => `
+            <label class="check-row" role="listitem">
+              <input type="checkbox" data-layer-id="${escapeHtml(layer.id)}" ${layer.visible ? "checked" : ""} />
+              <span>${escapeHtml(layer.title)}</span>
+            </label>
+          `,
+                  )
+                  .join("")
+          }
+        </div>
+      </fieldset>
+    `);
+    this.shadowRoot?.querySelectorAll<HTMLInputElement>("input[data-layer-id]").forEach((input) => {
+      input.addEventListener("change", () => {
+        const layerId = input.dataset.layerId;
+        if (!layerId) return;
+        this.controller?.setLayerVisibility(layerId, input.checked);
+        this.dispatchTypedEvent<HonuaLayerVisibilityChangeDetail>("honua-layer-visibility-change", {
+          layerId,
+          visible: input.checked,
+        });
+      });
+    });
+  }
+}
+
+export class HonuaLegendElement<T = Record<string, unknown>> extends HonuaElementBase<T> {
+  static get observedAttributes(): string[] {
+    return ["for", "label"];
+  }
+
+  public attributeChangedCallback(): void {
+    this.resolveControllerFromContext();
+    this.render();
+  }
+
+  protected render(): void {
+    const legend = this.state?.legend ?? [];
+    const label = this.getAttribute("label") ?? "Legend";
+    this.setShadowHtml(`
+      <style>${baseStyles()}${listStyles()}</style>
+      <section class="panel" part="panel" aria-label="${escapeHtml(label)}">
+        <h2>${escapeHtml(label)}</h2>
+        <ul class="legend">
+          ${
+            legend.length === 0
+              ? `<li class="empty">No legend</li>`
+              : legend
+                  .map(
+                    (item) => `
+            <li>
+              ${
+                item.iconUrl
+                  ? `<img class="swatch" alt="" src="${escapeAttribute(item.iconUrl)}" />`
+                  : `<span class="swatch" style="--swatch:${escapeAttribute(item.color ?? "#64748b")}"></span>`
+              }
+              <span>${escapeHtml(item.label)}</span>
+            </li>
+          `,
+                  )
+                  .join("")
+          }
+        </ul>
+      </section>
+    `);
+  }
+}
+
+export class HonuaFeatureTableElement<T = Record<string, unknown>> extends HonuaElementBase<T> {
+  static get observedAttributes(): string[] {
+    return ["for", "source", "fields", "page-size", "filter-text", "label"];
+  }
+
+  #model: HonuaFeatureTableModel<T> | undefined;
+  #refreshToken = 0;
+
+  public attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null): void {
+    this.resolveControllerFromContext();
+    if (name === "filter-text") {
+      const detail: HonuaFilterChangeDetail = {
+        sourceId: this.sourceId(),
+        text: newValue ?? "",
+      };
+      this.controller?.setFilter(detail);
+      this.dispatchTypedEvent<HonuaFilterChangeDetail>("honua-filter-change", detail);
+    }
+    void this.refresh();
+  }
+
+  public connectedCallback(): void {
+    super.connectedCallback();
+    void this.refresh();
+  }
+
+  protected stateChanged(): void {
+    void this.refresh();
+  }
+
+  public async refresh(): Promise<HonuaFeatureTableModel<T> | undefined> {
+    const controller = this.controller;
+    if (!controller) return undefined;
+    const token = ++this.#refreshToken;
+    const model = await controller.queryFeatures(this.sourceId(), {
+      fields: this.fields(),
+      pagination: { limit: this.pageSize() },
+    });
+    if (token !== this.#refreshToken) return this.#model;
+    this.#model = model;
+    this.render();
+    return model;
+  }
+
+  protected render(): void {
+    const state = this.state;
+    const model = this.#model ?? tableModelFromState(state, this.sourceId(), this.fields(), this.pageSize());
+    const selectedId = state?.selection?.featureId;
+    const label = this.getAttribute("label") ?? "Features";
+    this.setShadowHtml(`
+      <style>${baseStyles()}${tableStyles()}</style>
+      <section class="table-panel" part="panel" aria-label="${escapeHtml(label)}">
+        <div class="table-panel__bar">
+          <h2>${escapeHtml(label)}</h2>
+          <span>${escapeHtml(String(model.totalCount))}</span>
+        </div>
+        <div class="table-wrap">
+          <table role="grid" aria-rowcount="${escapeHtml(String(model.rows.length))}">
+            <thead>
+              <tr>${model.fields.map((field) => `<th scope="col">${escapeHtml(field)}</th>`).join("")}</tr>
+            </thead>
+            <tbody>
+              ${
+                model.rows.length === 0
+                  ? `<tr><td colspan="${Math.max(1, model.fields.length)}" class="empty">No rows</td></tr>`
+                  : model.rows
+                      .map(
+                        (row) => `
+                <tr tabindex="0" data-source-id="${escapeHtml(row.sourceId)}" data-feature-id="${escapeHtml(
+                  String(row.id),
+                )}" aria-selected="${String(String(selectedId ?? "") === String(row.id))}">
+                  ${model.fields.map((field) => `<td>${escapeHtml(formatCell((row.attributes as Record<string, unknown>)[field]))}</td>`).join("")}
+                </tr>
+              `,
+                      )
+                      .join("")
+              }
+            </tbody>
+          </table>
+        </div>
+      </section>
+    `);
+    this.shadowRoot?.querySelectorAll<HTMLTableRowElement>("tbody tr[data-feature-id]").forEach((row) => {
+      const select = () => this.selectRow(row);
+      row.addEventListener("click", select);
+      row.addEventListener("keydown", (event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        select();
+      });
+    });
+  }
+
+  private selectRow(row: HTMLTableRowElement): void {
+    const sourceId = row.dataset.sourceId;
+    const featureId = row.dataset.featureId;
+    if (!sourceId || featureId === undefined) return;
+    const feature = (this.#model?.rows ?? []).find((candidate) => String(candidate.id) === featureId);
+    this.controller?.selectFeature({ sourceId, featureId, ...(feature ? { feature } : {}) });
+    this.dispatchTypedEvent<HonuaSelectionChangeDetail<T>>("honua-selection-change", {
+      sourceId,
+      featureId,
+      ...(feature ? { feature } : {}),
+    });
+  }
+
+  private sourceId(): string | undefined {
+    return this.getAttribute("source") ?? undefined;
+  }
+
+  private fields(): readonly string[] | undefined {
+    const value = this.getAttribute("fields");
+    return value
+      ?.split(",")
+      .map((field) => field.trim())
+      .filter(Boolean);
+  }
+
+  private pageSize(): number | undefined {
+    const parsed = Number(this.getAttribute("page-size"));
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  }
+}
+
+export class HonuaSearchElement<T = Record<string, unknown>> extends HonuaElementBase<T> {
+  static get observedAttributes(): string[] {
+    return ["for", "source", "placeholder", "label"];
+  }
+
+  #query = "";
+  #results: readonly HonuaSearchResult<T>[] = [];
+
+  public attributeChangedCallback(): void {
+    this.resolveControllerFromContext();
+    this.render();
+  }
+
+  protected render(): void {
+    const label = this.getAttribute("label") ?? "Search";
+    const placeholder = this.getAttribute("placeholder") ?? "Search";
+    this.setShadowHtml(`
+      <style>${baseStyles()}${searchStyles()}</style>
+      <section class="search" part="panel" aria-label="${escapeHtml(label)}">
+        <form>
+          <label class="sr-only" for="honua-search-input">${escapeHtml(label)}</label>
+          <input id="honua-search-input" name="q" value="${escapeAttribute(this.#query)}" placeholder="${escapeAttribute(
+            placeholder,
+          )}" autocomplete="off" />
+          <button type="submit">Search</button>
+        </form>
+        <ul class="results" aria-live="polite">
+          ${this.#results.map((result) => `<li><button type="button" data-result-id="${escapeHtml(result.id)}">${escapeHtml(result.label)}</button></li>`).join("")}
+        </ul>
+      </section>
+    `);
+    this.shadowRoot?.querySelector("form")?.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const input = this.shadowRoot?.querySelector<HTMLInputElement>("input[name='q']");
+      void this.runSearch(input?.value ?? "");
+    });
+    this.shadowRoot?.querySelectorAll<HTMLButtonElement>("button[data-result-id]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const result = this.#results.find((candidate) => candidate.id === button.dataset.resultId);
+        if (!result?.featureId || !result.sourceId) return;
+        this.controller?.selectFeature({
+          sourceId: result.sourceId,
+          featureId: result.featureId,
+          ...(result.feature ? { feature: result.feature } : {}),
+        });
+        this.dispatchTypedEvent<HonuaSelectionChangeDetail<T>>("honua-selection-change", {
+          sourceId: result.sourceId,
+          featureId: result.featureId,
+          ...(result.feature ? { feature: result.feature } : {}),
+        });
+      });
+    });
+  }
+
+  private async runSearch(query: string): Promise<void> {
+    this.#query = query;
+    const sourceId = this.getAttribute("source") ?? undefined;
+    this.#results = await (this.controller?.search(query, { sourceId }) ?? []);
+    this.dispatchTypedEvent<HonuaSearchDetail<T>>("honua-search", { query, results: this.#results });
+    this.render();
+  }
+}
+
+export class HonuaEditorElement<T = Record<string, unknown>> extends HonuaElementBase<T> {
+  static get observedAttributes(): string[] {
+    return ["for", "source", "label"];
+  }
+
+  #model: HonuaEditorModel | undefined;
+
+  public get editorModel(): HonuaEditorModel | undefined {
+    return this.#model ?? this.state?.editor;
+  }
+
+  public set editorModel(model: HonuaEditorModel | undefined) {
+    this.#model = model;
+    this.render();
+  }
+
+  public attributeChangedCallback(): void {
+    this.resolveControllerFromContext();
+    this.render();
+  }
+
+  protected render(): void {
+    const state = this.state;
+    const model = this.#model ?? state?.editor ?? defaultEditorModel(this.getAttribute("source") ?? undefined);
+    const selected = state?.selection?.feature;
+    const canUpdate = model.capabilities.canUpdate && !model.capabilities.readOnly;
+    const label = this.getAttribute("label") ?? "Editor";
+    this.setShadowHtml(`
+      <style>${baseStyles()}${editorStyles()}</style>
+      <section class="editor" part="panel" aria-label="${escapeHtml(label)}">
+        <div class="editor__bar">
+          <h2>${escapeHtml(label)}</h2>
+          <span data-status>${escapeHtml(model.status)}</span>
+        </div>
+        <p class="selection">${escapeHtml(selected?.title ?? "No selection")}</p>
+        <p class="muted">${escapeHtml(model.capabilities.readOnly ? (model.capabilities.reason ?? "Read-only") : "Editable")}</p>
+        <div class="editor__actions">
+          <button type="button" data-action="new" ${model.capabilities.canCreate && !model.capabilities.readOnly ? "" : "disabled"}>New</button>
+          <button type="button" data-action="save" ${canUpdate ? "" : "disabled"}>Save</button>
+          <button type="button" data-action="delete" ${model.capabilities.canDelete && !model.capabilities.readOnly ? "" : "disabled"}>Delete</button>
+        </div>
+      </section>
+    `);
+    this.shadowRoot?.querySelectorAll<HTMLButtonElement>("button[data-action]").forEach((button) => {
+      button.addEventListener("click", () => {
+        void this.runEdit(button.dataset.action ?? "update", model);
+      });
+    });
+  }
+
+  private async runEdit(action: string, model: HonuaEditorModel): Promise<void> {
+    const feature = this.state?.selection?.feature;
+    const sourceId = this.getAttribute("source") ?? model.sourceId ?? feature?.sourceId;
+    if (!feature || !sourceId) return;
+    const operation = action === "new" ? "create" : action === "delete" ? "delete" : "update";
+    const request = { sourceId, feature, operation } as const;
+    const next = await (this.controller?.applyEdit?.(request) ??
+      Promise.resolve({ ...model, status: "unsupported" as const }));
+    this.#model = next;
+    this.dispatchTypedEvent<HonuaEditChangeDetail<T>>("honua-edit-change", {
+      status: next.status,
+      request,
+      model: next,
+    });
+    this.render();
+  }
+}
+
+export class HonuaChartElement<T = Record<string, unknown>> extends HonuaElementBase<T> {
+  static get observedAttributes(): string[] {
+    return ["for", "label"];
+  }
+
+  #model: HonuaChartModel | undefined;
+
+  public get chartModel(): HonuaChartModel | undefined {
+    return this.#model ?? this.state?.chart;
+  }
+
+  public set chartModel(model: HonuaChartModel | undefined) {
+    this.#model = model;
+    this.render();
+  }
+
+  public attributeChangedCallback(): void {
+    this.resolveControllerFromContext();
+    this.render();
+  }
+
+  protected render(): void {
+    const model = this.chartModel ?? defaultChartModel(this.getAttribute("label") ?? "Chart");
+    const max = Math.max(1, ...(model.data ?? []).map((datum) => datum.value));
+    this.setShadowHtml(`
+      <style>${baseStyles()}${chartStyles()}</style>
+      <section class="chart" part="panel" aria-label="${escapeHtml(model.title)}">
+        <h2>${escapeHtml(model.title)}</h2>
+        <div class="bars">
+          ${
+            model.data?.length
+              ? model.data
+                  .map(
+                    (datum) => `
+            <div class="bar-row">
+              <span>${escapeHtml(datum.label)}</span>
+              <span class="bar" style="--bar:${(datum.value / max) * 100}%;--bar-color:${escapeAttribute(
+                datum.color ?? "#2563eb",
+              )}"></span>
+              <strong>${escapeHtml(String(datum.value))}</strong>
+            </div>
+          `,
+                  )
+                  .join("")
+              : `<p class="empty">${escapeHtml(model.message ?? "No chart data")}</p>`
+          }
+        </div>
+      </section>
+    `);
+  }
+}
+
+export function defineHonuaWebComponents(registry = globalDom.customElements): void {
+  if (!registry) return;
+  defineIfMissing(registry, "honua-map", HonuaMapElement);
+  defineIfMissing(registry, "honua-layer-list", HonuaLayerListElement);
+  defineIfMissing(registry, "honua-legend", HonuaLegendElement);
+  defineIfMissing(registry, "honua-feature-table", HonuaFeatureTableElement);
+  defineIfMissing(registry, "honua-search", HonuaSearchElement);
+  defineIfMissing(registry, "honua-editor", HonuaEditorElement);
+  defineIfMissing(registry, "honua-chart", HonuaChartElement);
+}
+
+function defineIfMissing(registry: CustomElementRegistry, tagName: string, ctor: CustomElementConstructor): void {
+  if (!registry.get(tagName)) registry.define(tagName, ctor);
+}
+
+if (globalDom.customElements) {
+  defineHonuaWebComponents(globalDom.customElements);
+}
+
+function tableModelFromState<T>(
+  state: HonuaWebComponentState<T> | undefined,
+  sourceId: string | undefined,
+  fields: readonly string[] | undefined,
+  pageSize: number | undefined,
+): HonuaFeatureTableModel<T> {
+  const resolvedSourceId = sourceId ?? Object.keys(state?.featuresBySource ?? {})[0];
+  const rows = resolvedSourceId ? [...(state?.featuresBySource[resolvedSourceId] ?? [])] : [];
+  const modelFields = fields ?? inferFields(rows);
+  return {
+    sourceId: resolvedSourceId,
+    status: state?.status ?? "idle",
+    fields: modelFields,
+    rows: pageSize ? rows.slice(0, pageSize) : rows,
+    totalCount: rows.length,
+  };
+}
+
+function defaultEditorModel(sourceId: string | undefined): HonuaEditorModel {
+  return {
+    sourceId,
+    status: "idle",
+    capabilities: {
+      canCreate: false,
+      canUpdate: false,
+      canDelete: false,
+      readOnly: true,
+      reason: "Editing is not enabled for this source.",
+    },
+  };
+}
+
+function defaultChartModel(title: string): HonuaChartModel {
+  return {
+    id: "placeholder",
+    title,
+    kind: "placeholder",
+    status: "idle",
+    message: "No chart data",
+  };
+}
+
+function inferFields<T>(rows: readonly HonuaFeatureRecord<T>[]): string[] {
+  const fields = new Set<string>();
+  for (const row of rows) {
+    for (const field of Object.keys(row.attributes as Record<string, unknown>)) fields.add(field);
+  }
+  return [...fields];
+}
+
+function getElementById(root: Document | ShadowRoot | undefined, id: string): Element | null {
+  if (root && "getElementById" in root) return root.getElementById(id);
+  return typeof document !== "undefined" ? document.getElementById(id) : null;
+}
+
+function layerBackdrop(title: string, index: number, total: number): string {
+  const top = 18 + index * 12;
+  const height = Math.max(18, 72 - total * 4);
+  return `<div class="layer-plane" style="--top:${top}px;--height:${height}px;--shade:${index}" aria-hidden="true"></div><span class="layer-label" style="--top:${
+    top + height + 4
+  }px">${escapeHtml(title)}</span>`;
+}
+
+function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function escapeAttribute(value: string): string {
+  return escapeHtml(value).replace(/'/g, "&#39;");
+}
+
+function baseStyles(): string {
+  return `
+    :host {
+      --honua-ui-bg: #ffffff;
+      --honua-ui-fg: #172033;
+      --honua-ui-muted: #667085;
+      --honua-ui-border: #d0d5dd;
+      --honua-ui-accent: #1d4ed8;
+      --honua-ui-accent-fg: #ffffff;
+      --honua-ui-surface: #f8fafc;
+      box-sizing: border-box;
+      color: var(--honua-ui-fg);
+      display: block;
+      font: 14px/1.4 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    *, *::before, *::after { box-sizing: inherit; }
+    button, input, select { font: inherit; }
+    button {
+      border: 1px solid var(--honua-ui-border);
+      background: var(--honua-ui-bg);
+      border-radius: 6px;
+      color: inherit;
+      cursor: pointer;
+      min-height: 32px;
+      padding: 0 10px;
+    }
+    button:disabled { cursor: not-allowed; opacity: 0.55; }
+    h2 { font-size: 14px; margin: 0; }
+    .empty, .muted { color: var(--honua-ui-muted); }
+    .sr-only {
+      border: 0;
+      clip: rect(0 0 0 0);
+      height: 1px;
+      margin: -1px;
+      overflow: hidden;
+      padding: 0;
+      position: absolute;
+      width: 1px;
+    }
+  `;
+}
+
+function mapStyles(): string {
+  return `
+    .map {
+      background: #dbeafe;
+      border: 1px solid var(--honua-ui-border);
+      border-radius: 8px;
+      display: grid;
+      grid-template-rows: auto minmax(220px, 1fr) auto;
+      min-height: 320px;
+      overflow: hidden;
+    }
+    .map__chrome, .map__footer {
+      align-items: center;
+      background: rgba(255, 255, 255, 0.9);
+      display: flex;
+      gap: 8px;
+      justify-content: space-between;
+      padding: 8px 10px;
+    }
+    .map__controls { align-items: center; display: flex; gap: 6px; }
+    .icon-button { min-width: 32px; padding: 0; }
+    .zoom { min-width: 32px; text-align: center; }
+    .map__canvas {
+      background:
+        linear-gradient(90deg, rgba(255,255,255,0.32) 1px, transparent 1px),
+        linear-gradient(0deg, rgba(255,255,255,0.32) 1px, transparent 1px),
+        #bfdbfe;
+      background-size: 40px 40px;
+      min-height: 220px;
+      position: relative;
+    }
+    .layer-plane {
+      background: color-mix(in srgb, #2563eb calc(25% + var(--shade) * 10%), #16a34a);
+      border: 1px solid rgba(15, 23, 42, 0.18);
+      border-radius: 8px;
+      height: var(--height);
+      left: calc(18px + var(--shade) * 24px);
+      opacity: 0.74;
+      position: absolute;
+      right: calc(24px + var(--shade) * 18px);
+      top: var(--top);
+    }
+    .layer-label {
+      background: rgba(255,255,255,0.82);
+      border-radius: 4px;
+      left: calc(22px + var(--shade, 0) * 24px);
+      padding: 2px 6px;
+      position: absolute;
+      top: var(--top);
+    }
+  `;
+}
+
+function listStyles(): string {
+  return `
+    .panel {
+      background: var(--honua-ui-bg);
+      border: 1px solid var(--honua-ui-border);
+      border-radius: 8px;
+      margin: 0;
+      padding: 10px;
+    }
+    legend { font-weight: 650; padding: 0 4px; }
+    .stack { display: grid; gap: 8px; }
+    .check-row { align-items: center; display: flex; gap: 8px; min-height: 28px; }
+    .legend { display: grid; gap: 8px; list-style: none; margin: 10px 0 0; padding: 0; }
+    .legend li { align-items: center; display: flex; gap: 8px; min-height: 24px; }
+    .swatch {
+      background: var(--swatch);
+      border: 1px solid rgba(15, 23, 42, 0.18);
+      border-radius: 3px;
+      display: inline-block;
+      height: 16px;
+      width: 24px;
+    }
+    img.swatch { object-fit: cover; }
+  `;
+}
+
+function tableStyles(): string {
+  return `
+    .table-panel {
+      border: 1px solid var(--honua-ui-border);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .table-panel__bar {
+      align-items: center;
+      background: var(--honua-ui-surface);
+      display: flex;
+      justify-content: space-between;
+      padding: 8px 10px;
+    }
+    .table-wrap { max-height: 300px; overflow: auto; }
+    table { border-collapse: collapse; min-width: 100%; table-layout: fixed; }
+    th, td {
+      border-top: 1px solid var(--honua-ui-border);
+      overflow: hidden;
+      padding: 7px 9px;
+      text-align: left;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    th { background: #f8fafc; font-weight: 650; }
+    tr[aria-selected="true"] td { background: #dbeafe; }
+    tbody tr[data-feature-id] { cursor: pointer; }
+    tbody tr[data-feature-id]:focus { outline: 2px solid var(--honua-ui-accent); outline-offset: -2px; }
+  `;
+}
+
+function searchStyles(): string {
+  return `
+    .search {
+      border: 1px solid var(--honua-ui-border);
+      border-radius: 8px;
+      padding: 10px;
+    }
+    form { display: grid; gap: 8px; grid-template-columns: minmax(120px, 1fr) auto; }
+    input {
+      border: 1px solid var(--honua-ui-border);
+      border-radius: 6px;
+      min-height: 32px;
+      min-width: 0;
+      padding: 0 9px;
+    }
+    .results { display: grid; gap: 6px; list-style: none; margin: 10px 0 0; padding: 0; }
+    .results button { text-align: left; width: 100%; }
+  `;
+}
+
+function editorStyles(): string {
+  return `
+    .editor {
+      border: 1px solid var(--honua-ui-border);
+      border-radius: 8px;
+      padding: 10px;
+    }
+    .editor__bar, .editor__actions { align-items: center; display: flex; gap: 8px; justify-content: space-between; }
+    .editor__actions { justify-content: flex-start; }
+    .selection { margin: 10px 0 4px; }
+    .muted { margin: 0 0 10px; }
+  `;
+}
+
+function chartStyles(): string {
+  return `
+    .chart {
+      border: 1px solid var(--honua-ui-border);
+      border-radius: 8px;
+      padding: 10px;
+    }
+    .bars { display: grid; gap: 8px; margin-top: 10px; }
+    .bar-row { align-items: center; display: grid; gap: 8px; grid-template-columns: minmax(70px, 1fr) 3fr auto; }
+    .bar { background: #e5e7eb; border-radius: 999px; height: 10px; overflow: hidden; position: relative; }
+    .bar::before {
+      background: var(--bar-color);
+      border-radius: inherit;
+      content: "";
+      inset: 0 auto 0 0;
+      position: absolute;
+      width: var(--bar);
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "honua-map": HonuaMapElement;
+    "honua-layer-list": HonuaLayerListElement;
+    "honua-legend": HonuaLegendElement;
+    "honua-feature-table": HonuaFeatureTableElement;
+    "honua-search": HonuaSearchElement;
+    "honua-editor": HonuaEditorElement;
+    "honua-chart": HonuaChartElement;
+  }
+
+  interface HTMLElementEventMap {
+    "honua-controller-ready": CustomEvent<HonuaControllerReadyDetail>;
+    "honua-layer-visibility-change": CustomEvent<HonuaLayerVisibilityChangeDetail>;
+    "honua-selection-change": CustomEvent<HonuaSelectionChangeDetail>;
+    "honua-viewport-change": CustomEvent<HonuaViewportChangeDetail>;
+    "honua-filter-change": CustomEvent<HonuaFilterChangeDetail>;
+    "honua-search": CustomEvent<HonuaSearchDetail>;
+    "honua-edit-change": CustomEvent<HonuaEditChangeDetail>;
+  }
+}

--- a/src/web-components/index.ts
+++ b/src/web-components/index.ts
@@ -1,0 +1,62 @@
+/**
+ * Framework-neutral Honua custom elements.
+ *
+ * Importing this module registers the shipped custom elements when a browser
+ * `customElements` registry is present. Node imports are safe; call
+ * `defineHonuaWebComponents()` explicitly when using a scoped registry.
+ *
+ * @module
+ */
+
+import "./elements.js";
+
+export {
+  HonuaInMemoryWebComponentController,
+  createHonuaWebComponentController,
+  createHonuaWebComponentControllerFromRuntime,
+  layersFromMapPackage,
+  legendFromMapPackage,
+} from "./controller.js";
+
+export {
+  HonuaChartElement,
+  HonuaEditorElement,
+  HonuaFeatureTableElement,
+  HonuaLayerListElement,
+  HonuaLegendElement,
+  HonuaMapElement,
+  HonuaSearchElement,
+  defineHonuaWebComponents,
+} from "./elements.js";
+
+export type {
+  CreateHonuaWebComponentControllerOptions,
+  HonuaChartDatum,
+  HonuaChartModel,
+  HonuaComponentStatus,
+  HonuaControllerReadyDetail,
+  HonuaControllerStateListener,
+  HonuaControllerSubscription,
+  HonuaEditCapabilities,
+  HonuaEditChangeDetail,
+  HonuaEditRequest,
+  HonuaEditorModel,
+  HonuaFeatureRecord,
+  HonuaFeatureTableModel,
+  HonuaFilterChangeDetail,
+  HonuaFilterState,
+  HonuaLayerModel,
+  HonuaLayerVisibilityChangeDetail,
+  HonuaLegendItem,
+  HonuaQueryFeaturesOptions,
+  HonuaSearchDetail,
+  HonuaSearchOptions,
+  HonuaSearchResult,
+  HonuaSelectionChangeDetail,
+  HonuaSelectionState,
+  HonuaViewportChangeDetail,
+  HonuaViewportState,
+  HonuaWebComponentController,
+  HonuaWebComponentRuntimeLike,
+  HonuaWebComponentState,
+} from "./types.js";

--- a/src/web-components/types.ts
+++ b/src/web-components/types.ts
@@ -1,0 +1,225 @@
+import type { FeatureId, Query } from "../contract/index.js";
+import type { HonuaTypedFeature } from "../core/types.js";
+import type { HonuaMapPackage, HonuaMapPackageLegendEntry } from "../runtime/index.js";
+import type { HonuaLayerSpecification } from "../style/index.js";
+
+export type HonuaComponentStatus = "idle" | "loading" | "ready" | "error" | "unsupported";
+
+export interface HonuaLayerModel {
+  id: string;
+  title: string;
+  sourceId?: string;
+  type?: string;
+  visible: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface HonuaLegendItem {
+  id: string;
+  label: string;
+  color?: string;
+  iconUrl?: string;
+  layerId?: string;
+  minValue?: number;
+  maxValue?: number;
+}
+
+export interface HonuaViewportState {
+  bbox?: readonly [number, number, number, number];
+  center?: readonly [number, number];
+  zoom?: number;
+  pitch?: number;
+  bearing?: number;
+}
+
+export interface HonuaFeatureRecord<T = Record<string, unknown>> {
+  id: FeatureId;
+  sourceId: string;
+  attributes: T;
+  geometry?: HonuaTypedFeature<T>["geometry"];
+  title?: string;
+}
+
+export interface HonuaFeatureTableModel<T = Record<string, unknown>> {
+  sourceId: string | undefined;
+  status: HonuaComponentStatus;
+  fields: readonly string[];
+  rows: readonly HonuaFeatureRecord<T>[];
+  totalCount: number;
+  exceededTransferLimit?: boolean;
+  error?: unknown;
+}
+
+export interface HonuaSearchResult<T = Record<string, unknown>> {
+  id: string;
+  label: string;
+  sourceId?: string;
+  featureId?: FeatureId;
+  feature?: HonuaFeatureRecord<T>;
+  subtitle?: string;
+  score?: number;
+  viewport?: HonuaViewportState;
+}
+
+export interface HonuaSelectionState<T = Record<string, unknown>> {
+  sourceId?: string;
+  featureId?: FeatureId;
+  feature?: HonuaFeatureRecord<T>;
+}
+
+export interface HonuaFilterState {
+  sourceId?: string;
+  expression?: string;
+  text?: string;
+}
+
+export interface HonuaEditCapabilities {
+  canCreate: boolean;
+  canUpdate: boolean;
+  canDelete: boolean;
+  readOnly: boolean;
+  reason?: string;
+}
+
+export interface HonuaEditorModel {
+  sourceId?: string;
+  status: HonuaComponentStatus;
+  capabilities: HonuaEditCapabilities;
+  selectedFeatureId?: FeatureId;
+  fields?: readonly string[];
+  message?: string;
+}
+
+export interface HonuaChartDatum {
+  label: string;
+  value: number;
+  color?: string;
+}
+
+export interface HonuaChartModel {
+  id: string;
+  title: string;
+  kind: "bar" | "line" | "pie" | "number" | "placeholder";
+  status: HonuaComponentStatus;
+  sourceId?: string;
+  data?: readonly HonuaChartDatum[];
+  message?: string;
+}
+
+export interface HonuaWebComponentState<T = Record<string, unknown>> {
+  packageId?: string;
+  status: HonuaComponentStatus;
+  mapPackage?: HonuaMapPackage;
+  layers: readonly HonuaLayerModel[];
+  legend: readonly HonuaLegendItem[];
+  viewport: HonuaViewportState;
+  featuresBySource: Readonly<Record<string, readonly HonuaFeatureRecord<T>[]>>;
+  selection?: HonuaSelectionState<T>;
+  filters: Readonly<Record<string, HonuaFilterState>>;
+  editor?: HonuaEditorModel;
+  chart?: HonuaChartModel;
+  refreshedAt?: string;
+  stale?: boolean;
+}
+
+export type HonuaControllerStateListener<T = Record<string, unknown>> = (state: HonuaWebComponentState<T>) => void;
+
+export interface HonuaControllerSubscription {
+  remove(): void;
+}
+
+export interface HonuaQueryFeaturesOptions {
+  sourceId?: string;
+  fields?: readonly string[];
+  filter?: HonuaFilterState;
+  pagination?: { offset?: number; limit?: number };
+  signal?: AbortSignal;
+}
+
+export interface HonuaSearchOptions {
+  sourceId?: string;
+  limit?: number;
+  fields?: readonly string[];
+  signal?: AbortSignal;
+}
+
+export interface HonuaEditRequest<T = Record<string, unknown>> {
+  sourceId: string;
+  feature: HonuaFeatureRecord<T>;
+  operation: "create" | "update" | "delete";
+  signal?: AbortSignal;
+}
+
+export interface HonuaWebComponentController<T = Record<string, unknown>> {
+  getState(): HonuaWebComponentState<T>;
+  subscribe(listener: HonuaControllerStateListener<T>): HonuaControllerSubscription;
+  setLayerVisibility(layerId: string, visible: boolean): void;
+  setViewport(viewport: HonuaViewportState): void;
+  setFilter(filter: HonuaFilterState): void;
+  selectFeature(selection: HonuaSelectionState<T>): void;
+  clearSelection(): void;
+  queryFeatures(sourceId?: string, options?: HonuaQueryFeaturesOptions): Promise<HonuaFeatureTableModel<T>>;
+  search(query: string, options?: HonuaSearchOptions): Promise<readonly HonuaSearchResult<T>[]>;
+  applyEdit?(request: HonuaEditRequest<T>): Promise<HonuaEditorModel>;
+  updateFeatures?(sourceId: string, features: readonly HonuaFeatureRecord<T>[]): void;
+}
+
+export interface CreateHonuaWebComponentControllerOptions<T = Record<string, unknown>> {
+  mapPackage?: HonuaMapPackage;
+  layers?: readonly HonuaLayerModel[];
+  legend?: readonly HonuaLegendItem[];
+  viewport?: HonuaViewportState;
+  featuresBySource?: Readonly<Record<string, readonly HonuaFeatureRecord<T>[]>>;
+  fieldsBySource?: Readonly<Record<string, readonly string[]>>;
+  editor?: Partial<HonuaEditorModel>;
+  chart?: HonuaChartModel;
+  searchFields?: readonly string[];
+  status?: HonuaComponentStatus;
+}
+
+export interface HonuaWebComponentRuntimeLike<T = Record<string, unknown>> {
+  readonly mapPackage: HonuaMapPackage;
+  readonly composedStyle: { layers: readonly HonuaLayerSpecification[] };
+  getLegend(): readonly HonuaMapPackageLegendEntry[];
+  setLayerVisibility(layerId: string, visible: boolean): void;
+  setViewState(viewport: HonuaViewportState): void;
+  readonly dataset?: {
+    source(id: string):
+      | {
+          query(request?: Query<T>): Promise<{
+            features: readonly HonuaTypedFeature<T>[];
+            totalCount?: number;
+            exceededTransferLimit?: boolean;
+            fields?: readonly { name: string }[];
+          }>;
+        }
+      | undefined;
+  };
+  on?(listener: (event: { type: string; sourceId?: string; error?: unknown }) => void): HonuaControllerSubscription;
+}
+
+export interface HonuaSelectionChangeDetail<T = Record<string, unknown>> extends HonuaSelectionState<T> {}
+
+export interface HonuaLayerVisibilityChangeDetail {
+  layerId: string;
+  visible: boolean;
+}
+
+export interface HonuaViewportChangeDetail extends HonuaViewportState {}
+
+export interface HonuaFilterChangeDetail extends HonuaFilterState {}
+
+export interface HonuaSearchDetail<T = Record<string, unknown>> {
+  query: string;
+  results: readonly HonuaSearchResult<T>[];
+}
+
+export interface HonuaEditChangeDetail<T = Record<string, unknown>> {
+  status: HonuaComponentStatus;
+  request?: HonuaEditRequest<T>;
+  model: HonuaEditorModel;
+}
+
+export interface HonuaControllerReadyDetail<T = Record<string, unknown>> {
+  controller: HonuaWebComponentController<T>;
+}

--- a/test/playwright/web-components-basic.spec.mjs
+++ b/test/playwright/web-components-basic.spec.mjs
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test";
+
+import { startWebComponentsFixtureServer } from "../../examples/web-components-basic/mock-server.mjs";
+
+test.setTimeout(90_000);
+
+test("web components compose map, layers, legend, table, search, and editor state", async ({ page }) => {
+  const pageErrors = [];
+  page.on("pageerror", (error) => {
+    pageErrors.push(error.message);
+  });
+
+  const server = await startWebComponentsFixtureServer();
+  try {
+    await page.goto(server.url);
+    await expect.poll(async () => page.evaluate(() => window.__HONUA_WEB_COMPONENTS_DEMO__?.ready === true)).toBe(true);
+
+    await expect(page.locator("honua-map").getByText("Public safety incidents")).toBeVisible();
+    await expect(page.locator("honua-layer-list").getByText("Incident labels")).toBeVisible();
+    await expect(page.locator("honua-legend").getByText("High priority")).toBeVisible();
+    await expect(page.locator("honua-feature-table").getByText("Harbor response district")).toBeVisible();
+    await expect(page.locator("honua-editor").getByText("Source metadata marks incidents read-only.")).toBeVisible();
+    await expect(page.locator("honua-editor button[data-action='save']")).toBeDisabled();
+    await expect(page.locator("honua-chart").getByText("High")).toBeVisible();
+
+    await page.getByLabel("Public safety incidents").uncheck();
+    await expect
+      .poll(async () => page.evaluate(() => window.__HONUA_WEB_COMPONENTS_DEMO__?.layerVisible("incident-points")))
+      .toBe(false);
+    await expect(page.locator("#event-log")).toHaveText("layer:incident-points:false");
+
+    await page.locator("honua-search").getByRole("textbox", { name: "Search" }).fill("harbor");
+    await page.locator("honua-search").getByRole("button", { name: "Search" }).click();
+    await expect(page.locator("#event-log")).toHaveText("search:harbor:1");
+    await page.getByRole("button", { name: "Harbor response district" }).click();
+    await expect
+      .poll(async () => page.evaluate(() => window.__HONUA_WEB_COMPONENTS_DEMO__?.selectedFeatureId))
+      .toBe(101);
+    await expect(page.locator("honua-editor").getByText("Harbor response district")).toBeVisible();
+
+    await page.locator("honua-feature-table tbody tr[data-feature-id='102']").focus();
+    await page.keyboard.press("Enter");
+    await expect
+      .poll(async () => page.evaluate(() => window.__HONUA_WEB_COMPONENTS_DEMO__?.selectedFeatureId))
+      .toBe("102");
+    await expect(
+      page.locator("honua-feature-table tbody tr[aria-selected='true']").getByText("Kakaako utility corridor"),
+    ).toBeVisible();
+
+    await page.locator("honua-feature-table").evaluate((element) => element.setAttribute("filter-text", "kakaako"));
+    await expect(page.locator("#event-log")).toHaveText("filter:incidents:kakaako");
+    await expect(page.locator("honua-feature-table").getByText("Ala Moana shelter route")).toHaveCount(0);
+
+    expect(pageErrors).toEqual([]);
+  } finally {
+    await server.close();
+  }
+});

--- a/test/web-components-controller.test.ts
+++ b/test/web-components-controller.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createHonuaWebComponentController,
+  createHonuaWebComponentControllerFromRuntime,
+  defineHonuaWebComponents,
+} from "../src/web-components/index.js";
+import type { HonuaFeatureRecord, HonuaWebComponentRuntimeLike } from "../src/web-components/index.js";
+
+const features: HonuaFeatureRecord[] = [
+  {
+    id: 1,
+    sourceId: "incidents",
+    title: "Harbor response district",
+    attributes: { name: "Harbor response district", status: "Open", priority: "High" },
+    geometry: { x: -157.87, y: 21.31 },
+  },
+  {
+    id: 2,
+    sourceId: "incidents",
+    title: "Kakaako utility corridor",
+    attributes: { name: "Kakaako utility corridor", status: "Monitoring", priority: "Medium" },
+    geometry: { x: -157.86, y: 21.29 },
+  },
+];
+
+function mapPackage() {
+  return {
+    mapPackageId: "component-test",
+    format: "honua_map_package.v1" as const,
+    sourceBindings: [],
+    legend: [{ label: "Open incident", color: "#dc2626" }],
+    initialView: { center: [-157.86, 21.3] as const, zoom: 10 },
+    mapSpec: {
+      version: 8 as const,
+      sources: {
+        incidents: {
+          type: "geojson",
+          data: { type: "FeatureCollection", features: [] },
+        },
+      },
+      layers: [
+        {
+          id: "incident-points",
+          source: "incidents",
+          type: "circle",
+          metadata: { title: "Incident points" },
+          paint: { "circle-color": "#dc2626" },
+        },
+      ],
+    },
+  };
+}
+
+describe("Honua web component controller", () => {
+  it("creates map, layer, legend, table, and search state from plain TypeScript", async () => {
+    const controller = createHonuaWebComponentController({
+      mapPackage: mapPackage(),
+      featuresBySource: { incidents: features },
+      fieldsBySource: { incidents: ["name", "status", "priority"] },
+      searchFields: ["name", "priority"],
+    });
+
+    const seenVisible: boolean[] = [];
+    const handle = controller.subscribe((state) => {
+      seenVisible.push(state.layers[0]?.visible ?? false);
+    });
+
+    controller.setLayerVisibility("incident-points", false);
+    const table = await controller.queryFeatures("incidents", { fields: ["name", "status"] });
+    const searchResults = await controller.search("harbor");
+    controller.selectFeature({ sourceId: "incidents", featureId: 1 });
+
+    handle.remove();
+
+    expect(controller.getState().packageId).toBe("component-test");
+    expect(controller.getState().layers[0]).toMatchObject({ title: "Incident points", visible: false });
+    expect(controller.getState().legend[0]).toMatchObject({ label: "Open incident", color: "#dc2626" });
+    expect(table.fields).toEqual(["name", "status"]);
+    expect(table.rows).toHaveLength(2);
+    expect(searchResults[0]).toMatchObject({ label: "Harbor response district", sourceId: "incidents" });
+    expect(controller.getState().selection?.feature?.title).toBe("Harbor response district");
+    expect(seenVisible.slice(0, 2)).toEqual([true, false]);
+  });
+
+  it("filters in-memory table rows and accepts realtime feature updates", async () => {
+    const controller = createHonuaWebComponentController({
+      mapPackage: mapPackage(),
+      featuresBySource: { incidents: features },
+    });
+
+    controller.setFilter({ sourceId: "incidents", text: "kakaako" });
+    expect((await controller.queryFeatures("incidents")).rows.map((row) => row.id)).toEqual([2]);
+
+    controller.updateFeatures?.("incidents", [
+      ...features,
+      {
+        id: 3,
+        sourceId: "incidents",
+        attributes: { name: "Kakaako backup shelter", status: "Open" },
+      },
+    ]);
+
+    expect((await controller.queryFeatures("incidents")).rows.map((row) => row.id)).toEqual([2, 3]);
+  });
+
+  it("adapts an existing runtime without taking over controller internals", async () => {
+    const setLayerVisibility = vi.fn();
+    const setViewState = vi.fn();
+    const runtime = {
+      mapPackage: mapPackage(),
+      composedStyle: mapPackage().mapSpec,
+      getLegend: () => [{ id: "open", label: "Open incident", color: "#dc2626" }],
+      setLayerVisibility,
+      setViewState,
+      dataset: {
+        source: () => ({
+          query: async () => ({
+            features: [{ attributes: { OBJECTID: 11, name: "Runtime feature" }, geometry: null }],
+            totalCount: 1,
+            exceededTransferLimit: false,
+            fields: [{ name: "name" }],
+          }),
+        }),
+      },
+    } satisfies HonuaWebComponentRuntimeLike;
+
+    const controller = createHonuaWebComponentControllerFromRuntime(runtime);
+    controller.setLayerVisibility("incident-points", false);
+    controller.setViewport({ zoom: 12 });
+    const table = await controller.queryFeatures("incidents");
+
+    expect(setLayerVisibility).toHaveBeenCalledWith("incident-points", false);
+    expect(setViewState).toHaveBeenCalledWith({ zoom: 12 });
+    expect(table.rows[0]).toMatchObject({ id: 11, title: "Runtime feature" });
+  });
+
+  it("can be imported in Node and registers only when a registry is supplied", () => {
+    const defined = new Map<string, CustomElementConstructor>();
+    const registry = {
+      get: (name: string) => defined.get(name),
+      define: (name: string, ctor: CustomElementConstructor) => {
+        defined.set(name, ctor);
+      },
+    } as unknown as CustomElementRegistry;
+
+    defineHonuaWebComponents(registry);
+
+    expect(defined.has("honua-map")).toBe(true);
+    expect(defined.has("honua-feature-table")).toBe(true);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -69,6 +69,10 @@ export default defineConfig({
         replacement: path.resolve(import.meta.dirname, "src/runtime/index.ts"),
       },
       {
+        find: "@honua/sdk-js/web-components",
+        replacement: path.resolve(import.meta.dirname, "src/web-components/index.ts"),
+      },
+      {
         find: "@honua/sdk-js",
         replacement: path.resolve(import.meta.dirname, "src/index.ts"),
       },


### PR DESCRIPTION
## Summary

- Adds `@honua/sdk-js/web-components` with framework-neutral custom elements for map, layer list, legend, feature table, search, editor, and chart.
- Adds a small controller interface with in-memory and runtime-adapter bindings for shared layer, selection, filter, search, edit, and viewport state.
- Adds docs, a plain TypeScript Vite example, focused unit tests, and a Playwright smoke flow.

Closes #149

## Validation

- `npm run typecheck --silent`
- `npm run build --silent`
- `npm run demo:web-components:typecheck --silent`
- `npx vitest run test/web-components-controller.test.ts`
- `npm run test:playwright:web-components --silent`
- `npx biome check package.json vitest.config.ts src/web-components test/web-components-controller.test.ts test/playwright/web-components-basic.spec.mjs examples/web-components-basic/src/main.ts examples/web-components-basic/src/styles.css examples/web-components-basic/vite.config.ts examples/web-components-basic/mock-server.mjs docs/web-components.md`