### PR TITLE
feat(migration): MapLibre widget classification

### DIFF
--- a/src/migration/parity-matrix.ts
+++ b/src/migration/parity-matrix.ts
@@ -54,11 +54,37 @@ const LAYER_KINDS = new Set<CodemodConstructorKind>([
 
 const CANONICAL_MODULE_BY_KIND = buildCanonicalModuleMap();
 
+// Per-kind overrides for the Honua MapLibre target. The codemod's
+// HONUA_MAPLIBRE_NATIVE_KINDS only enumerates kinds with a deterministic
+// native mapping; the entries here narrow the remaining "assisted" default
+// for kinds whose verdict is grounded in docs/migration-punch-list.md or
+// concrete codemod behavior (rather than guesswork).
+const HONUA_MAPLIBRE_STATUS_OVERRIDES: Readonly<Partial<Record<CodemodConstructorKind, JsParityStatus>>> =
+  Object.freeze({
+    // Search depends on a Locator-equivalent surface (HonuaGeocodeService),
+    // which is tracked as a blocking item in the migration punch list
+    // ("Locator + Geoprocessor compat (Task C)") — no compat path exists yet.
+    "search-widget": "unsupported",
+  });
+
+const HONUA_MAPLIBRE_NOTE_OVERRIDES: Readonly<Partial<Record<CodemodConstructorKind, string>>> = Object.freeze({
+  "layer-list": "LayerListCompat renders through the Honua widget host; MapLibre apps must wire it manually.",
+  "legend-widget": "LegendCompat renders through the Honua widget host; MapLibre apps must wire it manually.",
+  "popup-widget":
+    "PopupCompat covers the simple template case; Arcade expressions and arrow-function fieldInfos.format fall through to manual TODO.",
+  "search-widget":
+    "Search requires a Locator-equivalent backend (HonuaGeocodeService); blocked on migration-punch-list Task C.",
+  "feature-table-widget":
+    "FeatureTableCompat renders through the Honua widget host; MapLibre apps must wire layout/columns manually.",
+});
+
 const BASE_MATRIX_ROWS: JsParityMatrixEntry[] = (Object.keys(CANONICAL_MODULE_BY_KIND) as CodemodConstructorKind[])
   .sort()
   .map((kind) => {
     const honuaCompat: JsParityStatus = isKindSupportedForTarget(kind, "honua-compat") ? "compat" : "unsupported";
-    const honuaMapLibre: JsParityStatus = isKindSupportedForTarget(kind, "honua-maplibre") ? "native" : "assisted";
+    const honuaMapLibre: JsParityStatus =
+      HONUA_MAPLIBRE_STATUS_OVERRIDES[kind] ??
+      (isKindSupportedForTarget(kind, "honua-maplibre") ? "native" : "assisted");
     const esriLeaflet: JsParityStatus = isKindSupportedForTarget(kind, "esri-leaflet") ? "compat" : "assisted";
     return {
       kind,
@@ -68,9 +94,10 @@ const BASE_MATRIX_ROWS: JsParityMatrixEntry[] = (Object.keys(CANONICAL_MODULE_BY
       honuaMapLibre,
       esriLeaflet,
       notes:
-        honuaMapLibre === "native"
+        HONUA_MAPLIBRE_NOTE_OVERRIDES[kind] ??
+        (honuaMapLibre === "native"
           ? "Honua MapLibre target emits native helper mappings"
-          : "assisted migration with TODO/report gating",
+          : "assisted migration with TODO/report gating"),
     };
   });
 

--- a/src/migration/runtime-matrix.ts
+++ b/src/migration/runtime-matrix.ts
@@ -281,12 +281,21 @@ const BASE_RUNTIME_MATRIX: readonly BaseRuntimeParityEntry[] = Object.freeze([
   },
   {
     surface: "widget",
-    capability: "popup-and-search",
-    arcGisJsApi: "Popup/Search",
+    capability: "popup-widget",
+    arcGisJsApi: "Popup",
     honuaCompat: "compat",
     esriLeaflet: "compat",
     notes:
-      "Popup/Search are deterministic in esri-leaflet target via compat fallback wrappers and shared event bus integration.",
+      "Popup is deterministic in esri-leaflet target via compat fallback wrappers; MapLibre target maps via PopupCompat for the simple case, with Arcade expressions and arrow-function fieldInfos.format flagged as manual TODO.",
+  },
+  {
+    surface: "widget",
+    capability: "search-widget",
+    arcGisJsApi: "Search",
+    honuaCompat: "compat",
+    esriLeaflet: "compat",
+    notes:
+      "Search is deterministic in esri-leaflet target via compat fallback wrappers; MapLibre target is blocked on a Locator-equivalent (HonuaGeocodeService) per migration punch list Task C.",
   },
   {
     surface: "widget",
@@ -381,6 +390,15 @@ function inferHonuaMapLibreRuntimeStatus(entry: BaseRuntimeParityEntry): JsRunti
   }
   if (entry.surface === "map-view" && entry.capability === "navigation-go-to") {
     return "native";
+  }
+  // Search depends on a Locator-equivalent backend (HonuaGeocodeService) that is
+  // not yet shimmed; see docs/migration-punch-list.md "Locator + Geoprocessor
+  // compat (Task C)".
+  if (entry.surface === "widget" && entry.capability === "search-widget") {
+    return "unsupported";
+  }
+  if (entry.surface === "widget" && entry.capability === "search-expanded-options") {
+    return "unsupported";
   }
   return "assisted";
 }

--- a/test/migration-parity-matrix.test.ts
+++ b/test/migration-parity-matrix.test.ts
@@ -243,6 +243,36 @@ describe("JS parity matrix", () => {
     });
   });
 
+  it("classifies MapLibre widget kinds (LayerList/Legend/Popup/Search/FeatureTable)", () => {
+    const matrix = getJsParityMatrix();
+    const layerList = matrix.find((row) => row.kind === "layer-list");
+    const legend = matrix.find((row) => row.kind === "legend-widget");
+    const popup = matrix.find((row) => row.kind === "popup-widget");
+    const search = matrix.find((row) => row.kind === "search-widget");
+    const featureTable = matrix.find((row) => row.kind === "feature-table-widget");
+
+    expect(layerList).toMatchObject({ honuaMapLibre: "assisted" });
+    expect(legend).toMatchObject({ honuaMapLibre: "assisted" });
+    expect(popup).toMatchObject({ honuaMapLibre: "assisted" });
+    expect(search).toMatchObject({ honuaMapLibre: "unsupported" });
+    expect(featureTable).toMatchObject({ honuaMapLibre: "assisted" });
+  });
+
+  it("keeps MapLibre data-layer/view verdicts as native (no regression)", () => {
+    const matrix = getJsParityMatrix();
+    const featureLayer = matrix.find((row) => row.kind === "feature-layer");
+    const mapImageLayer = matrix.find((row) => row.kind === "map-image-layer");
+    const tileLayer = matrix.find((row) => row.kind === "tile-layer");
+    const map = matrix.find((row) => row.kind === "map");
+    const mapView = matrix.find((row) => row.kind === "map-view");
+
+    expect(featureLayer).toMatchObject({ honuaMapLibre: "native" });
+    expect(mapImageLayer).toMatchObject({ honuaMapLibre: "native" });
+    expect(tileLayer).toMatchObject({ honuaMapLibre: "native" });
+    expect(map).toMatchObject({ honuaMapLibre: "native" });
+    expect(mapView).toMatchObject({ honuaMapLibre: "native" });
+  });
+
   it("summarizes tier counts for both targets", () => {
     const matrix = getJsParityMatrix();
     const summary = summarizeJsParityMatrix(matrix);
@@ -256,6 +286,7 @@ describe("JS parity matrix", () => {
     expect(summary.honuaCompat.compat).toBeGreaterThan(0);
     expect(summary.honuaMapLibre.native).toBe(5);
     expect(summary.honuaMapLibre.assisted).toBeGreaterThan(0);
+    expect(summary.honuaMapLibre.unsupported).toBeGreaterThanOrEqual(1);
     expect(summary.esriLeaflet.compat).toBeGreaterThan(0);
     expect(summary.esriLeaflet.assisted).toBe(0);
   });

--- a/test/migration-runtime-matrix.test.ts
+++ b/test/migration-runtime-matrix.test.ts
@@ -87,6 +87,64 @@ describe("JS runtime parity matrix", () => {
     });
   });
 
+  it("classifies MapLibre widget capabilities (LayerList/Legend/Popup/Search/FeatureTable)", () => {
+    const matrix = getJsRuntimeParityMatrix();
+    const layerListLegend = matrix.find(
+      (entry) => entry.surface === "widget" && entry.capability === "layer-list-and-legend",
+    );
+    const popup = matrix.find((entry) => entry.surface === "widget" && entry.capability === "popup-widget");
+    const search = matrix.find((entry) => entry.surface === "widget" && entry.capability === "search-widget");
+    const searchOptions = matrix.find(
+      (entry) => entry.surface === "widget" && entry.capability === "search-expanded-options",
+    );
+    const featureTableOptions = matrix.find(
+      (entry) => entry.surface === "widget" && entry.capability === "feature-table-expanded-options",
+    );
+
+    expect(layerListLegend).toMatchObject({
+      honuaCompat: "compat",
+      honuaMapLibre: "assisted",
+      esriLeaflet: "compat",
+    });
+    expect(popup).toMatchObject({
+      arcGisJsApi: "Popup",
+      honuaCompat: "compat",
+      honuaMapLibre: "assisted",
+      esriLeaflet: "compat",
+    });
+    expect(search).toMatchObject({
+      arcGisJsApi: "Search",
+      honuaCompat: "compat",
+      honuaMapLibre: "unsupported",
+      esriLeaflet: "compat",
+    });
+    expect(searchOptions).toMatchObject({
+      honuaCompat: "compat",
+      honuaMapLibre: "unsupported",
+      esriLeaflet: "compat",
+    });
+    expect(featureTableOptions).toMatchObject({
+      honuaCompat: "compat",
+      honuaMapLibre: "assisted",
+      esriLeaflet: "compat",
+    });
+  });
+
+  it("keeps MapLibre data-layer/view runtime verdicts as native (no regression)", () => {
+    const matrix = getJsRuntimeParityMatrix();
+    const featureLayerQuery = matrix.find(
+      (entry) => entry.surface === "feature-layer" && entry.capability === "query-features",
+    );
+    const mapImageQuery = matrix.find(
+      (entry) => entry.surface === "map-image-layer" && entry.capability === "query-features",
+    );
+    const mapViewGoTo = matrix.find((entry) => entry.surface === "map-view" && entry.capability === "navigation-go-to");
+
+    expect(featureLayerQuery).toMatchObject({ honuaMapLibre: "native" });
+    expect(mapImageQuery).toMatchObject({ honuaMapLibre: "native" });
+    expect(mapViewGoTo).toMatchObject({ honuaMapLibre: "native" });
+  });
+
   it("summarizes runtime parity counts for both targets", () => {
     const matrix = getJsRuntimeParityMatrix();
     const summary = summarizeJsRuntimeParity(matrix);
@@ -101,6 +159,7 @@ describe("JS runtime parity matrix", () => {
     expect(summary.honuaCompat.compat).toBeGreaterThan(0);
     expect(summary.honuaMapLibre.native).toBeGreaterThan(0);
     expect(summary.honuaMapLibre.assisted).toBeGreaterThan(0);
+    expect(summary.honuaMapLibre.unsupported).toBeGreaterThanOrEqual(1);
     expect(summary.esriLeaflet.assisted).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Slice for #205 (not closing). Classifies the five ArcGIS widget kinds called out in the issue acceptance criterion for the `honua-maplibre` codemod target, so the migration parity + runtime matrices tell the truth rather than defaulting everything to "assisted".

### Verdicts

| Kind | MapLibre verdict | Rationale |
| --- | --- | --- |
| `layer-list` | `assisted` | `LayerListCompat` renders through `HonuaWidgetHost`; MapLibre apps must wire it manually. |
| `legend-widget` | `assisted` | `LegendCompat` renders through `HonuaWidgetHost`; same manual-wiring caveat. |
| `popup-widget` | `assisted` | `PopupCompat` covers the simple template case; Arcade expressions and arrow-function `fieldInfos.format` already fall through to manual TODO via the codemod's `isSafePopupTemplateCompatCall`. |
| `search-widget` | `unsupported` | Depends on a `Locator`-equivalent backend (`HonuaGeocodeService`); blocked on migration-punch-list Task C (Locator + Geoprocessor compat). |
| `feature-table-widget` | `assisted` | `FeatureTableCompat` renders through `HonuaWidgetHost`; MapLibre apps must wire layout/columns manually. |

### Mechanism

- `src/migration/parity-matrix.ts`: added a small `HONUA_MAPLIBRE_STATUS_OVERRIDES` table (currently just `search-widget` -> `unsupported`) plus per-kind note overrides for the five widget rows. The native/assisted default for everything else is unchanged.
- `src/migration/runtime-matrix.ts`: split the bundled `popup-and-search` row into separate `popup-widget` and `search-widget` rows so they can carry different MapLibre verdicts; refined `inferHonuaMapLibreRuntimeStatus` to return `unsupported` for `search-widget` (and the related `search-expanded-options` capability).
- Tests: extended `test/migration-parity-matrix.test.ts` and `test/migration-runtime-matrix.test.ts` to assert the five widget verdicts and pin the existing native verdicts (`feature-layer`, `map-image-layer`, `tile-layer`, `map`, `map-view`) against regression.

No widget runtime code in `src/esri-compat/*` was touched. No docs were touched (per PR #216 in flight). No `sample-corpus*` / `migration-entry.ts` / `migration-sample-corpus-evidence.test.ts` were touched (per PR #217 in flight).

### Follow-ups (not in this PR)

None — all five widget kinds were already registered in `codemod.ts`'s `SUPPORTED_ARCGIS_MODULE_KIND_BY_PATH` (via the `LayerList`, `Legend`, `Popup`, `Search`, `FeatureTable` rewrite specs).

## Validation

- `npm test -- --run test/migration-runtime-matrix.test.ts test/migration-parity-matrix.test.ts test/migration-codemod.test.ts test/migration-report.test.ts` -> 113 passed
- `npm run typecheck --silent` -> clean
- `npx biome check` on the four touched files -> clean

## Test plan

- [x] Unit: parity matrix returns the five widget verdicts as documented above
- [x] Unit: data-layer/view MapLibre verdicts (feature-layer, map-image-layer, tile-layer, map, map-view) still `native`
- [x] Unit: runtime matrix `popup-widget` row is `assisted` and `search-widget` row is `unsupported` for MapLibre
- [x] Existing codemod + report suites unaffected (`migration-codemod.test.ts`, `migration-report.test.ts`)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>