### PR TITLE
feat(migration): per-sample evidence emitter for Esri sample corpus

### DIFF
--- a/docs/esri-sample-corpus.md
+++ b/docs/esri-sample-corpus.md
@@ -52,6 +52,41 @@ void summary;
 void analysis;
 ```
 
+## Per-sample evidence
+
+For each curated sample, the migration entrypoint can run the existing codemod
+against the local fixture and emit a structured evidence record:
+
+```ts
+import { emitEsriSampleCorpusEvidence } from "@honua/sdk-js/migration";
+
+const evidence = emitEsriSampleCorpusEvidence({
+  manifestPath: "test/fixtures/esri-sample-corpus/manifest.json",
+  // Defaults to "honua-maplibre". Other codemod targets are also accepted.
+});
+
+for (const sample of evidence.samples) {
+  // sample.status === "migrated" | "skipped" | "error"
+  // sample.classification.auto / manual / unsupported
+  // sample.manualTodos.reasons (deduped by reason, includes affected kinds)
+  // sample.referencedServices / sample.portalItems / sample.guardrailFlags
+  // sample.urlRewriteSummary.byKind / sample.unsupportedApis
+}
+
+// Aggregate across the corpus — per-status counts always sum to the manifest
+// length, and unsupported APIs are deduplicated.
+const { statusCounts, totals, uniqueUnsupportedApis } = evidence.aggregate;
+void statusCounts;
+void totals;
+void uniqueUnsupportedApis;
+```
+
+Samples whose manifest entry is `status: "skipped"` (private-portal, routing
+API-key, premium-service, etc.) appear in the evidence record with
+`status: "skipped"` and the manifest skip reason — they always count toward the
+aggregate, but never as `migrated`. No live Esri services are contacted; the
+helper operates entirely on the committed fixture corpus.
+
 ## Live Evidence Lanes
 
 Live Esri sample/service evidence is reserved for scheduled or manual runs. A

--- a/src/migration-entry.ts
+++ b/src/migration-entry.ts
@@ -134,6 +134,23 @@ export type {
   PortalItemReference,
 } from "./migration/sample-corpus.js";
 export {
+  buildEsriSampleCorpusEvidence,
+  emitEsriSampleCorpusEvidence,
+} from "./migration/sample-corpus-evidence.js";
+export type {
+  BuildEsriSampleCorpusEvidenceOptions,
+  EmitEsriSampleCorpusEvidenceOptions,
+  EsriSampleCorpusEvidence,
+  EsriSampleEvidenceAggregate,
+  EsriSampleEvidenceClassification,
+  EsriSampleEvidenceManualTodoReason,
+  EsriSampleEvidenceManualTodos,
+  EsriSampleEvidenceRecord,
+  EsriSampleEvidenceStatus,
+  EsriSampleEvidenceStatusCounts,
+  EsriSampleEvidenceUrlRewriteSummary,
+} from "./migration/sample-corpus-evidence.js";
+export {
   MIGRATION_DEMO_FALLBACK_TARGET,
   MIGRATION_DEMO_ISSUE_NUMBER,
   MIGRATION_DEMO_PRIMARY_TARGET,

--- a/src/migration/sample-corpus-evidence.ts
+++ b/src/migration/sample-corpus-evidence.ts
@@ -1,0 +1,361 @@
+import path from "node:path";
+
+import {
+  type CodemodConstructorKind,
+  type CodemodTarget,
+  type EsriCompatCodemodResult,
+  type MigrationTodo,
+  runEsriCompatCodemod,
+} from "./codemod.js";
+import {
+  type ArcGisServiceReference,
+  type EsriSampleCorpusManifest,
+  type EsriSampleCorpusSample,
+  type EsriSampleFixtureAnalysis,
+  type EsriSampleGuardrailFlag,
+  type EsriSampleLicenseMetadata,
+  type EsriSampleSkipReason,
+  type EsriSampleSourceReference,
+  type EsriSampleTermsMetadata,
+  type PortalItemReference,
+  analyzeEsriSampleFixture,
+  loadEsriSampleCorpusManifest,
+} from "./sample-corpus.js";
+
+const DEFAULT_CODEMOD_TARGET: CodemodTarget = "honua-maplibre";
+
+// Skip reasons that prevent the codemod from running against a sample. These
+// correspond to samples that would require Esri credentials, premium service
+// access, or private Portal content to even render — the codemod has nothing
+// useful to say about them in a fixture-only lane, so we record them as
+// `status: "skipped"` evidence and surface the manifest skip reasons.
+const RUN_BLOCKING_SKIP_REASONS: ReadonlySet<EsriSampleSkipReason> = new Set([
+  "requires-api-key",
+  "requires-oauth",
+  "premium-service",
+  "private-content",
+  "unclear-content-terms",
+  "unsupported-sample-family",
+]);
+
+export type EsriSampleEvidenceStatus = "migrated" | "skipped" | "error";
+
+export interface EsriSampleEvidenceClassification {
+  auto: number;
+  manual: number;
+  unsupported: number;
+}
+
+export interface EsriSampleEvidenceManualTodoReason {
+  reason: string;
+  count: number;
+  kinds: CodemodConstructorKind[];
+}
+
+export interface EsriSampleEvidenceManualTodos {
+  total: number;
+  reasons: EsriSampleEvidenceManualTodoReason[];
+}
+
+export interface EsriSampleEvidenceUrlRewriteSummary {
+  total: number;
+  byKind: Record<string, number>;
+}
+
+export interface EsriSampleEvidenceRecord {
+  sampleId: string;
+  status: EsriSampleEvidenceStatus;
+  reason?: string;
+  codemodTarget: CodemodTarget;
+  sourceRef: EsriSampleSourceReference;
+  license: EsriSampleLicenseMetadata;
+  terms: EsriSampleTermsMetadata;
+  skipReasons: EsriSampleSkipReason[];
+  classification: EsriSampleEvidenceClassification;
+  manualTodos: EsriSampleEvidenceManualTodos;
+  referencedServices: ArcGisServiceReference[];
+  portalItems: PortalItemReference[];
+  guardrailFlags: EsriSampleGuardrailFlag[];
+  urlRewriteSummary: EsriSampleEvidenceUrlRewriteSummary;
+  unsupportedApis: string[];
+  filesScanned: number;
+  filesChanged: number;
+}
+
+export interface EsriSampleEvidenceStatusCounts {
+  migrated: number;
+  skipped: number;
+  error: number;
+}
+
+export interface EsriSampleEvidenceAggregate {
+  sampleCount: number;
+  codemodTarget: CodemodTarget;
+  statusCounts: EsriSampleEvidenceStatusCounts;
+  totals: EsriSampleEvidenceClassification;
+  manualTodoTotal: number;
+  uniqueUnsupportedApis: string[];
+}
+
+export interface EsriSampleCorpusEvidence {
+  manifestPath?: string;
+  codemodTarget: CodemodTarget;
+  samples: EsriSampleEvidenceRecord[];
+  aggregate: EsriSampleEvidenceAggregate;
+}
+
+export interface EmitEsriSampleCorpusEvidenceOptions {
+  manifestPath: string;
+  codemodTarget?: CodemodTarget;
+}
+
+export interface BuildEsriSampleCorpusEvidenceOptions {
+  manifest: EsriSampleCorpusManifest;
+  manifestDir: string;
+  codemodTarget?: CodemodTarget;
+}
+
+/**
+ * Loads the curated manifest from `manifestPath`, runs the migration codemod
+ * (default target: `honua-maplibre`) against each runnable fixture, and emits
+ * a structured per-sample + aggregate evidence record. Skipped samples are
+ * surfaced as `status: "skipped"` with the manifest skip reason; no live Esri
+ * services are contacted.
+ */
+export function emitEsriSampleCorpusEvidence(options: EmitEsriSampleCorpusEvidenceOptions): EsriSampleCorpusEvidence {
+  const manifest = loadEsriSampleCorpusManifest(options.manifestPath);
+  const manifestDir = path.dirname(path.resolve(options.manifestPath));
+  const evidence = buildEsriSampleCorpusEvidence({
+    manifest,
+    manifestDir,
+    codemodTarget: options.codemodTarget,
+  });
+  return {
+    ...evidence,
+    manifestPath: path.resolve(options.manifestPath),
+  };
+}
+
+/**
+ * Build evidence directly from an already-loaded manifest. Useful when the
+ * caller has already parsed the manifest and wants to avoid re-reading from
+ * disk. Behaves identically to `emitEsriSampleCorpusEvidence` otherwise.
+ */
+export function buildEsriSampleCorpusEvidence(options: BuildEsriSampleCorpusEvidenceOptions): EsriSampleCorpusEvidence {
+  const codemodTarget = options.codemodTarget ?? DEFAULT_CODEMOD_TARGET;
+  const samples = options.manifest.samples.map((sample) =>
+    buildSampleEvidence(sample, options.manifestDir, codemodTarget),
+  );
+  const aggregate = summarizeEvidence(samples, codemodTarget);
+  return {
+    codemodTarget,
+    samples,
+    aggregate,
+  };
+}
+
+function buildSampleEvidence(
+  sample: EsriSampleCorpusSample,
+  manifestDir: string,
+  codemodTarget: CodemodTarget,
+): EsriSampleEvidenceRecord {
+  const analysis = analyzeEsriSampleFixture(sample, { manifestDir });
+  const skipReason = resolveSkipReason(sample);
+
+  if (skipReason) {
+    return buildSkippedEvidence(sample, analysis, codemodTarget, skipReason);
+  }
+
+  let codemodResult: EsriCompatCodemodResult;
+  try {
+    codemodResult = runEsriCompatCodemod({
+      rootDir: path.resolve(manifestDir, sample.fixture.root),
+      target: codemodTarget,
+      write: false,
+      annotateTodos: false,
+    });
+  } catch (error) {
+    return buildErrorEvidence(sample, analysis, codemodTarget, error);
+  }
+
+  return buildMigratedEvidence(sample, analysis, codemodTarget, codemodResult);
+}
+
+function buildMigratedEvidence(
+  sample: EsriSampleCorpusSample,
+  analysis: EsriSampleFixtureAnalysis,
+  codemodTarget: CodemodTarget,
+  codemodResult: EsriCompatCodemodResult,
+): EsriSampleEvidenceRecord {
+  const metrics = codemodResult.metrics;
+  const classification: EsriSampleEvidenceClassification = {
+    auto: metrics.autoMigratedCallSites,
+    manual: metrics.manualCallSites,
+    unsupported: countUnsupportedCallSites(codemodResult.manualTodos),
+  };
+  const manualTodos = summarizeManualTodos(codemodResult.manualTodos);
+  const unsupportedApis = collectUnsupportedApis(codemodResult.manualTodos);
+  const urlRewriteSummary = buildUrlRewriteSummary(analysis.serviceUrls);
+
+  return {
+    sampleId: sample.id,
+    status: "migrated",
+    codemodTarget,
+    sourceRef: sample.source,
+    license: sample.license,
+    terms: sample.terms,
+    skipReasons: analysis.skipReasons,
+    classification,
+    manualTodos,
+    referencedServices: analysis.serviceUrls,
+    portalItems: analysis.portalItems,
+    guardrailFlags: analysis.guardrailFlags,
+    urlRewriteSummary,
+    unsupportedApis,
+    filesScanned: codemodResult.filesScanned,
+    filesChanged: codemodResult.filesChanged,
+  };
+}
+
+function buildSkippedEvidence(
+  sample: EsriSampleCorpusSample,
+  analysis: EsriSampleFixtureAnalysis,
+  codemodTarget: CodemodTarget,
+  reason: string,
+): EsriSampleEvidenceRecord {
+  return {
+    sampleId: sample.id,
+    status: "skipped",
+    reason,
+    codemodTarget,
+    sourceRef: sample.source,
+    license: sample.license,
+    terms: sample.terms,
+    skipReasons: analysis.skipReasons,
+    classification: { auto: 0, manual: 0, unsupported: 0 },
+    manualTodos: { total: 0, reasons: [] },
+    referencedServices: analysis.serviceUrls,
+    portalItems: analysis.portalItems,
+    guardrailFlags: analysis.guardrailFlags,
+    urlRewriteSummary: buildUrlRewriteSummary(analysis.serviceUrls),
+    unsupportedApis: [],
+    filesScanned: analysis.filesScanned,
+    filesChanged: 0,
+  };
+}
+
+function buildErrorEvidence(
+  sample: EsriSampleCorpusSample,
+  analysis: EsriSampleFixtureAnalysis,
+  codemodTarget: CodemodTarget,
+  error: unknown,
+): EsriSampleEvidenceRecord {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    sampleId: sample.id,
+    status: "error",
+    reason: `codemod failed: ${message}`,
+    codemodTarget,
+    sourceRef: sample.source,
+    license: sample.license,
+    terms: sample.terms,
+    skipReasons: analysis.skipReasons,
+    classification: { auto: 0, manual: 0, unsupported: 0 },
+    manualTodos: { total: 0, reasons: [] },
+    referencedServices: analysis.serviceUrls,
+    portalItems: analysis.portalItems,
+    guardrailFlags: analysis.guardrailFlags,
+    urlRewriteSummary: buildUrlRewriteSummary(analysis.serviceUrls),
+    unsupportedApis: [],
+    filesScanned: analysis.filesScanned,
+    filesChanged: 0,
+  };
+}
+
+function resolveSkipReason(sample: EsriSampleCorpusSample): string | undefined {
+  if (sample.status !== "skipped") {
+    return undefined;
+  }
+  const reasons = sample.skipReasons ?? [];
+  const blocking = reasons.filter((reason) => RUN_BLOCKING_SKIP_REASONS.has(reason));
+  if (blocking.length === 0) {
+    // Sample is marked skipped but doesn't list a run-blocking reason — record
+    // the raw manifest reasons (or a generic fallback) so callers can still
+    // see why CI elected to skip it.
+    return reasons.length > 0 ? reasons.join(", ") : "manifest marks sample as skipped";
+  }
+  return blocking.join(", ");
+}
+
+function countUnsupportedCallSites(todos: readonly MigrationTodo[]): number {
+  return todos.filter((todo) => todo.difficulty === "complex").length;
+}
+
+function summarizeManualTodos(todos: readonly MigrationTodo[]): EsriSampleEvidenceManualTodos {
+  const grouped = new Map<string, { count: number; kinds: Set<CodemodConstructorKind> }>();
+  for (const todo of todos) {
+    let bucket = grouped.get(todo.reason);
+    if (!bucket) {
+      bucket = { count: 0, kinds: new Set<CodemodConstructorKind>() };
+      grouped.set(todo.reason, bucket);
+    }
+    bucket.count += 1;
+    bucket.kinds.add(todo.kind);
+  }
+
+  const reasons = Array.from(grouped.entries())
+    .map(([reason, bucket]) => ({
+      reason,
+      count: bucket.count,
+      kinds: Array.from(bucket.kinds).sort(),
+    }))
+    .sort((a, b) => (a.count === b.count ? a.reason.localeCompare(b.reason) : b.count - a.count));
+
+  return { total: todos.length, reasons };
+}
+
+function collectUnsupportedApis(todos: readonly MigrationTodo[]): string[] {
+  const kinds = new Set<CodemodConstructorKind>();
+  for (const todo of todos) {
+    kinds.add(todo.kind);
+  }
+  return Array.from(kinds).sort();
+}
+
+function buildUrlRewriteSummary(services: readonly ArcGisServiceReference[]): EsriSampleEvidenceUrlRewriteSummary {
+  const byKind: Record<string, number> = {};
+  for (const service of services) {
+    byKind[service.kind] = (byKind[service.kind] ?? 0) + 1;
+  }
+  return { total: services.length, byKind };
+}
+
+function summarizeEvidence(
+  samples: readonly EsriSampleEvidenceRecord[],
+  codemodTarget: CodemodTarget,
+): EsriSampleEvidenceAggregate {
+  const statusCounts: EsriSampleEvidenceStatusCounts = { migrated: 0, skipped: 0, error: 0 };
+  const totals: EsriSampleEvidenceClassification = { auto: 0, manual: 0, unsupported: 0 };
+  let manualTodoTotal = 0;
+  const uniqueUnsupportedApis = new Set<string>();
+
+  for (const sample of samples) {
+    statusCounts[sample.status] += 1;
+    totals.auto += sample.classification.auto;
+    totals.manual += sample.classification.manual;
+    totals.unsupported += sample.classification.unsupported;
+    manualTodoTotal += sample.manualTodos.total;
+    for (const api of sample.unsupportedApis) {
+      uniqueUnsupportedApis.add(api);
+    }
+  }
+
+  return {
+    sampleCount: samples.length,
+    codemodTarget,
+    statusCounts,
+    totals,
+    manualTodoTotal,
+    uniqueUnsupportedApis: Array.from(uniqueUnsupportedApis).sort(),
+  };
+}

--- a/test/migration-sample-corpus-evidence.test.ts
+++ b/test/migration-sample-corpus-evidence.test.ts
@@ -1,0 +1,104 @@
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { emitEsriSampleCorpusEvidence } from "../src/migration/sample-corpus-evidence.js";
+import { loadEsriSampleCorpusManifest } from "../src/migration/sample-corpus.js";
+
+const corpusRoot = path.join(import.meta.dirname, "fixtures", "esri-sample-corpus");
+const manifestPath = path.join(corpusRoot, "manifest.json");
+
+describe("Esri sample corpus per-sample evidence", () => {
+  it("runs the migration codemod against the public feature-layer fixture and records plausible evidence", () => {
+    const evidence = emitEsriSampleCorpusEvidence({ manifestPath });
+    const record = evidence.samples.find((sample) => sample.sampleId === "feature-layer-popup-public");
+
+    expect(record).toBeDefined();
+    if (!record) {
+      return;
+    }
+
+    expect(record.status).toBe("migrated");
+    expect(record.codemodTarget).toBe("honua-maplibre");
+    expect(record.sourceRef.url).toMatch(/developers\.arcgis\.com/);
+    expect(record.license.notice).toMatch(/Do not vendor Esri sample source/);
+    expect(record.skipReasons).toEqual([]);
+
+    // Auto + manual + unsupported counts must be non-negative numbers and the
+    // codemod must have scanned at least the entrypoint file. Exact values
+    // intentionally not asserted — they will shift as the codemod evolves.
+    expect(record.filesScanned).toBeGreaterThan(0);
+    expect(record.classification.auto).toBeGreaterThanOrEqual(0);
+    expect(record.classification.manual).toBeGreaterThanOrEqual(0);
+    expect(record.classification.unsupported).toBeGreaterThanOrEqual(0);
+    expect(record.classification.auto + record.classification.manual).toBeGreaterThan(0);
+
+    // Structural checks on derived fields.
+    expect(Array.isArray(record.unsupportedApis)).toBe(true);
+    for (const api of record.unsupportedApis) {
+      expect(typeof api).toBe("string");
+    }
+    expect(record.manualTodos.total).toBe(record.classification.manual);
+    expect(record.referencedServices.map((service) => service.kind)).toContain("FeatureServer");
+    expect(record.urlRewriteSummary.total).toBe(record.referencedServices.length);
+    expect(record.urlRewriteSummary.byKind.FeatureServer).toBeGreaterThanOrEqual(1);
+    expect(record.portalItems).toEqual([{ id: "0123456789abcdef0123456789abcdef" }]);
+  });
+
+  it("records skipped samples with status 'skipped' and the manifest skip reason", () => {
+    const manifest = loadEsriSampleCorpusManifest(manifestPath);
+    const evidence = emitEsriSampleCorpusEvidence({ manifestPath });
+
+    const routingRecord = evidence.samples.find((sample) => sample.sampleId === "routing-api-key-skipped");
+    const portalRecord = evidence.samples.find((sample) => sample.sampleId === "private-portal-skipped");
+
+    expect(routingRecord).toBeDefined();
+    expect(portalRecord).toBeDefined();
+    if (!routingRecord || !portalRecord) {
+      return;
+    }
+
+    const routingManifest = manifest.samples.find((sample) => sample.id === "routing-api-key-skipped");
+    const portalManifest = manifest.samples.find((sample) => sample.id === "private-portal-skipped");
+
+    expect(routingRecord.status).toBe("skipped");
+    expect(routingRecord.skipReasons).toEqual(routingManifest?.skipReasons);
+    expect(routingRecord.reason).toContain("requires-api-key");
+    expect(routingRecord.reason).toContain("premium-service");
+    expect(routingRecord.classification).toEqual({ auto: 0, manual: 0, unsupported: 0 });
+    expect(routingRecord.manualTodos.total).toBe(0);
+    expect(routingRecord.unsupportedApis).toEqual([]);
+
+    expect(portalRecord.status).toBe("skipped");
+    expect(portalRecord.skipReasons).toEqual(portalManifest?.skipReasons);
+    expect(portalRecord.reason).toContain("requires-oauth");
+    expect(portalRecord.reason).toContain("private-content");
+  });
+
+  it("aggregates per-status counts that sum to the manifest length and dedupes unsupported APIs", () => {
+    const manifest = loadEsriSampleCorpusManifest(manifestPath);
+    const evidence = emitEsriSampleCorpusEvidence({ manifestPath });
+    const { aggregate } = evidence;
+
+    expect(aggregate.sampleCount).toBe(manifest.samples.length);
+    expect(aggregate.codemodTarget).toBe("honua-maplibre");
+
+    const summedStatus =
+      aggregate.statusCounts.migrated + aggregate.statusCounts.skipped + aggregate.statusCounts.error;
+    expect(summedStatus).toBe(manifest.samples.length);
+    expect(aggregate.statusCounts.migrated).toBeGreaterThanOrEqual(1);
+    expect(aggregate.statusCounts.skipped).toBeGreaterThanOrEqual(2);
+    expect(aggregate.statusCounts.error).toBe(0);
+
+    // Totals are non-negative sums over the per-sample classification counts.
+    const expectedAuto = evidence.samples.reduce((sum, sample) => sum + sample.classification.auto, 0);
+    const expectedManual = evidence.samples.reduce((sum, sample) => sum + sample.classification.manual, 0);
+    expect(aggregate.totals.auto).toBe(expectedAuto);
+    expect(aggregate.totals.manual).toBe(expectedManual);
+
+    // Unique unsupported APIs are deduplicated and sorted.
+    const sorted = [...aggregate.uniqueUnsupportedApis].sort();
+    expect(aggregate.uniqueUnsupportedApis).toEqual(sorted);
+    expect(new Set(aggregate.uniqueUnsupportedApis).size).toBe(aggregate.uniqueUnsupportedApis.length);
+  });
+});


### PR DESCRIPTION
## Issue Link

Related to #206 (slice — not closing). Builds on the manifest/guardrails from #207.

## Summary

Runs the existing migration codemod against each corpus fixture and emits a per-sample + aggregate evidence record. Fixture-only, no live Esri network access. Other AC items (service import, Playwright smoke, scheduled live lane, cross-repo evidence link) remain open per the snapshot comment on #206.

## Changes

- `src/migration/sample-corpus*.ts` — new evidence emitter
- `src/migration-entry.ts` — re-export
- `test/migration-sample-corpus-evidence.test.ts` — coverage
- `docs/esri-sample-corpus.md` — docs cross-link

## Validation

- `npm test -- --run test/migration-sample-corpus-evidence.test.ts test/migration-sample-corpus.test.ts test/entrypoints.test.ts`
- `npm run typecheck --silent`
- `npx biome check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>