### PR TITLE
[codex] Fix release publish workflow dispatch ref

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,6 +29,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          release_ref="${GITHUB_SHA}"
+          release_ref="${GITHUB_REF_NAME}"
           gh workflow run publish-js-sdk.yml --repo "${GITHUB_REPOSITORY}" --ref "${release_ref}" -f dry_run=false
           gh workflow run publish-mcp-server.yml --repo "${GITHUB_REPOSITORY}" --ref "${release_ref}" -f dry_run=false


### PR DESCRIPTION
## Summary

- Updates Release Please publish dispatch to use the branch ref name instead of the raw commit SHA.
- This matches GitHub workflow_dispatch ref requirements and prevents the post-release publish dispatch from failing.

## Validation

- `git diff --check`
- Observed failed Release Please run 25653151123 rejected raw SHA ref with HTTP 422.
- Manual publish workflows dispatched against `trunk`: 25653430531 and 25653431599.