### PR TITLE
feat: add honua-maplibre migration target (#205)

### DIFF
--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -6,3 +6,20 @@ export type {
   LayerSnapshot,
   ResolvedMapSource,
 } from "./honua-map.js";
+export {
+  createHonuaFeatureServiceLayer,
+  createHonuaMapLibreMapOptions,
+  createHonuaMapLibreStyle,
+  createHonuaMapServiceLayer,
+  createHonuaTileServiceLayer,
+} from "./maplibre-target.js";
+export type {
+  HonuaFeatureServiceLayerOptions,
+  HonuaMapLibreLayerDefinition,
+  HonuaMapLibreLayerOptionsBase,
+  HonuaMapLibreMapOptions,
+  HonuaMapLibreRasterSourceSpecification,
+  HonuaMapLibreStyleOptions,
+  HonuaMapServiceLayerOptions,
+  HonuaTileServiceLayerOptions,
+} from "./maplibre-target.js";

--- a/src/map/maplibre-target.ts
+++ b/src/map/maplibre-target.ts
@@ -1,0 +1,255 @@
+import type {
+  HonuaFeatureServiceSourceSpecification,
+  HonuaLayerSpecification,
+  HonuaMapServiceSourceSpecification,
+  HonuaStyleSpecification,
+} from "../style/specification.js";
+
+/** Standard MapLibre raster source shape used by migrated tiled services. */
+export interface HonuaMapLibreRasterSourceSpecification {
+  [key: string]: unknown;
+  type: "raster";
+  tiles: string[];
+  tileSize?: number;
+  attribution?: string;
+}
+
+/** Layer/source pair consumed by {@link createHonuaMapLibreStyle}. */
+export interface HonuaMapLibreLayerDefinition {
+  id: string;
+  sourceId: string;
+  source:
+    | HonuaFeatureServiceSourceSpecification
+    | HonuaMapServiceSourceSpecification
+    | HonuaMapLibreRasterSourceSpecification;
+  layer: HonuaLayerSpecification;
+}
+
+/** Shared options for migrated ArcGIS layer constructors. */
+export interface HonuaMapLibreLayerOptionsBase {
+  id?: string;
+  title?: string;
+  visible?: boolean;
+  opacity?: number;
+  minScale?: number;
+  maxScale?: number;
+  attribution?: string;
+  paint?: Record<string, unknown>;
+  layout?: Record<string, unknown>;
+}
+
+/** Options for an ArcGIS FeatureLayer migrated into a Honua feature-service source. */
+export interface HonuaFeatureServiceLayerOptions extends HonuaMapLibreLayerOptionsBase {
+  url: string;
+  outFields?: string[];
+  definitionExpression?: string;
+  returnGeometry?: boolean;
+  outSR?: number;
+  layerType?: "circle" | "line" | "fill";
+}
+
+/** Options for an ArcGIS MapImageLayer migrated into a Honua map-service source. */
+export interface HonuaMapServiceLayerOptions extends HonuaMapLibreLayerOptionsBase {
+  url: string;
+  sublayers?: unknown;
+  layers?: string;
+  dpi?: number;
+  format?: "png" | "png24" | "png32" | "jpg" | "gif";
+  transparent?: boolean;
+}
+
+/** Options for an ArcGIS TileLayer migrated into a MapLibre raster tile source. */
+export interface HonuaTileServiceLayerOptions extends HonuaMapLibreLayerOptionsBase {
+  url: string;
+  tileSize?: number;
+}
+
+/** Options for an ArcGIS Map migrated into a MapLibre style document. */
+export interface HonuaMapLibreStyleOptions {
+  basemap?: string;
+  layers?: readonly HonuaMapLibreLayerDefinition[];
+  name?: string;
+  center?: [number, number];
+  zoom?: number;
+}
+
+/** Options for an ArcGIS MapView migrated into MapLibre's `Map` constructor. */
+export interface HonuaMapLibreMapOptions {
+  map?: HonuaStyleSpecification;
+  style?: HonuaStyleSpecification;
+  container?: string | HTMLElement;
+  center?: [number, number];
+  zoom?: number;
+  bearing?: number;
+  pitch?: number;
+}
+
+/**
+ * Create a Honua feature-service source and a default MapLibre render layer.
+ */
+export function createHonuaFeatureServiceLayer(options: HonuaFeatureServiceLayerOptions): HonuaMapLibreLayerDefinition {
+  const sourceId = normalizeLayerId(options.id, options.title, options.url, "feature-service");
+  const layerType = options.layerType ?? "circle";
+  const source: HonuaFeatureServiceSourceSpecification = {
+    type: "honua-feature-service",
+    url: options.url,
+    ...(options.attribution ? { attribution: options.attribution } : {}),
+    ...(options.definitionExpression ? { definitionExpression: options.definitionExpression } : {}),
+    ...(options.outFields ? { outFields: [...options.outFields] } : {}),
+    ...(options.returnGeometry !== undefined ? { returnGeometry: options.returnGeometry } : {}),
+    ...(options.outSR !== undefined ? { outSR: options.outSR } : {}),
+  };
+
+  return {
+    id: sourceId,
+    sourceId,
+    source,
+    layer: buildLayer(sourceId, layerType, options),
+  };
+}
+
+/**
+ * Create a Honua map-service source and a default MapLibre raster layer.
+ */
+export function createHonuaMapServiceLayer(options: HonuaMapServiceLayerOptions): HonuaMapLibreLayerDefinition {
+  const sourceId = normalizeLayerId(options.id, options.title, options.url, "map-service");
+  const source: HonuaMapServiceSourceSpecification = {
+    type: "honua-map-service",
+    url: options.url,
+    ...(options.attribution ? { attribution: options.attribution } : {}),
+    ...(options.layers ? { layers: options.layers } : {}),
+    ...(options.dpi !== undefined ? { dpi: options.dpi } : {}),
+    ...(options.format ? { format: options.format } : {}),
+    ...(options.transparent !== undefined ? { transparent: options.transparent } : {}),
+  };
+
+  return {
+    id: sourceId,
+    sourceId,
+    source,
+    layer: buildLayer(sourceId, "raster", options),
+  };
+}
+
+/**
+ * Create a MapLibre raster source and layer for an ArcGIS tiled service.
+ */
+export function createHonuaTileServiceLayer(options: HonuaTileServiceLayerOptions): HonuaMapLibreLayerDefinition {
+  const sourceId = normalizeLayerId(options.id, options.title, options.url, "tile-service");
+  const baseUrl = options.url.replace(/\/+$/, "");
+  const source: HonuaMapLibreRasterSourceSpecification = {
+    type: "raster",
+    tiles: [`${baseUrl}/tile/{z}/{y}/{x}`],
+    tileSize: options.tileSize ?? 256,
+    ...(options.attribution ? { attribution: options.attribution } : {}),
+  };
+
+  return {
+    id: sourceId,
+    sourceId,
+    source,
+    layer: buildLayer(sourceId, "raster", options),
+  };
+}
+
+/**
+ * Create a MapLibre style document from migrated ArcGIS `Map` options.
+ */
+export function createHonuaMapLibreStyle(options: HonuaMapLibreStyleOptions = {}): HonuaStyleSpecification {
+  const sources: HonuaStyleSpecification["sources"] = {};
+  const layers: HonuaLayerSpecification[] = [];
+
+  for (const layer of options.layers ?? []) {
+    sources[layer.sourceId] = layer.source;
+    layers.push(layer.layer);
+  }
+
+  return {
+    version: 8,
+    ...(options.name ? { name: options.name } : {}),
+    ...(options.center ? { center: options.center } : {}),
+    ...(options.zoom !== undefined ? { zoom: options.zoom } : {}),
+    metadata: options.basemap ? { "honua:arcgis-basemap": options.basemap } : undefined,
+    sources,
+    layers,
+  };
+}
+
+/**
+ * Create the options object passed to `new maplibregl.Map(...)`.
+ */
+export function createHonuaMapLibreMapOptions(options: HonuaMapLibreMapOptions): Record<string, unknown> {
+  const style = options.style ?? options.map ?? createHonuaMapLibreStyle();
+  return {
+    style,
+    ...(options.container !== undefined ? { container: options.container } : {}),
+    ...(options.center ? { center: options.center } : {}),
+    ...(options.zoom !== undefined ? { zoom: options.zoom } : {}),
+    ...(options.bearing !== undefined ? { bearing: options.bearing } : {}),
+    ...(options.pitch !== undefined ? { pitch: options.pitch } : {}),
+  };
+}
+
+function buildLayer(
+  sourceId: string,
+  type: "circle" | "line" | "fill" | "raster",
+  options: HonuaMapLibreLayerOptionsBase,
+): HonuaLayerSpecification {
+  return {
+    id: `${sourceId}-${type}`,
+    source: sourceId,
+    type,
+    ...(options.visible === false ? { layout: { ...(options.layout ?? {}), visibility: "none" } } : {}),
+    ...(options.visible !== false && options.layout ? { layout: options.layout } : {}),
+    ...(options.paint || options.opacity !== undefined ? { paint: buildPaint(type, options) } : {}),
+    ...(options.minScale !== undefined ? { minzoom: scaleToZoom(options.minScale) } : {}),
+    ...(options.maxScale !== undefined ? { maxzoom: scaleToZoom(options.maxScale) } : {}),
+    metadata: {
+      ...(options.title ? { title: options.title } : {}),
+      ...(options.id ? { "honua:source-id": options.id } : {}),
+    },
+  };
+}
+
+function buildPaint(
+  type: "circle" | "line" | "fill" | "raster",
+  options: HonuaMapLibreLayerOptionsBase,
+): Record<string, unknown> {
+  const paint = { ...(options.paint ?? {}) };
+  if (options.opacity === undefined) {
+    return paint;
+  }
+
+  if (type === "circle") paint["circle-opacity"] = options.opacity;
+  if (type === "line") paint["line-opacity"] = options.opacity;
+  if (type === "fill") paint["fill-opacity"] = options.opacity;
+  if (type === "raster") paint["raster-opacity"] = options.opacity;
+  return paint;
+}
+
+function normalizeLayerId(id: string | undefined, title: string | undefined, url: string, fallback: string): string {
+  return sanitizeId(id ?? title ?? lastUrlSegment(url) ?? fallback);
+}
+
+function lastUrlSegment(url: string): string | undefined {
+  const trimmed = url.replace(/[?#].*$/, "").replace(/\/+$/, "");
+  const segment = trimmed.slice(trimmed.lastIndexOf("/") + 1);
+  return segment || undefined;
+}
+
+function sanitizeId(value: string): string {
+  const id = value
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/[^A-Za-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
+  return id || "layer";
+}
+
+function scaleToZoom(scale: number): number {
+  if (!Number.isFinite(scale) || scale <= 0) {
+    return 0;
+  }
+  return Math.max(0, Math.log2(591657550.5 / scale));
+}

--- a/src/migration/cli.ts
+++ b/src/migration/cli.ts
@@ -193,6 +193,9 @@ function runMatrix(reportPath?: string): void {
       `honuaCompat=${summary.honuaCompat.compat}`,
       `honuaAssisted=${summary.honuaCompat.assisted}`,
       `honuaUnsupported=${summary.honuaCompat.unsupported}`,
+      `honuaMapLibreNative=${summary.honuaMapLibre.native}`,
+      `honuaMapLibreAssisted=${summary.honuaMapLibre.assisted}`,
+      `honuaMapLibreUnsupported=${summary.honuaMapLibre.unsupported}`,
       `esriLeafletCompat=${summary.esriLeaflet.compat}`,
       `esriLeafletAssisted=${summary.esriLeaflet.assisted}`,
       `esriLeafletUnsupported=${summary.esriLeaflet.unsupported}`,
@@ -217,6 +220,9 @@ function runRuntimeMatrix(reportPath?: string): void {
       `honuaCompat=${summary.honuaCompat.compat}`,
       `honuaAssisted=${summary.honuaCompat.assisted}`,
       `honuaUnsupported=${summary.honuaCompat.unsupported}`,
+      `honuaMapLibreNative=${summary.honuaMapLibre.native}`,
+      `honuaMapLibreAssisted=${summary.honuaMapLibre.assisted}`,
+      `honuaMapLibreUnsupported=${summary.honuaMapLibre.unsupported}`,
       `esriLeafletCompat=${summary.esriLeaflet.compat}`,
       `esriLeafletAssisted=${summary.esriLeaflet.assisted}`,
       `esriLeafletUnsupported=${summary.esriLeaflet.unsupported}`,
@@ -1199,7 +1205,7 @@ function parseArgs(argv: string[]): ParsedArgs | undefined {
         i += 1;
         continue;
       }
-      if (next !== "honua" && next !== "honua-compat" && next !== "esri-leaflet") {
+      if (next !== "honua" && next !== "honua-compat" && next !== "esri-leaflet" && next !== "honua-maplibre") {
         return undefined;
       }
       codemodTarget = next === "honua" ? "honua-compat" : next;
@@ -1641,12 +1647,12 @@ function printUsage(): void {
     [
       "Usage:",
       "  honua-migrate [scan] <path> [--report <file>]",
-      "  honua-migrate codemod <path> [--target <honua|honua-compat|esri-leaflet>] [--write] [--annotate-todos] [--report <file>] [--compat-import-path <pkg>] [--fail-on-manual] [--fail-on-unhandled] [--fail-on-blocked] [--max-manual-ratio <0..1>] [--max-manual-intervention-ratio <0..1>]",
+      "  honua-migrate codemod <path> [--target <honua|honua-compat|honua-maplibre|esri-leaflet>] [--write] [--annotate-todos] [--report <file>] [--compat-import-path <pkg>] [--fail-on-manual] [--fail-on-unhandled] [--fail-on-blocked] [--max-manual-ratio <0..1>] [--max-manual-intervention-ratio <0..1>]",
       "  honua-migrate matrix [--report <file>]",
       "  honua-migrate runtime-matrix [--report <file>]",
-      "  honua-migrate fixtures [<fixtures-root>] [--target <honua|honua-compat|esri-leaflet>] [--fixtures <name1,name2,...>] [--report <file>] [--fail-on-manual] [--fail-on-unhandled] [--fail-on-blocked] [--max-manual-ratio <0..1>] [--max-manual-intervention-ratio <0..1>]",
+      "  honua-migrate fixtures [<fixtures-root>] [--target <honua|honua-compat|honua-maplibre|esri-leaflet>] [--fixtures <name1,name2,...>] [--report <file>] [--fail-on-manual] [--fail-on-unhandled] [--fail-on-blocked] [--max-manual-ratio <0..1>] [--max-manual-intervention-ratio <0..1>]",
       "  honua-migrate reconcile --source-base-url <url> --source-service-id <id> --target-base-url <url> --target-service-id <id> --layer-id <n> [--sample-size <n>] [--report <file>]",
-      "  honua-migrate demo [<fixture-name>] [--fixtures-root <dir>] [--output-dir <dir>] [--target <honua|honua-compat|esri-leaflet>] [--admin-base-url <url>] [--admin-api-key <key>] [--source-service-url <url>] [--layer-id <n>] [--table-name <name>] [--source-base-url <url>] [--source-service-id <id>] [--target-base-url <url>] [--target-service-id <id>] [--sample-size <n>] [--poll-interval-ms <n>] [--timeout-seconds <n>] [--skip-import] [--skip-reconcile] [--report <file>]",
+      "  honua-migrate demo [<fixture-name>] [--fixtures-root <dir>] [--output-dir <dir>] [--target <honua|honua-compat|honua-maplibre|esri-leaflet>] [--admin-base-url <url>] [--admin-api-key <key>] [--source-service-url <url>] [--layer-id <n>] [--table-name <name>] [--source-base-url <url>] [--source-service-id <id>] [--target-base-url <url>] [--target-service-id <id>] [--sample-size <n>] [--poll-interval-ms <n>] [--timeout-seconds <n>] [--skip-import] [--skip-reconcile] [--report <file>]",
       "  honua-migrate content scan --portal <url> [--token <token>] [--report <file>]",
       "  honua-migrate content export --portal <url> --output-dir <dir> [--token <token>] [--exclude-features] [--exclude-webmaps] [--exclude-hosted-layers] [--report <file>]",
       "  honua-migrate content import --source <dir> --target <url> [--admin-api-key <key>] [--output-dir <dir>] [--table-prefix <prefix>] [--source-url-prefix <url>] [--target-url-prefix <url>] [--exclude-webmaps] [--exclude-hosted-layers] [--report <file>]",
@@ -1656,6 +1662,7 @@ function printUsage(): void {
       "Examples:",
       "  node dist/src/migration/cli.js scan ./src",
       "  node dist/src/migration/cli.js codemod ./src --write --annotate-todos --report migration-report.json",
+      "  node dist/src/migration/cli.js codemod ./src --target honua-maplibre --write --report migration-report.json",
       "  node dist/src/migration/cli.js codemod ./src --target esri-leaflet --write --report migration-report.json",
       "  node dist/src/migration/cli.js matrix --report parity-matrix.json",
       "  node dist/src/migration/cli.js runtime-matrix --report runtime-parity-matrix.json",
@@ -1673,6 +1680,7 @@ function printUsage(): void {
       "Target semantics:",
       "  honua: alias of honua-compat.",
       "  honua-compat: migrate ArcGIS JS (@arcgis/core) to @honua/sdk-esri-compat.",
+      "  honua-maplibre: migrate supported ArcGIS JS (@arcgis/core) constructs to @honua/sdk-js/map plus maplibre-gl helpers.",
       "  esri-leaflet: migrate ArcGIS JS (@arcgis/core) to a mixed esri-leaflet + compat output.",
       "  Existing esri-leaflet apps generally do not need this codemod.",
     ].join("\n"),

--- a/src/migration/codemod.ts
+++ b/src/migration/codemod.ts
@@ -7,6 +7,9 @@ const SKIP_DIRS = new Set(["node_modules", "dist", ".git"]);
 const DEFAULT_COMPAT_IMPORT_PATH = "@honua/sdk-esri-compat";
 const ESRI_LEAFLET_IMPORT_PATH = "esri-leaflet";
 const ESRI_LEAFLET_NAMESPACE = "HonuaEsriLeaflet";
+const HONUA_MAP_IMPORT_PATH = "@honua/sdk-js/map";
+const MAPLIBRE_IMPORT_PATH = "maplibre-gl";
+const MAPLIBRE_NAMESPACE = "maplibregl";
 const TODO_MARKER = "TODO(honua-migrate)";
 const CJS_REQUIRE_MANUAL_REASON =
   "CommonJS require constructors are not auto-migrated; convert the module to ESM and rerun.";
@@ -14,6 +17,12 @@ const ESRI_LEAFLET_UNSUPPORTED_CONSTRUCTOR_REASON =
   "No deterministic esri-leaflet mapping for this constructor; requires manual migration.";
 const ESRI_LEAFLET_UNSUPPORTED_DYNAMIC_IMPORT_REASON =
   "Dynamic import has no deterministic esri-leaflet mapping; requires manual migration.";
+const HONUA_MAPLIBRE_UNSUPPORTED_CONSTRUCTOR_REASON =
+  "No deterministic Honua MapLibre mapping for this constructor; requires manual migration.";
+const HONUA_MAPLIBRE_UNSUPPORTED_DYNAMIC_IMPORT_REASON =
+  "Dynamic import has no deterministic Honua MapLibre mapping; requires manual migration.";
+const HONUA_MAPLIBRE_UNSUPPORTED_IMPORT_REASON =
+  "No deterministic Honua MapLibre mapping for this import; requires manual migration.";
 const REACTIVE_UTILS_IMPORT_UNSUPPORTED_REASON = "ReactiveUtils import shape is unsupported for automatic migration.";
 const ESRI_CONFIG_IMPORT_UNSUPPORTED_REASON = "esriConfig import shape is unsupported for automatic migration.";
 const IDENTITY_MANAGER_IMPORT_UNSUPPORTED_REASON =
@@ -23,6 +32,13 @@ const SHADOWED_IMPORT_CONSTRUCTOR_REASON =
   "Constructor identifier is shadowed by a local declaration; requires manual migration.";
 
 const ESRI_LEAFLET_NATIVE_KINDS = new Set<CodemodConstructorKind>(["feature-layer", "map-image-layer", "tile-layer"]);
+const HONUA_MAPLIBRE_NATIVE_KINDS = new Set<CodemodConstructorKind>([
+  "feature-layer",
+  "map-image-layer",
+  "tile-layer",
+  "map",
+  "map-view",
+]);
 const ESRI_LEAFLET_COMPAT_FALLBACK_KINDS = new Set<CodemodConstructorKind>([
   "graphic",
   "point-geometry",
@@ -91,7 +107,7 @@ const ESRI_LEAFLET_COMPAT_FALLBACK_KINDS = new Set<CodemodConstructorKind>([
   "reactive-utils",
 ]);
 
-export type CodemodTarget = "honua-compat" | "esri-leaflet";
+export type CodemodTarget = "honua-compat" | "esri-leaflet" | "honua-maplibre";
 
 export type CodemodConstructorKind =
   | "feature-layer"
@@ -527,6 +543,7 @@ const REWRITE_SPECS: readonly ConstructorRewriteSpec[] = [
 const TARGET_SUPPORTED_KINDS: Readonly<Record<CodemodTarget, ReadonlySet<CodemodConstructorKind>>> = Object.freeze({
   "honua-compat": new Set(REWRITE_SPECS.map((spec) => spec.kind)),
   "esri-leaflet": new Set([...ESRI_LEAFLET_NATIVE_KINDS, ...ESRI_LEAFLET_COMPAT_FALLBACK_KINDS]),
+  "honua-maplibre": HONUA_MAPLIBRE_NATIVE_KINDS,
 });
 
 export const SUPPORTED_ARCGIS_MODULES: readonly string[] = REWRITE_SPECS.flatMap((spec) =>
@@ -828,9 +845,12 @@ function codemodFile(
   const manualTodos: MigrationTodo[] = [];
   const todoCommentEdits: TextEdit[] = [];
   const requiredCompatSymbols = new Set<string>();
+  const requiredHonuaMapLibreSymbols = new Set<string>();
   const requiresEsriLeafletImport = { value: false };
+  const requiresMapLibreImport = { value: false };
   const esriLeafletNamespaceAlias =
     findNamespaceImportAlias(sourceFile, ESRI_LEAFLET_IMPORT_PATH) ?? ESRI_LEAFLET_NAMESPACE;
+  const mapLibreNamespaceAlias = findNamespaceImportAlias(sourceFile, MAPLIBRE_IMPORT_PATH) ?? MAPLIBRE_NAMESPACE;
   const fileExtension = path.extname(file).toLowerCase();
   const isCommonJsModule = fileExtension === ".cjs" || hasCommonJsExportMarkers(source);
 
@@ -840,6 +860,7 @@ function codemodFile(
     file,
     compatImportPath,
     annotateTodos,
+    target,
   });
   importEdits.push(...esriRequestImportRewrite.edits);
   rewrittenKinds.push(...esriRequestImportRewrite.rewrittenKinds);
@@ -852,6 +873,7 @@ function codemodFile(
     file,
     compatImportPath,
     annotateTodos,
+    target,
   });
   importEdits.push(...identityManagerImportRewrite.edits);
   rewrittenKinds.push(...identityManagerImportRewrite.rewrittenKinds);
@@ -864,6 +886,7 @@ function codemodFile(
     file,
     compatImportPath,
     annotateTodos,
+    target,
   });
   importEdits.push(...esriConfigImportRewrite.edits);
   rewrittenKinds.push(...esriConfigImportRewrite.rewrittenKinds);
@@ -876,6 +899,7 @@ function codemodFile(
     file,
     compatImportPath,
     annotateTodos,
+    target,
   });
   importEdits.push(...reactiveUtilsImportRewrite.edits);
   rewrittenKinds.push(...reactiveUtilsImportRewrite.rewrittenKinds);
@@ -899,6 +923,30 @@ function codemodFile(
             text: buildCompatDynamicImportExpression(compatImportPath, spec.compatSymbol),
           });
           rewrittenKinds.push(spec.kind);
+          return;
+        }
+
+        if (target === "honua-maplibre") {
+          const nodeStart = node.getStart(sourceFile);
+          const location = sourceFile.getLineAndCharacterOfPosition(nodeStart);
+          manualTodos.push({
+            kind: spec.kind,
+            file,
+            line: location.line + 1,
+            column: location.character + 1,
+            reason: HONUA_MAPLIBRE_UNSUPPORTED_DYNAMIC_IMPORT_REASON,
+            difficulty: "complex",
+          });
+          if (annotateTodos) {
+            const lineStart = findLineStartOffset(source, nodeStart);
+            if (shouldInsertTodoComment(source, lineStart, nodeStart)) {
+              todoCommentEdits.push({
+                start: lineStart,
+                end: lineStart,
+                text: `// ${TODO_MARKER}[${spec.kind}]: ${HONUA_MAPLIBRE_UNSUPPORTED_DYNAMIC_IMPORT_REASON}\n`,
+              });
+            }
+          }
           return;
         }
 
@@ -1019,6 +1067,52 @@ function codemodFile(
           text: spec.compatSymbol,
         });
         rewrittenKinds.push(importBinding.kind);
+        return;
+      }
+
+      if (target === "honua-maplibre") {
+        const replacement = buildHonuaMapLibreConstructorExpression(
+          importBinding.kind,
+          node,
+          sourceFile,
+          mapLibreNamespaceAlias,
+        );
+        if (replacement) {
+          constructorEdits.push({
+            start: node.getStart(sourceFile),
+            end: node.getEnd(),
+            text: replacement.text,
+          });
+          for (const symbol of replacement.helperSymbols) {
+            requiredHonuaMapLibreSymbols.add(symbol);
+          }
+          if (replacement.requiresMapLibreImport) {
+            requiresMapLibreImport.value = true;
+          }
+          rewrittenKinds.push(importBinding.kind);
+          return;
+        }
+
+        const nodeStart = node.getStart(sourceFile);
+        const location = sourceFile.getLineAndCharacterOfPosition(nodeStart);
+        manualTodos.push({
+          kind: importBinding.kind,
+          file,
+          line: location.line + 1,
+          column: location.character + 1,
+          reason: HONUA_MAPLIBRE_UNSUPPORTED_CONSTRUCTOR_REASON,
+          difficulty: "complex",
+        });
+        if (annotateTodos) {
+          const lineStart = findLineStartOffset(source, nodeStart);
+          if (shouldInsertTodoComment(source, lineStart, nodeStart)) {
+            todoCommentEdits.push({
+              start: lineStart,
+              end: lineStart,
+              text: `// ${TODO_MARKER}[${importBinding.kind}]: ${HONUA_MAPLIBRE_UNSUPPORTED_CONSTRUCTOR_REASON}\n`,
+            });
+          }
+        }
         return;
       }
 
@@ -1143,6 +1237,17 @@ function codemodFile(
     transformed = compatImportResult.nextSource;
     addedCompatImport = compatImportResult.changed;
   }
+  const honuaMapLibreSymbols = Array.from(requiredHonuaMapLibreSymbols).sort();
+  if (honuaMapLibreSymbols.length > 0) {
+    const honuaImportResult = ensureCompatNamedImports(file, transformed, honuaMapLibreSymbols, HONUA_MAP_IMPORT_PATH);
+    transformed = honuaImportResult.nextSource;
+    addedCompatImport = addedCompatImport || honuaImportResult.changed;
+  }
+  if (target === "honua-maplibre" && requiresMapLibreImport.value) {
+    const mapLibreImportResult = ensureNamespaceImport(file, transformed, MAPLIBRE_IMPORT_PATH, mapLibreNamespaceAlias);
+    transformed = mapLibreImportResult.nextSource;
+    addedCompatImport = addedCompatImport || mapLibreImportResult.changed;
+  }
   if (target === "esri-leaflet" && requiresEsriLeafletImport.value) {
     const esriLeafletImportResult = ensureNamespaceImport(
       file,
@@ -1167,12 +1272,51 @@ function codemodFile(
   };
 }
 
+function pushImportManualTodo(
+  options: {
+    source: string;
+    sourceFile: ts.SourceFile;
+    file: string;
+    annotateTodos: boolean;
+  },
+  statement: ts.ImportDeclaration,
+  kind: CodemodConstructorKind,
+  reason: string,
+  manualTodos: MigrationTodo[],
+  todoCommentEdits: TextEdit[],
+): void {
+  const nodeStart = statement.getStart(options.sourceFile);
+  const location = options.sourceFile.getLineAndCharacterOfPosition(nodeStart);
+  manualTodos.push({
+    kind,
+    file: options.file,
+    line: location.line + 1,
+    column: location.character + 1,
+    reason,
+    difficulty: "complex",
+  });
+
+  if (!options.annotateTodos) {
+    return;
+  }
+
+  const lineStart = findLineStartOffset(options.source, nodeStart);
+  if (shouldInsertTodoComment(options.source, lineStart, nodeStart)) {
+    todoCommentEdits.push({
+      start: lineStart,
+      end: lineStart,
+      text: `// ${TODO_MARKER}[${kind}]: ${reason}\n`,
+    });
+  }
+}
+
 function rewriteReactiveUtilsImports(options: {
   source: string;
   sourceFile: ts.SourceFile;
   file: string;
   compatImportPath: string;
   annotateTodos: boolean;
+  target: CodemodTarget;
 }): {
   edits: TextEdit[];
   rewrittenKinds: CodemodConstructorKind[];
@@ -1189,6 +1333,18 @@ function rewriteReactiveUtilsImports(options: {
       continue;
     }
     if (MODULE_TO_SPEC.get(statement.moduleSpecifier.text)?.kind !== "reactive-utils") {
+      continue;
+    }
+
+    if (options.target === "honua-maplibre") {
+      pushImportManualTodo(
+        options,
+        statement,
+        "reactive-utils",
+        HONUA_MAPLIBRE_UNSUPPORTED_IMPORT_REASON,
+        manualTodos,
+        todoCommentEdits,
+      );
       continue;
     }
 
@@ -1240,6 +1396,7 @@ function rewriteEsriRequestImports(options: {
   file: string;
   compatImportPath: string;
   annotateTodos: boolean;
+  target: CodemodTarget;
 }): {
   edits: TextEdit[];
   rewrittenKinds: CodemodConstructorKind[];
@@ -1259,6 +1416,18 @@ function rewriteEsriRequestImports(options: {
       continue;
     }
     if (MODULE_TO_SPEC.get(statement.moduleSpecifier.text)?.kind !== "esri-request") {
+      continue;
+    }
+
+    if (options.target === "honua-maplibre") {
+      pushImportManualTodo(
+        options,
+        statement,
+        "esri-request",
+        HONUA_MAPLIBRE_UNSUPPORTED_IMPORT_REASON,
+        manualTodos,
+        todoCommentEdits,
+      );
       continue;
     }
 
@@ -1348,6 +1517,7 @@ function rewriteIdentityManagerImports(options: {
   file: string;
   compatImportPath: string;
   annotateTodos: boolean;
+  target: CodemodTarget;
 }): {
   edits: TextEdit[];
   rewrittenKinds: CodemodConstructorKind[];
@@ -1367,6 +1537,18 @@ function rewriteIdentityManagerImports(options: {
       continue;
     }
     if (MODULE_TO_SPEC.get(statement.moduleSpecifier.text)?.kind !== "identity-manager") {
+      continue;
+    }
+
+    if (options.target === "honua-maplibre") {
+      pushImportManualTodo(
+        options,
+        statement,
+        "identity-manager",
+        HONUA_MAPLIBRE_UNSUPPORTED_IMPORT_REASON,
+        manualTodos,
+        todoCommentEdits,
+      );
       continue;
     }
 
@@ -1456,6 +1638,7 @@ function rewriteEsriConfigImports(options: {
   file: string;
   compatImportPath: string;
   annotateTodos: boolean;
+  target: CodemodTarget;
 }): {
   edits: TextEdit[];
   rewrittenKinds: CodemodConstructorKind[];
@@ -1475,6 +1658,18 @@ function rewriteEsriConfigImports(options: {
       continue;
     }
     if (MODULE_TO_SPEC.get(statement.moduleSpecifier.text)?.kind !== "esri-config") {
+      continue;
+    }
+
+    if (options.target === "honua-maplibre") {
+      pushImportManualTodo(
+        options,
+        statement,
+        "esri-config",
+        HONUA_MAPLIBRE_UNSUPPORTED_IMPORT_REASON,
+        manualTodos,
+        todoCommentEdits,
+      );
       continue;
     }
 
@@ -2407,6 +2602,77 @@ function buildEsriLeafletDynamicImportExpression(
   return `Promise.resolve({ default: ${namespaceAlias}.${method} })`;
 }
 
+function buildHonuaMapLibreConstructorExpression(
+  kind: CodemodConstructorKind,
+  node: ts.NewExpression,
+  sourceFile: ts.SourceFile,
+  mapLibreNamespaceAlias: string,
+): { text: string; helperSymbols: string[]; requiresMapLibreImport: boolean } | undefined {
+  if (!HONUA_MAPLIBRE_NATIVE_KINDS.has(kind)) {
+    return undefined;
+  }
+
+  switch (kind) {
+    case "feature-layer":
+      return {
+        text: `createHonuaFeatureServiceLayer(${buildHonuaMapLibreLayerOptionsText(node, sourceFile)})`,
+        helperSymbols: ["createHonuaFeatureServiceLayer"],
+        requiresMapLibreImport: false,
+      };
+    case "map-image-layer":
+      return {
+        text: `createHonuaMapServiceLayer(${buildHonuaMapLibreLayerOptionsText(node, sourceFile)})`,
+        helperSymbols: ["createHonuaMapServiceLayer"],
+        requiresMapLibreImport: false,
+      };
+    case "tile-layer":
+      return {
+        text: `createHonuaTileServiceLayer(${buildHonuaMapLibreLayerOptionsText(node, sourceFile)})`,
+        helperSymbols: ["createHonuaTileServiceLayer"],
+        requiresMapLibreImport: false,
+      };
+    case "map":
+      return {
+        text: `createHonuaMapLibreStyle(${buildOptionalObjectOptionsText(node, sourceFile)})`,
+        helperSymbols: ["createHonuaMapLibreStyle"],
+        requiresMapLibreImport: false,
+      };
+    case "map-view":
+      return {
+        text: `new ${mapLibreNamespaceAlias}.Map(createHonuaMapLibreMapOptions(${buildOptionalObjectOptionsText(
+          node,
+          sourceFile,
+        )}))`,
+        helperSymbols: ["createHonuaMapLibreMapOptions"],
+        requiresMapLibreImport: true,
+      };
+    default:
+      return undefined;
+  }
+}
+
+function buildHonuaMapLibreLayerOptionsText(node: ts.NewExpression, sourceFile: ts.SourceFile): string {
+  const arg = node.arguments?.[0];
+  if (!arg || !ts.isObjectLiteralExpression(arg)) {
+    return "{}";
+  }
+
+  const assignedIdentifier = resolveAssignedIdentifierForNewExpression(node, sourceFile);
+  if (!assignedIdentifier || objectLiteralHasProperty(arg, "id")) {
+    return arg.getText(sourceFile);
+  }
+
+  return addObjectLiteralPropertyText(arg, sourceFile, "id", JSON.stringify(assignedIdentifier));
+}
+
+function buildOptionalObjectOptionsText(node: ts.NewExpression, sourceFile: ts.SourceFile): string {
+  const arg = node.arguments?.[0];
+  if (!arg) {
+    return "{}";
+  }
+  return arg.getText(sourceFile);
+}
+
 function esriLeafletMethodForKind(kind: CodemodConstructorKind): string | undefined {
   if (!ESRI_LEAFLET_NATIVE_KINDS.has(kind)) {
     return undefined;
@@ -2788,6 +3054,9 @@ function countIdentifierUsagesExcludingImports(sourceFile: ts.SourceFile, name: 
     if (isInImportContext(node)) {
       return;
     }
+    if (isPropertyAccessName(node)) {
+      return;
+    }
     count += 1;
   });
 
@@ -2805,6 +3074,9 @@ function countIdentifierUsagesExcludingImportsAndDefinitions(sourceFile: ts.Sour
       return;
     }
     if (isVariableDeclarationName(node)) {
+      return;
+    }
+    if (isPropertyAccessName(node)) {
       return;
     }
     count += 1;
@@ -2828,6 +3100,10 @@ function isInImportContext(node: ts.Identifier): boolean {
     current = current.parent;
   }
   return false;
+}
+
+function isPropertyAccessName(node: ts.Identifier): boolean {
+  return ts.isPropertyAccessExpression(node.parent) && node.parent.name === node;
 }
 
 function isVariableDeclarationName(node: ts.Identifier): boolean {
@@ -2911,11 +3187,38 @@ function collectUnsupportedPropertyNames(arg: ts.ObjectLiteralExpression, allowe
   return unsupported;
 }
 
+function objectLiteralHasProperty(arg: ts.ObjectLiteralExpression, propertyName: string): boolean {
+  return arg.properties.some(
+    (property) => isAssignableObjectProperty(property) && getObjectPropertyName(property) === propertyName,
+  );
+}
+
+function addObjectLiteralPropertyText(
+  arg: ts.ObjectLiteralExpression,
+  sourceFile: ts.SourceFile,
+  propertyName: string,
+  valueText: string,
+): string {
+  const text = arg.getText(sourceFile);
+  const inner = text.slice(1, -1).trim();
+  if (!inner) {
+    return `{ ${propertyName}: ${valueText} }`;
+  }
+  return `{ ${propertyName}: ${valueText}, ${inner} }`;
+}
+
 function isSafeConstructorCall(
   kind: CodemodConstructorKind,
   node: ts.NewExpression,
   target: CodemodTarget,
 ): { ok: true } | { ok: false; reason: string } {
+  if (target === "honua-maplibre" && !HONUA_MAPLIBRE_NATIVE_KINDS.has(kind)) {
+    return {
+      ok: false,
+      reason: HONUA_MAPLIBRE_UNSUPPORTED_CONSTRUCTOR_REASON,
+    };
+  }
+
   switch (kind) {
     case "feature-layer":
       return isSafeFeatureLayerCompatCall(node, target);
@@ -2966,9 +3269,9 @@ function isSafeConstructorCall(
     case "basemap":
       return isSafeBasemapCompatCall(node);
     case "map":
-      return isSafeMapCompatCall(node);
+      return isSafeMapCompatCall(node, target);
     case "map-view":
-      return isSafeMapViewCompatCall(node);
+      return isSafeMapViewCompatCall(node, target);
     case "scene-view":
       return isSafeSceneViewCompatCall(node);
     case "web-map":
@@ -3248,7 +3551,25 @@ function isSafeFeatureLayerCompatCall(
           "client",
           "maxAttachmentBytes",
         ])
-      : new Set(["url", "outFields", "definitionExpression"]);
+      : target === "honua-maplibre"
+        ? new Set([
+            "url",
+            "id",
+            "title",
+            "outFields",
+            "definitionExpression",
+            "returnGeometry",
+            "outSR",
+            "opacity",
+            "visible",
+            "minScale",
+            "maxScale",
+            "attribution",
+            "paint",
+            "layout",
+            "layerType",
+          ])
+        : new Set(["url", "outFields", "definitionExpression"]);
 
   for (const property of arg.properties) {
     if (!isAssignableObjectProperty(property)) {
@@ -3970,7 +4291,25 @@ function isSafeMapImageLayerCompatCall(
           "legendEnabled",
           "client",
         ])
-      : new Set(["url", "sublayers", "opacity", "visible"]);
+      : target === "honua-maplibre"
+        ? new Set([
+            "url",
+            "id",
+            "title",
+            "sublayers",
+            "layers",
+            "dpi",
+            "format",
+            "transparent",
+            "opacity",
+            "visible",
+            "minScale",
+            "maxScale",
+            "attribution",
+            "paint",
+            "layout",
+          ])
+        : new Set(["url", "sublayers", "opacity", "visible"]);
   for (const property of arg.properties) {
     if (!isAssignableObjectProperty(property)) {
       return {
@@ -4027,7 +4366,21 @@ function isSafeTileLayerCompatCall(
   const allowed =
     target === "honua-compat"
       ? new Set(["url", "id", "title", "opacity", "visible", "minScale", "maxScale", "listMode", "client"])
-      : new Set(["url", "opacity", "visible"]);
+      : target === "honua-maplibre"
+        ? new Set([
+            "url",
+            "id",
+            "title",
+            "opacity",
+            "visible",
+            "minScale",
+            "maxScale",
+            "attribution",
+            "paint",
+            "layout",
+            "tileSize",
+          ])
+        : new Set(["url", "opacity", "visible"]);
   for (const property of arg.properties) {
     if (!isAssignableObjectProperty(property)) {
       return {
@@ -4142,7 +4495,10 @@ function isSafeGroupLayerCompatCall(node: ts.NewExpression): { ok: true } | { ok
   return { ok: true };
 }
 
-function isSafeMapCompatCall(node: ts.NewExpression): { ok: true } | { ok: false; reason: string } {
+function isSafeMapCompatCall(
+  node: ts.NewExpression,
+  target: CodemodTarget,
+): { ok: true } | { ok: false; reason: string } {
   const args = node.arguments;
   if (!args || args.length === 0) {
     return { ok: true };
@@ -4162,7 +4518,10 @@ function isSafeMapCompatCall(node: ts.NewExpression): { ok: true } | { ok: false
     };
   }
 
-  const allowed = new Set(["basemap", "layers", "ground", "tables", "portalItem", "spatialReference"]);
+  const allowed =
+    target === "honua-maplibre"
+      ? new Set(["basemap", "layers", "name", "center", "zoom"])
+      : new Set(["basemap", "layers", "ground", "tables", "portalItem", "spatialReference"]);
   for (const property of arg.properties) {
     if (!isAssignableObjectProperty(property)) {
       return {
@@ -4183,7 +4542,10 @@ function isSafeMapCompatCall(node: ts.NewExpression): { ok: true } | { ok: false
   return { ok: true };
 }
 
-function isSafeMapViewCompatCall(node: ts.NewExpression): { ok: true } | { ok: false; reason: string } {
+function isSafeMapViewCompatCall(
+  node: ts.NewExpression,
+  target: CodemodTarget,
+): { ok: true } | { ok: false; reason: string } {
   const args = node.arguments;
   if (!args || args.length === 0) {
     return { ok: true };
@@ -4203,20 +4565,23 @@ function isSafeMapViewCompatCall(node: ts.NewExpression): { ok: true } | { ok: f
     };
   }
 
-  const allowed = new Set([
-    "map",
-    "container",
-    "center",
-    "zoom",
-    "scale",
-    "rotation",
-    "extent",
-    "constraints",
-    "padding",
-    "highlightOptions",
-    "spatialReference",
-    "popup",
-  ]);
+  const allowed =
+    target === "honua-maplibre"
+      ? new Set(["map", "style", "container", "center", "zoom", "bearing", "pitch"])
+      : new Set([
+          "map",
+          "container",
+          "center",
+          "zoom",
+          "scale",
+          "rotation",
+          "extent",
+          "constraints",
+          "padding",
+          "highlightOptions",
+          "spatialReference",
+          "popup",
+        ]);
   for (const property of arg.properties) {
     if (!isAssignableObjectProperty(property)) {
       return {

--- a/src/migration/parity-matrix.ts
+++ b/src/migration/parity-matrix.ts
@@ -13,12 +13,14 @@ export interface JsParityMatrixEntry {
   category: JsParityCategory;
   arcGisModule: string;
   honuaCompat: JsParityStatus;
+  honuaMapLibre: JsParityStatus;
   esriLeaflet: JsParityStatus;
   notes: string;
 }
 
 export interface JsParitySummary {
   honuaCompat: Record<JsParityStatus, number>;
+  honuaMapLibre: Record<JsParityStatus, number>;
   esriLeaflet: Record<JsParityStatus, number>;
 }
 
@@ -51,16 +53,18 @@ const BASE_MATRIX_ROWS: JsParityMatrixEntry[] = (Object.keys(CANONICAL_MODULE_BY
   .sort()
   .map((kind) => {
     const honuaCompat: JsParityStatus = isKindSupportedForTarget(kind, "honua-compat") ? "compat" : "unsupported";
+    const honuaMapLibre: JsParityStatus = isKindSupportedForTarget(kind, "honua-maplibre") ? "native" : "assisted";
     const esriLeaflet: JsParityStatus = isKindSupportedForTarget(kind, "esri-leaflet") ? "compat" : "assisted";
     return {
       kind,
       category: classifyCategory(kind),
       arcGisModule: CANONICAL_MODULE_BY_KIND[kind],
       honuaCompat,
+      honuaMapLibre,
       esriLeaflet,
       notes:
-        esriLeaflet === "compat"
-          ? "deterministic codemod mapping available"
+        honuaMapLibre === "native"
+          ? "Honua MapLibre target emits native helper mappings"
           : "assisted migration with TODO/report gating",
     };
   });
@@ -79,6 +83,12 @@ export function summarizeJsParityMatrix(matrix: readonly JsParityMatrixEntry[] =
       assisted: 0,
       unsupported: 0,
     },
+    honuaMapLibre: {
+      native: 0,
+      compat: 0,
+      assisted: 0,
+      unsupported: 0,
+    },
     esriLeaflet: {
       native: 0,
       compat: 0,
@@ -89,6 +99,7 @@ export function summarizeJsParityMatrix(matrix: readonly JsParityMatrixEntry[] =
 
   for (const row of matrix) {
     summary.honuaCompat[row.honuaCompat] += 1;
+    summary.honuaMapLibre[row.honuaMapLibre] += 1;
     summary.esriLeaflet[row.esriLeaflet] += 1;
   }
 

--- a/src/migration/report.ts
+++ b/src/migration/report.ts
@@ -27,7 +27,7 @@ export interface ManualInterventionMetric {
 
 export interface JsMigrationReport {
   rootDir: string;
-  codemodTarget: "honua-compat" | "esri-leaflet";
+  codemodTarget: "honua-compat" | "esri-leaflet" | "honua-maplibre";
   scanSummary: string;
   scanReport: ArcGisScanReport;
   codemodResult: EsriCompatCodemodResult;

--- a/src/migration/runtime-matrix.ts
+++ b/src/migration/runtime-matrix.ts
@@ -7,16 +7,20 @@ export interface JsRuntimeParityEntry {
   capability: string;
   arcGisJsApi: string;
   honuaCompat: JsRuntimeParityStatus;
+  honuaMapLibre: JsRuntimeParityStatus;
   esriLeaflet: JsRuntimeParityStatus;
   notes: string;
 }
 
 export interface JsRuntimeParitySummary {
   honuaCompat: Record<JsRuntimeParityStatus, number>;
+  honuaMapLibre: Record<JsRuntimeParityStatus, number>;
   esriLeaflet: Record<JsRuntimeParityStatus, number>;
 }
 
-const BASE_RUNTIME_MATRIX: readonly JsRuntimeParityEntry[] = Object.freeze([
+type BaseRuntimeParityEntry = Omit<JsRuntimeParityEntry, "honuaMapLibre">;
+
+const BASE_RUNTIME_MATRIX: readonly BaseRuntimeParityEntry[] = Object.freeze([
   {
     surface: "feature-layer",
     capability: "query-features",
@@ -327,7 +331,12 @@ const BASE_RUNTIME_MATRIX: readonly JsRuntimeParityEntry[] = Object.freeze([
   },
 ]);
 
-export const JS_RUNTIME_PARITY_MATRIX: readonly JsRuntimeParityEntry[] = Object.freeze([...BASE_RUNTIME_MATRIX]);
+export const JS_RUNTIME_PARITY_MATRIX: readonly JsRuntimeParityEntry[] = Object.freeze(
+  BASE_RUNTIME_MATRIX.map((entry) => ({
+    ...entry,
+    honuaMapLibre: inferHonuaMapLibreRuntimeStatus(entry),
+  })),
+);
 
 export function getJsRuntimeParityMatrix(): readonly JsRuntimeParityEntry[] {
   return JS_RUNTIME_PARITY_MATRIX;
@@ -343,6 +352,12 @@ export function summarizeJsRuntimeParity(
       assisted: 0,
       unsupported: 0,
     },
+    honuaMapLibre: {
+      native: 0,
+      compat: 0,
+      assisted: 0,
+      unsupported: 0,
+    },
     esriLeaflet: {
       native: 0,
       compat: 0,
@@ -353,8 +368,19 @@ export function summarizeJsRuntimeParity(
 
   for (const row of matrix) {
     summary.honuaCompat[row.honuaCompat] += 1;
+    summary.honuaMapLibre[row.honuaMapLibre] += 1;
     summary.esriLeaflet[row.esriLeaflet] += 1;
   }
 
   return summary;
+}
+
+function inferHonuaMapLibreRuntimeStatus(entry: BaseRuntimeParityEntry): JsRuntimeParityStatus {
+  if (entry.surface === "feature-layer" || entry.surface === "map-image-layer") {
+    return "native";
+  }
+  if (entry.surface === "map-view" && entry.capability === "navigation-go-to") {
+    return "native";
+  }
+  return "assisted";
 }

--- a/test/fixtures/esri-maplibre-simple-app/src/main.ts
+++ b/test/fixtures/esri-maplibre-simple-app/src/main.ts
@@ -1,0 +1,35 @@
+import Map from "@arcgis/core/Map";
+import FeatureLayer from "@arcgis/core/layers/FeatureLayer";
+import MapImageLayer from "@arcgis/core/layers/MapImageLayer";
+import TileLayer from "@arcgis/core/layers/TileLayer";
+import MapView from "@arcgis/core/views/MapView";
+
+const incidents = new FeatureLayer({
+  id: "incidents",
+  title: "Incidents",
+  url: "https://example.test/rest/services/incidents/FeatureServer/0",
+  outFields: ["*"],
+  definitionExpression: "status = 'open'",
+  opacity: 0.8,
+});
+const districts = new MapImageLayer({
+  id: "districts",
+  url: "https://example.test/rest/services/districts/MapServer",
+  visible: true,
+});
+const basemapTiles = new TileLayer({
+  id: "basemap-tiles",
+  url: "https://example.test/rest/services/basemap/MapServer",
+});
+const map = new Map({
+  basemap: "streets-vector",
+  layers: [basemapTiles, districts, incidents],
+});
+const view = new MapView({
+  map,
+  container: "viewDiv",
+  center: [-157.8, 21.3],
+  zoom: 12,
+});
+
+void view;

--- a/test/migration-cli-fixtures.test.ts
+++ b/test/migration-cli-fixtures.test.ts
@@ -109,7 +109,7 @@ describe("migration cli fixtures metrics", () => {
     expect(report.fixtures).toHaveLength(4);
     expect(report.fixtures.every((fixture) => fixture.readiness === "ready")).toBe(true);
     expect(report.fixtures.every((fixture) => fixture.manualCallSites === 0)).toBe(true);
-  }, 60_000);
+  }, 240_000);
 
   it("supports fixture subset selection", () => {
     ensureBuiltCliArtifacts();
@@ -141,7 +141,57 @@ describe("migration cli fixtures metrics", () => {
     expect(report.summary.fixtureCount).toBe(1);
     expect(report.fixtureNames).toEqual(["esri-real-sample-network-app"]);
     expect(report.fixtures).toEqual([expect.objectContaining({ fixture: "esri-real-sample-network-app" })]);
-  }, 60_000);
+  }, 240_000);
+
+  it("reports honua-maplibre fixture metrics for native supported sample", () => {
+    ensureBuiltCliArtifacts();
+    const root = makeTempDir();
+    const reportPath = path.join(root, "maplibre-metrics.json");
+
+    const result = runCli(
+      ["fixtures", "--target", "honua-maplibre", "--fixtures", "esri-maplibre-simple-app", "--report", reportPath],
+      getProjectRoot(),
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("fixtures=1");
+    expect(result.stdout).toContain("target=honua-maplibre");
+    expect(fs.existsSync(reportPath)).toBe(true);
+
+    const report = JSON.parse(fs.readFileSync(reportPath, "utf8")) as {
+      codemodTarget: string;
+      summary: {
+        fixtureCount: number;
+        ready: number;
+        autoMigratedCallSites: number;
+        manualCallSites: number;
+        unhandledUsageHits: number;
+      };
+      fixtures: Array<{
+        fixture: string;
+        readiness: string;
+        totalCallSites: number;
+        autoMigratedCallSites: number;
+        manualCallSites: number;
+      }>;
+    };
+
+    expect(report.codemodTarget).toBe("honua-maplibre");
+    expect(report.summary.fixtureCount).toBe(1);
+    expect(report.summary.ready).toBe(1);
+    expect(report.summary.autoMigratedCallSites).toBe(5);
+    expect(report.summary.manualCallSites).toBe(0);
+    expect(report.summary.unhandledUsageHits).toBe(0);
+    expect(report.fixtures).toEqual([
+      expect.objectContaining({
+        fixture: "esri-maplibre-simple-app",
+        readiness: "ready",
+        totalCallSites: 5,
+        autoMigratedCallSites: 5,
+        manualCallSites: 0,
+      }),
+    ]);
+  }, 240_000);
 
   it("passes strict fixture gates for honua-compat target", () => {
     ensureBuiltCliArtifacts();
@@ -162,7 +212,7 @@ describe("migration cli fixtures metrics", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("fixturesGate=pass");
-  }, 60_000);
+  }, 240_000);
 
   it("passes fixture gates for esri-leaflet network sample after compat-fallback expansion", () => {
     ensureBuiltCliArtifacts();
@@ -184,7 +234,7 @@ describe("migration cli fixtures metrics", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("fixturesGate=pass");
     expect(result.stdout).toContain("manual=0");
-  }, 60_000);
+  }, 240_000);
 
   it("passes strict fixture gates for deterministic esri-leaflet subset", () => {
     ensureBuiltCliArtifacts();
@@ -212,5 +262,5 @@ describe("migration cli fixtures metrics", () => {
     expect(result.stdout).toContain("target=esri-leaflet");
     expect(result.stdout).toContain("manual=0");
     expect(result.stdout).toContain("unhandled=0");
-  }, 60_000);
+  }, 240_000);
 });

--- a/test/migration-cli-matrix.test.ts
+++ b/test/migration-cli-matrix.test.ts
@@ -65,6 +65,7 @@ describe("migration cli parity matrix", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("entries=");
+    expect(result.stdout).toContain("honuaMapLibreNative=");
     expect(result.stdout).toContain("esriLeafletCompat=");
     expect(result.stdout).toContain(`reportWritten=${reportPath}`);
     expect(fs.existsSync(reportPath)).toBe(true);
@@ -72,11 +73,13 @@ describe("migration cli parity matrix", () => {
     const report = JSON.parse(fs.readFileSync(reportPath, "utf8")) as {
       summary: {
         honuaCompat: Record<string, number>;
+        honuaMapLibre: Record<string, number>;
         esriLeaflet: Record<string, number>;
       };
       matrix: Array<{
         kind: string;
         honuaCompat: string;
+        honuaMapLibre: string;
         esriLeaflet: string;
       }>;
     };
@@ -117,7 +120,7 @@ describe("migration cli parity matrix", () => {
     const esriRequest = report.matrix.find((row) => row.kind === "esri-request");
     const esriConfig = report.matrix.find((row) => row.kind === "esri-config");
     const reactiveUtils = report.matrix.find((row) => row.kind === "reactive-utils");
-    expect(featureLayer).toMatchObject({ honuaCompat: "compat", esriLeaflet: "compat" });
+    expect(featureLayer).toMatchObject({ honuaCompat: "compat", honuaMapLibre: "native", esriLeaflet: "compat" });
     expect(graphic).toMatchObject({ honuaCompat: "compat", esriLeaflet: "compat" });
     expect(point).toMatchObject({ honuaCompat: "compat", esriLeaflet: "compat" });
     expect(polyline).toMatchObject({ honuaCompat: "compat", esriLeaflet: "compat" });
@@ -134,8 +137,8 @@ describe("migration cli parity matrix", () => {
     expect(classBreaksRenderer).toMatchObject({ honuaCompat: "compat", esriLeaflet: "compat" });
     expect(simpleRenderer).toMatchObject({ honuaCompat: "compat", esriLeaflet: "compat" });
     expect(uniqueValueRenderer).toMatchObject({ honuaCompat: "compat", esriLeaflet: "compat" });
-    expect(basemap).toMatchObject({ honuaCompat: "compat", esriLeaflet: "compat" });
-    expect(sceneView).toMatchObject({ honuaCompat: "compat", esriLeaflet: "compat" });
+    expect(basemap).toMatchObject({ honuaCompat: "compat", honuaMapLibre: "assisted", esriLeaflet: "compat" });
+    expect(sceneView).toMatchObject({ honuaCompat: "compat", honuaMapLibre: "assisted", esriLeaflet: "compat" });
     expect(track).toMatchObject({ honuaCompat: "compat", esriLeaflet: "compat" });
     expect(routeTask).toMatchObject({ honuaCompat: "compat", esriLeaflet: "compat" });
     expect(swipe).toMatchObject({ honuaCompat: "compat", esriLeaflet: "compat" });
@@ -154,8 +157,9 @@ describe("migration cli parity matrix", () => {
     expect(esriConfig).toMatchObject({ honuaCompat: "compat", esriLeaflet: "compat" });
     expect(reactiveUtils).toMatchObject({ honuaCompat: "compat", esriLeaflet: "compat" });
     expect(report.summary.honuaCompat.compat).toBeGreaterThan(0);
+    expect(report.summary.honuaMapLibre.native).toBe(5);
     expect(report.summary.esriLeaflet.assisted).toBe(0);
-  }, 60_000);
+  }, 240_000);
 
   it("prints and writes the runtime parity matrix artifact", () => {
     ensureBuiltCliArtifacts();
@@ -166,6 +170,7 @@ describe("migration cli parity matrix", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("entries=");
+    expect(result.stdout).toContain("honuaMapLibreNative=");
     expect(result.stdout).toContain("esriLeafletAssisted=");
     expect(result.stdout).toContain(`reportWritten=${reportPath}`);
     expect(fs.existsSync(reportPath)).toBe(true);
@@ -173,6 +178,7 @@ describe("migration cli parity matrix", () => {
     const report = JSON.parse(fs.readFileSync(reportPath, "utf8")) as {
       summary: {
         honuaCompat: Record<string, number>;
+        honuaMapLibre: Record<string, number>;
         esriLeaflet: Record<string, number>;
       };
       matrix: Array<{
@@ -180,11 +186,13 @@ describe("migration cli parity matrix", () => {
         capability: string;
         arcGisJsApi: string;
         honuaCompat: string;
+        honuaMapLibre: string;
         esriLeaflet: string;
       }>;
     };
 
     expect(report.summary.honuaCompat.compat).toBeGreaterThan(0);
+    expect(report.summary.honuaMapLibre.native).toBeGreaterThan(0);
     expect(report.summary.esriLeaflet.assisted).toBe(0);
 
     const queryFeatures = report.matrix.find(
@@ -250,5 +258,5 @@ describe("migration cli parity matrix", () => {
       arcGisJsApi: "MapView.goTo",
       honuaCompat: "compat",
     });
-  }, 60_000);
+  }, 240_000);
 });

--- a/test/migration-cli-target.test.ts
+++ b/test/migration-cli-target.test.ts
@@ -77,7 +77,7 @@ describe("migration cli target selection", () => {
     const migrated = fs.readFileSync(appFile, "utf8");
     expect(migrated).toContain('import { MapCompat } from "@honua/sdk-esri-compat";');
     expect(migrated).toContain("const map = new MapCompat({ basemap: 'streets' });");
-  }, 60_000);
+  }, 240_000);
 
   it("runs codemod with --target esri-leaflet and emits a deterministic mixed mapping report", () => {
     ensureBuiltCliArtifacts();
@@ -122,7 +122,57 @@ describe("migration cli target selection", () => {
     expect(report.readiness).toBe("ready");
     expect(report.manualTodos).toEqual([]);
     expect(report.unhandledArcGisModules).toEqual([]);
-  }, 60_000);
+  }, 240_000);
+
+  it("runs codemod with --target honua-maplibre and records native target report fields", () => {
+    ensureBuiltCliArtifacts();
+    const root = makeTempDir();
+    const appFile = path.join(root, "app.ts");
+    const reportPath = path.join(root, "report-maplibre.json");
+
+    fs.writeFileSync(
+      appFile,
+      [
+        "import Map from '@arcgis/core/Map';",
+        "import FeatureLayer from '@arcgis/core/layers/FeatureLayer';",
+        "import MapView from '@arcgis/core/views/MapView';",
+        "const layer = new FeatureLayer({ url: serviceUrl });",
+        "const map = new Map({ basemap: 'streets-vector', layers: [layer] });",
+        "const view = new MapView({ map, container: 'viewDiv', center: [-157.8, 21.3], zoom: 12 });",
+        "void view;",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = runCli(
+      ["codemod", root, "--target", "honua-maplibre", "--write", "--annotate-todos", "--report", reportPath],
+      getProjectRoot(),
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("target=honua-maplibre");
+    expect(result.stdout).toContain("manual=[trivial:0 moderate:0 complex:0]");
+    expect(fs.existsSync(reportPath)).toBe(true);
+
+    const migrated = fs.readFileSync(appFile, "utf8");
+    expect(migrated).toContain('import * as maplibregl from "maplibre-gl";');
+    expect(migrated).toContain('from "@honua/sdk-js/map";');
+    expect(migrated).toContain("createHonuaFeatureServiceLayer({");
+    expect(migrated).toContain("createHonuaMapLibreStyle({");
+    expect(migrated).toContain("new maplibregl.Map(createHonuaMapLibreMapOptions({");
+    expect(migrated).not.toContain("@honua/sdk-esri-compat");
+
+    const report = JSON.parse(fs.readFileSync(reportPath, "utf8")) as {
+      codemodTarget: string;
+      readiness: string;
+      manualTodos: Array<{ kind: string; reason: string }>;
+      unhandledArcGisModules: Array<{ modulePath: string; usageStyle: string; count: number }>;
+    };
+    expect(report.codemodTarget).toBe("honua-maplibre");
+    expect(report.readiness).toBe("ready");
+    expect(report.manualTodos).toEqual([]);
+    expect(report.unhandledArcGisModules).toEqual([]);
+  }, 240_000);
 
   it("fails fast for invalid --target values", () => {
     ensureBuiltCliArtifacts();
@@ -132,7 +182,7 @@ describe("migration cli target selection", () => {
 
     expect(result.status).toBe(1);
     expect(result.stdout).toContain("Usage:");
-  }, 60_000);
+  }, 240_000);
 
   it("prints a note when project only contains esri-leaflet imports", () => {
     ensureBuiltCliArtifacts();
@@ -154,7 +204,7 @@ describe("migration cli target selection", () => {
     expect(result.stdout).toContain(
       "note=esri-leaflet-imports-detected-without-arcgis-js; codemod targets @arcgis/core inputs (not migrations from esri-leaflet)",
     );
-  }, 60_000);
+  }, 240_000);
 
   it("emits explicit TODO annotations for unsupported esri-leaflet mappings", () => {
     ensureBuiltCliArtifacts();
@@ -198,5 +248,5 @@ describe("migration cli target selection", () => {
     expect(report.manualTodos).toHaveLength(1);
     expect(report.manualTodos[0]?.kind).toBe("scene-view");
     expect(report.manualTodos[0]?.reason).toContain("unsupported properties");
-  }, 60_000);
+  }, 240_000);
 });

--- a/test/migration-codemod.test.ts
+++ b/test/migration-codemod.test.ts
@@ -1782,6 +1782,103 @@ describe("runEsriCompatCodemod", () => {
     expect(nextSource).not.toContain("@arcgis/core/layers/TileLayer");
   });
 
+  it("rewrites supported constructors for honua-maplibre target without compat imports", () => {
+    const root = makeTempProject();
+    const file = path.join(root, "honua-maplibre.ts");
+    fs.writeFileSync(
+      file,
+      [
+        "import Map from '@arcgis/core/Map';",
+        "import FeatureLayer from '@arcgis/core/layers/FeatureLayer';",
+        "import MapImageLayer from '@arcgis/core/layers/MapImageLayer';",
+        "import TileLayer from '@arcgis/core/layers/TileLayer';",
+        "import MapView from '@arcgis/core/views/MapView';",
+        "const incidents = new FeatureLayer({ url: serviceUrl, outFields: ['*'] });",
+        "const districts = new MapImageLayer({ url: mapUrl, visible: true });",
+        "const tiles = new TileLayer({ url: tileUrl });",
+        "const map = new Map({ basemap: 'streets-vector', layers: [tiles, districts, incidents] });",
+        "const view = new MapView({ map, container: 'viewDiv', center: [-157.8, 21.3], zoom: 12 });",
+        "void view;",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = runEsriCompatCodemod({
+      rootDir: root,
+      target: "honua-maplibre",
+      write: true,
+    });
+
+    expect(result.target).toBe("honua-maplibre");
+    expect(result.filesChanged).toBe(1);
+    expect(result.metrics.totalCodemodScopedCallSites).toBe(5);
+    expect(result.metrics.autoMigratedCallSites).toBe(5);
+    expect(result.metrics.manualCallSites).toBe(0);
+    expect(result.metrics.byKind["feature-layer"]).toMatchObject({ total: 1, autoMigrated: 1, manual: 0 });
+    expect(result.metrics.byKind["map-image-layer"]).toMatchObject({ total: 1, autoMigrated: 1, manual: 0 });
+    expect(result.metrics.byKind["tile-layer"]).toMatchObject({ total: 1, autoMigrated: 1, manual: 0 });
+    expect(result.metrics.byKind.map).toMatchObject({ total: 1, autoMigrated: 1, manual: 0 });
+    expect(result.metrics.byKind["map-view"]).toMatchObject({ total: 1, autoMigrated: 1, manual: 0 });
+
+    const nextSource = fs.readFileSync(file, "utf8");
+    expect(nextSource).toContain('import * as maplibregl from "maplibre-gl";');
+    expect(nextSource).toContain(
+      'import { createHonuaFeatureServiceLayer, createHonuaMapLibreMapOptions, createHonuaMapLibreStyle, createHonuaMapServiceLayer, createHonuaTileServiceLayer } from "@honua/sdk-js/map";',
+    );
+    expect(nextSource).toContain(
+      "const incidents = createHonuaFeatureServiceLayer({ id: \"incidents\", url: serviceUrl, outFields: ['*'] });",
+    );
+    expect(nextSource).toContain(
+      'const districts = createHonuaMapServiceLayer({ id: "districts", url: mapUrl, visible: true });',
+    );
+    expect(nextSource).toContain('const tiles = createHonuaTileServiceLayer({ id: "tiles", url: tileUrl });');
+    expect(nextSource).toContain(
+      "const map = createHonuaMapLibreStyle({ basemap: 'streets-vector', layers: [tiles, districts, incidents] });",
+    );
+    expect(nextSource).toContain(
+      "const view = new maplibregl.Map(createHonuaMapLibreMapOptions({ map, container: 'viewDiv', center: [-157.8, 21.3], zoom: 12 }));",
+    );
+    expect(nextSource).not.toContain("@honua/sdk-esri-compat");
+    expect(nextSource).not.toContain("@arcgis/core/");
+  });
+
+  it("classifies unsupported honua-maplibre widgets as manual todos", () => {
+    const root = makeTempProject();
+    const file = path.join(root, "honua-maplibre-widget.ts");
+    fs.writeFileSync(
+      file,
+      [
+        "import Search from '@arcgis/core/widgets/Search';",
+        "const search = new Search({ view, includeDefaultSources: false });",
+        "void search;",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = runEsriCompatCodemod({
+      rootDir: root,
+      target: "honua-maplibre",
+      write: true,
+      annotateTodos: true,
+    });
+
+    expect(result.filesChanged).toBe(1);
+    expect(result.metrics.totalCodemodScopedCallSites).toBe(1);
+    expect(result.metrics.autoMigratedCallSites).toBe(0);
+    expect(result.metrics.manualCallSites).toBe(1);
+    expect(result.manualTodos).toEqual([
+      expect.objectContaining({
+        kind: "search-widget",
+        reason: "No deterministic Honua MapLibre mapping for this constructor; requires manual migration.",
+      }),
+    ]);
+
+    const nextSource = fs.readFileSync(file, "utf8");
+    expect(nextSource).toContain("// TODO(honua-migrate)[search-widget]:");
+    expect(nextSource).toContain("new Search({ view, includeDefaultSources: false })");
+    expect(nextSource).not.toContain("@honua/sdk-esri-compat");
+  });
+
   it("rewrites map/view/widget constructors to compat fallbacks for esri-leaflet target", () => {
     const root = makeTempProject();
     const file = path.join(root, "esri-leaflet-compat-fallbacks.ts");

--- a/test/migration-integration.test.ts
+++ b/test/migration-integration.test.ts
@@ -1177,6 +1177,55 @@ describe("arcgis migration integration", () => {
     expect(migratedMain).toContain("new MapCompat({");
   });
 
+  it("supports honua-maplibre codemod target for native MapLibre fixture", () => {
+    const { workingCopy, report, codemodResult } = runFixtureMigration("esri-maplibre-simple-app", {
+      target: "honua-maplibre",
+    });
+
+    expect(codemodResult.filesChanged).toBe(1);
+    expect(codemodResult.metrics.totalCodemodScopedCallSites).toBe(5);
+    expect(codemodResult.metrics.autoMigratedCallSites).toBe(5);
+    expect(codemodResult.metrics.manualCallSites).toBe(0);
+    expect(report.codemodTarget).toBe("honua-maplibre");
+    expect(report.readiness).toBe("ready");
+    expect(report.manualTodos).toEqual([]);
+    expect(report.unhandledArcGisModules).toEqual([]);
+
+    const migratedMain = fs.readFileSync(path.join(workingCopy, "src", "main.ts"), "utf8");
+    expect(migratedMain).toContain('import * as maplibregl from "maplibre-gl";');
+    expect(migratedMain).toContain('from "@honua/sdk-js/map";');
+    expect(migratedMain).toContain("createHonuaFeatureServiceLayer({");
+    expect(migratedMain).toContain("createHonuaMapServiceLayer({");
+    expect(migratedMain).toContain("createHonuaTileServiceLayer({");
+    expect(migratedMain).toContain("createHonuaMapLibreStyle({");
+    expect(migratedMain).toContain("new maplibregl.Map(createHonuaMapLibreMapOptions({");
+    expect(migratedMain).not.toContain("@honua/sdk-esri-compat");
+    expect(migratedMain).not.toContain("@arcgis/core/");
+  });
+
+  it("reports unsupported widgets as manual for honua-maplibre target", () => {
+    const { report, codemodResult } = runFixtureMigration("esri-widget-controls-app", {
+      target: "honua-maplibre",
+      annotateTodos: true,
+    });
+
+    expect(codemodResult.metrics.autoMigratedCallSites).toBeGreaterThan(0);
+    expect(codemodResult.metrics.manualCallSites).toBeGreaterThan(0);
+    expect(report.codemodTarget).toBe("honua-maplibre");
+    expect(report.readiness).toBe("assisted");
+    expect(report.manualTodos).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "home-widget" }),
+        expect.objectContaining({ kind: "basemap-toggle-widget" }),
+      ]),
+    );
+    expect(report.unhandledArcGisModules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ modulePath: "@arcgis/core/widgets/Home", usageStyle: "static-import" }),
+      ]),
+    );
+  });
+
   it("migrates map + group-layer + graphics-layer fixture with ready gating", () => {
     const { workingCopy, scanReport, report, codemodResult } = runFixtureMigration("esri-layer-tree-app");
 

--- a/test/migration-parity-matrix.test.ts
+++ b/test/migration-parity-matrix.test.ts
@@ -63,6 +63,7 @@ describe("JS parity matrix", () => {
 
     expect(featureLayer).toMatchObject({
       honuaCompat: "compat",
+      honuaMapLibre: "native",
       esriLeaflet: "compat",
     });
     expect(graphic).toMatchObject({
@@ -135,14 +136,17 @@ describe("JS parity matrix", () => {
     });
     expect(map).toMatchObject({
       honuaCompat: "compat",
+      honuaMapLibre: "native",
       esriLeaflet: "compat",
     });
     expect(mapView).toMatchObject({
       honuaCompat: "compat",
+      honuaMapLibre: "native",
       esriLeaflet: "compat",
     });
     expect(sceneView).toMatchObject({
       honuaCompat: "compat",
+      honuaMapLibre: "assisted",
       esriLeaflet: "compat",
     });
     expect(homeWidget).toMatchObject({
@@ -243,11 +247,15 @@ describe("JS parity matrix", () => {
     const matrix = getJsParityMatrix();
     const summary = summarizeJsParityMatrix(matrix);
     const totalHonua = Object.values(summary.honuaCompat).reduce((acc, value) => acc + value, 0);
+    const totalHonuaMapLibre = Object.values(summary.honuaMapLibre).reduce((acc, value) => acc + value, 0);
     const totalEsriLeaflet = Object.values(summary.esriLeaflet).reduce((acc, value) => acc + value, 0);
 
     expect(totalHonua).toBe(matrix.length);
+    expect(totalHonuaMapLibre).toBe(matrix.length);
     expect(totalEsriLeaflet).toBe(matrix.length);
     expect(summary.honuaCompat.compat).toBeGreaterThan(0);
+    expect(summary.honuaMapLibre.native).toBe(5);
+    expect(summary.honuaMapLibre.assisted).toBeGreaterThan(0);
     expect(summary.esriLeaflet.compat).toBeGreaterThan(0);
     expect(summary.esriLeaflet.assisted).toBe(0);
   });

--- a/test/migration-runtime-matrix.test.ts
+++ b/test/migration-runtime-matrix.test.ts
@@ -36,6 +36,7 @@ describe("JS runtime parity matrix", () => {
     expect(featureLayerQuery).toMatchObject({
       arcGisJsApi: "FeatureLayer.queryFeatures",
       honuaCompat: "compat",
+      honuaMapLibre: "native",
     });
     expect(mapImageFind).toMatchObject({
       arcGisJsApi: "MapImageLayer.find",
@@ -70,11 +71,13 @@ describe("JS runtime parity matrix", () => {
     expect(mapViewGoTo).toMatchObject({
       arcGisJsApi: "MapView.goTo",
       honuaCompat: "compat",
+      honuaMapLibre: "native",
       esriLeaflet: "compat",
     });
     expect(navigationWidgets).toMatchObject({
       arcGisJsApi: "BasemapGallery/Bookmarks/Expand",
       honuaCompat: "compat",
+      honuaMapLibre: "assisted",
       esriLeaflet: "compat",
     });
     expect(commonControls).toMatchObject({
@@ -89,11 +92,15 @@ describe("JS runtime parity matrix", () => {
     const summary = summarizeJsRuntimeParity(matrix);
 
     const totalHonua = Object.values(summary.honuaCompat).reduce((acc, value) => acc + value, 0);
+    const totalHonuaMapLibre = Object.values(summary.honuaMapLibre).reduce((acc, value) => acc + value, 0);
     const totalEsriLeaflet = Object.values(summary.esriLeaflet).reduce((acc, value) => acc + value, 0);
 
     expect(totalHonua).toBe(matrix.length);
+    expect(totalHonuaMapLibre).toBe(matrix.length);
     expect(totalEsriLeaflet).toBe(matrix.length);
     expect(summary.honuaCompat.compat).toBeGreaterThan(0);
+    expect(summary.honuaMapLibre.native).toBeGreaterThan(0);
+    expect(summary.honuaMapLibre.assisted).toBeGreaterThan(0);
     expect(summary.esriLeaflet.assisted).toBe(0);
   });
 });


### PR DESCRIPTION
Related to #205

## Changes Made
- Adds a `honua-maplibre` migration target for ArcGIS JS to Honua JS plus MapLibre.
- Rewrites the simple native subset for `FeatureLayer`, `MapImageLayer`, `TileLayer`, `Map`, and `MapView`.
- Updates CLI target handling, parity/runtime reporting, and fixture coverage for the MapLibre target.

## Validation
- `npm test -- --run test/migration-codemod.test.ts test/migration-integration.test.ts test/migration-parity-matrix.test.ts test/migration-runtime-matrix.test.ts`
- `npm test -- --run test/migration-cli-target.test.ts`
- `npm test -- --run test/migration-cli-fixtures.test.ts`
- `npm test -- --run test/migration-cli-matrix.test.ts`
- `npm run typecheck --silent`
- `npx biome check` on touched files
- `git diff --check`

## Remaining Gaps
- WebMap, widgets, dynamic imports, and richer ArcGIS API usage remain classified as manual or assisted in reports rather than migrated automatically.