### PR TITLE
[codex] Add realtime MapPackage watch channel (#165)

### DIFF
--- a/docs/map-package-realtime-watch.md
+++ b/docs/map-package-realtime-watch.md
@@ -1,0 +1,138 @@
+# MapPackage Realtime Watch
+
+`watchMapPackage` can follow hosted `MapPackage` changes over a realtime
+channel when one is configured by the caller or advertised by the package. The
+polling watcher remains the fallback path and is still used when no realtime
+channel is available.
+
+## Client Usage
+
+```ts
+import { watchMapPackage } from "@honua/sdk-js/runtime";
+
+const watcher = watchMapPackage("map_123", {
+  client,
+  runtime,
+  realtime: {
+    url: "/api/v1/map-packages/map_123/watch",
+    withCredentials: true,
+    staleAfterMs: 90_000,
+  },
+  onEvent(event) {
+    if (event.type === "fallback") console.warn(event.reason);
+    if (event.type === "reload-required") console.info(event.reason);
+  },
+});
+
+watcher.dispose();
+```
+
+When `realtime` is omitted, `watchMapPackage` looks for an advertised channel
+on the current or fetched package:
+
+```json
+{
+  "realtime": {
+    "mapPackageWatch": {
+      "channel": "honua.map-package.watch.v1",
+      "transport": "sse",
+      "href": "/api/v1/map-packages/map_123/watch",
+      "withCredentials": true,
+      "staleAfterMs": 90000,
+      "fallback": "polling"
+    }
+  }
+}
+```
+
+The SDK currently ships an SSE adapter and accepts custom transports through
+`realtime.transport`. Unsupported advertised transports fall back to polling.
+
+## Message Contract
+
+All messages are JSON objects on channel `honua.map-package.watch.v1`. A server
+may send the object directly or wrap it as `{ "event": { ... } }`.
+
+Common fields:
+
+```ts
+interface MapPackageRealtimeMessageBase {
+  type: string;
+  channel?: "honua.map-package.watch.v1";
+  packageId?: string;
+  eventId?: string;
+  sequence?: number;
+  fingerprint?: string;
+  updatedAt?: string;
+  validator?: { etag?: string; lastModified?: string };
+}
+```
+
+Supported message types:
+
+- `ready`: channel is established. The SDK also emits `connected` when the
+  transport opens.
+- `heartbeat`: keepalive. Resets SDK stale timers when configured.
+- `stale`: server says the subscription is stale. The SDK emits `stale` and,
+  by default, falls back to polling.
+- `updated`: package changed. The update payload must be one of:
+  `{ kind: "package", mapPackage }`, `{ kind: "refetch", path? }`, or
+  `{ kind: "patch", patch, baseFingerprint? }`.
+- `refetch-required`: explicit refetch signal. Equivalent to an `updated`
+  message with `{ kind: "refetch" }`.
+- `reload-required`: server knows the change requires a full style reload; the
+  SDK emits `reload-required` after diffing the fetched or supplied package.
+- `error`: channel error. `terminal: true` falls back to polling immediately.
+- `disconnected`: server is closing the channel. The SDK reconnects, then
+  falls back if reconnect attempts are exhausted.
+
+Patch payloads are intentionally distinguishable, but the runtime does not yet
+apply server patches directly. A patch-only update triggers a refetch through
+the polling fetch path so existing validation, cache, and diff behavior stays
+consistent.
+
+## Lifecycle And Fallback
+
+`watchMapPackage` emits typed watch events:
+
+- `connected`
+- `disconnected`
+- `stale`
+- `updated`
+- `reload-required`
+- `fallback`
+- `error`
+- Existing polling events: `fetched`, `unchanged`, and `disposed`
+
+Realtime reconnect defaults to 3 attempts with exponential backoff from 1s to
+30s. Configure it with `realtime.reconnect`, set it to `false` to skip
+reconnect and fall back immediately, or use `maxAttempts: Infinity` to keep
+retrying.
+
+Duplicate application is avoided with three guards:
+
+- `eventId` values are remembered for recent realtime update messages.
+- `sequence` values at or below the last applied realtime update are ignored.
+- The package fingerprint is compared before `updated` is emitted or
+  `runtime.updatePackage` is called.
+
+`dispose()` aborts active fetches, aborts the realtime subscription signal,
+closes the transport handle, clears reconnect/stale/debounce timers, and emits
+`disposed`.
+
+## Auth
+
+Polling fetches use `HonuaClient.pipelineFetch`, so they inherit client auth,
+headers, retries, timeout, and interceptors.
+
+SSE in browsers cannot send arbitrary headers. For the built-in SSE adapter:
+
+- Use same-origin cookies with `withCredentials` or
+  `realtime.auth: { kind: "cookie", withCredentials: true }`.
+- Use `realtime.auth: { kind: "query-token", token }` only when the deployment
+  explicitly allows token-bearing watch URLs.
+- Use `realtime.transport` for WebSocket, fetch-stream, or platform-specific
+  transports that need custom auth headers.
+
+When realtime auth fails, servers should send an `error` message with
+`terminal: true` and a stable `code`; the SDK emits `error`, then `fallback`.

--- a/docs/maplibre-runtime.md
+++ b/docs/maplibre-runtime.md
@@ -152,6 +152,12 @@ same-origin URL, a `honua://map-packages/{id}` locator, or an object with
 `/api/v1/map-packages/{id}`; pass `resolvePath` when a deployment uses a
 different hosted package route.
 
+For low-latency hosted package updates, `watchMapPackage` can use a configured
+or package-advertised realtime channel and fall back to polling when the
+channel is unavailable. See [`map-package-realtime-watch.md`](./map-package-realtime-watch.md)
+for the message schema, lifecycle events, reconnect behavior, auth notes, and
+fallback contract.
+
 Fetch results include:
 
 - `mapPackage`: the validated package, with missing style-ref bodies

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -45,6 +45,41 @@ export type {
   MapPackagePathResolver,
 } from "./map-package-fetch.js";
 
+export {
+  MAP_PACKAGE_REALTIME_CHANNEL_V1,
+  createMapPackageServerSentEventsTransport,
+  decodeMapPackageRealtimeMessage,
+  encodeMapPackageRealtimeUrl,
+  readMapPackageRealtimeAdvertisement,
+} from "./map-package-realtime.js";
+export type {
+  MapPackageRealtimeAdvertisement,
+  MapPackageRealtimeAuth,
+  MapPackageRealtimeChannel,
+  MapPackageRealtimeCheckpoint,
+  MapPackageRealtimeDisconnectedMessage,
+  MapPackageRealtimeErrorMessage,
+  MapPackageRealtimeEventSource,
+  MapPackageRealtimeEventSourceFactory,
+  MapPackageRealtimeFallbackMode,
+  MapPackageRealtimeHeartbeatMessage,
+  MapPackageRealtimeMessage,
+  MapPackageRealtimeMessageBase,
+  MapPackageRealtimeObserver,
+  MapPackageRealtimeReadyMessage,
+  MapPackageRealtimeReconnectOptions,
+  MapPackageRealtimeRefetchRequiredMessage,
+  MapPackageRealtimeReloadRequiredMessage,
+  MapPackageRealtimeStaleMessage,
+  MapPackageRealtimeSubscribeRequest,
+  MapPackageRealtimeSubscriptionHandle,
+  MapPackageRealtimeTransport,
+  MapPackageRealtimeTransportKind,
+  MapPackageRealtimeUpdate,
+  MapPackageRealtimeUpdatedMessage,
+  MapPackageRealtimeWatchOptions,
+  MapPackageServerSentEventsTransportOptions,
+} from "./map-package-realtime.js";
 export { watchMapPackage } from "./map-package-watch.js";
 export type { MapPackageWatchEvent, MapPackageWatchHandle, WatchMapPackageOptions } from "./map-package-watch.js";
 

--- a/src/runtime/map-package-realtime.ts
+++ b/src/runtime/map-package-realtime.ts
@@ -1,0 +1,537 @@
+import type { HonuaCacheValidator } from "../core/cache-state.js";
+import type { HonuaClient } from "../core/client.js";
+import type { MapPackageLocator } from "./map-package-fetch.js";
+import type { HonuaMapPackage } from "./map-package.js";
+
+export const MAP_PACKAGE_REALTIME_CHANNEL_V1 = "honua.map-package.watch.v1" as const;
+
+export type MapPackageRealtimeChannel = typeof MAP_PACKAGE_REALTIME_CHANNEL_V1;
+export type MapPackageRealtimeTransportKind = "sse" | "websocket" | "custom" | "mock";
+export type MapPackageRealtimeFallbackMode = "polling" | "none";
+
+export interface MapPackageRealtimeCheckpoint {
+  readonly eventId?: string;
+  readonly sequence?: number;
+  readonly fingerprint?: string;
+  readonly updatedAt?: string;
+  readonly validator?: HonuaCacheValidator;
+}
+
+export interface MapPackageRealtimeMessageBase extends MapPackageRealtimeCheckpoint {
+  readonly channel?: MapPackageRealtimeChannel | string;
+  readonly packageId?: string;
+  readonly receivedAt?: string;
+}
+
+export type MapPackageRealtimeUpdate =
+  | {
+      readonly kind: "package";
+      readonly mapPackage: HonuaMapPackage;
+    }
+  | {
+      readonly kind: "patch";
+      readonly patch: unknown;
+      readonly baseFingerprint?: string;
+    }
+  | {
+      readonly kind: "refetch";
+      readonly path?: string;
+      readonly validator?: HonuaCacheValidator;
+    };
+
+export interface MapPackageRealtimeReadyMessage extends MapPackageRealtimeMessageBase {
+  readonly type: "ready";
+}
+
+export interface MapPackageRealtimeHeartbeatMessage extends MapPackageRealtimeMessageBase {
+  readonly type: "heartbeat";
+}
+
+export interface MapPackageRealtimeStaleMessage extends MapPackageRealtimeMessageBase {
+  readonly type: "stale";
+  readonly reason?: string;
+  readonly retryAfterMs?: number;
+}
+
+export interface MapPackageRealtimeUpdatedMessage extends MapPackageRealtimeMessageBase {
+  readonly type: "updated";
+  readonly update: MapPackageRealtimeUpdate;
+}
+
+export interface MapPackageRealtimeRefetchRequiredMessage extends MapPackageRealtimeMessageBase {
+  readonly type: "refetch-required";
+  readonly reason?: string;
+  readonly path?: string;
+  readonly validator?: HonuaCacheValidator;
+}
+
+export interface MapPackageRealtimeReloadRequiredMessage extends MapPackageRealtimeMessageBase {
+  readonly type: "reload-required";
+  readonly reason: string;
+  readonly update?: MapPackageRealtimeUpdate;
+}
+
+export interface MapPackageRealtimeErrorMessage extends MapPackageRealtimeMessageBase {
+  readonly type: "error";
+  readonly error: unknown;
+  readonly code?: string;
+  readonly terminal?: boolean;
+  readonly retryAfterMs?: number;
+}
+
+export interface MapPackageRealtimeDisconnectedMessage extends MapPackageRealtimeMessageBase {
+  readonly type: "disconnected";
+  readonly reason?: string;
+  readonly retryAfterMs?: number;
+}
+
+export type MapPackageRealtimeMessage =
+  | MapPackageRealtimeReadyMessage
+  | MapPackageRealtimeHeartbeatMessage
+  | MapPackageRealtimeStaleMessage
+  | MapPackageRealtimeUpdatedMessage
+  | MapPackageRealtimeRefetchRequiredMessage
+  | MapPackageRealtimeReloadRequiredMessage
+  | MapPackageRealtimeErrorMessage
+  | MapPackageRealtimeDisconnectedMessage;
+
+export interface MapPackageRealtimeConnectionInfo {
+  readonly channel?: string;
+  readonly transport: MapPackageRealtimeTransportKind;
+  readonly url?: string;
+}
+
+export interface MapPackageRealtimeDisconnectInfo {
+  readonly reason?: string;
+  readonly retryAfterMs?: number;
+}
+
+export interface MapPackageRealtimeObserver {
+  connected(info: MapPackageRealtimeConnectionInfo): void;
+  message(message: MapPackageRealtimeMessage): void;
+  disconnected(info?: MapPackageRealtimeDisconnectInfo): void;
+  error(error: unknown): void;
+}
+
+export interface MapPackageRealtimeSubscribeRequest {
+  readonly locator: MapPackageLocator;
+  readonly packageId?: string;
+  readonly path: string;
+  readonly client: HonuaClient;
+  readonly headers?: HeadersInit;
+  readonly signal: AbortSignal;
+  readonly resumeFrom?: MapPackageRealtimeCheckpoint;
+}
+
+export interface MapPackageRealtimeSubscriptionHandle {
+  close(): void;
+}
+
+export interface MapPackageRealtimeTransport {
+  readonly kind?: MapPackageRealtimeTransportKind;
+  subscribe(
+    request: MapPackageRealtimeSubscribeRequest,
+    observer: MapPackageRealtimeObserver,
+  ): MapPackageRealtimeSubscriptionHandle;
+}
+
+export interface MapPackageRealtimeReconnectOptions {
+  /** Defaults to 3; use `Infinity` for unbounded reconnect attempts. */
+  readonly maxAttempts?: number;
+  /** Defaults to 1000 ms. */
+  readonly minDelayMs?: number;
+  /** Defaults to 30000 ms. */
+  readonly maxDelayMs?: number;
+  /** Defaults to 2. */
+  readonly factor?: number;
+}
+
+export type MapPackageRealtimeAuth =
+  | { readonly kind: "none" }
+  | { readonly kind: "cookie"; readonly withCredentials?: boolean }
+  | { readonly kind: "query-token"; readonly token: string; readonly parameterName?: string };
+
+export interface MapPackageRealtimeWatchOptions {
+  readonly transport?: MapPackageRealtimeTransport;
+  readonly url?: string;
+  readonly eventSourceFactory?: MapPackageRealtimeEventSourceFactory;
+  readonly eventTypes?: readonly string[];
+  readonly withCredentials?: boolean;
+  readonly auth?: MapPackageRealtimeAuth;
+  readonly advertise?: boolean;
+  readonly fallback?: MapPackageRealtimeFallbackMode;
+  readonly reconnect?: false | MapPackageRealtimeReconnectOptions;
+  readonly staleAfterMs?: number;
+  readonly fallbackOnStale?: boolean;
+}
+
+export interface MapPackageRealtimeAdvertisement {
+  readonly channel?: string;
+  readonly transport?: MapPackageRealtimeTransportKind | string;
+  readonly href?: string;
+  readonly url?: string;
+  readonly path?: string;
+  readonly withCredentials?: boolean;
+  readonly fallback?: MapPackageRealtimeFallbackMode;
+  readonly staleAfterMs?: number;
+}
+
+export interface MapPackageRealtimeEventSource {
+  readonly readyState?: number;
+  onopen: ((event: Event) => void) | null;
+  onmessage: ((event: MessageEvent<string>) => void) | null;
+  onerror: ((event: Event) => void) | null;
+  close(): void;
+  addEventListener?(type: string, listener: (event: MessageEvent<string>) => void): void;
+  removeEventListener?(type: string, listener: (event: MessageEvent<string>) => void): void;
+}
+
+export type MapPackageRealtimeEventSourceFactory = (
+  url: string,
+  init?: EventSourceInit,
+) => MapPackageRealtimeEventSource;
+
+export interface MapPackageServerSentEventsTransportOptions {
+  readonly url: string;
+  readonly eventSourceFactory?: MapPackageRealtimeEventSourceFactory;
+  readonly eventTypes?: readonly string[];
+  readonly withCredentials?: boolean;
+  readonly auth?: MapPackageRealtimeAuth;
+}
+
+const DEFAULT_MAP_PACKAGE_EVENT_TYPES = [
+  "ready",
+  "heartbeat",
+  "stale",
+  "updated",
+  "refetch-required",
+  "reload-required",
+  "error",
+  "disconnected",
+] as const;
+
+export function createMapPackageServerSentEventsTransport(
+  options: MapPackageServerSentEventsTransportOptions,
+): MapPackageRealtimeTransport {
+  return {
+    kind: "sse",
+    subscribe(request, observer): MapPackageRealtimeSubscriptionHandle {
+      const encoded = encodeMapPackageRealtimeUrl(new URL(options.url, request.client.serverBaseUrl), request);
+      applyMapPackageRealtimeAuth(encoded, options.auth);
+      const source = createEventSource(resolveEventSourceUrl(options.url, encoded), options);
+      const listeners: Array<readonly [string, (event: MessageEvent<string>) => void]> = [];
+      let closed = false;
+
+      const emitPayload = (payload: string): void => {
+        if (closed || payload.trim() === "") return;
+        try {
+          observer.message(decodeMapPackageRealtimeMessage(JSON.parse(payload)));
+        } catch (error) {
+          observer.error(error);
+        }
+      };
+
+      const messageListener = (event: MessageEvent<string>): void => emitPayload(event.data);
+
+      source.onopen = () => {
+        if (!closed) {
+          observer.connected({
+            channel: MAP_PACKAGE_REALTIME_CHANNEL_V1,
+            transport: "sse",
+            url: encoded.toString(),
+          });
+        }
+      };
+      source.onmessage = messageListener;
+      source.onerror = (event) => {
+        if (closed) return;
+        if (isEventSourceClosed(source)) {
+          observer.error(event);
+          closeSource("sse-closed");
+        } else {
+          observer.message({
+            type: "stale",
+            channel: MAP_PACKAGE_REALTIME_CHANNEL_V1,
+            packageId: request.packageId,
+            reason: "sse-error",
+          });
+        }
+      };
+
+      for (const type of options.eventTypes ?? DEFAULT_MAP_PACKAGE_EVENT_TYPES) {
+        if (!source.addEventListener) break;
+        const listener = (event: MessageEvent<string>): void => emitPayload(event.data);
+        source.addEventListener(type, listener);
+        listeners.push([type, listener]);
+      }
+
+      const abortListener = (): void => closeSource("aborted");
+      request.signal.addEventListener("abort", abortListener, { once: true });
+
+      function closeSource(reason?: string): void {
+        if (closed) return;
+        closed = true;
+        request.signal.removeEventListener("abort", abortListener);
+        for (const [type, listener] of listeners) source.removeEventListener?.(type, listener);
+        source.onopen = null;
+        source.onmessage = null;
+        source.onerror = null;
+        source.close();
+        observer.disconnected({ reason });
+      }
+
+      return {
+        close: () => closeSource("closed"),
+      };
+    },
+  };
+}
+
+export function encodeMapPackageRealtimeUrl(url: URL, request: MapPackageRealtimeSubscribeRequest): URL {
+  url.searchParams.set("channel", MAP_PACKAGE_REALTIME_CHANNEL_V1);
+  url.searchParams.set("path", request.path);
+  if (request.packageId) url.searchParams.set("packageId", request.packageId);
+  if (request.resumeFrom?.eventId) url.searchParams.set("eventId", request.resumeFrom.eventId);
+  if (request.resumeFrom?.fingerprint) url.searchParams.set("fingerprint", request.resumeFrom.fingerprint);
+  if (request.resumeFrom?.updatedAt) url.searchParams.set("updatedAt", request.resumeFrom.updatedAt);
+  if (request.resumeFrom?.sequence !== undefined) url.searchParams.set("sequence", String(request.resumeFrom.sequence));
+  if (request.resumeFrom?.validator?.etag) url.searchParams.set("etag", request.resumeFrom.validator.etag);
+  if (request.resumeFrom?.validator?.lastModified) {
+    url.searchParams.set("lastModified", request.resumeFrom.validator.lastModified);
+  }
+  return url;
+}
+
+export function decodeMapPackageRealtimeMessage(payload: unknown): MapPackageRealtimeMessage {
+  const event = unwrapRealtimeEnvelope(payload);
+  const rawType = typeof event.type === "string" ? event.type : typeof event.kind === "string" ? event.kind : undefined;
+  if (!rawType) throw new Error("MapPackage realtime message is missing type.");
+
+  const base = realtimeMessageBase(event);
+  switch (rawType) {
+    case "ready":
+    case "connected":
+      return { ...base, type: "ready" };
+    case "heartbeat":
+      return { ...base, type: "heartbeat" };
+    case "stale":
+      return {
+        ...base,
+        type: "stale",
+        ...(typeof event.reason === "string" ? { reason: event.reason } : {}),
+        ...(typeof event.retryAfterMs === "number" ? { retryAfterMs: event.retryAfterMs } : {}),
+      };
+    case "updated":
+    case "package":
+      return { ...base, type: "updated", update: decodeRealtimeUpdate(event) };
+    case "refetch-required":
+      return {
+        ...base,
+        type: "refetch-required",
+        ...(typeof event.reason === "string" ? { reason: event.reason } : {}),
+        ...(typeof event.path === "string" ? { path: event.path } : {}),
+        ...(isCacheValidator(event.validator) ? { validator: event.validator } : {}),
+      };
+    case "reload-required":
+      return {
+        ...base,
+        type: "reload-required",
+        reason: typeof event.reason === "string" ? event.reason : "MapPackage update requires a full style reload.",
+        ...(hasRealtimeUpdate(event) ? { update: decodeRealtimeUpdate(event) } : {}),
+      };
+    case "error":
+      return {
+        ...base,
+        type: "error",
+        error: event.error ?? event.message ?? "MapPackage realtime channel error.",
+        ...(typeof event.code === "string" ? { code: event.code } : {}),
+        ...(typeof event.terminal === "boolean" ? { terminal: event.terminal } : {}),
+        ...(typeof event.retryAfterMs === "number" ? { retryAfterMs: event.retryAfterMs } : {}),
+      };
+    case "disconnected":
+      return {
+        ...base,
+        type: "disconnected",
+        ...(typeof event.reason === "string" ? { reason: event.reason } : {}),
+        ...(typeof event.retryAfterMs === "number" ? { retryAfterMs: event.retryAfterMs } : {}),
+      };
+    default:
+      throw new Error(`Unsupported MapPackage realtime message type "${rawType}".`);
+  }
+}
+
+export function readMapPackageRealtimeAdvertisement(
+  pkg: HonuaMapPackage | undefined,
+): MapPackageRealtimeAdvertisement | undefined {
+  if (!pkg) return undefined;
+  const record = pkg as Record<string, unknown>;
+  const directCandidates = [
+    valueAt(record, ["realtime", "mapPackageWatch"]),
+    valueAt(record, ["realtime", "mapPackage"]),
+    valueAt(record, ["watch", "realtime"]),
+    record.realtimeWatch,
+    record.watchChannel,
+  ];
+
+  for (const candidate of directCandidates) {
+    const normalized = normalizeAdvertisement(candidate);
+    if (normalized) return normalized;
+  }
+
+  if (Array.isArray(record.links)) {
+    for (const link of record.links) {
+      const normalized = normalizeLinkAdvertisement(link);
+      if (normalized) return normalized;
+    }
+  }
+  return undefined;
+}
+
+function createEventSource(
+  url: string,
+  options: MapPackageServerSentEventsTransportOptions,
+): MapPackageRealtimeEventSource {
+  const factory =
+    options.eventSourceFactory ??
+    ((globalThis as unknown as { EventSource?: MapPackageRealtimeEventSourceFactory }).EventSource as
+      | MapPackageRealtimeEventSourceFactory
+      | undefined);
+  if (!factory) throw new Error("EventSource is not available; provide eventSourceFactory for this runtime.");
+  return factory(url, { withCredentials: options.withCredentials });
+}
+
+function applyMapPackageRealtimeAuth(url: URL, auth: MapPackageRealtimeAuth | undefined): void {
+  if (!auth || auth.kind !== "query-token") return;
+  url.searchParams.set(auth.parameterName ?? "access_token", auth.token);
+}
+
+function resolveEventSourceUrl(input: string, url: URL): string {
+  if (input.startsWith("http://") || input.startsWith("https://")) return url.toString();
+  return `${url.pathname}${url.search}`;
+}
+
+function isEventSourceClosed(source: MapPackageRealtimeEventSource): boolean {
+  return source.readyState === 2;
+}
+
+function unwrapRealtimeEnvelope(payload: unknown): Record<string, unknown> {
+  if (!isRecord(payload)) throw new Error("MapPackage realtime message must be a JSON object.");
+  if (isRecord(payload.event)) return payload.event;
+  if (isRecord(payload.message)) return payload.message;
+  if (isRecord(payload.mapPackageWatch)) return payload.mapPackageWatch;
+  return payload;
+}
+
+function realtimeMessageBase(event: Record<string, unknown>): MapPackageRealtimeMessageBase {
+  return {
+    ...(typeof event.channel === "string" ? { channel: event.channel } : {}),
+    ...(typeof event.packageId === "string" ? { packageId: event.packageId } : {}),
+    ...(typeof event.eventId === "string" ? { eventId: event.eventId } : {}),
+    ...(typeof event.sequence === "number" ? { sequence: event.sequence } : {}),
+    ...(typeof event.fingerprint === "string" ? { fingerprint: event.fingerprint } : {}),
+    ...(typeof event.updatedAt === "string" ? { updatedAt: event.updatedAt } : {}),
+    ...(typeof event.receivedAt === "string" ? { receivedAt: event.receivedAt } : {}),
+    ...(isCacheValidator(event.validator) ? { validator: event.validator } : {}),
+  };
+}
+
+function hasRealtimeUpdate(event: Record<string, unknown>): boolean {
+  return isRecord(event.update) || isRecord(event.mapPackage) || "patch" in event || event.refetchRequired === true;
+}
+
+function decodeRealtimeUpdate(event: Record<string, unknown>): MapPackageRealtimeUpdate {
+  const update = isRecord(event.update) ? event.update : undefined;
+  const kind =
+    typeof update?.kind === "string" ? update.kind : typeof update?.type === "string" ? update.type : undefined;
+
+  if (kind === "package" && isRecord(update?.mapPackage)) {
+    return { kind: "package", mapPackage: update.mapPackage as unknown as HonuaMapPackage };
+  }
+  if (kind === "patch" && update && "patch" in update) {
+    return {
+      kind: "patch",
+      patch: update.patch,
+      ...(typeof update.baseFingerprint === "string" ? { baseFingerprint: update.baseFingerprint } : {}),
+    };
+  }
+  if (kind === "refetch") {
+    return {
+      kind: "refetch",
+      ...(typeof update?.path === "string" ? { path: update.path } : {}),
+      ...(isCacheValidator(update?.validator) ? { validator: update.validator } : {}),
+    };
+  }
+  if (isRecord(event.mapPackage)) {
+    return { kind: "package", mapPackage: event.mapPackage as unknown as HonuaMapPackage };
+  }
+  if ("patch" in event) {
+    return {
+      kind: "patch",
+      patch: event.patch,
+      ...(typeof event.baseFingerprint === "string" ? { baseFingerprint: event.baseFingerprint } : {}),
+    };
+  }
+  if (event.refetchRequired === true || event.refetch === true) {
+    return {
+      kind: "refetch",
+      ...(typeof event.path === "string" ? { path: event.path } : {}),
+      ...(isCacheValidator(event.validator) ? { validator: event.validator } : {}),
+    };
+  }
+
+  throw new Error("MapPackage realtime update must include package, patch, or refetch payload.");
+}
+
+function normalizeAdvertisement(value: unknown): MapPackageRealtimeAdvertisement | undefined {
+  if (!isRecord(value)) return undefined;
+  const href = stringField(value, "href");
+  const url = stringField(value, "url");
+  const path = stringField(value, "path");
+  const transport = stringField(value, "transport") ?? (href || url || path ? "sse" : undefined);
+  if (!transport && !href && !url && !path) return undefined;
+  return {
+    ...(stringField(value, "channel") ? { channel: stringField(value, "channel") } : {}),
+    ...(transport ? { transport } : {}),
+    ...(href ? { href } : {}),
+    ...(url ? { url } : {}),
+    ...(path ? { path } : {}),
+    ...(typeof value.withCredentials === "boolean" ? { withCredentials: value.withCredentials } : {}),
+    ...(value.fallback === "polling" || value.fallback === "none" ? { fallback: value.fallback } : {}),
+    ...(typeof value.staleAfterMs === "number" ? { staleAfterMs: value.staleAfterMs } : {}),
+  };
+}
+
+function normalizeLinkAdvertisement(value: unknown): MapPackageRealtimeAdvertisement | undefined {
+  if (!isRecord(value)) return undefined;
+  const rel = stringField(value, "rel");
+  if (rel !== "map-package-watch" && rel !== "map-package-realtime-watch" && rel !== "honua:map-package-watch") {
+    return undefined;
+  }
+  return normalizeAdvertisement({
+    ...value,
+    transport: stringField(value, "transport") ?? "sse",
+    href: stringField(value, "href") ?? stringField(value, "url"),
+  });
+}
+
+function valueAt(record: Record<string, unknown>, path: readonly string[]): unknown {
+  let current: unknown = record;
+  for (const segment of path) {
+    if (!isRecord(current)) return undefined;
+    current = current[segment];
+  }
+  return current;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function isCacheValidator(value: unknown): value is HonuaCacheValidator {
+  return isRecord(value) && (typeof value.etag === "string" || typeof value.lastModified === "string");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/runtime/map-package-watch.ts
+++ b/src/runtime/map-package-watch.ts
@@ -1,15 +1,61 @@
 import { type MapPackageDiff, diffPackages } from "./diff.js";
+import { HonuaMapPackageError } from "./errors.js";
 import {
   type FetchMapPackageOptions,
   type FetchMapPackageResult,
   type MapPackageLocator,
   fetchMapPackage,
   mapPackageFingerprint,
+  resolveMapPackagePath,
 } from "./map-package-fetch.js";
+import {
+  MAP_PACKAGE_REALTIME_CHANNEL_V1,
+  createMapPackageServerSentEventsTransport,
+  readMapPackageRealtimeAdvertisement,
+} from "./map-package-realtime.js";
+import type {
+  MapPackageRealtimeCheckpoint,
+  MapPackageRealtimeFallbackMode,
+  MapPackageRealtimeMessage,
+  MapPackageRealtimeReconnectOptions,
+  MapPackageRealtimeSubscriptionHandle,
+  MapPackageRealtimeTransport,
+  MapPackageRealtimeTransportKind,
+  MapPackageRealtimeUpdate,
+  MapPackageRealtimeWatchOptions,
+} from "./map-package-realtime.js";
+import { hasMapPackageDiagnosticErrors, validateMapPackage } from "./map-package-validation.js";
 import type { HonuaMapPackage } from "./map-package.js";
 import type { HonuaMapRuntime } from "./runtime.js";
 
 export type MapPackageWatchEvent =
+  | {
+      readonly type: "connected";
+      readonly transport: MapPackageRealtimeTransportKind;
+      readonly channel?: string;
+      readonly url?: string;
+      readonly advertised: boolean;
+      readonly resumedFrom?: MapPackageRealtimeCheckpoint;
+    }
+  | {
+      readonly type: "disconnected";
+      readonly transport?: MapPackageRealtimeTransportKind;
+      readonly reason?: string;
+      readonly willReconnect: boolean;
+      readonly reconnectAttempt?: number;
+    }
+  | {
+      readonly type: "stale";
+      readonly reason: string;
+      readonly retryAfterMs?: number;
+      readonly fallback: boolean;
+    }
+  | {
+      readonly type: "fallback";
+      readonly mode: MapPackageRealtimeFallbackMode;
+      readonly reason: string;
+      readonly error?: unknown;
+    }
   | { readonly type: "fetched"; readonly result: FetchMapPackageResult }
   | { readonly type: "unchanged"; readonly result: FetchMapPackageResult }
   | {
@@ -40,6 +86,8 @@ export interface WatchMapPackageOptions extends FetchMapPackageOptions {
   readonly debounceMs?: number;
   /** Fetch immediately on watcher creation. Defaults to true. */
   readonly immediate?: boolean;
+  /** Realtime channel configuration. Omit to use package-advertised channels; pass false to force polling. */
+  readonly realtime?: false | MapPackageRealtimeWatchOptions;
   readonly onEvent?: (event: MapPackageWatchEvent) => void | Promise<void>;
   readonly onUpdate?: (event: Extract<MapPackageWatchEvent, { type: "updated" }>) => void | Promise<void>;
   readonly onError?: (error: unknown) => void | Promise<void>;
@@ -51,17 +99,62 @@ export interface MapPackageWatchHandle {
   dispose(): void;
 }
 
+interface PendingApply {
+  readonly result: FetchMapPackageResult;
+  readonly reloadReason?: string;
+}
+
+interface ActiveRealtimeSource {
+  readonly transport: MapPackageRealtimeTransport;
+  readonly transportKind: MapPackageRealtimeTransportKind;
+  readonly advertised: boolean;
+  readonly url?: string;
+  readonly channel?: string;
+  readonly fallback: MapPackageRealtimeFallbackMode;
+  readonly reconnect: false | Required<MapPackageRealtimeReconnectOptions>;
+  readonly staleAfterMs?: number;
+  readonly fallbackOnStale: boolean;
+}
+
+type RealtimeResolution =
+  | { readonly type: "available"; readonly source: ActiveRealtimeSource }
+  | { readonly type: "unsupported"; readonly reason: string; readonly fallback: MapPackageRealtimeFallbackMode };
+
 const DEFAULT_WATCH_INTERVAL_MS = 30_000;
+const DEFAULT_RECONNECT_OPTIONS: Required<MapPackageRealtimeReconnectOptions> = {
+  maxAttempts: 3,
+  minDelayMs: 1_000,
+  maxDelayMs: 30_000,
+  factor: 2,
+};
 
 export function watchMapPackage(locator: MapPackageLocator, options: WatchMapPackageOptions): MapPackageWatchHandle {
   let disposed = false;
   let inFlight = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
   let debounceTimer: ReturnType<typeof setTimeout> | undefined;
-  let pendingResult: FetchMapPackageResult | undefined;
+  let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+  let staleTimer: ReturnType<typeof setTimeout> | undefined;
+  let pendingApply: PendingApply | undefined;
   let previousPackage = options.initialPackage ?? options.runtime?.mapPackage;
+  let lastFetchedPackage = previousPackage;
   let previousFingerprint = previousPackage ? mapPackageFingerprint(previousPackage) : undefined;
   let currentAbort: AbortController | undefined;
+  let realtimeAbort: AbortController | undefined;
+  let realtimeSubscription: MapPackageRealtimeSubscriptionHandle | undefined;
+  let activeRealtime: ActiveRealtimeSource | undefined;
+  let suppressRealtimeDisconnect = false;
+  let reconnectAttempt = 0;
+  let fallbackActive = false;
+  let unsupportedRealtimeNotified = false;
+  let lastRealtimeCheckpoint: MapPackageRealtimeCheckpoint | undefined = previousPackage
+    ? {
+        fingerprint: previousFingerprint,
+        updatedAt: previousPackage.updatedAt,
+      }
+    : undefined;
+  let lastAppliedRealtimeSequence: number | undefined;
+  const seenRealtimeEventIds: string[] = [];
 
   const intervalMs = normalizeDelay(options.intervalMs, DEFAULT_WATCH_INTERVAL_MS);
   const debounceMs = normalizeDelay(options.debounceMs, 0);
@@ -73,9 +166,9 @@ export function watchMapPackage(locator: MapPackageLocator, options: WatchMapPac
   };
 
   const schedule = (): void => {
-    if (disposed) return;
+    if (disposed || realtimeSubscription) return;
     timer = setTimeout(() => {
-      void poll();
+      void poll({ scheduleAfter: true, discoverRealtime: true });
     }, intervalMs);
   };
 
@@ -84,8 +177,15 @@ export function watchMapPackage(locator: MapPackageLocator, options: WatchMapPac
     timer = undefined;
   };
 
-  const queueApply = (result: FetchMapPackageResult): void => {
-    pendingResult = result;
+  const clearRealtimeTimers = (): void => {
+    if (reconnectTimer) clearTimeout(reconnectTimer);
+    if (staleTimer) clearTimeout(staleTimer);
+    reconnectTimer = undefined;
+    staleTimer = undefined;
+  };
+
+  const queueApply = (result: FetchMapPackageResult, reloadReason?: string): void => {
+    pendingApply = { result, ...(reloadReason ? { reloadReason } : {}) };
     if (debounceMs === 0) {
       void applyPending();
       return;
@@ -99,10 +199,11 @@ export function watchMapPackage(locator: MapPackageLocator, options: WatchMapPac
 
   const applyPending = async (): Promise<void> => {
     try {
-      const result = pendingResult;
-      pendingResult = undefined;
-      if (!result || disposed) return;
+      const pending = pendingApply;
+      pendingApply = undefined;
+      if (!pending || disposed) return;
 
+      const { result, reloadReason } = pending;
       const nextFingerprint = mapPackageFingerprint(result.mapPackage);
       if (previousFingerprint === nextFingerprint) {
         emit({ type: "unchanged", result });
@@ -110,12 +211,12 @@ export function watchMapPackage(locator: MapPackageLocator, options: WatchMapPac
       }
 
       const diff = previousPackage ? diffPackages(previousPackage, result.mapPackage) : undefined;
-      if (diff && !diff.incremental) {
+      if (diff && (reloadReason || !diff.incremental)) {
         emit({
           type: "reload-required",
           result,
           diff,
-          reason: diff.structuralReason ?? "MapPackage update requires a full style reload.",
+          reason: reloadReason ?? diff.structuralReason ?? "MapPackage update requires a full style reload.",
         });
       }
 
@@ -124,57 +225,491 @@ export function watchMapPackage(locator: MapPackageLocator, options: WatchMapPac
         await options.runtime?.updatePackage(result.mapPackage);
       }
       previousPackage = result.mapPackage;
+      lastFetchedPackage = result.mapPackage;
       previousFingerprint = nextFingerprint;
+      lastRealtimeCheckpoint = {
+        ...lastRealtimeCheckpoint,
+        fingerprint: nextFingerprint,
+        updatedAt: result.mapPackage.updatedAt,
+        validator: result.cache.validator,
+      };
       emit({ type: "updated", result, diff, applied: shouldApply });
     } catch (error) {
       if (!disposed) emit({ type: "error", error });
     }
   };
 
-  const poll = async (): Promise<void> => {
+  const poll = async (
+    input: {
+      readonly locatorOverride?: MapPackageLocator;
+      readonly scheduleAfter?: boolean;
+      readonly discoverRealtime?: boolean;
+    } = {},
+  ): Promise<void> => {
     if (disposed || inFlight) return;
     inFlight = true;
     currentAbort = new AbortController();
     try {
-      const result = await fetchMapPackage(locator, {
+      const result = await fetchMapPackage(input.locatorOverride ?? locator, {
         ...options,
         signal: linkAbortSignals(options.signal, currentAbort.signal),
       });
+      lastFetchedPackage = result.mapPackage;
       emit({ type: "fetched", result });
       if (result.cache.status === "not-modified") {
         emit({ type: "unchanged", result });
-        return;
+      } else {
+        queueApply(result);
       }
-      queueApply(result);
+      if (input.discoverRealtime !== false && !realtimeSubscription && !fallbackActive) {
+        startRealtime();
+      }
     } catch (error) {
       if (!disposed) emit({ type: "error", error });
     } finally {
       inFlight = false;
       currentAbort = undefined;
-      schedule();
+      if (input.scheduleAfter !== false) schedule();
     }
+  };
+
+  const startRealtime = (): boolean => {
+    if (disposed || realtimeSubscription || options.realtime === false || fallbackActive) return false;
+    const resolution = resolveRealtimeSource();
+    if (!resolution) return false;
+    if (resolution.type === "unsupported") {
+      if (!unsupportedRealtimeNotified) {
+        unsupportedRealtimeNotified = true;
+        emit({ type: "fallback", mode: resolution.fallback, reason: resolution.reason });
+      }
+      return false;
+    }
+
+    const source = resolution.source;
+    const abort = new AbortController();
+    const signal = linkAbortSignals(options.signal, abort.signal);
+    const path = resolveMapPackagePath(locator, options.resolvePath);
+    activeRealtime = source;
+    realtimeAbort = abort;
+    clearScheduled();
+
+    try {
+      const subscription = source.transport.subscribe(
+        {
+          locator,
+          packageId: packageIdFromLocator(locator) ?? previousPackage?.mapPackageId ?? lastFetchedPackage?.mapPackageId,
+          path,
+          client: options.client,
+          headers: options.headers,
+          signal,
+          resumeFrom: lastRealtimeCheckpoint,
+        },
+        {
+          connected: (info) => {
+            if (disposed) return;
+            reconnectAttempt = 0;
+            armRealtimeStaleTimer(source);
+            emit({
+              type: "connected",
+              transport: info.transport,
+              advertised: source.advertised,
+              ...(info.channel ? { channel: info.channel } : source.channel ? { channel: source.channel } : {}),
+              ...(info.url ? { url: info.url } : source.url ? { url: source.url } : {}),
+              ...(lastRealtimeCheckpoint ? { resumedFrom: lastRealtimeCheckpoint } : {}),
+            });
+          },
+          message: (message) => {
+            if (!disposed) void handleRealtimeMessage(message);
+          },
+          disconnected: (info) => {
+            if (disposed || suppressRealtimeDisconnect) return;
+            handleRealtimeFailure(info?.reason ?? "disconnected", undefined, info?.retryAfterMs);
+          },
+          error: (error) => {
+            if (disposed) return;
+            emit({ type: "error", error });
+            handleRealtimeFailure("error", error);
+          },
+        },
+      );
+      if (disposed || activeRealtime !== source || fallbackActive) {
+        suppressRealtimeDisconnect = true;
+        try {
+          subscription.close();
+        } finally {
+          suppressRealtimeDisconnect = false;
+        }
+        return false;
+      }
+      realtimeSubscription = subscription;
+      return true;
+    } catch (error) {
+      cleanupRealtime(true);
+      emit({ type: "error", error });
+      startFallback("realtime-unavailable", error, source);
+      return false;
+    }
+  };
+
+  const handleRealtimeMessage = async (message: MapPackageRealtimeMessage): Promise<void> => {
+    if (disposed) return;
+    armRealtimeStaleTimer(activeRealtime);
+    updateRealtimeCheckpoint(message);
+
+    if (!isExpectedPackageMessage(message)) return;
+
+    switch (message.type) {
+      case "ready":
+      case "heartbeat":
+        return;
+      case "stale":
+        emit({
+          type: "stale",
+          reason: message.reason ?? "realtime-stale",
+          ...(message.retryAfterMs !== undefined ? { retryAfterMs: message.retryAfterMs } : {}),
+          fallback: activeRealtime?.fallbackOnStale === true,
+        });
+        if (activeRealtime?.fallbackOnStale === true) {
+          const source = activeRealtime;
+          cleanupRealtime(true);
+          startFallback(message.reason ?? "realtime-stale", undefined, source);
+        }
+        return;
+      case "updated":
+        if (!rememberRealtimeMutation(message)) return;
+        await applyRealtimeUpdate(message.update);
+        return;
+      case "refetch-required":
+        if (!rememberRealtimeMutation(message)) return;
+        await refetchFromRealtime(message.path, message.reason);
+        return;
+      case "reload-required":
+        if (!rememberRealtimeMutation(message)) return;
+        if (message.update) {
+          await applyRealtimeUpdate(message.update, message.reason);
+        } else {
+          await refetchFromRealtime(undefined, message.reason);
+        }
+        return;
+      case "error":
+        emit({ type: "error", error: message.error });
+        if (message.terminal) {
+          const source = activeRealtime;
+          cleanupRealtime(true);
+          startFallback(message.code ?? "realtime-terminal-error", message.error, source);
+        }
+        return;
+      case "disconnected":
+        handleRealtimeFailure(message.reason ?? "disconnected", undefined, message.retryAfterMs);
+        return;
+    }
+  };
+
+  const applyRealtimeUpdate = async (update: MapPackageRealtimeUpdate, reloadReason?: string): Promise<void> => {
+    if (update.kind === "package") {
+      queueApply(buildRealtimeFetchResult(update.mapPackage), reloadReason);
+      return;
+    }
+    if (update.kind === "refetch") {
+      await refetchFromRealtime(update.path, reloadReason ?? "realtime-refetch-required");
+      return;
+    }
+
+    emit({ type: "fallback", mode: "polling", reason: "realtime-patch-refetch" });
+    await refetchFromRealtime(undefined, reloadReason ?? "realtime-patch-refetch");
+  };
+
+  const refetchFromRealtime = async (path: string | undefined, reloadReason?: string): Promise<void> => {
+    if (disposed) return;
+    inFlight = true;
+    currentAbort = new AbortController();
+    try {
+      const result = await fetchMapPackage(path ? { path } : locator, {
+        ...options,
+        signal: linkAbortSignals(options.signal, currentAbort.signal),
+      });
+      lastFetchedPackage = result.mapPackage;
+      emit({ type: "fetched", result });
+      if (result.cache.status === "not-modified") {
+        emit({ type: "unchanged", result });
+      } else {
+        queueApply(result, reloadReason);
+      }
+    } catch (error) {
+      if (!disposed) emit({ type: "error", error });
+    } finally {
+      inFlight = false;
+      currentAbort = undefined;
+    }
+  };
+
+  const handleRealtimeFailure = (reason: string, error?: unknown, retryAfterMs?: number): void => {
+    const source = activeRealtime;
+    if (!source || disposed) return;
+    cleanupRealtime(true);
+    const reconnect = source.reconnect;
+    if (reconnect !== false && reconnectAttempt < reconnect.maxAttempts) {
+      reconnectAttempt += 1;
+      emit({
+        type: "disconnected",
+        transport: source.transportKind,
+        reason,
+        willReconnect: true,
+        reconnectAttempt,
+      });
+      const delayMs = retryAfterMs ?? reconnectDelayMs(reconnectAttempt, reconnect);
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = undefined;
+        startRealtime();
+      }, delayMs);
+      return;
+    }
+
+    emit({ type: "disconnected", transport: source.transportKind, reason, willReconnect: false });
+    startFallback(reason, error, source);
+  };
+
+  const startFallback = (
+    reason: string,
+    error?: unknown,
+    source: ActiveRealtimeSource | undefined = activeRealtime,
+  ): void => {
+    const mode = source?.fallback ?? "polling";
+    if (fallbackActive) return;
+    fallbackActive = true;
+    emit({ type: "fallback", mode, reason, ...(error ? { error } : {}) });
+    if (mode === "polling") {
+      void poll({ scheduleAfter: true, discoverRealtime: false });
+    }
+  };
+
+  const cleanupRealtime = (close: boolean): void => {
+    clearRealtimeTimers();
+    const subscription = realtimeSubscription;
+    realtimeSubscription = undefined;
+    realtimeAbort?.abort();
+    realtimeAbort = undefined;
+    activeRealtime = undefined;
+    if (close && subscription) {
+      suppressRealtimeDisconnect = true;
+      try {
+        subscription.close();
+      } finally {
+        suppressRealtimeDisconnect = false;
+      }
+    }
+  };
+
+  const armRealtimeStaleTimer = (source: ActiveRealtimeSource | undefined): void => {
+    if (staleTimer) clearTimeout(staleTimer);
+    staleTimer = undefined;
+    if (!source?.staleAfterMs || disposed) return;
+    staleTimer = setTimeout(() => {
+      staleTimer = undefined;
+      if (disposed) return;
+      emit({ type: "stale", reason: "heartbeat-timeout", fallback: source.fallbackOnStale });
+      if (source.fallbackOnStale) {
+        cleanupRealtime(true);
+        startFallback("heartbeat-timeout", undefined, source);
+      }
+    }, source.staleAfterMs);
+  };
+
+  const resolveRealtimeSource = (): RealtimeResolution | undefined => {
+    if (options.realtime === false) return undefined;
+    const realtime = options.realtime ?? {};
+    const fallback = realtime.fallback ?? "polling";
+    const reconnect = normalizeReconnectOptions(realtime.reconnect);
+
+    if (realtime.transport) {
+      return {
+        type: "available",
+        source: {
+          transport: realtime.transport,
+          transportKind: realtime.transport.kind ?? "custom",
+          advertised: false,
+          fallback,
+          reconnect,
+          ...(realtime.staleAfterMs !== undefined ? { staleAfterMs: normalizeDelay(realtime.staleAfterMs, 0) } : {}),
+          fallbackOnStale: realtime.fallbackOnStale !== false,
+        },
+      };
+    }
+
+    if (realtime.url) {
+      return {
+        type: "available",
+        source: {
+          transport: createMapPackageServerSentEventsTransport({
+            url: realtime.url,
+            eventSourceFactory: realtime.eventSourceFactory,
+            eventTypes: realtime.eventTypes,
+            withCredentials: realtime.withCredentials ?? cookieCredentials(realtime),
+            auth: realtime.auth,
+          }),
+          transportKind: "sse",
+          advertised: false,
+          url: realtime.url,
+          channel: MAP_PACKAGE_REALTIME_CHANNEL_V1,
+          fallback,
+          reconnect,
+          ...(realtime.staleAfterMs !== undefined ? { staleAfterMs: normalizeDelay(realtime.staleAfterMs, 0) } : {}),
+          fallbackOnStale: realtime.fallbackOnStale !== false,
+        },
+      };
+    }
+
+    if (realtime.advertise === false) return undefined;
+
+    const advertisement = readMapPackageRealtimeAdvertisement(lastFetchedPackage ?? previousPackage);
+    if (!advertisement) return undefined;
+    const advertisedFallback = realtime.fallback ?? advertisement.fallback ?? "polling";
+    const advertisedTransport = advertisement.transport ?? "sse";
+    if (advertisedTransport !== "sse") {
+      return {
+        type: "unsupported",
+        reason: `unsupported-realtime-transport:${advertisedTransport}`,
+        fallback: advertisedFallback,
+      };
+    }
+
+    const url = advertisement.href ?? advertisement.url ?? advertisement.path;
+    if (!url) {
+      return { type: "unsupported", reason: "missing-realtime-url", fallback: advertisedFallback };
+    }
+
+    return {
+      type: "available",
+      source: {
+        transport: createMapPackageServerSentEventsTransport({
+          url,
+          eventSourceFactory: realtime.eventSourceFactory,
+          eventTypes: realtime.eventTypes,
+          withCredentials: realtime.withCredentials ?? advertisement.withCredentials ?? cookieCredentials(realtime),
+          auth: realtime.auth,
+        }),
+        transportKind: "sse",
+        advertised: true,
+        url,
+        channel: advertisement.channel ?? MAP_PACKAGE_REALTIME_CHANNEL_V1,
+        fallback: advertisedFallback,
+        reconnect,
+        ...(realtime.staleAfterMs !== undefined
+          ? { staleAfterMs: normalizeDelay(realtime.staleAfterMs, 0) }
+          : advertisement.staleAfterMs !== undefined
+            ? { staleAfterMs: normalizeDelay(advertisement.staleAfterMs, 0) }
+            : {}),
+        fallbackOnStale: realtime.fallbackOnStale !== false,
+      },
+    };
+  };
+
+  const buildRealtimeFetchResult = (mapPackage: HonuaMapPackage): FetchMapPackageResult => {
+    const path = resolveMapPackagePath(locator, options.resolvePath);
+    const validation = validateMapPackage(mapPackage, {
+      maxAgeMs: options.maxAgeMs,
+      now: options.now,
+    });
+    if (hasMapPackageDiagnosticErrors(validation.diagnostics) && options.allowInvalid !== true) {
+      throw new HonuaMapPackageError("MapPackage validation failed", {
+        packageId: mapPackage.mapPackageId,
+        stage: "validate",
+        detail: { diagnostics: validation.diagnostics, path },
+      });
+    }
+    return {
+      mapPackage,
+      diagnostics: validation.diagnostics,
+      cache: {
+        status: "refreshed",
+        key: path,
+        fetchedAt: new Date().toISOString(),
+        ...(lastRealtimeCheckpoint?.validator ? { validator: lastRealtimeCheckpoint.validator } : {}),
+      },
+    };
+  };
+
+  const isExpectedPackageMessage = (message: MapPackageRealtimeMessage): boolean => {
+    if (!message.packageId) return true;
+    const expected = previousPackage?.mapPackageId ?? lastFetchedPackage?.mapPackageId ?? packageIdFromLocator(locator);
+    if (!expected || expected === message.packageId) return true;
+    emit({
+      type: "error",
+      error: new HonuaMapPackageError("MapPackage realtime message packageId does not match watcher locator", {
+        packageId: message.packageId,
+        stage: "fetch",
+        detail: { expectedPackageId: expected },
+      }),
+    });
+    return false;
+  };
+
+  const updateRealtimeCheckpoint = (message: MapPackageRealtimeMessage): void => {
+    lastRealtimeCheckpoint = {
+      ...lastRealtimeCheckpoint,
+      ...(message.eventId ? { eventId: message.eventId } : {}),
+      ...(message.sequence !== undefined ? { sequence: message.sequence } : {}),
+      ...(message.fingerprint ? { fingerprint: message.fingerprint } : {}),
+      ...(message.updatedAt ? { updatedAt: message.updatedAt } : {}),
+      ...(message.validator ? { validator: message.validator } : {}),
+    };
+  };
+
+  const rememberRealtimeMutation = (message: MapPackageRealtimeMessage): boolean => {
+    if (message.eventId && seenRealtimeEventIds.includes(message.eventId)) return false;
+    if (
+      message.sequence !== undefined &&
+      lastAppliedRealtimeSequence !== undefined &&
+      message.sequence <= lastAppliedRealtimeSequence
+    ) {
+      return false;
+    }
+    if (message.eventId) {
+      seenRealtimeEventIds.push(message.eventId);
+      if (seenRealtimeEventIds.length > 100) seenRealtimeEventIds.shift();
+    }
+    if (message.sequence !== undefined) lastAppliedRealtimeSequence = message.sequence;
+    return true;
+  };
+
+  const abortFromOptions = (): void => {
+    handle.dispose();
   };
 
   const handle: MapPackageWatchHandle = {
     get disposed() {
       return disposed;
     },
-    refresh: poll,
+    refresh: () => poll({ scheduleAfter: false, discoverRealtime: true }),
     dispose() {
       if (disposed) return;
       disposed = true;
       clearScheduled();
+      clearRealtimeTimers();
       if (debounceTimer) clearTimeout(debounceTimer);
       debounceTimer = undefined;
-      pendingResult = undefined;
+      pendingApply = undefined;
       currentAbort?.abort();
+      cleanupRealtime(true);
+      options.signal?.removeEventListener("abort", abortFromOptions);
       emit({ type: "disposed" });
     },
   };
 
+  if (options.signal?.aborted) {
+    handle.dispose();
+    return handle;
+  }
+  options.signal?.addEventListener("abort", abortFromOptions, { once: true });
+
   if (options.immediate !== false) {
-    void poll();
-  } else {
+    void poll({ scheduleAfter: false, discoverRealtime: true }).finally(() => {
+      if (!disposed && !realtimeSubscription && !fallbackActive) {
+        startRealtime();
+        schedule();
+      }
+    });
+  } else if (!startRealtime()) {
     schedule();
   }
 
@@ -184,6 +719,48 @@ export function watchMapPackage(locator: MapPackageLocator, options: WatchMapPac
 function normalizeDelay(value: number | undefined, fallback: number): number {
   if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
   return Math.max(0, Math.trunc(value));
+}
+
+function normalizeReconnectOptions(
+  value: false | MapPackageRealtimeReconnectOptions | undefined,
+): false | Required<MapPackageRealtimeReconnectOptions> {
+  if (value === false) return false;
+  return {
+    maxAttempts: normalizeReconnectAttempts(value?.maxAttempts, DEFAULT_RECONNECT_OPTIONS.maxAttempts),
+    minDelayMs: normalizeDelay(value?.minDelayMs, DEFAULT_RECONNECT_OPTIONS.minDelayMs),
+    maxDelayMs: normalizeDelay(value?.maxDelayMs, DEFAULT_RECONNECT_OPTIONS.maxDelayMs),
+    factor: normalizeReconnectFactor(value?.factor),
+  };
+}
+
+function normalizeReconnectAttempts(value: number | undefined, fallback: number): number {
+  if (value === Number.POSITIVE_INFINITY) return Number.POSITIVE_INFINITY;
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.max(0, Math.trunc(value));
+}
+
+function normalizeReconnectFactor(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return DEFAULT_RECONNECT_OPTIONS.factor;
+  return Math.max(1, value);
+}
+
+function reconnectDelayMs(attempt: number, options: Required<MapPackageRealtimeReconnectOptions>): number {
+  const delay = options.minDelayMs * options.factor ** Math.max(0, attempt - 1);
+  return Math.min(options.maxDelayMs, Math.max(0, Math.trunc(delay)));
+}
+
+function cookieCredentials(options: MapPackageRealtimeWatchOptions): boolean | undefined {
+  return options.auth?.kind === "cookie" ? options.auth.withCredentials : undefined;
+}
+
+function packageIdFromLocator(locator: MapPackageLocator): string | undefined {
+  if (typeof locator === "string") {
+    if (locator.startsWith("/") || locator.startsWith("http://") || locator.startsWith("https://")) return undefined;
+    const prefix = "honua://map-packages/";
+    if (locator.startsWith(prefix)) return decodeURIComponent(locator.slice(prefix.length));
+    return locator;
+  }
+  return locator.packageId ?? locator.id;
 }
 
 function linkAbortSignals(a: AbortSignal | undefined, b: AbortSignal): AbortSignal {

--- a/test/runtime/map-package-watch.test.ts
+++ b/test/runtime/map-package-watch.test.ts
@@ -1,0 +1,333 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { HonuaClient } from "../../src/core/client.js";
+import {
+  HONUA_MAP_PACKAGE_FORMAT_V1,
+  type HonuaMapPackage,
+  type HonuaMapRuntime,
+  MAP_PACKAGE_REALTIME_CHANNEL_V1,
+  type MapPackageRealtimeEventSource,
+  type MapPackageRealtimeObserver,
+  type MapPackageRealtimeSubscribeRequest,
+  type MapPackageRealtimeTransport,
+  type MapPackageWatchEvent,
+  mapPackageFingerprint,
+  watchMapPackage,
+} from "../../src/runtime/index.js";
+
+class MockMapPackageEventSource implements MapPackageRealtimeEventSource {
+  public onopen: ((event: Event) => void) | null = null;
+  public onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  public onerror: ((event: Event) => void) | null = null;
+  public readyState = 0;
+  public closed = false;
+  private readonly listeners = new Map<string, Array<(event: MessageEvent<string>) => void>>();
+
+  public constructor(public readonly url: string) {}
+
+  public addEventListener(type: string, listener: (event: MessageEvent<string>) => void): void {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
+  }
+
+  public removeEventListener(type: string, listener: (event: MessageEvent<string>) => void): void {
+    this.listeners.set(
+      type,
+      (this.listeners.get(type) ?? []).filter((candidate) => candidate !== listener),
+    );
+  }
+
+  public close(): void {
+    this.closed = true;
+    this.readyState = 2;
+  }
+
+  public open(): void {
+    this.readyState = 1;
+    this.onopen?.(new Event("open"));
+  }
+
+  public message(payload: unknown): void {
+    this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(payload) }));
+  }
+
+  public namedMessage(type: string, payload: unknown): void {
+    const event = new MessageEvent(type, { data: JSON.stringify(payload) });
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("watchMapPackage realtime", () => {
+  test("applies realtime package updates once and ignores duplicate update messages", async () => {
+    const initial = makePackage();
+    const next = makePackage({
+      updatedAt: "2026-05-11T00:01:00.000Z",
+      mapSpec: styleWithFill("#0055ff"),
+    });
+    const events: MapPackageWatchEvent[] = [];
+    let observer: MapPackageRealtimeObserver | undefined;
+    let request: MapPackageRealtimeSubscribeRequest | undefined;
+    const close = vi.fn();
+    const transport: MapPackageRealtimeTransport = {
+      kind: "mock",
+      subscribe(nextRequest, nextObserver) {
+        request = nextRequest;
+        observer = nextObserver;
+        return { close };
+      },
+    };
+    const updatePackage = vi.fn(async () => {});
+    const runtime = { mapPackage: initial, updatePackage } as unknown as HonuaMapRuntime;
+
+    const handle = watchMapPackage("pkg-001", {
+      client: makeClient(vi.fn()),
+      initialPackage: initial,
+      runtime,
+      immediate: false,
+      realtime: { transport, reconnect: false },
+      onEvent: (event) => {
+        events.push(event);
+      },
+    });
+
+    expect(request?.resumeFrom?.fingerprint).toBe(mapPackageFingerprint(initial));
+    observer?.connected({ transport: "mock", channel: MAP_PACKAGE_REALTIME_CHANNEL_V1 });
+    observer?.message({
+      type: "updated",
+      packageId: "pkg-001",
+      eventId: "evt-2",
+      sequence: 2,
+      update: { kind: "package", mapPackage: next },
+    });
+    await flushPromises();
+    observer?.message({
+      type: "updated",
+      packageId: "pkg-001",
+      eventId: "evt-2",
+      sequence: 2,
+      update: { kind: "package", mapPackage: next },
+    });
+    await flushPromises();
+
+    expect(updatePackage).toHaveBeenCalledTimes(1);
+    expect(updatePackage).toHaveBeenCalledWith(next);
+    expect(events.map((event) => event.type)).toContain("connected");
+    expect(events.filter((event) => event.type === "updated")).toHaveLength(1);
+
+    handle.dispose();
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(request?.signal.aborted).toBe(true);
+  });
+
+  test("uses an advertised SSE watch channel", async () => {
+    const initial = makePackage({
+      realtime: {
+        mapPackageWatch: {
+          channel: MAP_PACKAGE_REALTIME_CHANNEL_V1,
+          transport: "sse",
+          href: "/api/v1/map-packages/pkg-001/watch",
+          withCredentials: true,
+        },
+      },
+    });
+    const next = makePackage({
+      updatedAt: "2026-05-11T00:02:00.000Z",
+      mapSpec: styleWithFill("#ff5500"),
+    });
+    const events: MapPackageWatchEvent[] = [];
+    const sources: MockMapPackageEventSource[] = [];
+    const updatePackage = vi.fn(async () => {});
+
+    const handle = watchMapPackage("pkg-001", {
+      client: makeClient(vi.fn()),
+      initialPackage: initial,
+      runtime: { mapPackage: initial, updatePackage } as unknown as HonuaMapRuntime,
+      immediate: false,
+      realtime: {
+        eventSourceFactory(url, init) {
+          expect(init?.withCredentials).toBe(true);
+          const source = new MockMapPackageEventSource(url);
+          sources.push(source);
+          return source;
+        },
+      },
+      onEvent: (event) => {
+        events.push(event);
+      },
+    });
+
+    const [source] = sources;
+    expect(source?.url).toContain("/api/v1/map-packages/pkg-001/watch?");
+    expect(source?.url).toContain(`channel=${encodeURIComponent(MAP_PACKAGE_REALTIME_CHANNEL_V1)}`);
+    expect(source?.url).toContain("packageId=pkg-001");
+
+    source?.open();
+    source?.message({
+      type: "updated",
+      packageId: "pkg-001",
+      eventId: "evt-3",
+      sequence: 3,
+      mapPackage: next,
+    });
+    await flushPromises();
+
+    expect(events).toEqual(expect.arrayContaining([expect.objectContaining({ type: "connected", advertised: true })]));
+    expect(updatePackage).toHaveBeenCalledWith(next);
+
+    handle.dispose();
+    expect(source?.closed).toBe(true);
+  });
+
+  test("falls back to polling when the realtime channel is terminal", async () => {
+    const initial = makePackage();
+    const next = makePackage({
+      updatedAt: "2026-05-11T00:03:00.000Z",
+      mapSpec: styleWithFill("#22aa66"),
+    });
+    const fetchFn = vi.fn(async () => jsonResponse(next));
+    const events: MapPackageWatchEvent[] = [];
+    let observer: MapPackageRealtimeObserver | undefined;
+    const transport: MapPackageRealtimeTransport = {
+      kind: "mock",
+      subscribe(_request, nextObserver) {
+        observer = nextObserver;
+        return { close: vi.fn() };
+      },
+    };
+    const updatePackage = vi.fn(async () => {});
+
+    const handle = watchMapPackage("pkg-001", {
+      client: makeClient(fetchFn),
+      initialPackage: initial,
+      runtime: { mapPackage: initial, updatePackage } as unknown as HonuaMapRuntime,
+      immediate: false,
+      realtime: { transport, reconnect: false },
+      onEvent: (event) => {
+        events.push(event);
+      },
+    });
+
+    observer?.message({
+      type: "error",
+      packageId: "pkg-001",
+      code: "AUTH",
+      terminal: true,
+      error: "permission denied",
+    });
+    await flushPromises();
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(updatePackage).toHaveBeenCalledWith(next);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "fallback", mode: "polling", reason: "AUTH" }),
+        expect.objectContaining({ type: "fetched" }),
+        expect.objectContaining({ type: "updated" }),
+      ]),
+    );
+
+    handle.dispose();
+  });
+
+  test("refetch-required messages can surface reload-required diffs", async () => {
+    const initial = makePackage();
+    const next = makePackage({
+      updatedAt: "2026-05-11T00:04:00.000Z",
+      mapSpec: {
+        version: 8,
+        sources: {},
+        layers: [
+          { id: "parcels-fill", type: "fill", source: "parcels", paint: { "fill-color": "#cccccc" } },
+          { id: "parcels-line", type: "line", source: "parcels", paint: { "line-color": "#111111" } },
+        ],
+      },
+    });
+    const fetchFn = vi.fn(async () => jsonResponse(next));
+    const events: MapPackageWatchEvent[] = [];
+    let observer: MapPackageRealtimeObserver | undefined;
+    const transport: MapPackageRealtimeTransport = {
+      kind: "mock",
+      subscribe(_request, nextObserver) {
+        observer = nextObserver;
+        return { close: vi.fn() };
+      },
+    };
+
+    const handle = watchMapPackage("pkg-001", {
+      client: makeClient(fetchFn),
+      initialPackage: initial,
+      immediate: false,
+      realtime: { transport, reconnect: false },
+      onEvent: (event) => {
+        events.push(event);
+      },
+    });
+
+    observer?.message({
+      type: "reload-required",
+      packageId: "pkg-001",
+      eventId: "evt-4",
+      sequence: 4,
+      reason: "server-composed-structural-change",
+    });
+    await flushPromises();
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "reload-required",
+          reason: "server-composed-structural-change",
+          diff: expect.objectContaining({ incremental: false }),
+        }),
+        expect.objectContaining({ type: "updated", applied: false }),
+      ]),
+    );
+
+    handle.dispose();
+  });
+});
+
+function makePackage(overrides: Partial<HonuaMapPackage> = {}): HonuaMapPackage {
+  return {
+    mapPackageId: "pkg-001",
+    format: HONUA_MAP_PACKAGE_FORMAT_V1,
+    status: "Ready",
+    updatedAt: "2026-05-11T00:00:00.000Z",
+    sourceBindings: [
+      {
+        sourceId: "parcels",
+        protocol: "geoservices_feature_service",
+        locator: { url: "https://server.example.com/rest/services/Parcels/FeatureServer/0" },
+      },
+    ],
+    mapSpec: styleWithFill("#cccccc"),
+    ...overrides,
+  };
+}
+
+function styleWithFill(color: string): HonuaMapPackage["mapSpec"] {
+  return {
+    version: 8,
+    sources: {},
+    layers: [{ id: "parcels-fill", type: "fill", source: "parcels", paint: { "fill-color": color } }],
+  };
+}
+
+function makeClient(fetchFn: typeof fetch): HonuaClient {
+  return new HonuaClient({ baseUrl: "https://mock.honua.test", fetchFn });
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function flushPromises(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}


### PR DESCRIPTION
## Summary

Implements the realtime MapPackage watch channel for issue #165.

- Adds a runtime MapPackage realtime contract with typed messages, checkpointing, SSE transport support, advertisement parsing, auth options, reconnect settings, and polling fallback controls.
- Extends `watchMapPackage` to connect to configured or package-advertised realtime channels while preserving polling, `refresh()`, `dispose()`, debounce, diffing, and runtime update behavior.
- Emits typed `connected`, `disconnected`, `stale`, `updated`, `reload-required`, `fallback`, and `error` events, with duplicate update suppression by event id, sequence, and package fingerprint.
- Documents the channel schema, lifecycle, reconnect, auth, and fallback behavior.

## Changed Paths

- `src/runtime/map-package-realtime.ts`
- `src/runtime/map-package-watch.ts`
- `src/runtime/index.ts`
- `test/runtime/map-package-watch.test.ts`
- `docs/map-package-realtime-watch.md`
- `docs/maplibre-runtime.md`

## Validation

- `npm run check`
- `npm run typecheck`
- `npm test -- test/runtime/map-package-fetch.test.ts test/runtime/map-package-watch.test.ts`
- `npm run build`

Closes #165.