### PR TITLE
[codex] Add collaboration reconnect replay flow

### DIFF
--- a/docs/saved-map-collaboration.md
+++ b/docs/saved-map-collaboration.md
@@ -43,7 +43,26 @@ Server adapters should map each server message to `SavedMapCollaborationEnvelope
 }
 ```
 
-`sequence` is stream ordering. `cursor` is the server replay token. Consumers keep the latest `snapshot.cursor` and pass it back through `joinSavedMap({ resumeFrom: { cursor } })` or `replayOperations({ afterCursor })`.
+`sequence` is stream ordering. `cursor` is the server replay token. Consumers keep the latest `snapshot.cursor` and pass it back through `joinSavedMap({ resumeFrom: { cursor } })`, `replayOperations({ afterCursor })`, or `reconnect()`.
+
+## Reconnect
+
+Use `session.disconnect()` when the host detects an interrupted channel but should keep the logical saved-map participant. The snapshot status becomes `stale` and subscriptions remain registered. `session.reconnect()` closes the stale subscription, replays committed operations from the last snapshot cursor by default, merges unseen operations, and opens a fresh subscription:
+
+```ts
+session.disconnect();
+
+try {
+  const replay = await session.reconnect();
+  console.log(replay?.operations.length ?? 0);
+} catch (error) {
+  if (error instanceof HonuaCollaborationError && error.resyncRequired) {
+    await session.leave();
+  }
+}
+```
+
+Pass `reconnect({ replayOperations: false })` when the server channel itself will deliver an authoritative snapshot on subscribe. Pass `afterCursor` or `afterSequence` to override the default resume point.
 
 ## Event Shapes
 
@@ -82,4 +101,4 @@ Typical Portal flow:
 3. Publish cursor/selection/follow events from UI interactions.
 4. Claim a feature lock before editing; handle `lock-held` by keeping the feature read-only.
 5. Submit saved-map operations with `expectedRevision` when optimistic concurrency is available.
-6. On reconnect, replay operations from the last cursor. On `resync-required`, discard local collaboration state and join without a resume cursor.
+6. On reconnect, call `session.reconnect()` to replay operations from the last cursor. On `resync-required`, discard local collaboration state and join without a resume cursor.

--- a/src/collaboration/client.ts
+++ b/src/collaboration/client.ts
@@ -2,6 +2,7 @@ import { HonuaCollaborationError } from "./errors.js";
 import type {
   SavedMapCollaborationEnvelope,
   SavedMapCollaborationJoinRequest,
+  SavedMapCollaborationReconnectOptions,
   SavedMapCollaborationSessionRef,
   SavedMapCollaborationSnapshot,
   SavedMapCollaborationSnapshotListener,
@@ -52,6 +53,7 @@ export class HonuaSavedMapCollaborationSession<TPayload = unknown> {
   #snapshot: SavedMapCollaborationSnapshot<TPayload>;
   #handle: SavedMapCollaborationSubscriptionHandle | undefined;
   #closed = false;
+  #subscriptionGeneration = 0;
 
   public constructor(
     transport: SavedMapCollaborationTransport<TPayload>,
@@ -90,42 +92,68 @@ export class HonuaSavedMapCollaborationSession<TPayload = unknown> {
     };
   }
 
-  public connect(): void {
+  public connect(status: "connecting" | "reconnecting" = "connecting"): void {
     if (this.#closed || this.#handle) return;
-    this.#snapshot = { ...this.#snapshot, status: "connecting" };
+    const generation = ++this.#subscriptionGeneration;
+    this.#snapshot = { ...this.#snapshot, status, error: undefined };
+    this.emit();
     this.#handle = this.#transport.subscribe(this.#session, {
-      next: (envelope) => this.apply(envelope),
+      next: (envelope) => {
+        if (generation === this.#subscriptionGeneration) this.apply(envelope);
+      },
       error: (error) => {
-        const collaborationError =
-          error instanceof HonuaCollaborationError
-            ? error
-            : new HonuaCollaborationError("transport-failure", "Collaboration transport failed.", { cause: error });
-        this.#snapshot = {
-          ...this.#snapshot,
-          status: "error",
-          error: {
-            type: "error",
-            code: collaborationError.code,
-            message: collaborationError.message,
-            retryAfterMs: collaborationError.retryAfterMs,
-            resyncRequired: collaborationError.resyncRequired,
-            details: collaborationError.details,
-          },
-        };
-        this.emit();
+        if (generation === this.#subscriptionGeneration) this.applyError(error);
       },
       complete: () => {
+        if (generation !== this.#subscriptionGeneration) return;
         this.#snapshot = { ...this.#snapshot, status: "closed" };
+        this.#handle = undefined;
         this.emit();
       },
     });
   }
 
+  public disconnect(): void {
+    if (this.#closed) return;
+    this.closeSubscription();
+    this.#snapshot = { ...this.#snapshot, status: "stale" };
+    this.emit();
+  }
+
+  public async reconnect(
+    options: SavedMapCollaborationReconnectOptions = {},
+  ): Promise<SavedMapOperationReplayResult<TPayload> | undefined> {
+    if (this.#closed) {
+      throw new HonuaCollaborationError("transport-failure", "Cannot reconnect a closed collaboration session.");
+    }
+
+    this.closeSubscription();
+    this.#snapshot = { ...this.#snapshot, status: "reconnecting", error: undefined };
+    this.emit();
+
+    let replay: SavedMapOperationReplayResult<TPayload> | undefined;
+    if (options.replayOperations !== false) {
+      try {
+        replay = await this.#transport.replayOperations(
+          this.#session,
+          replayRequestForSnapshot(this.#snapshot, options),
+        );
+        this.#snapshot = mergeReplayedOperations(this.#snapshot, replay);
+        this.emit();
+      } catch (error) {
+        this.applyError(error);
+        throw error;
+      }
+    }
+
+    this.connect("reconnecting");
+    return replay;
+  }
+
   public async leave(): Promise<void> {
     if (this.#closed) return;
     this.#closed = true;
-    this.#handle?.close();
-    this.#handle = undefined;
+    this.closeSubscription();
     await this.#transport.leave(this.#session);
     this.#snapshot = { ...this.#snapshot, status: "closed" };
     this.emit();
@@ -182,6 +210,34 @@ export class HonuaSavedMapCollaborationSession<TPayload = unknown> {
 
   private emit(envelope?: SavedMapCollaborationEnvelope<TPayload>): void {
     for (const listener of [...this.#listeners]) listener(this.#snapshot, envelope);
+  }
+
+  private closeSubscription(): void {
+    if (!this.#handle) return;
+    const handle = this.#handle;
+    this.#handle = undefined;
+    this.#subscriptionGeneration++;
+    handle.close();
+  }
+
+  private applyError(error: unknown): void {
+    const collaborationError =
+      error instanceof HonuaCollaborationError
+        ? error
+        : new HonuaCollaborationError("transport-failure", "Collaboration transport failed.", { cause: error });
+    this.#snapshot = {
+      ...this.#snapshot,
+      status: "error",
+      error: {
+        type: "error",
+        code: collaborationError.code,
+        message: collaborationError.message,
+        retryAfterMs: collaborationError.retryAfterMs,
+        resyncRequired: collaborationError.resyncRequired,
+        details: collaborationError.details,
+      },
+    };
+    this.emit();
   }
 }
 
@@ -295,4 +351,33 @@ function sameFeatureLockTarget(
 function omitKey<T>(record: Readonly<Record<string, T>>, key: string): Readonly<Record<string, T>> {
   const { [key]: _removed, ...rest } = record;
   return rest;
+}
+
+function replayRequestForSnapshot<TPayload>(
+  snapshot: SavedMapCollaborationSnapshot<TPayload>,
+  options: SavedMapCollaborationReconnectOptions,
+): SavedMapOperationReplayRequest {
+  const { replayOperations: _replayOperations, ...request } = options;
+  if (request.afterCursor !== undefined || request.afterSequence !== undefined) return request;
+  if (snapshot.cursor !== undefined) return { ...request, afterCursor: snapshot.cursor };
+  return { ...request, afterSequence: snapshot.sequence };
+}
+
+function mergeReplayedOperations<TPayload>(
+  snapshot: SavedMapCollaborationSnapshot<TPayload>,
+  replay: SavedMapOperationReplayResult<TPayload>,
+): SavedMapCollaborationSnapshot<TPayload> {
+  const operationIds = new Set(snapshot.operations.map((operation) => operation.id));
+  const operations = [...snapshot.operations];
+  for (const operation of replay.operations) {
+    if (operationIds.has(operation.id)) continue;
+    operationIds.add(operation.id);
+    operations.push(operation);
+  }
+  return {
+    ...snapshot,
+    operations,
+    sequence: Math.max(snapshot.sequence, replay.sequence),
+    cursor: replay.cursor ?? snapshot.cursor,
+  };
 }

--- a/src/collaboration/index.ts
+++ b/src/collaboration/index.ts
@@ -36,6 +36,7 @@ export type {
   SavedMapCollaborationObserver,
   SavedMapCollaborationParticipant,
   SavedMapCollaborationParticipantId,
+  SavedMapCollaborationReconnectOptions,
   SavedMapCollaborationSessionId,
   SavedMapCollaborationSessionRef,
   SavedMapCollaborationSnapshot,

--- a/src/collaboration/types.ts
+++ b/src/collaboration/types.ts
@@ -260,6 +260,10 @@ export interface SavedMapOperationReplayResult<TPayload = unknown> {
   readonly resyncRequired?: boolean;
 }
 
+export interface SavedMapCollaborationReconnectOptions extends SavedMapOperationReplayRequest {
+  readonly replayOperations?: boolean;
+}
+
 export interface SavedMapCollaborationObserver<TPayload = unknown> {
   next(envelope: SavedMapCollaborationEnvelope<TPayload>): void;
   error(error: unknown): void;

--- a/test/collaboration.test.ts
+++ b/test/collaboration.test.ts
@@ -108,6 +108,38 @@ describe("saved-map collaboration client", () => {
     expect(replay.operations.map((operation) => operation.id)).toEqual([second.id]);
   });
 
+  it("reconnects deterministically by replaying operations from the last cursor", async () => {
+    const client = createHonuaSavedMapCollaboration({
+      transport: createFixtureSavedMapCollaborationTransport({
+        now: () => new Date("2026-05-11T10:00:00.000Z"),
+      }),
+    });
+    const alice = await client.joinSavedMap({ mapId: "map-ops", participantId: "alice" });
+    const bob = await client.joinSavedMap({ mapId: "map-ops", participantId: "bob" });
+    const listener = vi.fn();
+    alice.subscribe(listener);
+
+    alice.disconnect();
+    expect(alice.snapshot.status).toBe("stale");
+
+    const operation = await bob.submitOperation({
+      expectedRevision: 0,
+      operation: {
+        kind: "style",
+        payload: { layerId: "incidents", paint: { "circle-color": "#e11d48" } },
+      },
+    });
+
+    expect(alice.snapshot.operations).toHaveLength(0);
+
+    const replay = await alice.reconnect();
+
+    expect(replay?.operations.map((candidate) => candidate.id)).toEqual([operation.id]);
+    expect(alice.snapshot.status).toBe("live");
+    expect(alice.snapshot.operations.map((candidate) => candidate.id)).toEqual([operation.id]);
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({ status: "reconnecting" }), undefined);
+  });
+
   it("surfaces deterministic resync and stale cursor errors", async () => {
     const transport = createFixtureSavedMapCollaborationTransport({
       now: () => new Date("2026-05-11T10:00:00.000Z"),


### PR DESCRIPTION
## Summary
- add explicit `session.disconnect()` and `session.reconnect()` behavior for saved-map collaboration sessions
- replay committed operations from the last snapshot cursor during reconnect and merge unseen operations deterministically
- guard stale subscription callbacks with a generation token so closed channels cannot overwrite the active snapshot
- document the reconnect flow and export `SavedMapCollaborationReconnectOptions`

## Scope
Follow-up to PR #200. That PR shipped the main saved-map collaboration SDK contract; this closes the remaining #199 acceptance gap for deterministic reconnect/replay coverage. Server protocol adapters remain tracked in honua-io/honua-server#971, honua-io/honua-server#972, and honua-io/honua-server#973.

Closes #199
Refs #200
Refs honua-io/honua-server#971
Refs honua-io/honua-server#972
Refs honua-io/honua-server#973

## Validation
- `npm test -- --run test/collaboration.test.ts` passed: 6/6
- `npm run typecheck -- --pretty false` passed
- `npm run check` passed
- `npm run verify:split-packages` passed
- `git diff --check origin/trunk...HEAD` passed
- `npm test -- --run` passed before rebasing the same reconnect patch onto current `origin/trunk`: 181 files, 1851 tests