### PR TITLE
feat: add Esri sample corpus guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,6 +914,9 @@ node dist/src/migration/cli.js runtime-matrix --report runtime-parity-matrix.jso
 # Generate readiness metrics for bundled complex real-sample fixtures
 node dist/src/migration/cli.js fixtures --report reports/real-sample-metrics.json
 
+# Inspect the fixture-only Esri sample migration corpus helpers from tests/docs
+# See docs/esri-sample-corpus.md and test/fixtures/esri-sample-corpus/manifest.json
+
 # Enforce strict readiness gates for bundled real-sample fixtures
 node dist/src/migration/cli.js fixtures --fail-on-manual --fail-on-unhandled --fail-on-blocked --max-manual-ratio 0 --max-manual-intervention-ratio 0 --report reports/real-sample-metrics.json
 
@@ -977,6 +980,15 @@ for source inventory, migration manifest, parity evidence pack, cutover
 readiness, and readiness attestations. Manifest, parity, and readiness artifacts
 are modeled for client-side review workflows only; the SDK does not assume
 server routes for those artifacts.
+
+## Esri Sample Corpus (#206)
+
+The first paired sample-app/service corpus slice is fixture-only and documented
+in [`docs/esri-sample-corpus.md`](./docs/esri-sample-corpus.md). The curated
+manifest at `test/fixtures/esri-sample-corpus/manifest.json` records Esri sample
+source URLs as metadata only, license/terms notes, skip reasons, and expected
+service/Portal references. PR CI uses Honua-owned snippets and must not contact
+live Esri services, vendor Esri sample code, or commit Esri service data.
 
 ## FeatureTable Demo Lane (#327)
 

--- a/docs/esri-sample-corpus.md
+++ b/docs/esri-sample-corpus.md
@@ -1,0 +1,70 @@
+# Esri Sample Migration Corpus
+
+This corpus is the first bounded slice for paired Esri sample app and referenced
+service migration evidence. It is intentionally fixture-first.
+
+## PR CI Guardrails
+
+- PR CI must not contact live Esri services.
+- PR CI must not vendor Esri sample source code.
+- PR CI must not commit Esri-hosted service data, basemaps, screenshots, or
+  Portal exports.
+- Sample source URLs are metadata references only.
+- Samples that require API keys, OAuth, private content, premium services, or
+  unclear content terms stay skipped unless credentials, permission, and terms
+  review are explicitly configured.
+
+The committed manifest lives at
+`test/fixtures/esri-sample-corpus/manifest.json`. Its fixtures are tiny
+Honua-owned snippets that mimic common ArcGIS Maps SDK for JavaScript patterns:
+service URL references, Portal item references, API-key routing references, and
+OAuth/private Portal references.
+
+## Manifest Shape
+
+The manifest uses `schemaVersion: "honua.esri-sample-corpus.v1"` and records:
+
+- global guardrails for no vendored Esri code, no committed Esri service data,
+  fixture-only PR CI, and opt-in live evidence lanes
+- one entry per curated sample with `id`, `title`, source URL metadata,
+  fixture location, status, license metadata, terms notes, skip reasons, and
+  expected references
+- status values: `ci-fixture`, `live-evidence`, and `skipped`
+- skip reasons: `requires-api-key`, `requires-oauth`, `premium-service`,
+  `private-content`, `unclear-content-terms`, and `unsupported-sample-family`
+
+The migration entrypoint exports helpers to load and inspect the corpus:
+
+```ts
+import {
+  analyzeEsriSampleFixture,
+  loadEsriSampleCorpusManifest,
+  summarizeEsriSampleCorpus,
+} from "@honua/sdk-js/migration";
+
+const manifest = loadEsriSampleCorpusManifest("test/fixtures/esri-sample-corpus/manifest.json");
+const summary = summarizeEsriSampleCorpus(manifest);
+const analysis = analyzeEsriSampleFixture(manifest.samples[0], {
+  manifestDir: "test/fixtures/esri-sample-corpus",
+});
+
+void summary;
+void analysis;
+```
+
+## Live Evidence Lanes
+
+Live Esri sample/service evidence is reserved for scheduled or manual runs. A
+live lane should:
+
+- require an explicit environment flag and any needed credentials
+- rate-limit requests and avoid load/performance testing against Esri services
+- record source sample URL, retrieved date, service URLs, Portal item ids,
+  service import result, app migration result, unsupported/manual-review items,
+  and browser smoke result
+- skip samples requiring credentials, premium services, private content, or
+  unclear content terms unless the lane has explicit permission
+- emit artifacts for review rather than committing Esri source or service data
+
+Follow-on issue #206 work can layer service import, app codemod, URL rewriting,
+and Playwright smoke evidence on top of this manifest and extraction helper.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -10,7 +10,7 @@ This repository owns the JavaScript/TypeScript SDK, browser runtime helpers, mig
 - MapLibre runtime helpers for `MapPackage`, source/layer style validation, WMS/WMTS source specs, web-map conversion, and warning contracts.
 - Generated-app manifest projection and operations-dashboard preview runtime under `@honua/sdk-js/generated-app`.
 - Esri compatibility layer for migration-critical layers, views, widgets, controls, routing helpers, search, popup, time slider, measurement, editor/sketch, graphics, groups, web maps, and basic scene-view compatibility.
-- Migration tooling for ArcGIS usage scanning, safe codemods, parity matrices, fixture metrics, content export/import/reconcile, URL rewriting, service reconciliation, and migration demo reports.
+- Migration tooling for ArcGIS usage scanning, safe codemods, parity matrices, fixture metrics, content export/import/reconcile, URL rewriting, service reconciliation, migration demo reports, and a fixture-only Esri sample corpus with license/terms guardrails.
 - Example apps for MapLibre quickstart, 2.5D storytelling, kepler analytics, and an exploratory Cesium route-playback spike.
 - MCP server package with tools and resources for service listing, layer description, extent, counts, feature queries, and statistics.
 

--- a/src/migration-entry.ts
+++ b/src/migration-entry.ts
@@ -105,6 +105,35 @@ export type {
   ContentReconcileReport,
 } from "./migration/content.js";
 export {
+  analyzeEsriSampleFixture,
+  classifyArcGisServiceUrl,
+  extractEsriSampleReferences,
+  loadEsriSampleCorpusManifest,
+  parseEsriSampleCorpusManifest,
+  summarizeEsriSampleCorpus,
+} from "./migration/sample-corpus.js";
+export type {
+  ArcGisServiceKind,
+  ArcGisServiceReference,
+  EsriSampleCorpusGuardrails,
+  EsriSampleCorpusLane,
+  EsriSampleCorpusManifest,
+  EsriSampleCorpusSample,
+  EsriSampleCorpusSampleStatus,
+  EsriSampleCorpusSchemaVersion,
+  EsriSampleCorpusSummary,
+  EsriSampleExpectedReferences,
+  EsriSampleFixtureAnalysis,
+  EsriSampleFixtureReference,
+  EsriSampleGuardrailFlag,
+  EsriSampleLicenseMetadata,
+  EsriSampleReferenceExtraction,
+  EsriSampleSkipReason,
+  EsriSampleSourceReference,
+  EsriSampleTermsMetadata,
+  PortalItemReference,
+} from "./migration/sample-corpus.js";
+export {
   MIGRATION_DEMO_FALLBACK_TARGET,
   MIGRATION_DEMO_ISSUE_NUMBER,
   MIGRATION_DEMO_PRIMARY_TARGET,

--- a/src/migration/sample-corpus.ts
+++ b/src/migration/sample-corpus.ts
@@ -1,0 +1,418 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+const SKIP_DIRS = new Set(["node_modules", "dist", ".git"]);
+const ARCGIS_SERVICE_URL_REGEX =
+  /https?:\/\/[^\s"'`<>)]+?\/arcgis\/rest\/services\/[^\s"'`<>)]+?\/(?:FeatureServer|MapServer|ImageServer|VectorTileServer|GeometryServer|GPServer|GeocodeServer|RouteServer)(?:\/\d+)?(?:\?[^\s"'`<>)]+)?/gi;
+const PORTAL_ITEM_OBJECT_REGEX =
+  /\bportalItem\s*:\s*\{[\s\S]{0,320}?\bid\s*:\s*["']([A-Za-z0-9_-]{6,})["'][\s\S]{0,320}?\}/g;
+const PORTAL_ITEM_ID_REGEX = /\b(?:itemId|portalItemId)\s*:\s*["']([A-Za-z0-9_-]{6,})["']/g;
+const API_KEY_REGEX = /\b(?:apiKey|api_key)\b/i;
+const OAUTH_REGEX = /\b(?:OAuthInfo|IdentityManager|registerToken|checkSignInStatus|getCredential)\b/i;
+const PREMIUM_REGEX = /\b(?:Directions|RouteLayer|RouteTask|ClosestFacility|ServiceArea|UtilityNetwork)\b/i;
+
+export type EsriSampleCorpusSchemaVersion = "honua.esri-sample-corpus.v1";
+
+export type EsriSampleCorpusLane = "pr-fixture" | "manual-live" | "scheduled-live";
+
+export type EsriSampleCorpusSampleStatus = "ci-fixture" | "live-evidence" | "skipped";
+
+export type EsriSampleSkipReason =
+  | "requires-api-key"
+  | "requires-oauth"
+  | "premium-service"
+  | "private-content"
+  | "unclear-content-terms"
+  | "unsupported-sample-family";
+
+export type ArcGisServiceKind =
+  | "FeatureServer"
+  | "MapServer"
+  | "ImageServer"
+  | "VectorTileServer"
+  | "GeometryServer"
+  | "GPServer"
+  | "GeocodeServer"
+  | "RouteServer"
+  | "unknown";
+
+export interface EsriSampleCorpusManifest {
+  schemaVersion: EsriSampleCorpusSchemaVersion;
+  generatedBy: "honua";
+  guardrails: EsriSampleCorpusGuardrails;
+  samples: EsriSampleCorpusSample[];
+}
+
+export interface EsriSampleCorpusGuardrails {
+  noVendoredEsriSampleCode: boolean;
+  noCommittedEsriServiceData: boolean;
+  prCiUsesFixtureOnly: boolean;
+  liveRunsRequireOptIn: boolean;
+  liveRunLanes: EsriSampleCorpusLane[];
+  notes: string[];
+}
+
+export interface EsriSampleCorpusSample {
+  id: string;
+  title: string;
+  source: EsriSampleSourceReference;
+  fixture: EsriSampleFixtureReference;
+  status: EsriSampleCorpusSampleStatus;
+  license: EsriSampleLicenseMetadata;
+  terms: EsriSampleTermsMetadata;
+  skipReasons?: EsriSampleSkipReason[];
+  expected?: EsriSampleExpectedReferences;
+}
+
+export interface EsriSampleSourceReference {
+  url: string;
+  sampleCodePath?: string;
+  referenceOnly: boolean;
+  retrievedAt?: string;
+}
+
+export interface EsriSampleFixtureReference {
+  root: string;
+  entrypoints: string[];
+  ownership: "honua";
+  description: string;
+}
+
+export interface EsriSampleLicenseMetadata {
+  label: string;
+  url: string;
+  notice: string;
+}
+
+export interface EsriSampleTermsMetadata {
+  sampleCode: string;
+  serviceContent: string;
+  liveEvidence: string;
+}
+
+export interface EsriSampleExpectedReferences {
+  serviceKinds?: ArcGisServiceKind[];
+  portalItemIds?: string[];
+  guardrailFlags?: EsriSampleGuardrailFlag[];
+}
+
+export interface ArcGisServiceReference {
+  url: string;
+  normalizedUrl: string;
+  kind: ArcGisServiceKind;
+  servicePath?: string;
+  layerId?: number;
+}
+
+export interface PortalItemReference {
+  id: string;
+}
+
+export type EsriSampleGuardrailFlag =
+  | "api-key-reference"
+  | "oauth-reference"
+  | "premium-service-reference"
+  | "external-live-service-reference";
+
+export interface EsriSampleReferenceExtraction {
+  serviceUrls: ArcGisServiceReference[];
+  portalItems: PortalItemReference[];
+  guardrailFlags: EsriSampleGuardrailFlag[];
+}
+
+export interface EsriSampleFixtureAnalysis extends EsriSampleReferenceExtraction {
+  sampleId: string;
+  filesScanned: number;
+  status: EsriSampleCorpusSampleStatus;
+  skipReasons: EsriSampleSkipReason[];
+}
+
+export interface EsriSampleCorpusSummary {
+  sampleCount: number;
+  fixtureCiCount: number;
+  liveEvidenceCount: number;
+  skippedCount: number;
+  guardrailFailures: string[];
+}
+
+export function loadEsriSampleCorpusManifest(manifestPath: string): EsriSampleCorpusManifest {
+  const parsed = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as unknown;
+  return parseEsriSampleCorpusManifest(parsed, manifestPath);
+}
+
+export function parseEsriSampleCorpusManifest(value: unknown, sourceName = "manifest"): EsriSampleCorpusManifest {
+  const record = expectRecord(value, sourceName);
+  if (record.schemaVersion !== "honua.esri-sample-corpus.v1") {
+    throw new Error(`${sourceName} must use schemaVersion honua.esri-sample-corpus.v1.`);
+  }
+  if (record.generatedBy !== "honua") {
+    throw new Error(`${sourceName} must be generatedBy honua.`);
+  }
+
+  const guardrails = expectRecord(
+    record.guardrails,
+    `${sourceName}.guardrails`,
+  ) as unknown as EsriSampleCorpusGuardrails;
+  const samples = expectArray(record.samples, `${sourceName}.samples`).map((sample, index) =>
+    parseSample(sample, `${sourceName}.samples[${index}]`),
+  );
+
+  return {
+    schemaVersion: "honua.esri-sample-corpus.v1",
+    generatedBy: "honua",
+    guardrails: {
+      noVendoredEsriSampleCode: expectBoolean(
+        guardrails.noVendoredEsriSampleCode,
+        `${sourceName}.guardrails.noVendoredEsriSampleCode`,
+      ),
+      noCommittedEsriServiceData: expectBoolean(
+        guardrails.noCommittedEsriServiceData,
+        `${sourceName}.guardrails.noCommittedEsriServiceData`,
+      ),
+      prCiUsesFixtureOnly: expectBoolean(
+        guardrails.prCiUsesFixtureOnly,
+        `${sourceName}.guardrails.prCiUsesFixtureOnly`,
+      ),
+      liveRunsRequireOptIn: expectBoolean(
+        guardrails.liveRunsRequireOptIn,
+        `${sourceName}.guardrails.liveRunsRequireOptIn`,
+      ),
+      liveRunLanes: expectStringArray(
+        guardrails.liveRunLanes,
+        `${sourceName}.guardrails.liveRunLanes`,
+      ) as EsriSampleCorpusLane[],
+      notes: expectStringArray(guardrails.notes, `${sourceName}.guardrails.notes`),
+    },
+    samples,
+  };
+}
+
+export function summarizeEsriSampleCorpus(manifest: EsriSampleCorpusManifest): EsriSampleCorpusSummary {
+  const guardrailFailures: string[] = [];
+  if (!manifest.guardrails.noVendoredEsriSampleCode) {
+    guardrailFailures.push("guardrails.noVendoredEsriSampleCode must remain true");
+  }
+  if (!manifest.guardrails.noCommittedEsriServiceData) {
+    guardrailFailures.push("guardrails.noCommittedEsriServiceData must remain true");
+  }
+  if (!manifest.guardrails.prCiUsesFixtureOnly) {
+    guardrailFailures.push("guardrails.prCiUsesFixtureOnly must remain true");
+  }
+  if (!manifest.guardrails.liveRunsRequireOptIn) {
+    guardrailFailures.push("guardrails.liveRunsRequireOptIn must remain true");
+  }
+
+  for (const sample of manifest.samples) {
+    if (!sample.source.referenceOnly) {
+      guardrailFailures.push(`${sample.id}: source.referenceOnly must remain true`);
+    }
+    if (sample.fixture.ownership !== "honua") {
+      guardrailFailures.push(`${sample.id}: fixture.ownership must be honua`);
+    }
+    if (sample.status === "skipped" && (!sample.skipReasons || sample.skipReasons.length === 0)) {
+      guardrailFailures.push(`${sample.id}: skipped samples must record skipReasons`);
+    }
+  }
+
+  return {
+    sampleCount: manifest.samples.length,
+    fixtureCiCount: manifest.samples.filter((sample) => sample.status === "ci-fixture").length,
+    liveEvidenceCount: manifest.samples.filter((sample) => sample.status === "live-evidence").length,
+    skippedCount: manifest.samples.filter((sample) => sample.status === "skipped").length,
+    guardrailFailures,
+  };
+}
+
+export function analyzeEsriSampleFixture(
+  sample: EsriSampleCorpusSample,
+  options: { manifestDir: string },
+): EsriSampleFixtureAnalysis {
+  const fixtureRoot = path.resolve(options.manifestDir, sample.fixture.root);
+  const entrypointFiles = sample.fixture.entrypoints.map((entrypoint) => path.resolve(fixtureRoot, entrypoint));
+  const files = entrypointFiles.length > 0 ? entrypointFiles : collectSourceFiles(fixtureRoot);
+  const combined: EsriSampleReferenceExtraction = {
+    serviceUrls: [],
+    portalItems: [],
+    guardrailFlags: [],
+  };
+
+  for (const file of files) {
+    const extraction = extractEsriSampleReferences(fs.readFileSync(file, "utf8"));
+    combined.serviceUrls.push(...extraction.serviceUrls);
+    combined.portalItems.push(...extraction.portalItems);
+    combined.guardrailFlags.push(...extraction.guardrailFlags);
+  }
+
+  const serviceUrls = uniqueBy(combined.serviceUrls, (item) => item.normalizedUrl);
+  const portalItems = uniqueBy(combined.portalItems, (item) => item.id);
+  const guardrailFlags = Array.from(new Set(combined.guardrailFlags)).sort();
+
+  return {
+    sampleId: sample.id,
+    filesScanned: files.length,
+    status: sample.status,
+    skipReasons: sample.skipReasons ?? [],
+    serviceUrls,
+    portalItems,
+    guardrailFlags,
+  };
+}
+
+export function extractEsriSampleReferences(source: string): EsriSampleReferenceExtraction {
+  const serviceUrls: ArcGisServiceReference[] = [];
+  const portalItems: PortalItemReference[] = [];
+  const guardrailFlags = new Set<EsriSampleGuardrailFlag>();
+
+  for (const match of source.matchAll(ARCGIS_SERVICE_URL_REGEX)) {
+    const service = classifyArcGisServiceUrl(match[0]);
+    serviceUrls.push(service);
+    if (service.normalizedUrl.startsWith("http://") || service.normalizedUrl.startsWith("https://")) {
+      guardrailFlags.add("external-live-service-reference");
+    }
+    if (service.kind === "RouteServer") {
+      guardrailFlags.add("premium-service-reference");
+    }
+  }
+
+  for (const match of source.matchAll(PORTAL_ITEM_OBJECT_REGEX)) {
+    portalItems.push({ id: match[1] });
+  }
+  for (const match of source.matchAll(PORTAL_ITEM_ID_REGEX)) {
+    portalItems.push({ id: match[1] });
+  }
+
+  if (API_KEY_REGEX.test(source)) {
+    guardrailFlags.add("api-key-reference");
+  }
+  if (OAUTH_REGEX.test(source)) {
+    guardrailFlags.add("oauth-reference");
+  }
+  if (PREMIUM_REGEX.test(source)) {
+    guardrailFlags.add("premium-service-reference");
+  }
+
+  return {
+    serviceUrls: uniqueBy(serviceUrls, (item) => item.normalizedUrl),
+    portalItems: uniqueBy(portalItems, (item) => item.id),
+    guardrailFlags: Array.from(guardrailFlags).sort(),
+  };
+}
+
+export function classifyArcGisServiceUrl(url: string): ArcGisServiceReference {
+  const cleanedUrl = url.replace(/[),.;\]]+$/, "");
+  const parsed = new URL(cleanedUrl);
+  parsed.search = "";
+  parsed.hash = "";
+  const normalizedUrl = parsed.toString().replace(/\/$/, "");
+  const serviceMatch = normalizedUrl.match(
+    /\/arcgis\/rest\/services\/(.+?)\/(FeatureServer|MapServer|ImageServer|VectorTileServer|GeometryServer|GPServer|GeocodeServer|RouteServer)(?:\/(\d+))?$/i,
+  );
+
+  if (!serviceMatch) {
+    return {
+      url: cleanedUrl,
+      normalizedUrl,
+      kind: "unknown",
+    };
+  }
+
+  const kind = serviceMatch[2] as ArcGisServiceKind;
+  const layerId = serviceMatch[3] === undefined ? undefined : Number.parseInt(serviceMatch[3], 10);
+  return {
+    url: cleanedUrl,
+    normalizedUrl,
+    kind,
+    servicePath: serviceMatch[1],
+    layerId: Number.isFinite(layerId) ? layerId : undefined,
+  };
+}
+
+function parseSample(value: unknown, sourceName: string): EsriSampleCorpusSample {
+  const record = expectRecord(value, sourceName);
+  const status = expectString(record.status, `${sourceName}.status`) as EsriSampleCorpusSampleStatus;
+  const skipReasons =
+    record.skipReasons === undefined
+      ? undefined
+      : (expectStringArray(record.skipReasons, `${sourceName}.skipReasons`) as EsriSampleSkipReason[]);
+
+  return {
+    id: expectString(record.id, `${sourceName}.id`),
+    title: expectString(record.title, `${sourceName}.title`),
+    source: expectRecord(record.source, `${sourceName}.source`) as unknown as EsriSampleSourceReference,
+    fixture: expectRecord(record.fixture, `${sourceName}.fixture`) as unknown as EsriSampleFixtureReference,
+    status,
+    license: expectRecord(record.license, `${sourceName}.license`) as unknown as EsriSampleLicenseMetadata,
+    terms: expectRecord(record.terms, `${sourceName}.terms`) as unknown as EsriSampleTermsMetadata,
+    skipReasons,
+    expected: record.expected as EsriSampleExpectedReferences | undefined,
+  };
+}
+
+function collectSourceFiles(rootDir: string): string[] {
+  const queue = [rootDir];
+  const result: string[] = [];
+  while (queue.length > 0) {
+    const current = queue.pop()!;
+    const entries = fs.readdirSync(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        if (!SKIP_DIRS.has(entry.name)) {
+          queue.push(fullPath);
+        }
+      } else if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+        result.push(fullPath);
+      }
+    }
+  }
+  return result.sort();
+}
+
+function uniqueBy<T>(items: T[], getKey: (item: T) => string): T[] {
+  const seen = new Set<string>();
+  const result: T[] = [];
+  for (const item of items) {
+    const key = getKey(item);
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(item);
+    }
+  }
+  return result;
+}
+
+function expectRecord(value: unknown, sourceName: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${sourceName} must be an object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function expectArray(value: unknown, sourceName: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${sourceName} must be an array.`);
+  }
+  return value;
+}
+
+function expectString(value: unknown, sourceName: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${sourceName} must be a non-empty string.`);
+  }
+  return value;
+}
+
+function expectBoolean(value: unknown, sourceName: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`${sourceName} must be a boolean.`);
+  }
+  return value;
+}
+
+function expectStringArray(value: unknown, sourceName: string): string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string" || item.length === 0)) {
+    throw new Error(`${sourceName} must be an array of non-empty strings.`);
+  }
+  return value as string[];
+}

--- a/src/migration/sample-corpus.ts
+++ b/src/migration/sample-corpus.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
 const SKIP_DIRS = new Set(["node_modules", "dist", ".git"]);
 const ARCGIS_SERVICE_URL_REGEX =
-  /https?:\/\/[^\s"'`<>)]+?\/arcgis\/rest\/services\/[^\s"'`<>)]+?\/(?:FeatureServer|MapServer|ImageServer|VectorTileServer|GeometryServer|GPServer|GeocodeServer|RouteServer)(?:\/\d+)?(?:\?[^\s"'`<>)]+)?/gi;
+  /https?:\/\/[^\s"'`<>)]+?\/arcgis\/rest\/services\/[^\s"'`<>)]+?\/(?:FeatureServer|MapServer|ImageServer|VectorTileServer|GeometryServer|GPServer|GeocodeServer|RouteServer|NAServer)(?:\/[A-Za-z0-9_-]+)?(?:\/\d+)?(?:\?[^\s"'`<>)]+)?/gi;
 const PORTAL_ITEM_OBJECT_REGEX =
   /\bportalItem\s*:\s*\{[\s\S]{0,320}?\bid\s*:\s*["']([A-Za-z0-9_-]{6,})["'][\s\S]{0,320}?\}/g;
 const PORTAL_ITEM_ID_REGEX = /\b(?:itemId|portalItemId)\s*:\s*["']([A-Za-z0-9_-]{6,})["']/g;
@@ -35,6 +35,7 @@ export type ArcGisServiceKind =
   | "GPServer"
   | "GeocodeServer"
   | "RouteServer"
+  | "NAServer"
   | "unknown";
 
 export interface EsriSampleCorpusManifest {
@@ -270,7 +271,7 @@ export function extractEsriSampleReferences(source: string): EsriSampleReference
     if (service.normalizedUrl.startsWith("http://") || service.normalizedUrl.startsWith("https://")) {
       guardrailFlags.add("external-live-service-reference");
     }
-    if (service.kind === "RouteServer") {
+    if (service.kind === "RouteServer" || service.kind === "NAServer") {
       guardrailFlags.add("premium-service-reference");
     }
   }
@@ -306,7 +307,7 @@ export function classifyArcGisServiceUrl(url: string): ArcGisServiceReference {
   parsed.hash = "";
   const normalizedUrl = parsed.toString().replace(/\/$/, "");
   const serviceMatch = normalizedUrl.match(
-    /\/arcgis\/rest\/services\/(.+?)\/(FeatureServer|MapServer|ImageServer|VectorTileServer|GeometryServer|GPServer|GeocodeServer|RouteServer)(?:\/(\d+))?$/i,
+    /\/arcgis\/rest\/services\/(.+?)\/(FeatureServer|MapServer|ImageServer|VectorTileServer|GeometryServer|GPServer|GeocodeServer|RouteServer|NAServer)(?:\/([A-Za-z0-9_-]+))?(?:\/(\d+))?$/i,
   );
 
   if (!serviceMatch) {
@@ -318,12 +319,25 @@ export function classifyArcGisServiceUrl(url: string): ArcGisServiceReference {
   }
 
   const kind = serviceMatch[2] as ArcGisServiceKind;
-  const layerId = serviceMatch[3] === undefined ? undefined : Number.parseInt(serviceMatch[3], 10);
+  // For NAServer, the third capture is the network-analyst sub-service name
+  // (e.g., Route_World, ClosestFacility_World) — fold it into servicePath so
+  // downstream consumers see it. For other kinds it's the numeric layer id.
+  let servicePath = serviceMatch[1];
+  let layerToken: string | undefined;
+  if (kind === "NAServer") {
+    if (serviceMatch[3]) {
+      servicePath = `${servicePath}/NAServer/${serviceMatch[3]}`;
+    }
+    layerToken = serviceMatch[4];
+  } else {
+    layerToken = serviceMatch[3] ?? serviceMatch[4];
+  }
+  const layerId = layerToken === undefined ? undefined : Number.parseInt(layerToken, 10);
   return {
     url: cleanedUrl,
     normalizedUrl,
     kind,
-    servicePath: serviceMatch[1],
+    servicePath,
     layerId: Number.isFinite(layerId) ? layerId : undefined,
   };
 }

--- a/test/fixtures/esri-sample-corpus/README.md
+++ b/test/fixtures/esri-sample-corpus/README.md
@@ -1,0 +1,8 @@
+# Esri Sample Corpus Fixtures
+
+These snippets are Honua-owned fixtures for migration tooling tests. They are
+not copied from Esri sample applications and do not include Esri service data.
+
+The manifest records Esri sample source URLs as reference metadata only. PR CI
+uses these local snippets to validate URL, Portal item, auth, and terms
+classification without contacting Esri-hosted services.

--- a/test/fixtures/esri-sample-corpus/feature-layer-popup-public/src/main.ts
+++ b/test/fixtures/esri-sample-corpus/feature-layer-popup-public/src/main.ts
@@ -1,0 +1,17 @@
+import FeatureLayer from "@arcgis/core/layers/FeatureLayer";
+import WebMap from "@arcgis/core/WebMap";
+
+const publicLayer = new FeatureLayer({
+  url: "https://sampleserver.example.com/arcgis/rest/services/Public/Incidents/FeatureServer/0",
+  outFields: ["OBJECTID", "status"],
+  popupTemplate: { title: "{status}" },
+});
+
+const map = new WebMap({
+  portalItem: {
+    id: "0123456789abcdef0123456789abcdef",
+  },
+  layers: [publicLayer],
+});
+
+void map;

--- a/test/fixtures/esri-sample-corpus/manifest.json
+++ b/test/fixtures/esri-sample-corpus/manifest.json
@@ -1,0 +1,111 @@
+{
+  "schemaVersion": "honua.esri-sample-corpus.v1",
+  "generatedBy": "honua",
+  "guardrails": {
+    "noVendoredEsriSampleCode": true,
+    "noCommittedEsriServiceData": true,
+    "prCiUsesFixtureOnly": true,
+    "liveRunsRequireOptIn": true,
+    "liveRunLanes": ["manual-live", "scheduled-live"],
+    "notes": [
+      "Fixture snippets are Honua-authored and mimic reference patterns only.",
+      "Esri sample URLs are metadata references, not vendored source.",
+      "Live evidence lanes must rate-limit requests and skip samples requiring credentials unless explicitly configured."
+    ]
+  },
+  "samples": [
+    {
+      "id": "feature-layer-popup-public",
+      "title": "FeatureLayer popup sample pattern",
+      "source": {
+        "url": "https://developers.arcgis.com/javascript/latest/sample-code/featurelayer-query/",
+        "sampleCodePath": "sample-code/featurelayer-query/",
+        "referenceOnly": true
+      },
+      "fixture": {
+        "root": "feature-layer-popup-public",
+        "entrypoints": ["src/main.ts"],
+        "ownership": "honua",
+        "description": "Minimal Honua-owned snippet with FeatureServer and Portal item references."
+      },
+      "status": "ci-fixture",
+      "license": {
+        "label": "Reference metadata only",
+        "url": "https://developers.arcgis.com/terms/",
+        "notice": "Do not vendor Esri sample source without a separate license and notice review."
+      },
+      "terms": {
+        "sampleCode": "Reference only; no Esri sample code is committed.",
+        "serviceContent": "No Esri service data is committed.",
+        "liveEvidence": "Manual/scheduled lanes only; PR CI uses local fixtures."
+      },
+      "expected": {
+        "serviceKinds": ["FeatureServer"],
+        "portalItemIds": ["0123456789abcdef0123456789abcdef"],
+        "guardrailFlags": ["external-live-service-reference"]
+      }
+    },
+    {
+      "id": "routing-api-key-skipped",
+      "title": "Routing sample pattern requiring credentials",
+      "source": {
+        "url": "https://developers.arcgis.com/javascript/latest/sample-code/widgets-directions/",
+        "sampleCodePath": "sample-code/widgets-directions/",
+        "referenceOnly": true
+      },
+      "fixture": {
+        "root": "routing-api-key-skipped",
+        "entrypoints": ["src/main.ts"],
+        "ownership": "honua",
+        "description": "Minimal Honua-owned snippet that exercises skip classification for API-key and premium routing patterns."
+      },
+      "status": "skipped",
+      "skipReasons": ["requires-api-key", "premium-service"],
+      "license": {
+        "label": "Reference metadata only",
+        "url": "https://developers.arcgis.com/terms/",
+        "notice": "Do not vendor Esri sample source without a separate license and notice review."
+      },
+      "terms": {
+        "sampleCode": "Reference only; no Esri sample code is committed.",
+        "serviceContent": "No Esri service data is committed.",
+        "liveEvidence": "Skipped unless credentials, permissions, and terms review are configured."
+      },
+      "expected": {
+        "serviceKinds": ["RouteServer"],
+        "guardrailFlags": ["api-key-reference", "external-live-service-reference", "premium-service-reference"]
+      }
+    },
+    {
+      "id": "private-portal-skipped",
+      "title": "Private Portal content pattern",
+      "source": {
+        "url": "https://developers.arcgis.com/javascript/latest/sample-code/webmap-basic/",
+        "sampleCodePath": "sample-code/webmap-basic/",
+        "referenceOnly": true
+      },
+      "fixture": {
+        "root": "private-portal-skipped",
+        "entrypoints": ["src/main.ts"],
+        "ownership": "honua",
+        "description": "Minimal Honua-owned snippet that mimics OAuth/private Portal access."
+      },
+      "status": "skipped",
+      "skipReasons": ["requires-oauth", "private-content"],
+      "license": {
+        "label": "Reference metadata only",
+        "url": "https://developers.arcgis.com/terms/",
+        "notice": "Do not vendor Esri sample source without a separate license and notice review."
+      },
+      "terms": {
+        "sampleCode": "Reference only; no Esri sample code is committed.",
+        "serviceContent": "No private Portal content or exported data is committed.",
+        "liveEvidence": "Skipped unless credentials and content permissions are explicitly configured."
+      },
+      "expected": {
+        "portalItemIds": ["privatePortalItem001"],
+        "guardrailFlags": ["oauth-reference"]
+      }
+    }
+  ]
+}

--- a/test/fixtures/esri-sample-corpus/private-portal-skipped/src/main.ts
+++ b/test/fixtures/esri-sample-corpus/private-portal-skipped/src/main.ts
@@ -1,0 +1,12 @@
+import IdentityManager from "@arcgis/core/identity/IdentityManager";
+import WebMap from "@arcgis/core/WebMap";
+
+IdentityManager.checkSignInStatus("https://portal.example.com/sharing");
+
+const map = new WebMap({
+  portalItem: {
+    id: "privatePortalItem001",
+  },
+});
+
+void map;

--- a/test/fixtures/esri-sample-corpus/routing-api-key-skipped/src/main.ts
+++ b/test/fixtures/esri-sample-corpus/routing-api-key-skipped/src/main.ts
@@ -1,0 +1,11 @@
+import esriConfig from "@arcgis/core/config";
+import RouteLayer from "@arcgis/core/layers/RouteLayer";
+
+esriConfig.apiKey = "fixture-api-key-placeholder";
+
+const routeLayer = new RouteLayer({
+  url: "https://route.example.com/arcgis/rest/services/World/Route/NAServer/Route_World",
+  routeServiceUrl: "https://route.example.com/arcgis/rest/services/World/RouteServer",
+});
+
+void routeLayer;

--- a/test/migration-sample-corpus.test.ts
+++ b/test/migration-sample-corpus.test.ts
@@ -82,6 +82,13 @@ describe("Esri sample migration corpus", () => {
     ]);
     expect(analyses[1].serviceUrls).toEqual([
       {
+        url: "https://route.example.com/arcgis/rest/services/World/Route/NAServer/Route_World",
+        normalizedUrl: "https://route.example.com/arcgis/rest/services/World/Route/NAServer/Route_World",
+        kind: "NAServer",
+        servicePath: "World/Route/NAServer/Route_World",
+        layerId: undefined,
+      },
+      {
         url: "https://route.example.com/arcgis/rest/services/World/RouteServer",
         normalizedUrl: "https://route.example.com/arcgis/rest/services/World/RouteServer",
         kind: "RouteServer",
@@ -102,6 +109,29 @@ describe("Esri sample migration corpus", () => {
       kind: "MapServer",
       servicePath: "Hosted/Parcels",
       layerId: 2,
+    });
+  });
+
+  it("recognizes NAServer routing endpoints and flags them as premium-service references", () => {
+    const extraction = extractEsriSampleReferences(`
+      const routeUrl = "https://route.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World";
+      const closestUrl = "https://route.arcgis.com/arcgis/rest/services/World/ClosestFacility/NAServer/ClosestFacility_World";
+    `);
+
+    expect(extraction.serviceUrls).toHaveLength(2);
+    expect(extraction.serviceUrls.every((entry) => entry.kind === "NAServer")).toBe(true);
+    expect(extraction.guardrailFlags).toContain("premium-service-reference");
+  });
+
+  it("classifies NAServer URLs with the network-analyst sub-service name folded into servicePath", () => {
+    expect(
+      classifyArcGisServiceUrl("https://route.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World"),
+    ).toEqual({
+      url: "https://route.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World",
+      normalizedUrl: "https://route.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World",
+      kind: "NAServer",
+      servicePath: "World/Route/NAServer/Route_World",
+      layerId: undefined,
     });
   });
 

--- a/test/migration-sample-corpus.test.ts
+++ b/test/migration-sample-corpus.test.ts
@@ -1,0 +1,120 @@
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  analyzeEsriSampleFixture,
+  classifyArcGisServiceUrl,
+  extractEsriSampleReferences,
+  loadEsriSampleCorpusManifest,
+  summarizeEsriSampleCorpus,
+} from "../src/migration/sample-corpus.js";
+
+const corpusRoot = path.join(import.meta.dirname, "fixtures", "esri-sample-corpus");
+const manifestPath = path.join(corpusRoot, "manifest.json");
+
+describe("Esri sample migration corpus", () => {
+  it("loads the curated manifest with licensing and CI guardrails", () => {
+    const manifest = loadEsriSampleCorpusManifest(manifestPath);
+    const summary = summarizeEsriSampleCorpus(manifest);
+
+    expect(manifest.schemaVersion).toBe("honua.esri-sample-corpus.v1");
+    expect(manifest.guardrails).toEqual(
+      expect.objectContaining({
+        noVendoredEsriSampleCode: true,
+        noCommittedEsriServiceData: true,
+        prCiUsesFixtureOnly: true,
+        liveRunsRequireOptIn: true,
+      }),
+    );
+    expect(summary).toEqual({
+      sampleCount: 3,
+      fixtureCiCount: 1,
+      liveEvidenceCount: 0,
+      skippedCount: 2,
+      guardrailFailures: [],
+    });
+    expect(manifest.samples.every((sample) => sample.source.referenceOnly)).toBe(true);
+    expect(manifest.samples.every((sample) => sample.fixture.ownership === "honua")).toBe(true);
+    expect(manifest.samples.map((sample) => sample.license.notice)).toEqual([
+      "Do not vendor Esri sample source without a separate license and notice review.",
+      "Do not vendor Esri sample source without a separate license and notice review.",
+      "Do not vendor Esri sample source without a separate license and notice review.",
+    ]);
+  });
+
+  it("extracts service URLs, Portal items, and auth guardrail flags from fixture snippets", () => {
+    const manifest = loadEsriSampleCorpusManifest(manifestPath);
+    const analyses = manifest.samples.map((sample) => analyzeEsriSampleFixture(sample, { manifestDir: corpusRoot }));
+
+    expect(analyses).toEqual([
+      expect.objectContaining({
+        sampleId: "feature-layer-popup-public",
+        filesScanned: 1,
+        status: "ci-fixture",
+        skipReasons: [],
+        portalItems: [{ id: "0123456789abcdef0123456789abcdef" }],
+        guardrailFlags: ["external-live-service-reference"],
+      }),
+      expect.objectContaining({
+        sampleId: "routing-api-key-skipped",
+        status: "skipped",
+        skipReasons: ["requires-api-key", "premium-service"],
+        guardrailFlags: ["api-key-reference", "external-live-service-reference", "premium-service-reference"],
+      }),
+      expect.objectContaining({
+        sampleId: "private-portal-skipped",
+        status: "skipped",
+        skipReasons: ["requires-oauth", "private-content"],
+        portalItems: [{ id: "privatePortalItem001" }],
+        guardrailFlags: ["oauth-reference"],
+      }),
+    ]);
+
+    expect(analyses[0].serviceUrls).toEqual([
+      {
+        url: "https://sampleserver.example.com/arcgis/rest/services/Public/Incidents/FeatureServer/0",
+        normalizedUrl: "https://sampleserver.example.com/arcgis/rest/services/Public/Incidents/FeatureServer/0",
+        kind: "FeatureServer",
+        servicePath: "Public/Incidents",
+        layerId: 0,
+      },
+    ]);
+    expect(analyses[1].serviceUrls).toEqual([
+      {
+        url: "https://route.example.com/arcgis/rest/services/World/RouteServer",
+        normalizedUrl: "https://route.example.com/arcgis/rest/services/World/RouteServer",
+        kind: "RouteServer",
+        servicePath: "World",
+        layerId: undefined,
+      },
+    ]);
+  });
+
+  it("classifies ArcGIS service URLs without retaining query strings", () => {
+    expect(
+      classifyArcGisServiceUrl(
+        "https://example.com/arcgis/rest/services/Hosted/Parcels/MapServer/2?f=json&token=not-retained",
+      ),
+    ).toEqual({
+      url: "https://example.com/arcgis/rest/services/Hosted/Parcels/MapServer/2?f=json&token=not-retained",
+      normalizedUrl: "https://example.com/arcgis/rest/services/Hosted/Parcels/MapServer/2",
+      kind: "MapServer",
+      servicePath: "Hosted/Parcels",
+      layerId: 2,
+    });
+  });
+
+  it("deduplicates references found through common sample code shapes", () => {
+    const extraction = extractEsriSampleReferences(`
+      const serviceUrl = "https://example.com/arcgis/rest/services/Hosted/Parcels/FeatureServer/0";
+      const duplicate = "https://example.com/arcgis/rest/services/Hosted/Parcels/FeatureServer/0?f=json";
+      const webmap = { itemId: "abcdef0123456789abcdef0123456789" };
+      const map = { portalItem: { id: "abcdef0123456789abcdef0123456789" } };
+    `);
+
+    expect(extraction.serviceUrls).toHaveLength(1);
+    expect(extraction.portalItems).toEqual([{ id: "abcdef0123456789abcdef0123456789" }]);
+    expect(extraction.guardrailFlags).toEqual(["external-live-service-reference"]);
+  });
+});


### PR DESCRIPTION
## Issue Link

Related to #206
Related to #205
Related to honua-io/honua-server#1024
Related to honua-io/honua-server#1025
Related to honua-io/honua-server#1018

## Summary

Adds the first safe slice for the paired Esri sample app + referenced service migration corpus. This PR does not run live Esri services or vendor Esri sample code; it creates the fixture-only manifest, extraction helpers, guardrail summary, and tests needed before adding live scheduled evidence lanes.

## Changes Made

- Added `src/migration/sample-corpus.ts` for manifest loading, sample reference extraction, service URL classification, Portal item detection, and guardrail summaries.
- Exported sample corpus helpers from the migration entrypoint.
- Added a Honua-owned fixture corpus manifest and tiny fixture snippets that mimic common ArcGIS JS sample reference patterns.
- Added tests for guardrails, service URL classification, Portal item extraction, skip reasons, and deduplication.
- Added docs describing PR CI guardrails, live/manual evidence lanes, and why Esri sample code/data is reference-only unless licensing/terms review allows otherwise.

## Testing

- `npm ci`
- `npm test -- --run test/migration-sample-corpus.test.ts`
- `npm test -- --run test/entrypoints.test.ts test/migration-sample-corpus.test.ts`
- `npm run typecheck --silent`
- `npx biome check src/migration/sample-corpus.ts test/migration-sample-corpus.test.ts`
- `git diff --check`
- `git diff --cached --check`

## Notes

This is intentionally a first slice. Follow-on work in #206 should wire service import, app codemod, Honua URL rewriting, and Playwright smoke evidence on top of this corpus.
