### PR TITLE
codemod + QueryCompat: deep-transform Query options to Honua shape (Task E)

### DIFF
--- a/docs/migration-punch-list.md
+++ b/docs/migration-punch-list.md
@@ -112,14 +112,27 @@ hold the surface stable).
    service-area, OD-cost-matrix, closest-facility,
    non-network geoprocessing) need their own surfaces under
    `src/core/` and matching compat classes.
-4. **`Query` argument depth.** The `Query` shim accepts the common
-   property set, but the codemod's options validator currently
-   allows-but-passes-through complex sub-objects
-   (`statisticDefinitions`, `quantizationParameters`, etc.) without
-   transforming them into the Honua-side request shape. A failing
-   query at runtime is preferable to a silently-wrong query — but
-   the codemod should detect these and emit a manual TODO instead
-   of letting the call through.
+4. **`Query` argument depth.** *Shipped (Task E).* The codemod now
+   deep-transforms `new Query({...})` argument literals into the
+   Honua `QueryFeaturesRequest` shape: renames `start` →
+   `resultOffset`, `num` → `resultRecordCount`, `outSpatialReference`
+   → `outSr`, `spatialRelationship` → `spatialRel`; splits
+   `geometry: { type, ...rest }` into a sibling `geometryType`
+   field with the matching `esriGeometry*` enum value; and
+   lowercases `outStatistics[i].statisticType` against the
+   STATISTIC_TYPE_MAP keyset (count/sum/min/max/avg/stddev/var).
+   Divergent / dynamic shapes emit a manual TODO with a precise
+   reason — specifically: `timeExtent` (no Honua field; use
+   `extraParams.time`), `quantizationParameters` (server-side
+   optimization with no Honua equivalent), `relationParam` (no
+   Honua support), `geometry` without a string-literal `type`
+   discriminator, and `outStatistics` items with a non-literal
+   `statisticType` or an unknown enum value. The shim
+   `QueryCompat` accepts either ArcGIS or Honua property
+   spellings (`spatialRelationship` / `spatialRel`,
+   `outSpatialReference` / `outSr`, `num` / `resultRecordCount`,
+   `start` / `resultOffset`) so codemod output and hand-written
+   callers both validate.
 5. **Popup actions / popup templates with `actions`,
    `outFields: ["*"]` expansions, and `fieldInfos` formatters.**
    These rewrite cleanly only for the simple case; arrow-function
@@ -223,14 +236,16 @@ In rough effort order:
 | --- | --- | --- |
 | Codemod event-name remap (Task D) | 1–2 days | Pure JS-side work; needs an event-name dictionary plus AST pass. |
 | Codemod dynamic-import + CJS (Task F) | 1–2 days | Mirror the static-ESM path; care needed for awaited dynamic imports' destructuring. |
-| Query argument deep-transform (Task E) | 3–5 days | Need to fork allowlist into "rewrite" vs "passthrough" props and emit transformed sub-objects. |
+| ~~Query argument deep-transform (Task E)~~ | ~~3–5 days~~ | Shipped: codemod renames `start`/`num`/`outSpatialReference`/`spatialRelationship`, splits `geometry` into `geometry`+`geometryType`, normalizes `outStatistics[i].statisticType` against `STATISTIC_TYPE_MAP`, and emits precise manual TODOs for `timeExtent`, `quantizationParameters`, `relationParam`, dynamic statisticType, and geometry without a literal `type`. `QueryCompat` accepts both ArcGIS and Honua property spellings. |
 | Locator + Geoprocessor compat (Task C) | 1–2 weeks | Requires `HonuaGeocodeService`, `HonuaGeoprocessService` surfaces (server work). |
 | Scene-layer compat (Task A-rest) | 4–8 weeks | Requires I3S/glTF pipeline on `honua-server`; not pure-JS work. |
 | ~~E2E demo conversion harness (Task I)~~ | ~~1 week~~ | Shipped: `examples/arcgis-source-app/` + `test/migration-e2e.test.ts`, wired into the JS SDK CI workflow after the unit-test step. |
 
-Until the first three rows ship, "automated app conversion" should
-be marketed as "deterministic constructor rewrite + manual-TODO
-report," not as a one-click migration. Until the last three rows
-ship, "parity with ArcGIS JS SDK" should be qualified as
-"deterministic 2D parity; scene/3D and advanced tasks remain
-assisted migration."
+With the first three rows (Tasks D/F/E) now shipped, "automated app
+conversion" reaches deterministic constructor rewrite + event-name
+remap + dynamic/CJS imports + Query argument deep-transform, plus a
+manual-TODO report for everything else. The remaining rows
+(Locator/Geoprocessor and Scene-layer compat) still gate the
+unqualified "parity with ArcGIS JS SDK" claim — that should remain
+qualified as "deterministic 2D parity; scene/3D and advanced tasks
+remain assisted migration" until they land.

--- a/src/esri-compat/query.ts
+++ b/src/esri-compat/query.ts
@@ -7,12 +7,22 @@ export interface QueryCompatOptions {
   objectIds?: number[] | string;
   geometry?: unknown;
   spatialRelationship?: string;
+  /** Honua-side alias for `spatialRelationship`; accepted by the shim for codemod-emitted call sites. */
+  spatialRel?: string;
   outSpatialReference?: unknown;
+  /** Honua-side alias for `outSpatialReference`; accepted by the shim for codemod-emitted call sites. */
+  outSr?: unknown;
   num?: number;
+  /** Honua-side alias for `num`; accepted by the shim for codemod-emitted call sites. */
+  resultRecordCount?: number;
   start?: number;
+  /** Honua-side alias for `start`; accepted by the shim for codemod-emitted call sites. */
+  resultOffset?: number;
   timeExtent?: unknown;
   groupByFieldsForStatistics?: string | string[];
   outStatistics?: unknown[];
+  /** Honua-side companion to `geometry`; accepted alongside the ArcGIS shape. */
+  geometryType?: string;
 }
 
 export type QueryLoadStatusCompat = "not-loaded" | "loading" | "loaded";
@@ -37,6 +47,8 @@ export class QueryCompat {
   public timeExtent: unknown;
   public groupByFieldsForStatistics: string[] | undefined;
   public outStatistics: unknown[] | undefined;
+  /** Honua-side companion to `geometry`; populated when the caller passes `geometryType` explicitly. */
+  public geometryType: string | undefined;
   private readonly watchListeners: Map<string, Set<(value: unknown) => void>>;
 
   public constructor(options: QueryCompatOptions = {}) {
@@ -48,13 +60,19 @@ export class QueryCompat {
     this.orderByFields = normalizeStringList(options.orderByFields);
     this.objectIds = normalizeObjectIds(options.objectIds);
     this.geometry = options.geometry;
-    this.spatialRelationship = options.spatialRelationship;
-    this.outSpatialReference = options.outSpatialReference;
-    this.num = normalizeFiniteNumber(options.num);
-    this.start = normalizeFiniteNumber(options.start);
+    // Accept either ArcGIS `spatialRelationship` or Honua `spatialRel`; ArcGIS spelling wins when both present.
+    this.spatialRelationship = options.spatialRelationship ?? options.spatialRel;
+    // Accept either ArcGIS `outSpatialReference` or Honua `outSr`; ArcGIS spelling wins when both present.
+    this.outSpatialReference = options.outSpatialReference ?? options.outSr;
+    // Accept either ArcGIS `num` or Honua `resultRecordCount`; ArcGIS spelling wins when both present.
+    this.num = normalizeFiniteNumber(options.num ?? options.resultRecordCount);
+    // Accept either ArcGIS `start` or Honua `resultOffset`; ArcGIS spelling wins when both present.
+    this.start = normalizeFiniteNumber(options.start ?? options.resultOffset);
     this.timeExtent = options.timeExtent;
     this.groupByFieldsForStatistics = normalizeStringList(options.groupByFieldsForStatistics);
     this.outStatistics = options.outStatistics ? [...options.outStatistics] : undefined;
+    // Honua-side companion field; only populated when the caller passes it explicitly.
+    this.geometryType = typeof options.geometryType === "string" ? options.geometryType : undefined;
     this.watchListeners = new Map();
   }
 
@@ -114,6 +132,7 @@ export class QueryCompat {
       timeExtent: this.timeExtent,
       groupByFieldsForStatistics: this.groupByFieldsForStatistics ? [...this.groupByFieldsForStatistics] : undefined,
       outStatistics: this.outStatistics ? [...this.outStatistics] : undefined,
+      geometryType: this.geometryType,
     };
   }
 

--- a/src/migration/codemod.ts
+++ b/src/migration/codemod.ts
@@ -1221,6 +1221,15 @@ function codemodFile(
           end: rewriteTarget.end,
           text: spec.compatSymbol,
         });
+        if (importBinding.kind === "query") {
+          // Deep-transform Query options into the Honua QueryFeaturesRequest
+          // shape (renames + geometry split + outStatistics normalization).
+          // Validation already guaranteed every rewrite below is safe.
+          const argEdits = buildQueryArgumentRewrite(node, sourceFile, source);
+          for (const edit of argEdits) {
+            constructorEdits.push(edit);
+          }
+        }
         rewrittenKinds.push(importBinding.kind);
         return;
       }
@@ -6909,6 +6918,66 @@ function isSafeCoordinateConversionWidgetCompatCall(
   return { ok: true };
 }
 
+/**
+ * ArcGIS-side `Query` property names that map to Honua-side
+ * `QueryFeaturesRequest` field names via straightforward rename.
+ *
+ * The values are the Honua-side names. Used by both the codemod
+ * argument rewrite and the QueryCompat constructor (which accepts
+ * either spelling).
+ */
+const QUERY_ARG_RENAME_MAP: Readonly<Record<string, string>> = {
+  start: "resultOffset",
+  num: "resultRecordCount",
+  outSpatialReference: "outSr",
+  spatialRelationship: "spatialRel",
+};
+
+/** Known ArcGIS `Query.outStatistics[i].statisticType` enum values. */
+const QUERY_STATISTIC_TYPES: ReadonlySet<string> = new Set(["count", "sum", "min", "max", "avg", "stddev", "var"]);
+
+/**
+ * Maps an ArcGIS `geometry.type` discriminator to the Honua-side
+ * `EsriGeometryType` field value (which mirrors the Esri REST API).
+ */
+const QUERY_GEOMETRY_TYPE_MAP: Readonly<Record<string, string>> = {
+  point: "esriGeometryPoint",
+  multipoint: "esriGeometryMultipoint",
+  polyline: "esriGeometryPolyline",
+  polygon: "esriGeometryPolygon",
+  extent: "esriGeometryEnvelope",
+  envelope: "esriGeometryEnvelope",
+};
+
+/**
+ * Properties allowed at the top of a `new Query({ ... })` literal.
+ * Some are pass-through; some are renamed; some are split; some are
+ * always manual-TODO (kept in the allowlist so we can give a precise
+ * reason instead of a generic "unsupported properties" message).
+ */
+const QUERY_ALLOWED_PROPS: ReadonlySet<string> = new Set([
+  // pass-through (same name on both sides)
+  "where",
+  "outFields",
+  "returnGeometry",
+  "orderByFields",
+  "objectIds",
+  "groupByFieldsForStatistics",
+  "distance",
+  "units",
+  "returnDistinctValues",
+  // renamed
+  ...Object.keys(QUERY_ARG_RENAME_MAP),
+  // split into geometry + geometryType
+  "geometry",
+  // normalized inner shape
+  "outStatistics",
+  // explicitly handled (manual TODO with reason)
+  "timeExtent",
+  "quantizationParameters",
+  "relationParam",
+]);
+
 function isSafeQueryCompatCall(node: ts.NewExpression): { ok: true } | { ok: false; reason: string } {
   const args = node.arguments;
   if (!args || args.length === 0) {
@@ -6929,21 +6998,6 @@ function isSafeQueryCompatCall(node: ts.NewExpression): { ok: true } | { ok: fal
     };
   }
 
-  const allowed = new Set([
-    "where",
-    "outFields",
-    "returnGeometry",
-    "orderByFields",
-    "objectIds",
-    "geometry",
-    "spatialRelationship",
-    "outSpatialReference",
-    "num",
-    "start",
-    "timeExtent",
-    "groupByFieldsForStatistics",
-    "outStatistics",
-  ]);
   for (const property of arg.properties) {
     if (!isAssignableObjectProperty(property)) {
       return {
@@ -6953,7 +7007,7 @@ function isSafeQueryCompatCall(node: ts.NewExpression): { ok: true } | { ok: fal
     }
   }
 
-  const unsupported = collectUnsupportedPropertyNames(arg, allowed);
+  const unsupported = collectUnsupportedPropertyNames(arg, QUERY_ALLOWED_PROPS);
   if (unsupported.length > 0) {
     return {
       ok: false,
@@ -6961,7 +7015,249 @@ function isSafeQueryCompatCall(node: ts.NewExpression): { ok: true } | { ok: fal
     };
   }
 
+  // Reject divergent options up front so the caller gets a precise reason.
+  for (const property of arg.properties) {
+    const name = getObjectPropertyName(property);
+    if (name === "timeExtent") {
+      return {
+        ok: false,
+        reason:
+          "Query.timeExtent has no direct Honua QueryFeaturesRequest field; pass via `extraParams.time` and migrate manually.",
+      };
+    }
+    if (name === "quantizationParameters") {
+      return {
+        ok: false,
+        reason:
+          "Query.quantizationParameters is an ArcGIS server-side optimization hint with no Honua equivalent; remove or migrate manually.",
+      };
+    }
+    if (name === "relationParam") {
+      return {
+        ok: false,
+        reason:
+          "Query.relationParam (used with `spatialRelationship: 'relation'`) is not supported by Honua; migrate manually.",
+      };
+    }
+  }
+
+  // Validate inner shape of complex sub-objects.
+  for (const property of arg.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+    const name = getPropertyNameText(property.name);
+    if (name === "geometry") {
+      const reason = validateQueryGeometryShape(property.initializer);
+      if (reason) return { ok: false, reason };
+    }
+    if (name === "outStatistics") {
+      const reason = validateQueryOutStatisticsShape(property.initializer);
+      if (reason) return { ok: false, reason };
+    }
+  }
+
   return { ok: true };
+}
+
+function validateQueryGeometryShape(expr: ts.Expression): string | undefined {
+  if (!ts.isObjectLiteralExpression(expr)) {
+    return "Query.geometry is not an object literal; cannot split into Honua `geometry` + `geometryType`. Migrate manually.";
+  }
+  let typeProp: ts.PropertyAssignment | undefined;
+  for (const property of expr.properties) {
+    if (!isAssignableObjectProperty(property)) {
+      return "Query.geometry contains spread/method/computed property syntax; migrate manually.";
+    }
+    if (ts.isPropertyAssignment(property) && getPropertyNameText(property.name) === "type") {
+      typeProp = property;
+    }
+  }
+  if (!typeProp) {
+    return "Query.geometry is missing a `type` discriminator; Honua requires a separate `geometryType` field. Migrate manually.";
+  }
+  const typeValue = typeProp.initializer;
+  if (!ts.isStringLiteral(typeValue) && !ts.isNoSubstitutionTemplateLiteral(typeValue)) {
+    return "Query.geometry.type is not a string literal; cannot resolve Honua `geometryType` statically. Migrate manually.";
+  }
+  if (!QUERY_GEOMETRY_TYPE_MAP[typeValue.text]) {
+    return `Query.geometry.type "${typeValue.text}" is not a recognized ArcGIS geometry kind (point/polyline/polygon/extent/multipoint); migrate manually.`;
+  }
+  return undefined;
+}
+
+function validateQueryOutStatisticsShape(expr: ts.Expression): string | undefined {
+  if (!ts.isArrayLiteralExpression(expr)) {
+    return "Query.outStatistics is not an array literal; cannot validate statisticType values. Migrate manually.";
+  }
+  for (let index = 0; index < expr.elements.length; index++) {
+    const element = expr.elements[index];
+    if (!ts.isObjectLiteralExpression(element)) {
+      return `Query.outStatistics[${index}] is not an object literal; migrate manually.`;
+    }
+    let statisticTypeProp: ts.PropertyAssignment | undefined;
+    let onFieldProp: ts.PropertyAssignment | undefined;
+    for (const property of element.properties) {
+      if (!isAssignableObjectProperty(property)) {
+        return `Query.outStatistics[${index}] contains spread/method/computed property syntax; migrate manually.`;
+      }
+      if (ts.isPropertyAssignment(property)) {
+        const name = getPropertyNameText(property.name);
+        if (name === "statisticType") statisticTypeProp = property;
+        if (name === "onStatisticField") onFieldProp = property;
+      }
+    }
+    if (!statisticTypeProp) {
+      return `Query.outStatistics[${index}] is missing \`statisticType\`; migrate manually.`;
+    }
+    if (!onFieldProp) {
+      return `Query.outStatistics[${index}] is missing \`onStatisticField\`; migrate manually.`;
+    }
+    const typeExpr = statisticTypeProp.initializer;
+    if (!ts.isStringLiteral(typeExpr) && !ts.isNoSubstitutionTemplateLiteral(typeExpr)) {
+      return `Query.outStatistics[${index}].statisticType is a dynamic expression; the Honua adapter requires a known enum string. Migrate manually.`;
+    }
+    if (!QUERY_STATISTIC_TYPES.has(typeExpr.text.toLowerCase())) {
+      return `Query.outStatistics[${index}].statisticType "${typeExpr.text}" is not in Honua's STATISTIC_TYPE_MAP (count/sum/min/max/avg/stddev/var); migrate manually.`;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Build a text edit that rewrites the Query constructor argument from
+ * the ArcGIS shape into the Honua QueryFeaturesRequest shape:
+ *   - rename `start`/`num`/`outSpatialReference`/`spatialRelationship`
+ *   - split `geometry: { type, ...rest }` into `geometry: { ...rest }`
+ *     plus a sibling `geometryType: "esriGeometry…"`
+ *   - lowercase `outStatistics[i].statisticType`
+ *
+ * Callers must have already passed `isSafeQueryCompatCall`. Returns
+ * `null` when no rewrites are needed (pure pass-through).
+ */
+function buildQueryArgumentRewrite(node: ts.NewExpression, sourceFile: ts.SourceFile, source: string): TextEdit[] {
+  const edits: TextEdit[] = [];
+  const args = node.arguments;
+  if (!args || args.length === 0) return edits;
+  const [arg] = args;
+  if (!ts.isObjectLiteralExpression(arg)) return edits;
+
+  for (const property of arg.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+    const name = getPropertyNameText(property.name);
+    if (!name) continue;
+
+    // Rename of top-level property key.
+    const renamed = QUERY_ARG_RENAME_MAP[name];
+    if (renamed) {
+      edits.push({
+        start: property.name.getStart(sourceFile),
+        end: property.name.getEnd(),
+        text: renamed,
+      });
+      continue;
+    }
+
+    if (name === "geometry" && ts.isObjectLiteralExpression(property.initializer)) {
+      const geometryEdits = buildGeometrySplitEdits(property, sourceFile, source);
+      edits.push(...geometryEdits);
+      continue;
+    }
+
+    if (name === "outStatistics" && ts.isArrayLiteralExpression(property.initializer)) {
+      edits.push(...buildOutStatisticsNormalizationEdits(property.initializer, sourceFile));
+    }
+  }
+
+  return edits;
+}
+
+function buildGeometrySplitEdits(
+  property: ts.PropertyAssignment,
+  sourceFile: ts.SourceFile,
+  source: string,
+): TextEdit[] {
+  const literal = property.initializer as ts.ObjectLiteralExpression;
+  let typeProp: ts.PropertyAssignment | undefined;
+  for (const prop of literal.properties) {
+    if (ts.isPropertyAssignment(prop) && getPropertyNameText(prop.name) === "type") {
+      typeProp = prop;
+      break;
+    }
+  }
+  if (!typeProp) return [];
+  const typeInit = typeProp.initializer;
+  if (!ts.isStringLiteral(typeInit) && !ts.isNoSubstitutionTemplateLiteral(typeInit)) {
+    return [];
+  }
+  const honuaType = QUERY_GEOMETRY_TYPE_MAP[typeInit.text];
+  if (!honuaType) return [];
+
+  const edits: TextEdit[] = [];
+
+  // Remove the `type: "..."` property from the geometry object literal,
+  // including its trailing comma + whitespace if present.
+  const removeStart = typeProp.getStart(sourceFile);
+  let removeEnd = typeProp.getEnd();
+  // Swallow a trailing comma immediately after the property.
+  while (removeEnd < source.length && /[\s]/.test(source.charAt(removeEnd))) {
+    removeEnd++;
+  }
+  if (source.charAt(removeEnd) === ",") {
+    removeEnd++;
+    // Eat one trailing space if it looks like single-line layout.
+    if (source.charAt(removeEnd) === " ") removeEnd++;
+  } else {
+    // If there's no trailing comma, also remove the leading comma+space
+    // before this property so we don't leave a dangling `,` from a
+    // preceding sibling.
+    let before = removeStart - 1;
+    while (before >= 0 && /[ \t]/.test(source.charAt(before))) before--;
+    if (before >= 0 && source.charAt(before) === ",") {
+      // Trim back the leading whitespace + comma.
+      removeEnd = typeProp.getEnd();
+      const preceding = before + 1;
+      // Reset removeStart to start at the leading comma's position.
+      edits.push({ start: before, end: removeStart, text: "" });
+      // Keep removeStart unchanged in the property-removal edit below.
+      // (We still need to drop the property itself.)
+      void preceding;
+    }
+  }
+  edits.push({ start: removeStart, end: removeEnd, text: "" });
+
+  // Append a sibling `geometryType: "..."` directly after the geometry
+  // property's closing token in the outer Query options literal.
+  const insertAt = property.getEnd();
+  edits.push({
+    start: insertAt,
+    end: insertAt,
+    text: `, geometryType: "${honuaType}"`,
+  });
+
+  return edits;
+}
+
+function buildOutStatisticsNormalizationEdits(
+  arrayLiteral: ts.ArrayLiteralExpression,
+  sourceFile: ts.SourceFile,
+): TextEdit[] {
+  const edits: TextEdit[] = [];
+  for (const element of arrayLiteral.elements) {
+    if (!ts.isObjectLiteralExpression(element)) continue;
+    for (const prop of element.properties) {
+      if (!ts.isPropertyAssignment(prop)) continue;
+      if (getPropertyNameText(prop.name) !== "statisticType") continue;
+      const init = prop.initializer;
+      if (!ts.isStringLiteral(init) && !ts.isNoSubstitutionTemplateLiteral(init)) continue;
+      const lower = init.text.toLowerCase();
+      if (lower === init.text) continue;
+      edits.push({
+        start: init.getStart(sourceFile),
+        end: init.getEnd(),
+        text: `"${lower}"`,
+      });
+    }
+  }
+  return edits;
 }
 
 function isSafeOAuthInfoCompatCall(node: ts.NewExpression): { ok: true } | { ok: false; reason: string } {

--- a/test/migration-codemod.test.ts
+++ b/test/migration-codemod.test.ts
@@ -4008,4 +4008,204 @@ describe("runEsriCompatCodemod", () => {
     expect(nextSource).toContain("new FeatureLayer({");
     expect(nextSource).not.toContain("new FeatureLayerCompat");
   });
+
+  it("renames Query property keys to their Honua QueryFeaturesRequest counterparts", () => {
+    const root = makeTempProject();
+    const file = path.join(root, "query-rename.ts");
+    fs.writeFileSync(
+      file,
+      [
+        "import Query from '@arcgis/core/rest/support/Query';",
+        "const q = new Query({",
+        "  where: \"status = 'active'\",",
+        "  start: 0,",
+        "  num: 50,",
+        "  outSpatialReference: { wkid: 3857 },",
+        "  spatialRelationship: 'intersects',",
+        "});",
+        "void q;",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = runEsriCompatCodemod({
+      rootDir: root,
+      write: true,
+      compatImportPath: "@honua/sdk-esri-compat",
+    });
+
+    expect(result.metrics.autoMigratedCallSites).toBe(1);
+    expect(result.metrics.manualCallSites).toBe(0);
+
+    const nextSource = fs.readFileSync(file, "utf8");
+    expect(nextSource).toContain("resultOffset: 0");
+    expect(nextSource).toContain("resultRecordCount: 50");
+    expect(nextSource).toContain("outSr: { wkid: 3857 }");
+    expect(nextSource).toContain("spatialRel: 'intersects'");
+    expect(nextSource).not.toMatch(/\bstart:/);
+    expect(nextSource).not.toMatch(/\bnum:/);
+    expect(nextSource).not.toContain("outSpatialReference");
+    expect(nextSource).not.toContain("spatialRelationship");
+  });
+
+  it("auto-migrates Query.outStatistics with a known statisticType literal", () => {
+    const root = makeTempProject();
+    const file = path.join(root, "query-stats.ts");
+    fs.writeFileSync(
+      file,
+      [
+        "import Query from '@arcgis/core/rest/support/Query';",
+        "const q = new Query({",
+        "  outStatistics: [{ statisticType: 'Sum', onStatisticField: 'POP', outStatisticFieldName: 'totalPop' }],",
+        "});",
+        "void q;",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = runEsriCompatCodemod({
+      rootDir: root,
+      write: true,
+      compatImportPath: "@honua/sdk-esri-compat",
+    });
+
+    expect(result.metrics.autoMigratedCallSites).toBe(1);
+    expect(result.metrics.manualCallSites).toBe(0);
+
+    const nextSource = fs.readFileSync(file, "utf8");
+    expect(nextSource).toContain('statisticType: "sum"');
+    expect(nextSource).not.toContain("statisticType: 'Sum'");
+  });
+
+  it("emits manual TODO for Query.outStatistics with a dynamic statisticType", () => {
+    const root = makeTempProject();
+    const file = path.join(root, "query-stats-dynamic.ts");
+    fs.writeFileSync(
+      file,
+      [
+        "import Query from '@arcgis/core/rest/support/Query';",
+        "const kind = 'sum';",
+        "const q = new Query({",
+        "  outStatistics: [{ statisticType: kind, onStatisticField: 'POP', outStatisticFieldName: 'totalPop' }],",
+        "});",
+        "void q;",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = runEsriCompatCodemod({
+      rootDir: root,
+      write: false,
+      compatImportPath: "@honua/sdk-esri-compat",
+    });
+
+    expect(result.metrics.autoMigratedCallSites).toBe(0);
+    expect(result.metrics.manualCallSites).toBe(1);
+    expect(result.manualTodos).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "query",
+          reason: expect.stringContaining("dynamic expression"),
+        }),
+      ]),
+    );
+  });
+
+  it("splits Query.geometry { type, ... } into geometry + geometryType", () => {
+    const root = makeTempProject();
+    const file = path.join(root, "query-geometry.ts");
+    fs.writeFileSync(
+      file,
+      [
+        "import Query from '@arcgis/core/rest/support/Query';",
+        "const q = new Query({",
+        "  geometry: { type: 'polygon', rings: [[[0, 0], [10, 0], [10, 10], [0, 0]]] },",
+        "});",
+        "void q;",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = runEsriCompatCodemod({
+      rootDir: root,
+      write: true,
+      compatImportPath: "@honua/sdk-esri-compat",
+    });
+
+    expect(result.metrics.autoMigratedCallSites).toBe(1);
+    expect(result.metrics.manualCallSites).toBe(0);
+
+    const nextSource = fs.readFileSync(file, "utf8");
+    expect(nextSource).toContain('geometryType: "esriGeometryPolygon"');
+    expect(nextSource).toContain("rings: [[[0, 0], [10, 0], [10, 10], [0, 0]]]");
+    expect(nextSource).not.toContain("type: 'polygon'");
+  });
+
+  it("emits manual TODO for Query.timeExtent (no direct Honua field)", () => {
+    const root = makeTempProject();
+    const file = path.join(root, "query-time.ts");
+    fs.writeFileSync(
+      file,
+      [
+        "import Query from '@arcgis/core/rest/support/Query';",
+        "const q = new Query({",
+        "  where: '1=1',",
+        "  timeExtent: { start: new Date(2020, 0, 1), end: new Date(2020, 11, 31) },",
+        "});",
+        "void q;",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = runEsriCompatCodemod({
+      rootDir: root,
+      write: false,
+      compatImportPath: "@honua/sdk-esri-compat",
+    });
+
+    expect(result.metrics.autoMigratedCallSites).toBe(0);
+    expect(result.metrics.manualCallSites).toBe(1);
+    expect(result.manualTodos).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "query",
+          reason: expect.stringContaining("timeExtent"),
+        }),
+      ]),
+    );
+  });
+
+  it("emits manual TODO for Query.quantizationParameters", () => {
+    const root = makeTempProject();
+    const file = path.join(root, "query-quant.ts");
+    fs.writeFileSync(
+      file,
+      [
+        "import Query from '@arcgis/core/rest/support/Query';",
+        "const q = new Query({",
+        "  where: '1=1',",
+        "  quantizationParameters: { mode: 'view', originPosition: 'upperLeft' },",
+        "});",
+        "void q;",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = runEsriCompatCodemod({
+      rootDir: root,
+      write: false,
+      compatImportPath: "@honua/sdk-esri-compat",
+    });
+
+    expect(result.metrics.autoMigratedCallSites).toBe(0);
+    expect(result.metrics.manualCallSites).toBe(1);
+    expect(result.manualTodos).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "query",
+          reason: expect.stringContaining("quantizationParameters"),
+        }),
+      ]),
+    );
+  });
 });

--- a/test/query-compat.test.ts
+++ b/test/query-compat.test.ts
@@ -57,6 +57,37 @@ describe("QueryCompat", () => {
     expect(query.start).toBe(5);
   });
 
+  it("accepts Honua-side aliases (resultOffset/resultRecordCount/outSr/spatialRel) interchangeably with ArcGIS spellings", () => {
+    const honuaShape = new QueryCompat({
+      resultOffset: 100,
+      resultRecordCount: 25,
+      outSr: { wkid: 3857 },
+      spatialRel: "esriSpatialRelIntersects",
+      geometryType: "esriGeometryPolygon",
+    });
+    expect(honuaShape.start).toBe(100);
+    expect(honuaShape.num).toBe(25);
+    expect(honuaShape.outSpatialReference).toEqual({ wkid: 3857 });
+    expect(honuaShape.spatialRelationship).toBe("esriSpatialRelIntersects");
+    expect(honuaShape.geometryType).toBe("esriGeometryPolygon");
+
+    // ArcGIS spelling takes precedence when both forms are present.
+    const ambiguous = new QueryCompat({
+      start: 5,
+      resultOffset: 999,
+      num: 10,
+      resultRecordCount: 999,
+      spatialRelationship: "intersects",
+      spatialRel: "contains",
+      outSpatialReference: { wkid: 4326 },
+      outSr: { wkid: 3857 },
+    });
+    expect(ambiguous.start).toBe(5);
+    expect(ambiguous.num).toBe(10);
+    expect(ambiguous.spatialRelationship).toBe("intersects");
+    expect(ambiguous.outSpatialReference).toEqual({ wkid: 4326 });
+  });
+
   it("clones and serializes safely", () => {
     const query = new QueryCompat({
       outFields: ["OBJECTID", "status"],


### PR DESCRIPTION
## Summary

Lands Task E from the migration punch list: the codemod's `Query` handler now validates and rewrites the constructor argument literal into the Honua `QueryFeaturesRequest` shape, instead of allowing-but-passing-through complex sub-objects.

This stacks on the in-flight branch work behind PR #210 (the parity-shims branch). The diff is on top of the most recent commits there (`cb60be4`).

### Divergence table implemented

| ArcGIS `Query.*` | Honua `QueryFeaturesRequest.*` | Codemod action |
| --- | --- | --- |
| `start` | `resultOffset` | rename |
| `num` | `resultRecordCount` | rename |
| `outSpatialReference` | `outSr` | rename |
| `spatialRelationship` | `spatialRel` | rename |
| `geometry: { type, ...rest }` | `geometry: { ...rest }` + `geometryType` | split (mapping `point`/`polyline`/`polygon`/`extent`/`multipoint` to the `esriGeometry*` enum) |
| `outStatistics[i].statisticType` | same field name | lowercase + validate against `STATISTIC_TYPE_MAP` (count/sum/min/max/avg/stddev/var) |
| `where`, `outFields`, `returnGeometry`, `orderByFields`, `objectIds`, `groupByFieldsForStatistics`, `distance`, `units`, `returnDistinctValues` | same | pass-through |

### Manual-TODO reasons (intentionally not auto-rewritten)

- **`timeExtent`** — no direct Honua field; should be passed via `extraParams.time`. Auto-rewriting the value into a key the server expects requires synthesizing a string from arbitrary `Date`/`number` expressions, which we cannot safely do statically.
- **`quantizationParameters`** — ArcGIS server-side optimization hint with no Honua equivalent. Silently dropping it would hide a perf regression.
- **`relationParam`** — only valid with `spatialRelationship: "relation"`, which Honua does not support.
- **`geometry` without a string-literal `type`** — we cannot resolve the `esriGeometry*` enum statically.
- **`outStatistics[i].statisticType` as identifier/expression** — the Honua gRPC adapter requires a known enum string; arbitrary identifiers can't be validated at codemod time.
- **`outStatistics[i].statisticType` as a string outside `{count, sum, min, max, avg, stddev, var}`** — would throw at runtime in `toProtoQueryRequest`; surface it as a TODO instead.

### Compat side

`QueryCompat` now accepts the Honua-side spellings (`resultOffset`, `resultRecordCount`, `outSr`, `spatialRel`, `geometryType`) as alternate aliases of the ArcGIS-side properties. ArcGIS spellings win when both forms are present. Each alias is documented with a one-line comment.

### Tests

- `test/migration-codemod.test.ts` (+6 cases): rename map, outStatistics auto-migration, outStatistics dynamic TODO, geometry split, timeExtent TODO, quantizationParameters TODO.
- `test/query-compat.test.ts` (+1 case): QueryCompat round-trips Honua-side aliases and ArcGIS-spelling-wins precedence.

### Docs

- `docs/migration-punch-list.md`: parity-gap item 4 flipped from open to shipped; the effort-order table row for Task E is struck through with a summary of what shipped; the closing paragraph reflects that Tasks D/F/E are now done.

## Test plan

- [x] `npx vitest run test/migration-codemod.test.ts test/migration-integration.test.ts test/migration-report.test.ts test/migration-gating.test.ts test/migration-parity-matrix.test.ts test/migration-e2e.test.ts test/query-compat.test.ts` — 139 passed.
- [x] `npx vitest run` — full suite 1892 passed.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx biome check src/migration/ src/esri-compat/query.ts test/` — clean.

Generated with Claude Code.