### PR TITLE
[codex] Add MapLibre style-spec runtime validation (#163)

### DIFF
--- a/docs/maplibre-runtime.md
+++ b/docs/maplibre-runtime.md
@@ -96,6 +96,7 @@ interface LoadMapPackageOptions {
   applyInitialView?: boolean;              // default true
   onEvent?: HonuaRuntimeEventListener;     // subscribed BEFORE initial emissions
   sourceErrorPolicy?: "tolerant" | "fail-fast"; // default "tolerant" — see Tolerant binding
+  styleSpecValidationMode?: "strict" | "warning-only" | "renderer-deferred"; // default "strict"
 }
 ```
 
@@ -110,6 +111,14 @@ observe the initial lifecycle without racing against `loadMapPackage`'s
 return must use this hook instead of calling `runtime.on(...)` after
 `await`. Subsequent events (`package-updated`, `disposed`, ...) also
 flow through the same listener.
+
+Runtime source/layer mutation helpers lazily use
+`@maplibre/maplibre-gl-style-spec` without constructing a MapLibre map.
+`"strict"` reports style-spec errors as fatal
+`HonuaRuntimeDiagnosticError` entries before renderer mutation,
+`"warning-only"` preserves the diagnostics as warnings, and
+`"renderer-deferred"` skips SDK style-spec checks so the host renderer
+reports invalid values.
 
 ## Hosted MapPackage Fetch
 
@@ -324,7 +333,7 @@ Theme application recurses into nested arrays / objects inside
 | `removeLayer(layerId)` / `moveLayer(layerId, order?)` | Removes or reorders runtime-owned layers while keeping `runtime.composedStyle` and `runtime.honuaMap` aligned with the renderer. |
 | `setLayerPaint(layerId, paint)` / `setLayerLayout(layerId, layout)` / `setLayerFilter(layerId, filter)` | Convenience wrappers around `updateLayer` for common Mapbox-style style changes. |
 | `setLayerVisibility(layerId, visible)` | `map.setLayoutProperty(layerId, "visibility", …)`. |
-| `validateStyleExpression(value)` / `validateFilterExpression(filter, layerId?)` | Runs Honua's lightweight expression validator and returns typed diagnostics with path, layer id, source id, protocol, and severity context. Mutating helpers throw `HonuaRuntimeDiagnosticError` before touching the renderer when diagnostics contain errors. |
+| `validateStyleExpression(value)` / `validateFilterExpression(filter, layerId?)` | Runs Honua expression checks plus MapLibre style-spec validation when enabled, returning typed diagnostics with path, layer id, source id, protocol, severity, and MapLibre validation context. Mutating helpers throw `HonuaRuntimeDiagnosticError` before touching the renderer when diagnostics contain errors. |
 | `getLegend()` | Runs `buildLegend` against the current package and composed style; backfills missing swatches from the first `fill-color` / `circle-color` / `line-color` paint property when it is a string literal. |
 | `bindPopup(layerId, binding?)` | Requires `opts.popupFactory`. When `binding` is omitted the runtime looks up `pkg.popupBindings[]` by the layer's source id. The default renderer emits an unstyled `<dl>` of the first feature's properties (or a `{field}` template when `binding.template` is set). Returns a `{ remove() }` handle; re-binding on the same layer tears down the prior handle. |
 | `bindHover(layerId, options?)` / `bindClick(layerId, handler, options?)` / `bindSelect(layerId, options?)` | Infers source and source-layer from the runtime layer, binds MapLibre layer events, and manages hover/click/select feature-state without requiring app code to pass MapLibre types. `bindClick` emits a source-qualified selection target when a feature id is available. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",
         "@connectrpc/connect": "^2.0.0",
-        "@connectrpc/connect-web": "^2.0.0"
+        "@connectrpc/connect-web": "^2.0.0",
+        "@maplibre/maplibre-gl-style-spec": "^24.7.0"
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
@@ -1010,7 +1011,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
       "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1033,7 +1033,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
       "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/vector-tile": {
@@ -1072,7 +1071,6 @@
       "version": "24.7.0",
       "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.7.0.tgz",
       "integrity": "sha512-Ed7rcKYU5iELfablg9Mj+TVCsXsPBgdMyXPRAxb2v7oWg9YJnpQdZ5msDs1LESu/mtXy3Z48Vdppv2t/x5kAhw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
@@ -2053,7 +2051,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
       "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/kdbush": {
@@ -2175,7 +2172,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2388,7 +2384,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
       "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/rbush": {
@@ -2460,7 +2455,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
@@ -2568,7 +2562,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/tinyrainbow": {

--- a/package.json
+++ b/package.json
@@ -259,7 +259,8 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.0.0",
     "@connectrpc/connect": "^2.0.0",
-    "@connectrpc/connect-web": "^2.0.0"
+    "@connectrpc/connect-web": "^2.0.0",
+    "@maplibre/maplibre-gl-style-spec": "^24.7.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -109,6 +109,16 @@ export { applyStyleRefs, applyTheme, composeStyle } from "./style-compose.js";
 export type { StyleComposeOptions, StyleRefResolver, ThemeResolver } from "./style-compose.js";
 
 export {
+  prepareRuntimeStyleSpecValidation,
+  validateRuntimeFilterStyleSpec,
+  validateRuntimeLayerStyleSpec,
+  validateRuntimeSourceStyleSpec,
+  validateRuntimeStyleExpressionStyleSpec,
+  validateRuntimeStyleSpec,
+} from "./style-spec-validation.js";
+export type { RuntimeStyleSpecValidationMode, RuntimeStyleSpecValidationOptions } from "./style-spec-validation.js";
+
+export {
   buildWmsRasterSourceSpec,
   buildWmtsRasterSourceSpec,
   projectSourceBindings,

--- a/src/runtime/load-package.ts
+++ b/src/runtime/load-package.ts
@@ -24,6 +24,9 @@ import {
 } from "./runtime.js";
 import { projectSourceBindings, toHonuaSourceSpec } from "./source-bridge.js";
 import { type StyleRefResolver, type ThemeResolver, composeStyle } from "./style-compose.js";
+import { throwRuntimeDiagnostics } from "./style-interactions.js";
+import { prepareRuntimeStyleSpecValidation } from "./style-spec-validation.js";
+import type { RuntimeStyleSpecValidationMode } from "./style-spec-validation.js";
 
 /**
  * How `loadMapPackage` reacts when a single protocol-backed source
@@ -94,6 +97,13 @@ export interface LoadMapPackageOptions {
    * binding failure (the historical single-source behaviour).
    */
   sourceErrorPolicy?: SourceErrorPolicy;
+  /**
+   * MapLibre style-spec validation mode used by runtime source/layer
+   * mutation helpers. Defaults to `"strict"`; pass `"warning-only"` to
+   * keep diagnostics non-fatal, or `"renderer-deferred"` to skip SDK
+   * style-spec checks and let the renderer report invalid style values.
+   */
+  styleSpecValidationMode?: RuntimeStyleSpecValidationMode;
 }
 
 /**
@@ -128,6 +138,11 @@ export async function loadMapPackage(
   });
 
   const sourceErrorPolicy: SourceErrorPolicy = options.sourceErrorPolicy ?? "tolerant";
+  const styleSpecValidationMode: RuntimeStyleSpecValidationMode = options.styleSpecValidationMode ?? "strict";
+  throwRuntimeDiagnostics(
+    await prepareRuntimeStyleSpecValidation(styleSpecValidationMode),
+    "Cannot initialize MapLibre style-spec validation.",
+  );
 
   const compose = async (
     target: HonuaMapPackage,
@@ -230,6 +245,7 @@ export async function loadMapPackage(
       telemetry: options.telemetry,
       popupFactory: options.popupFactory,
       popupRenderer: options.popupRenderer,
+      styleSpecValidationMode,
       reload: async (next): Promise<HonuaMapRuntimeReload> => {
         const result = await compose(next);
         for (const failed of result.failedSources) {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -54,6 +54,7 @@ import type {
   RuntimeSelectionInteractionOptions,
   RuntimeSourceSpecification,
 } from "./style-interactions.js";
+import type { RuntimeStyleSpecValidationMode } from "./style-spec-validation.js";
 
 /**
  * Minimal subset of `maplibre-gl.Map` required by the runtime. Mirrors
@@ -148,6 +149,7 @@ export interface HonuaMapRuntimeInternals {
   telemetry?: HonuaRuntimeTelemetry;
   popupFactory?: PopupFactory;
   popupRenderer?: PopupRenderer;
+  styleSpecValidationMode: RuntimeStyleSpecValidationMode;
   reload: (next: HonuaMapPackage) => Promise<HonuaMapRuntimeReload>;
 }
 
@@ -178,6 +180,7 @@ export class HonuaMapRuntime {
   readonly #telemetry: HonuaRuntimeTelemetry | undefined;
   readonly #popupFactory: PopupFactory | undefined;
   readonly #popupRenderer: PopupRenderer | undefined;
+  readonly #styleSpecValidationMode: RuntimeStyleSpecValidationMode;
   readonly #popupBindings = new Map<string, ActivePopupBinding>();
   readonly #reload: (next: HonuaMapPackage) => Promise<HonuaMapRuntimeReload>;
   #honuaMap: HonuaMap;
@@ -195,6 +198,7 @@ export class HonuaMapRuntime {
     this.#telemetry = internals.telemetry;
     this.#popupFactory = internals.popupFactory;
     this.#popupRenderer = internals.popupRenderer;
+    this.#styleSpecValidationMode = internals.styleSpecValidationMode;
     this.#reload = internals.reload;
   }
 
@@ -240,7 +244,9 @@ export class HonuaMapRuntime {
   }
 
   public validateStyleExpression(value: unknown): HonuaRuntimeDiagnostic[] {
-    return validateRuntimeStyleExpression(value);
+    return validateRuntimeStyleExpression(value, {
+      styleSpecValidationMode: this.#styleSpecValidationMode,
+    });
   }
 
   public validateFilterExpression(filter: unknown, layerId?: string): HonuaRuntimeDiagnostic[] {
@@ -255,6 +261,7 @@ export class HonuaMapRuntime {
             protocol: layerContext.protocol,
           }
         : {}),
+      styleSpecValidationMode: this.#styleSpecValidationMode,
     });
   }
 
@@ -278,6 +285,7 @@ export class HonuaMapRuntime {
         style: this.#composedStyle,
         mapPackage: this.#packageRef.current,
         operation: "addSource",
+        styleSpecValidationMode: this.#styleSpecValidationMode,
       }),
     ];
     throwRuntimeDiagnostics(diagnostics, `Cannot add source "${sourceId}".`);
@@ -333,6 +341,7 @@ export class HonuaMapRuntime {
         style: this.#composedStyle,
         mapPackage: this.#packageRef.current,
         operation: "updateSource",
+        styleSpecValidationMode: this.#styleSpecValidationMode,
       }),
     ];
     throwRuntimeDiagnostics(diagnostics, `Cannot update source "${sourceId}".`);
@@ -424,6 +433,7 @@ export class HonuaMapRuntime {
         style: this.#composedStyle,
         mapPackage: this.#packageRef.current,
         operation: "addLayer",
+        styleSpecValidationMode: this.#styleSpecValidationMode,
       }),
     ];
     throwRuntimeDiagnostics(diagnostics, `Cannot add layer "${spec.id}".`);
@@ -483,6 +493,7 @@ export class HonuaMapRuntime {
         style: this.#composedStyle,
         mapPackage: this.#packageRef.current,
         operation: "updateLayer",
+        styleSpecValidationMode: this.#styleSpecValidationMode,
       }),
     ];
     throwRuntimeDiagnostics(diagnostics, `Cannot update layer "${layerId}".`);

--- a/src/runtime/style-interactions.ts
+++ b/src/runtime/style-interactions.ts
@@ -21,6 +21,13 @@ import type {
 } from "../style/specification.js";
 import { isHonuaSource } from "../style/specification.js";
 import type { HonuaMapPackage } from "./map-package.js";
+import {
+  validateRuntimeFilterStyleSpecSync,
+  validateRuntimeLayerStyleSpecSync,
+  validateRuntimeSourceStyleSpecSync,
+  validateRuntimeStyleExpressionStyleSpecSync,
+} from "./style-spec-validation.js";
+import type { RuntimeStyleSpecValidationMode } from "./style-spec-validation.js";
 
 export type HonuaRuntimeDiagnosticSeverity = "error" | "warning";
 
@@ -89,12 +96,14 @@ export interface RuntimeExpressionValidationOptions {
   readonly context?: Readonly<Record<string, unknown>>;
   readonly requireExpression?: boolean;
   readonly strictUnknownOperators?: boolean;
+  readonly styleSpecValidationMode?: RuntimeStyleSpecValidationMode;
 }
 
 export interface RuntimeStyleValidationContext {
   readonly style?: HonuaStyleSpecification;
   readonly mapPackage?: HonuaMapPackage;
   readonly operation?: string;
+  readonly styleSpecValidationMode?: RuntimeStyleSpecValidationMode;
 }
 
 export interface RuntimeFeatureStateTarget {
@@ -316,6 +325,14 @@ export function validateRuntimeSource(
     });
   }
 
+  diagnostics.push(
+    ...validateRuntimeSourceStyleSpecSync(sourceId, source, {
+      mode: context.styleSpecValidationMode,
+      path: `sources.${sourceId}`,
+      ...sourceContext,
+    }),
+  );
+
   return diagnostics;
 }
 
@@ -407,6 +424,15 @@ export function validateRuntimeLayer(
     );
   }
 
+  diagnostics.push(
+    ...validateRuntimeLayerStyleSpecSync(materialized, {
+      mode: context.styleSpecValidationMode,
+      style: context.style,
+      path: `layers.${materialized.id}`,
+      ...sourceContext,
+    }),
+  );
+
   return diagnostics;
 }
 
@@ -427,7 +453,10 @@ export function validateRuntimeStyleExpression(
         ]
       : [];
   }
-  return validateExpressionArray(materialized, options);
+  return [
+    ...validateExpressionArray(materialized, options),
+    ...validateRuntimeStyleExpressionStyleSpecSync(materialized, styleSpecOptions(options)),
+  ];
 }
 
 export function validateRuntimeFilterExpression(
@@ -444,11 +473,15 @@ export function validateRuntimeFilterExpression(
       }),
     ];
   }
-  return validateRuntimeStyleExpression(materialized, {
-    kind: "filter",
+  const expressionOptions = {
+    kind: "filter" as const,
     requireExpression: true,
     ...options,
-  });
+  };
+  return [
+    ...validateRuntimeStyleExpression(materialized, expressionOptions),
+    ...validateRuntimeFilterStyleSpecSync(materialized, styleSpecOptions(expressionOptions)),
+  ];
 }
 
 export function throwRuntimeDiagnostics(
@@ -817,6 +850,24 @@ function diagnostic(
     ...(options.layerId ? { layerId: options.layerId } : {}),
     ...(options.protocol ? { protocol: options.protocol } : {}),
     ...(options.context ? { context: options.context } : {}),
+  };
+}
+
+function styleSpecOptions(options: RuntimeExpressionValidationOptions): {
+  mode: RuntimeStyleSpecValidationMode | undefined;
+  path: string | undefined;
+  sourceId: string | undefined;
+  layerId: string | undefined;
+  protocol: string | undefined;
+  context: Readonly<Record<string, unknown>> | undefined;
+} {
+  return {
+    mode: options.styleSpecValidationMode,
+    path: options.path,
+    sourceId: options.sourceId,
+    layerId: options.layerId,
+    protocol: options.protocol,
+    context: options.context,
   };
 }
 

--- a/src/runtime/style-spec-validation.ts
+++ b/src/runtime/style-spec-validation.ts
@@ -1,0 +1,474 @@
+import type { HonuaLayerSpecification, HonuaStyleSpecification } from "../style/specification.js";
+import type { HonuaRuntimeDiagnostic, HonuaRuntimeDiagnosticSeverity } from "./style-interactions.js";
+
+export type RuntimeStyleSpecValidationMode = "strict" | "warning-only" | "renderer-deferred";
+
+export interface RuntimeStyleSpecValidationOptions {
+  readonly mode?: RuntimeStyleSpecValidationMode;
+  readonly style?: HonuaStyleSpecification;
+  readonly path?: string;
+  readonly sourceId?: string;
+  readonly layerId?: string;
+  readonly protocol?: string;
+  readonly context?: Readonly<Record<string, unknown>>;
+}
+
+type RuntimeSourceLike = Record<string, unknown>;
+
+interface MapLibreValidationErrorLike {
+  readonly message?: unknown;
+  readonly identifier?: unknown;
+  readonly key?: unknown;
+  readonly line?: unknown;
+}
+
+interface MapLibreExpressionResult {
+  readonly result: "success" | "error";
+  readonly value: unknown;
+}
+
+interface MapLibreStyleSpecModule {
+  readonly validateStyleMin: (style: unknown) => readonly MapLibreValidationErrorLike[];
+  readonly createExpression: (expression: unknown) => MapLibreExpressionResult;
+}
+
+let loadAttempted = false;
+let loadedModule: MapLibreStyleSpecModule | undefined;
+let loadFailure: unknown;
+let loadPromise: Promise<MapLibreStyleSpecModule | undefined> | undefined;
+
+export async function prepareRuntimeStyleSpecValidation(
+  mode: RuntimeStyleSpecValidationMode = "strict",
+): Promise<HonuaRuntimeDiagnostic[]> {
+  if (mode === "renderer-deferred") return [];
+  const mod = await loadMapLibreStyleSpecModule();
+  if (mod) return [];
+  return [validatorUnavailableDiagnostic({ mode })];
+}
+
+export async function validateRuntimeStyleSpec(
+  style: HonuaStyleSpecification,
+  options: RuntimeStyleSpecValidationOptions = {},
+): Promise<HonuaRuntimeDiagnostic[]> {
+  const mode = options.mode ?? "strict";
+  if (mode === "renderer-deferred") return [];
+  const mod = await loadMapLibreStyleSpecModule();
+  if (!mod) return [validatorUnavailableDiagnostic({ ...options, mode })];
+  return mapStyleSpecErrors(mod.validateStyleMin(sanitizeStyle(style)), { ...options, mode }, {});
+}
+
+export async function validateRuntimeSourceStyleSpec(
+  sourceId: string,
+  source: unknown,
+  options: RuntimeStyleSpecValidationOptions = {},
+): Promise<HonuaRuntimeDiagnostic[]> {
+  const mode = options.mode ?? "strict";
+  if (mode === "renderer-deferred" || isHonuaSourceLike(source)) return [];
+  const mod = await loadMapLibreStyleSpecModule();
+  if (!mod)
+    return [
+      validatorUnavailableDiagnostic({ ...options, mode, sourceId, path: options.path ?? `sources.${sourceId}` }),
+    ];
+  return mapStyleSpecErrors(
+    mod.validateStyleMin({
+      version: 8,
+      sources: { [sourceId]: source },
+      layers: [],
+    }),
+    { ...options, mode, sourceId, path: options.path ?? `sources.${sourceId}` },
+    {},
+  );
+}
+
+export async function validateRuntimeLayerStyleSpec(
+  layer: HonuaLayerSpecification,
+  options: RuntimeStyleSpecValidationOptions = {},
+): Promise<HonuaRuntimeDiagnostic[]> {
+  const mode = options.mode ?? "strict";
+  if (mode === "renderer-deferred") return [];
+  const mod = await loadMapLibreStyleSpecModule();
+  if (!mod) {
+    return [
+      validatorUnavailableDiagnostic({
+        ...options,
+        mode,
+        layerId: options.layerId ?? layer.id,
+        sourceId: options.sourceId ?? layer.source,
+        path: options.path ?? layerPath(layer),
+      }),
+    ];
+  }
+  return mapStyleSpecErrors(
+    mod.validateStyleMin(styleForLayerValidation(layer, options)),
+    {
+      ...options,
+      mode,
+      layerId: options.layerId ?? layer.id,
+      sourceId: options.sourceId ?? layer.source,
+      path: options.path ?? layerPath(layer),
+    },
+    { layerId: layer.id },
+  );
+}
+
+export async function validateRuntimeStyleExpressionStyleSpec(
+  value: unknown,
+  options: RuntimeStyleSpecValidationOptions = {},
+): Promise<HonuaRuntimeDiagnostic[]> {
+  const mode = options.mode ?? "strict";
+  if (mode === "renderer-deferred") return [];
+  const mod = await loadMapLibreStyleSpecModule();
+  if (!mod) return [validatorUnavailableDiagnostic({ ...options, mode })];
+  return validateExpressionWithModule(mod, value, { ...options, mode });
+}
+
+export async function validateRuntimeFilterStyleSpec(
+  filter: unknown,
+  options: RuntimeStyleSpecValidationOptions = {},
+): Promise<HonuaRuntimeDiagnostic[]> {
+  const mode = options.mode ?? "strict";
+  if (mode === "renderer-deferred") return [];
+  const mod = await loadMapLibreStyleSpecModule();
+  if (!mod) return [validatorUnavailableDiagnostic({ ...options, mode })];
+  return mapStyleSpecErrors(
+    mod.validateStyleMin(styleForFilterValidation(filter, options.layerId)),
+    { ...options, mode, path: options.path ?? filterPath(options.layerId) },
+    { layerId: options.layerId ?? "__honua_filter_validation__" },
+  );
+}
+
+export function validateRuntimeSourceStyleSpecSync(
+  sourceId: string,
+  source: unknown,
+  options: RuntimeStyleSpecValidationOptions = {},
+): HonuaRuntimeDiagnostic[] {
+  if (!shouldRunSyncStyleSpecValidation(options.mode) || isHonuaSourceLike(source)) return [];
+  const mod = loadedStyleSpecModule();
+  if (!mod)
+    return [validatorUnavailableDiagnostic({ ...options, sourceId, path: options.path ?? `sources.${sourceId}` })];
+  return mapStyleSpecErrors(
+    mod.validateStyleMin({
+      version: 8,
+      sources: { [sourceId]: source },
+      layers: [],
+    }),
+    { ...options, sourceId, path: options.path ?? `sources.${sourceId}` },
+    {},
+  );
+}
+
+export function validateRuntimeLayerStyleSpecSync(
+  layer: HonuaLayerSpecification,
+  options: RuntimeStyleSpecValidationOptions = {},
+): HonuaRuntimeDiagnostic[] {
+  if (!shouldRunSyncStyleSpecValidation(options.mode)) return [];
+  const mod = loadedStyleSpecModule();
+  if (!mod) {
+    return [
+      validatorUnavailableDiagnostic({
+        ...options,
+        layerId: options.layerId ?? layer.id,
+        sourceId: options.sourceId ?? layer.source,
+        path: options.path ?? layerPath(layer),
+      }),
+    ];
+  }
+  return mapStyleSpecErrors(
+    mod.validateStyleMin(styleForLayerValidation(layer, options)),
+    {
+      ...options,
+      layerId: options.layerId ?? layer.id,
+      sourceId: options.sourceId ?? layer.source,
+      path: options.path ?? layerPath(layer),
+    },
+    { layerId: layer.id },
+  );
+}
+
+export function validateRuntimeStyleExpressionStyleSpecSync(
+  value: unknown,
+  options: RuntimeStyleSpecValidationOptions = {},
+): HonuaRuntimeDiagnostic[] {
+  if (!shouldRunSyncStyleSpecValidation(options.mode)) return [];
+  const mod = loadedStyleSpecModule();
+  if (!mod) return [validatorUnavailableDiagnostic(options)];
+  return validateExpressionWithModule(mod, value, options);
+}
+
+export function validateRuntimeFilterStyleSpecSync(
+  filter: unknown,
+  options: RuntimeStyleSpecValidationOptions = {},
+): HonuaRuntimeDiagnostic[] {
+  if (!shouldRunSyncStyleSpecValidation(options.mode)) return [];
+  const mod = loadedStyleSpecModule();
+  if (!mod) return [validatorUnavailableDiagnostic(options)];
+  return mapStyleSpecErrors(
+    mod.validateStyleMin(styleForFilterValidation(filter, options.layerId)),
+    { ...options, path: options.path ?? filterPath(options.layerId) },
+    { layerId: options.layerId ?? "__honua_filter_validation__" },
+  );
+}
+
+function validateExpressionWithModule(
+  mod: MapLibreStyleSpecModule,
+  value: unknown,
+  options: RuntimeStyleSpecValidationOptions,
+): HonuaRuntimeDiagnostic[] {
+  const result = mod.createExpression(value);
+  if (result.result !== "error" || !Array.isArray(result.value)) return [];
+  return result.value.map((error) => {
+    const mapLibrePath = pathWithExpressionKey(options.path, stringProperty(error, "key"));
+    return mapLibreDiagnostic(error, stringProperty(error, "message") ?? "Invalid MapLibre style expression.", {
+      ...options,
+      path: mapLibrePath,
+      mapLibrePath,
+    });
+  });
+}
+
+async function loadMapLibreStyleSpecModule(): Promise<MapLibreStyleSpecModule | undefined> {
+  if (loadedModule) return loadedModule;
+  loadAttempted = true;
+  loadPromise ??= import("@maplibre/maplibre-gl-style-spec")
+    .then((mod) => {
+      const candidate = mod as Partial<MapLibreStyleSpecModule>;
+      if (typeof candidate.validateStyleMin !== "function" || typeof candidate.createExpression !== "function") {
+        throw new Error("@maplibre/maplibre-gl-style-spec does not expose the expected validator API.");
+      }
+      loadedModule = {
+        validateStyleMin: candidate.validateStyleMin,
+        createExpression: candidate.createExpression,
+      };
+      loadFailure = undefined;
+      return loadedModule;
+    })
+    .catch((error: unknown) => {
+      loadFailure = error;
+      loadedModule = undefined;
+      return undefined;
+    });
+  return loadPromise;
+}
+
+function loadedStyleSpecModule(): MapLibreStyleSpecModule | undefined {
+  return loadedModule;
+}
+
+function shouldRunSyncStyleSpecValidation(mode: RuntimeStyleSpecValidationMode | undefined): boolean {
+  return mode !== undefined && mode !== "renderer-deferred";
+}
+
+function mapStyleSpecErrors(
+  errors: readonly MapLibreValidationErrorLike[],
+  options: RuntimeStyleSpecValidationOptions,
+  remap: { readonly layerId?: string },
+): HonuaRuntimeDiagnostic[] {
+  return errors.map((error) => {
+    const parsed = parseMapLibreMessage(stringProperty(error, "message") ?? "Invalid MapLibre style specification.");
+    const path = parsed.path ? normalizeStylePath(parsed.path, remap) : options.path;
+    return mapLibreDiagnostic(error, parsed.message, {
+      ...options,
+      path: path ?? options.path,
+      mapLibrePath: parsed.path,
+    });
+  });
+}
+
+function mapLibreDiagnostic(
+  error: MapLibreValidationErrorLike,
+  message: string,
+  options: RuntimeStyleSpecValidationOptions & { readonly mapLibrePath?: string },
+): HonuaRuntimeDiagnostic {
+  const mapLibreCode = stringProperty(error, "identifier") ?? "validation-error";
+  const line = numberProperty(error, "line");
+  return {
+    code: "style-spec-invalid",
+    severity: severityForMode(options.mode),
+    message,
+    ...(options.path ? { path: options.path } : {}),
+    ...(options.sourceId ? { sourceId: options.sourceId } : {}),
+    ...(options.layerId ? { layerId: options.layerId } : {}),
+    ...(options.protocol ? { protocol: options.protocol } : {}),
+    context: {
+      ...(options.context ?? {}),
+      mapLibreCode,
+      ...(options.mapLibrePath ? { mapLibrePath: options.mapLibrePath } : {}),
+      ...(line !== undefined ? { mapLibreLine: line } : {}),
+    },
+  };
+}
+
+function validatorUnavailableDiagnostic(options: RuntimeStyleSpecValidationOptions): HonuaRuntimeDiagnostic {
+  const cause = loadAttempted
+    ? errorMessage(loadFailure) || "unknown import failure"
+    : "validator has not been prepared";
+  return {
+    code: "style-spec-validator-unavailable",
+    severity: severityForMode(options.mode),
+    message:
+      "MapLibre style-spec validation is unavailable. Install @maplibre/maplibre-gl-style-spec or use renderer-deferred validation.",
+    ...(options.path ? { path: options.path } : {}),
+    ...(options.sourceId ? { sourceId: options.sourceId } : {}),
+    ...(options.layerId ? { layerId: options.layerId } : {}),
+    ...(options.protocol ? { protocol: options.protocol } : {}),
+    context: {
+      ...(options.context ?? {}),
+      mapLibreCode: "validator-unavailable",
+      cause,
+    },
+  };
+}
+
+function sanitizeStyle(style: HonuaStyleSpecification): unknown {
+  const sources: Record<string, unknown> = {};
+  for (const [sourceId, source] of Object.entries(style.sources)) {
+    sources[sourceId] = isHonuaSourceLike(source)
+      ? placeholderSourceForLayer(firstLayerForSource(style.layers, sourceId), source)
+      : source;
+  }
+  return {
+    ...style,
+    sources,
+  };
+}
+
+function styleForLayerValidation(layer: HonuaLayerSpecification, options: RuntimeStyleSpecValidationOptions): unknown {
+  const sources: Record<string, unknown> = {};
+  const sourceId = typeof layer.source === "string" ? layer.source : undefined;
+  if (sourceId) {
+    const existing = options.style?.sources[sourceId];
+    if (existing) {
+      sources[sourceId] = isHonuaSourceLike(existing) ? placeholderSourceForLayer(layer, existing) : existing;
+    } else if (!options.style) {
+      sources[sourceId] = placeholderSourceForLayer(layer);
+    }
+  }
+  return {
+    version: 8,
+    sources,
+    layers: [layer],
+  };
+}
+
+function styleForFilterValidation(filter: unknown, layerId: string | undefined): unknown {
+  const sourceId = "__honua_filter_source__";
+  return {
+    version: 8,
+    sources: {
+      [sourceId]: geoJsonPlaceholderSource(),
+    },
+    layers: [
+      {
+        id: layerId ?? "__honua_filter_validation__",
+        type: "circle",
+        source: sourceId,
+        filter,
+      },
+    ],
+  };
+}
+
+function placeholderSourceForLayer(layer: HonuaLayerSpecification | undefined, source?: unknown): RuntimeSourceLike {
+  const sourceType = isPlainObject(source) && typeof source.type === "string" ? source.type : undefined;
+  if (sourceType === "honua-wms" || sourceType === "honua-wmts" || sourceType === "honua-map-service") {
+    return rasterPlaceholderSource();
+  }
+
+  if (layer?.type === "raster") return rasterPlaceholderSource();
+  if (layer?.type === "hillshade") return rasterDemPlaceholderSource();
+  return geoJsonPlaceholderSource();
+}
+
+function geoJsonPlaceholderSource(): RuntimeSourceLike {
+  return {
+    type: "geojson",
+    data: { type: "FeatureCollection", features: [] },
+  };
+}
+
+function rasterPlaceholderSource(): RuntimeSourceLike {
+  return {
+    type: "raster",
+    tiles: ["https://example.invalid/{z}/{x}/{y}.png"],
+    tileSize: 256,
+  };
+}
+
+function rasterDemPlaceholderSource(): RuntimeSourceLike {
+  return {
+    type: "raster-dem",
+    tiles: ["https://example.invalid/{z}/{x}/{y}.png"],
+    tileSize: 256,
+  };
+}
+
+function firstLayerForSource(
+  layers: readonly HonuaLayerSpecification[],
+  sourceId: string,
+): HonuaLayerSpecification | undefined {
+  return layers.find((layer) => layer.source === sourceId);
+}
+
+function isHonuaSourceLike(value: unknown): boolean {
+  return isPlainObject(value) && typeof value.type === "string" && value.type.startsWith("honua-");
+}
+
+function parseMapLibreMessage(message: string): { path: string | undefined; message: string } {
+  const separator = message.indexOf(": ");
+  if (separator <= 0) return { path: undefined, message };
+  const path = message.slice(0, separator);
+  if (!looksLikeMapLibrePath(path)) return { path: undefined, message };
+  return { path, message: message.slice(separator + 2) };
+}
+
+function looksLikeMapLibrePath(path: string): boolean {
+  return /^(version|name|metadata|center|zoom|bearing|pitch|sources|layers|sprite|glyphs|transition|light|terrain|projection|sky)(?:$|[.[\]])/.test(
+    path,
+  );
+}
+
+function normalizeStylePath(path: string, remap: { readonly layerId?: string }): string {
+  if (remap.layerId) {
+    return path.replace(/^layers\[\d+\]/, `layers.${remap.layerId}`);
+  }
+  return path;
+}
+
+function pathWithExpressionKey(path: string | undefined, key: string | undefined): string | undefined {
+  if (!key) return path;
+  if (!path) return key.startsWith(".") ? key.slice(1) : key;
+  return key.startsWith("[") || key.startsWith(".") ? `${path}${key}` : `${path}.${key}`;
+}
+
+function filterPath(layerId: string | undefined): string {
+  return layerId ? `layers.${layerId}.filter` : "filter";
+}
+
+function layerPath(layer: HonuaLayerSpecification): string {
+  return layer.id ? `layers.${layer.id}` : "layers[]";
+}
+
+function severityForMode(mode: RuntimeStyleSpecValidationMode | undefined): HonuaRuntimeDiagnosticSeverity {
+  return mode === "warning-only" ? "warning" : "error";
+}
+
+function stringProperty(value: unknown, property: keyof MapLibreValidationErrorLike): string | undefined {
+  if (!isPlainObject(value)) return undefined;
+  const candidate = value[property];
+  return typeof candidate === "string" ? candidate : undefined;
+}
+
+function numberProperty(value: unknown, property: keyof MapLibreValidationErrorLike): number | undefined {
+  if (!isPlainObject(value)) return undefined;
+  const candidate = value[property];
+  return typeof candidate === "number" ? candidate : undefined;
+}
+
+function errorMessage(error: unknown): string | undefined {
+  if (error instanceof Error) return error.message;
+  return typeof error === "string" ? error : undefined;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/test/operator/operator-workspace.test.ts
+++ b/test/operator/operator-workspace.test.ts
@@ -275,6 +275,18 @@ async function waitForEvent(
   throw new Error(`event "${kind}" not observed within ${maxTicks} ticks`);
 }
 
+async function waitForAsyncEvent(
+  events: ReadonlyArray<WorkspaceEvent>,
+  kind: WorkspaceEvent["kind"],
+  maxTicks = 50,
+): Promise<void> {
+  for (let i = 0; i < maxTicks; i += 1) {
+    if (events.some((event) => event.kind === kind)) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error(`event "${kind}" not observed within ${maxTicks} event-loop ticks`);
+}
+
 class DismissingJobRun implements IJobRun<ExecutionResult> {
   public readonly id = "op-dismiss";
   public readonly type = "operator-plan";
@@ -378,6 +390,7 @@ describe("OperatorWorkspace", () => {
     await waitForEvent(events, "plan-loaded");
     workspace.planReview.accept();
     await waitForEvent(events, "execution-terminal");
+    await waitForAsyncEvent(events, "map-loaded");
 
     const pending = await workspace.approval.load("op-1");
     const granted = await workspace.approval.confirm("op-1");

--- a/test/runtime-style-interactions.test.ts
+++ b/test/runtime-style-interactions.test.ts
@@ -5,10 +5,13 @@ import { createExplorationContext, sourceFeatureSelectionTarget } from "../src/e
 import {
   HONUA_MAP_PACKAGE_FORMAT_V1,
   type HonuaMapPackage,
+  type HonuaRuntimeDiagnostic,
   HonuaRuntimeDiagnosticError,
+  type LoadMapPackageOptions,
   type MaplibreMap,
   loadMapPackage,
   validateRuntimeFilterExpression,
+  validateRuntimeStyleSpec,
 } from "../src/runtime/index.js";
 
 interface MockCall {
@@ -167,11 +170,15 @@ function makePackage(): HonuaMapPackage {
   };
 }
 
-async function loadRuntime(map = makeMockMap()) {
+async function loadRuntime(
+  map = makeMockMap(),
+  options: Partial<Pick<LoadMapPackageOptions, "styleSpecValidationMode">> = {},
+) {
   const runtime = await loadMapPackage(makePackage(), map, {
     client: makeClient(),
     skipCompatibilityCheck: true,
     applyInitialView: false,
+    ...options,
   });
   map._calls.length = 0;
   return { runtime, map };
@@ -180,6 +187,16 @@ async function loadRuntime(map = makeMockMap()) {
 async function flush(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
+}
+
+function captureRuntimeDiagnostics(action: () => void): readonly HonuaRuntimeDiagnostic[] {
+  try {
+    action();
+  } catch (error) {
+    expect(error).toBeInstanceOf(HonuaRuntimeDiagnosticError);
+    return (error as HonuaRuntimeDiagnosticError).diagnostics;
+  }
+  throw new Error("Expected HonuaRuntimeDiagnosticError.");
 }
 
 describe("runtime source/layer helpers", () => {
@@ -270,6 +287,135 @@ describe("runtime source/layer helpers", () => {
 
     expect(validateRuntimeFilterExpression("status = 'open'")).toContainEqual(
       expect.objectContaining({ code: "filter-invalid", severity: "error" }),
+    );
+  });
+
+  test("validates runtime sources and layer style values with MapLibre style-spec diagnostics", async () => {
+    const { runtime, map } = await loadRuntime();
+
+    const sourceDiagnostics = captureRuntimeDiagnostics(() => {
+      runtime.addSource("bad-source", { type: "geojson" });
+    });
+    expect(sourceDiagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "style-spec-invalid",
+        severity: "error",
+        path: "sources.bad-source",
+        sourceId: "bad-source",
+        context: expect.objectContaining({
+          mapLibreCode: "validation-error",
+          mapLibrePath: "sources.bad-source",
+        }),
+      }),
+    );
+
+    map._calls.length = 0;
+    const paintDiagnostics = captureRuntimeDiagnostics(() => {
+      runtime.setLayerPaint("parcels-fill", { "fill-opacity": "opaque" });
+    });
+    expect(paintDiagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "style-spec-invalid",
+        severity: "error",
+        path: "layers.parcels-fill.paint.fill-opacity",
+        layerId: "parcels-fill",
+        sourceId: "parcels",
+        protocol: "geoservices_feature_service",
+        context: expect.objectContaining({
+          mapLibreCode: "validation-error",
+          mapLibrePath: "layers[0].paint.fill-opacity",
+        }),
+      }),
+    );
+    expect(map._calls).toEqual([]);
+
+    const layoutDiagnostics = captureRuntimeDiagnostics(() => {
+      runtime.setLayerLayout("parcels-fill", { visibility: "sometimes" });
+    });
+    expect(layoutDiagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "style-spec-invalid",
+        path: "layers.parcels-fill.layout.visibility",
+      }),
+    );
+
+    const filterDiagnostics = runtime.validateFilterExpression(["==", ["get"]], "parcels-fill");
+    expect(filterDiagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "style-spec-invalid",
+        path: "layers.parcels-fill.filter",
+        layerId: "parcels-fill",
+      }),
+    );
+  });
+
+  test("supports warning-only and renderer-deferred style-spec validation modes", async () => {
+    const warningMap = makeMockMap();
+    const { runtime: warningRuntime } = await loadRuntime(warningMap, {
+      styleSpecValidationMode: "warning-only",
+    });
+    expect(() => warningRuntime.setLayerPaint("parcels-fill", { "fill-opacity": "opaque" })).not.toThrow();
+    expect(warningMap._calls).toContainEqual({
+      method: "setPaintProperty",
+      args: ["parcels-fill", "fill-opacity", "opaque"],
+    });
+
+    const deferredMap = makeMockMap();
+    const { runtime: deferredRuntime } = await loadRuntime(deferredMap, {
+      styleSpecValidationMode: "renderer-deferred",
+    });
+    expect(() => deferredRuntime.setLayerLayout("parcels-fill", { visibility: "sometimes" })).not.toThrow();
+    expect(deferredMap._calls).toContainEqual({
+      method: "setLayoutProperty",
+      args: ["parcels-fill", "visibility", "sometimes"],
+    });
+  });
+
+  test("validates full styles without initializing a MapLibre map", async () => {
+    await expect(
+      validateRuntimeStyleSpec({
+        version: 8,
+        sources: {
+          incidents: {
+            type: "geojson",
+            data: { type: "FeatureCollection", features: [] },
+          },
+        },
+        layers: [
+          {
+            id: "incidents",
+            type: "circle",
+            source: "incidents",
+            paint: { "circle-color": "#d33", "circle-radius": 6 },
+          },
+        ],
+      }),
+    ).resolves.toEqual([]);
+
+    await expect(
+      validateRuntimeStyleSpec({
+        version: 8,
+        sources: {
+          incidents: {
+            type: "geojson",
+            data: { type: "FeatureCollection", features: [] },
+          },
+        },
+        layers: [
+          {
+            id: "incidents",
+            type: "circle",
+            source: "incidents",
+            paint: { "circle-radius": "large" },
+          },
+        ],
+      }),
+    ).resolves.toContainEqual(
+      expect.objectContaining({
+        code: "style-spec-invalid",
+        severity: "error",
+        path: "layers[0].paint.circle-radius",
+      }),
     );
   });
 });


### PR DESCRIPTION
## Summary

- Adds a lazy MapLibre style-spec validation module for full style, source, layer, filter, and expression checks without constructing a MapLibre map.
- Wires runtime source/layer mutation helpers through strict, warning-only, and renderer-deferred validation modes while preserving Honua diagnostics and adding MapLibre code/path context.
- Documents the runtime validation modes and adds focused runtime validation coverage.

Closes #163.

## Changed Paths

- `src/runtime/style-spec-validation.ts`
- `src/runtime/style-interactions.ts`
- `src/runtime/load-package.ts`
- `src/runtime/runtime.ts`
- `src/runtime/index.ts`
- `test/runtime-style-interactions.test.ts`
- `docs/maplibre-runtime.md`
- `package.json`
- `package-lock.json`

## Validation

- `npm run check`
- `npm run typecheck`
- `npm run build`
- `npm run verify:split-packages`
- `npx vitest run test/runtime-style-interactions.test.ts`