### PR TITLE
[codex] fix JS package publish recovery

### DIFF
--- a/.github/workflows/publish-js-sdk.yml
+++ b/.github/workflows/publish-js-sdk.yml
@@ -8,6 +8,16 @@ on:
         required: false
         default: true
         type: boolean
+      release_version:
+        description: "Existing package version to publish from a branch recovery run"
+        required: false
+        default: ""
+        type: string
+      allow_branch_publish:
+        description: "Allow a non-dry-run branch recovery publish when release_version matches package.json"
+        required: false
+        default: false
+        type: boolean
   push:
     tags:
       - "js-sdk-*"
@@ -23,6 +33,8 @@ jobs:
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}
+      RELEASE_VERSION: ${{ github.event.inputs.release_version || '' }}
+      ALLOW_BRANCH_PUBLISH: ${{ github.event.inputs.allow_branch_publish == 'true' }}
 
     steps:
       - name: Checkout
@@ -56,22 +68,33 @@ jobs:
       - name: Validate publish ref and version
         if: env.DRY_RUN != 'true'
         run: |
-          if [[ "${GITHUB_REF_TYPE}" != "tag" || "${GITHUB_REF_NAME}" != js-sdk-* ]]; then
-            echo "Non-dry-run publish must run from a js-sdk-* tag. Current ref: ${GITHUB_REF_TYPE}/${GITHUB_REF_NAME}."
+          package_version="$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")"
+
+          if [[ -n "${RELEASE_VERSION}" && "${RELEASE_VERSION}" != "${package_version}" ]]; then
+            echo "release_version (${RELEASE_VERSION}) does not match package.json version (${package_version})."
             exit 1
           fi
-          package_version="$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")"
-          tag_version="${GITHUB_REF_NAME#js-sdk-}"
-          while [[ "$tag_version" == v* ]]; do
-            tag_version="${tag_version#v}"
-          done
-          if [[ "$tag_version" != "$package_version" ]]; then
-            echo "Tag version ($tag_version) does not match package.json version ($package_version)."
+
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == js-sdk-* ]]; then
+            tag_version="${GITHUB_REF_NAME#js-sdk-}"
+            while [[ "$tag_version" == v* ]]; do
+              tag_version="${tag_version#v}"
+            done
+            if [[ "$tag_version" != "$package_version" ]]; then
+              echo "Tag version ($tag_version) does not match package.json version ($package_version)."
+              exit 1
+            fi
+          elif [[ "${ALLOW_BRANCH_PUBLISH}" == "true" && -n "${RELEASE_VERSION}" ]]; then
+            echo "Running guarded branch recovery publish for ${package_version} from ${GITHUB_REF_TYPE}/${GITHUB_REF_NAME}."
+          else
+            echo "Non-dry-run publish must run from a js-sdk-* tag, or set allow_branch_publish with release_version for recovery. Current ref: ${GITHUB_REF_TYPE}/${GITHUB_REF_NAME}."
             exit 1
           fi
 
       - name: Publish split packages
         run: |
+          npm run build:split-packages --silent
+
           flags=""
           if [[ "${DRY_RUN}" == "true" ]]; then
             flags="--dry-run"


### PR DESCRIPTION
## Summary

Fixes the JS package publish workflow after the `0.0.10-alpha.0` release published the root `@honua/sdk-js` package but failed before publishing the split packages.

## Root Cause

The validation gate builds split packages, but later demo build steps can run the root build again and clean `dist/`, removing `dist/packages` before the publish step reads those generated package manifests.

## Changes

- Regenerate split packages immediately before publishing.
- Keep the normal non-dry-run path restricted to `js-sdk-*` release tags.
- Add a guarded branch recovery dispatch path requiring both `allow_branch_publish=true` and a matching `release_version` so the missing split packages can be published without moving the release tag.

## Validation

- `npm run build:split-packages --silent`
- `npm run verify:split-packages --silent`