### PR TITLE
feat(map): WebMap to MapLibre style derivation

### DIFF
--- a/docs/migration-punch-list.md
+++ b/docs/migration-punch-list.md
@@ -209,7 +209,43 @@ known constructors" into "automated app conversion":
    shapes). The shim accepts the ArcGIS shape at runtime, but
    the report should flag known-divergent property values so app
    authors can confirm intent.
-5. **End-to-end demo conversion.** Shipped at
+5. **WebMap JSON → MapLibre style derivation (`honua-maplibre`
+   target).** *Partially shipped.* `src/map/webmap-maplibre.ts`
+   exposes `webmapJsonToMapLibreStyle(webmap, options)`, a pure
+   converter that delegates the heavy lifting to the existing
+   `src/webmap/` pipeline — `parseWebMap` orchestrates
+   `convertBasemap`, `convertOperationalLayer`, `convertRenderer`,
+   `convertPopupInfo`, `convertLabelingInfo`, and
+   `convertExtent`/`convertInitialViewpoint` — and returns a
+   `HonuaStyleSpecification` ready for `map.setStyle(...)` plus a
+   structured `manualGaps: WebMapMapLibreManualGap[]` array.
+   `manualGaps` is the single source of truth for unsupported
+   constructs: every entry carries `{ kind, reason, path?,
+   layerId?, expression?, context? }` and the `kind` taxonomy
+   covers `arcade-expression` (popup `expressionInfos` and complex
+   Arcade label expressions), `unsupported-renderer` (heatmap,
+   dotDensity, and any other renderer the converter doesn't
+   handle), `scene-3d` (top-level `ground` / `camera` /
+   `viewingMode`, `ArcGISSceneServiceLayer`, `elevationInfo`,
+   `heightInfo`, `sceneProperties`), `dashboard-reference`,
+   `experience-builder-reference`, `custom-widget-reference`
+   (`applicationProperties.viewing.widgetsOnScreen` and the
+   top-level `widgets` array used by host shells), plus
+   pass-throughs for `unsupported-symbol`,
+   `unsupported-layer-type`, `unsupported-feature-collection`, and
+   `unsupported-webmap-version`. **What still requires manual
+   review:** the codemod does **not** yet wire this converter into
+   its import-rewriting pass — apps that call ArcGIS WebMap
+   loaders (`WebMap.load()`, `WebMap({ portalItem })`) still hit
+   the existing `web-map` compat shim, not the MapLibre style
+   path; the gap surface is also intentionally honest about its
+   ceiling, since Arcade execution, scene/3D rendering, Dashboard
+   widget hosts, Experience Builder pages, and custom-widget
+   plugins all require runtime support the JS SDK cannot
+   synthesize from JSON alone. Each emitted gap is a `// TODO`
+   anchor for an app author, not a promise of automated
+   migration.
+6. **End-to-end demo conversion.** Shipped at
    `examples/arcgis-source-app/` + `test/migration-e2e.test.ts`.
    The sample is a hand-written parcel viewer exercising
    `FeatureLayer` (with `outFields` + `popupTemplate`), `Map`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -444,6 +444,13 @@ export type {
 } from "./map/index.js";
 export { parseWebMap } from "./webmap/index.js";
 export type { ParseWebMapOptions, ParseWebMapResult } from "./webmap/index.js";
+export { webmapJsonToMapLibreStyle } from "./map/index.js";
+export type {
+  WebMapJsonToMapLibreStyleOptions,
+  WebMapJsonToMapLibreStyleResult,
+  WebMapMapLibreGapKind,
+  WebMapMapLibreManualGap,
+} from "./map/index.js";
 export type {
   ApplyEditsRequest,
   ExportMapRequest,

--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -23,3 +23,10 @@ export type {
   HonuaMapServiceLayerOptions,
   HonuaTileServiceLayerOptions,
 } from "./maplibre-target.js";
+export { webmapJsonToMapLibreStyle } from "./webmap-maplibre.js";
+export type {
+  WebMapJsonToMapLibreStyleOptions,
+  WebMapJsonToMapLibreStyleResult,
+  WebMapMapLibreGapKind,
+  WebMapMapLibreManualGap,
+} from "./webmap-maplibre.js";

--- a/src/map/webmap-maplibre.ts
+++ b/src/map/webmap-maplibre.ts
@@ -1,0 +1,283 @@
+/**
+ * WebMap JSON → MapLibre style derivation for the `honua-maplibre`
+ * migration target.
+ *
+ * This module is a thin orchestrator on top of `src/webmap/parseWebMap`
+ * (which already converts basemap, operational layers, renderers, popups,
+ * labels, and extents) plus a structured-gap classifier that records the
+ * unsupported constructs the migration punch list cares about:
+ *
+ *   - Arcade expressions (popupInfo.expressionInfos, label Arcade)
+ *   - Unknown / unsupported renderer types (heatmap, dotDensity, …)
+ *   - 3D / Scene references (ground, viewingMode, SceneServiceLayer, …)
+ *   - Dashboard / ExperienceBuilder / custom-widget host shells
+ *
+ * The function is pure: callers supply the WebMap JSON, no network or
+ * disk I/O is performed.
+ *
+ * @module
+ */
+
+import type { HonuaStyleSpecification } from "../style/specification.js";
+import { parseWebMap } from "../webmap/parse.js";
+import type { WebMapJson } from "../webmap/types.js";
+import type { WebMapWarning } from "../webmap/warnings.js";
+
+/** Stable taxonomy for the gaps the punch list expects callers to handle. */
+export type WebMapMapLibreGapKind =
+  | "arcade-expression"
+  | "unsupported-renderer"
+  | "scene-3d"
+  | "dashboard-reference"
+  | "experience-builder-reference"
+  | "custom-widget-reference"
+  | "unsupported-symbol"
+  | "unsupported-layer-type"
+  | "unsupported-feature-collection"
+  | "unsupported-webmap-version"
+  | "other";
+
+/** A single unsupported construct discovered while deriving the style. */
+export interface WebMapMapLibreManualGap {
+  kind: WebMapMapLibreGapKind;
+  /** Human-readable explanation surfaced in reports / TODO annotations. */
+  reason: string;
+  /** Path within the WebMap JSON (e.g. `operationalLayers[2].popupInfo`). */
+  path?: string;
+  /** Operational layer id, when the gap is attributable to a specific layer. */
+  layerId?: string;
+  /** The offending Arcade expression text, when applicable. */
+  expression?: string;
+  /** Extra context (renderer type, scene layer URL, widget name, …). */
+  context?: Record<string, unknown>;
+}
+
+export interface WebMapJsonToMapLibreStyleOptions {
+  /** Whether to include the basemap in the derived style. Defaults to true. */
+  includeBasemap?: boolean;
+}
+
+export interface WebMapJsonToMapLibreStyleResult {
+  /** A MapLibre-shaped style document suitable for `map.setStyle(...)`. */
+  style: HonuaStyleSpecification;
+  /** Structured gap entries — one per unsupported construct. */
+  manualGaps: WebMapMapLibreManualGap[];
+}
+
+/**
+ * Derive a MapLibre style document from an ArcGIS WebMap JSON payload.
+ *
+ * Reuses the entire `src/webmap/*` conversion pipeline (`convertBasemap`,
+ * `convertOperationalLayer`, `convertRenderer`, `convertPopupInfo`,
+ * `convertLabelingInfo`, `convertExtent`) via `parseWebMap`. The
+ * `parseWebMap` warnings are then mapped onto the structured `manualGaps`
+ * taxonomy, and additional gaps are appended for Dashboard /
+ * ExperienceBuilder / custom-widget shell properties that the WebMap
+ * converter itself doesn't model.
+ */
+export function webmapJsonToMapLibreStyle(
+  webmap: WebMapJson,
+  options: WebMapJsonToMapLibreStyleOptions = {},
+): WebMapJsonToMapLibreStyleResult {
+  const parsed = parseWebMap(webmap, {
+    includeBasemap: options.includeBasemap !== false,
+  });
+
+  const manualGaps: WebMapMapLibreManualGap[] = [];
+  for (const warning of parsed.warnings) {
+    const gap = classifyWarning(warning, webmap);
+    if (gap) {
+      manualGaps.push(gap);
+    }
+  }
+
+  // Detect Dashboard / ExperienceBuilder / custom-widget shells that
+  // `parseWebMap` does not model. These appear at the top of WebMap-
+  // adjacent application documents (Dashboards, Experience Builder
+  // configs, web-app items) and on the WebMap when authored by those
+  // apps. We never raise the renderer/popup conversion result over
+  // them — we only record a gap so the caller can replan that surface.
+  detectShellGaps(webmap, manualGaps);
+
+  return {
+    style: parsed.style,
+    manualGaps,
+  };
+}
+
+// ── Internals ───────────────────────────────────────────────────────────
+
+function classifyWarning(warning: WebMapWarning, webmap: WebMapJson): WebMapMapLibreManualGap | undefined {
+  const layerId = resolveLayerIdFromPath(warning.path, webmap);
+  const base: Pick<WebMapMapLibreManualGap, "path" | "layerId" | "context"> = {
+    path: warning.path,
+    ...(layerId ? { layerId } : {}),
+    ...(warning.context ? { context: warning.context } : {}),
+  };
+
+  switch (warning.code) {
+    case "unsupported-arcade-expression":
+    case "complex-arcade":
+    case "complex-label-expression": {
+      const expression = pickStringContext(warning.context, ["expression", "value"]);
+      return {
+        kind: "arcade-expression",
+        reason: warning.message,
+        ...(expression ? { expression } : {}),
+        ...base,
+      };
+    }
+
+    case "unsupported-renderer": {
+      return {
+        kind: "unsupported-renderer",
+        reason: warning.message,
+        ...base,
+      };
+    }
+
+    case "unsupported-3d-property": {
+      return {
+        kind: "scene-3d",
+        reason: warning.message,
+        ...base,
+      };
+    }
+
+    case "unsupported-symbol":
+      return { kind: "unsupported-symbol", reason: warning.message, ...base };
+
+    case "unsupported-layer-type":
+      return { kind: "unsupported-layer-type", reason: warning.message, ...base };
+
+    case "unsupported-feature-collection":
+      return { kind: "unsupported-feature-collection", reason: warning.message, ...base };
+
+    case "unsupported-webmap-version":
+      return { kind: "unsupported-webmap-version", reason: warning.message, ...base };
+
+    // Warnings the punch list does not (yet) treat as a manual gap:
+    // `sprite-required` (picture marker needs a sprite — degrades but
+    // doesn't block), `missing-field` (classBreaks misuse — caller's
+    // data error, not a target gap), `unknown-property` (forward-compat
+    // pass-through), `unsupported-viewpoint-geometry` (rare and
+    // recoverable). We deliberately do not invent gap entries for
+    // those; they remain in `parseWebMap` warnings for diagnostics.
+    case "sprite-required":
+    case "missing-field":
+    case "unknown-property":
+    case "unsupported-viewpoint-geometry":
+      return undefined;
+
+    default:
+      return {
+        kind: "other",
+        reason: warning.message,
+        ...base,
+      };
+  }
+}
+
+/**
+ * Inspect the WebMap document for shell properties belonging to
+ * Dashboards, Experience Builder, or generic custom-widget hosts.
+ *
+ * The WebMap JSON spec doesn't model these directly — they appear on
+ * application documents that wrap a WebMap — but they often leak into
+ * WebMap payloads exported from those products. Recording a gap lets
+ * the migration report flag them instead of silently dropping them.
+ */
+function detectShellGaps(webmap: WebMapJson, gaps: WebMapMapLibreManualGap[]): void {
+  // Dashboard authoring metadata.
+  if (hasOwn(webmap, "dashboard") || isDashboardItemType(webmap)) {
+    gaps.push({
+      kind: "dashboard-reference",
+      reason:
+        "WebMap payload carries Dashboard application properties; Dashboard widgets do not map to a MapLibre style and require manual reauthoring.",
+      path: hasOwn(webmap, "dashboard") ? "dashboard" : "type",
+    });
+  }
+
+  // Experience Builder authoring metadata.
+  if (hasOwn(webmap, "experience") || hasOwn(webmap, "experienceBuilder") || isExperienceBuilderItemType(webmap)) {
+    gaps.push({
+      kind: "experience-builder-reference",
+      reason:
+        "WebMap payload carries Experience Builder application properties; Experience Builder pages do not map to a MapLibre style and require manual reauthoring.",
+      path: hasOwn(webmap, "experience")
+        ? "experience"
+        : hasOwn(webmap, "experienceBuilder")
+          ? "experienceBuilder"
+          : "type",
+    });
+  }
+
+  // Generic custom-widget host shells. We do NOT treat the built-in 2D
+  // widget set (Home, Compass, Zoom, …) as a gap — those have parity
+  // shims in src/esri-compat. Only widget hosts that carry a free-form
+  // `widgets`/`widgetsOnScreen` payload, which is what custom widgets
+  // and 3rd-party plugins ride on, get flagged.
+  const appProps = (webmap as { applicationProperties?: unknown }).applicationProperties;
+  if (appProps && typeof appProps === "object") {
+    const viewing = (appProps as Record<string, unknown>).viewing;
+    if (viewing && typeof viewing === "object" && hasOwn(viewing as Record<string, unknown>, "widgetsOnScreen")) {
+      gaps.push({
+        kind: "custom-widget-reference",
+        reason:
+          "WebMap.applicationProperties.viewing.widgetsOnScreen references custom widgets that must be ported individually to MapLibre/Honua controls.",
+        path: "applicationProperties.viewing.widgetsOnScreen",
+      });
+    }
+  }
+
+  const customWidgets = (webmap as { widgets?: unknown }).widgets;
+  if (Array.isArray(customWidgets) && customWidgets.length > 0) {
+    gaps.push({
+      kind: "custom-widget-reference",
+      reason: "WebMap.widgets array references custom widgets that require manual MapLibre/Honua reimplementation.",
+      path: "widgets",
+      context: { count: customWidgets.length },
+    });
+  }
+}
+
+function isDashboardItemType(webmap: WebMapJson): boolean {
+  const value = (webmap as { type?: unknown }).type;
+  return typeof value === "string" && /dashboard/i.test(value);
+}
+
+function isExperienceBuilderItemType(webmap: WebMapJson): boolean {
+  const value = (webmap as { type?: unknown }).type;
+  return typeof value === "string" && /experience\s*builder|web\s*experience/i.test(value);
+}
+
+function hasOwn(obj: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function pickStringContext(context: Record<string, unknown> | undefined, keys: readonly string[]): string | undefined {
+  if (!context) return undefined;
+  for (const key of keys) {
+    const value = context[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Best-effort `layerId` extraction from a warning path such as
+ * `operationalLayers[2].layerDefinition.drawingInfo.renderer`. Falls
+ * back to the synthesized `operational-<index>` id used by
+ * `convertOperationalLayer` when no explicit id is present.
+ */
+function resolveLayerIdFromPath(path: string, webmap: WebMapJson): string | undefined {
+  const match = path.match(/operationalLayers\[(\d+)\]/);
+  if (!match) return undefined;
+  const index = Number.parseInt(match[1], 10);
+  if (!Number.isFinite(index)) return undefined;
+  const layer = webmap.operationalLayers?.[index];
+  if (!layer) return `operational-${index}`;
+  return layer.id ?? `operational-${index}`;
+}

--- a/test/webmap-maplibre-style.test.ts
+++ b/test/webmap-maplibre-style.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import { validateHonuaStyle, webmapJsonToMapLibreStyle } from "../src/index.js";
+import type { WebMapJson } from "../src/webmap/types.js";
+
+describe("webmapJsonToMapLibreStyle", () => {
+  it("converts a simple WebMap (FeatureLayer + TileLayer basemap) with zero gaps", () => {
+    const webmap: WebMapJson = {
+      version: "2.27",
+      baseMap: {
+        title: "Streets",
+        baseMapLayers: [
+          {
+            id: "streets",
+            url: "https://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer",
+            layerType: "ArcGISTiledMapServiceLayer",
+          },
+        ],
+      },
+      operationalLayers: [
+        {
+          id: "roads",
+          title: "Roads",
+          url: "https://services.example.com/arcgis/rest/services/Roads/FeatureServer/0",
+          layerType: "ArcGISFeatureLayer",
+          layerDefinition: {
+            drawingInfo: {
+              renderer: {
+                type: "simple",
+                symbol: {
+                  type: "esriSLS",
+                  style: "esriSLSSolid",
+                  color: [0, 0, 0, 255],
+                  width: 1,
+                },
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    const { style, manualGaps } = webmapJsonToMapLibreStyle(webmap);
+
+    expect(style.version).toBe(8);
+    expect(Object.keys(style.sources)).toContain("roads");
+    expect(style.layers.length).toBeGreaterThan(0);
+    expect(validateHonuaStyle(style)).toEqual([]);
+    expect(manualGaps).toEqual([]);
+  });
+
+  it("records a gap for an unsupported renderer type", () => {
+    const webmap: WebMapJson = {
+      operationalLayers: [
+        {
+          id: "heat",
+          title: "Crime Heatmap",
+          url: "https://services.example.com/arcgis/rest/services/Crime/FeatureServer/0",
+          layerType: "ArcGISFeatureLayer",
+          layerDefinition: {
+            drawingInfo: {
+              renderer: {
+                type: "heatmap",
+                blurRadius: 10,
+              } as never,
+            },
+          },
+        },
+      ],
+    };
+
+    const { style, manualGaps } = webmapJsonToMapLibreStyle(webmap);
+    expect(validateHonuaStyle(style)).toEqual([]);
+
+    const rendererGaps = manualGaps.filter((g) => g.kind === "unsupported-renderer");
+    expect(rendererGaps).toHaveLength(1);
+    expect(rendererGaps[0].layerId).toBe("heat");
+    expect(rendererGaps[0].context).toMatchObject({ type: "heatmap" });
+    expect(rendererGaps[0].path).toContain("operationalLayers[0]");
+  });
+
+  it("records a gap for Arcade expressions in popupInfo.expressionInfos", () => {
+    const webmap: WebMapJson = {
+      operationalLayers: [
+        {
+          id: "facilities",
+          url: "https://services.example.com/arcgis/rest/services/Facilities/FeatureServer/0",
+          layerType: "ArcGISFeatureLayer",
+          layerDefinition: {
+            drawingInfo: {
+              renderer: {
+                type: "simple",
+                symbol: {
+                  type: "esriSFS",
+                  style: "esriSFSSolid",
+                  color: [180, 180, 200, 255],
+                },
+              },
+            },
+          },
+          popupInfo: {
+            title: "{NAME}",
+            description: "Status: {STATUS}",
+            expressionInfos: [
+              {
+                name: "statusText",
+                expression: "IIF($feature.STATUS == 1, 'Open', 'Closed')",
+              },
+            ],
+          } as never,
+        },
+      ],
+    };
+
+    const { manualGaps } = webmapJsonToMapLibreStyle(webmap);
+
+    const arcadeGaps = manualGaps.filter((g) => g.kind === "arcade-expression");
+    expect(arcadeGaps.length).toBeGreaterThanOrEqual(1);
+    expect(arcadeGaps[0].layerId).toBe("facilities");
+    expect(arcadeGaps[0].context).toMatchObject({ count: 1 });
+    expect(arcadeGaps[0].path).toContain("popupInfo");
+  });
+
+  it("records a gap for a SceneLayer reference (3D)", () => {
+    const webmap: WebMapJson = {
+      operationalLayers: [
+        {
+          id: "scene-buildings",
+          title: "Buildings Scene",
+          layerType: "ArcGISSceneServiceLayer",
+          url: "https://services.example.com/arcgis/rest/services/Buildings/SceneServer/layers/0",
+        },
+      ],
+    };
+
+    const { manualGaps } = webmapJsonToMapLibreStyle(webmap);
+
+    const sceneGaps = manualGaps.filter((g) => g.kind === "scene-3d");
+    expect(sceneGaps.length).toBeGreaterThanOrEqual(1);
+    expect(sceneGaps[0].layerId).toBe("scene-buildings");
+    expect(sceneGaps[0].context).toMatchObject({ layerType: "ArcGISSceneServiceLayer" });
+  });
+
+  it("records a gap for top-level 3D ground / camera properties", () => {
+    const webmap: WebMapJson = {
+      ground: { surfaceColor: [255, 255, 255, 255] },
+      camera: { position: { x: 0, y: 0, z: 1000 } },
+      operationalLayers: [],
+    } as WebMapJson;
+
+    const { manualGaps } = webmapJsonToMapLibreStyle(webmap);
+
+    const sceneGaps = manualGaps.filter((g) => g.kind === "scene-3d");
+    expect(sceneGaps.length).toBeGreaterThanOrEqual(2);
+    const props = sceneGaps.map((g) => (g.context as { property?: string } | undefined)?.property);
+    expect(props).toContain("ground");
+    expect(props).toContain("camera");
+  });
+
+  it("records a gap for Dashboard-style application shells", () => {
+    const webmap = {
+      type: "Dashboard",
+      operationalLayers: [],
+    } as unknown as WebMapJson;
+
+    const { manualGaps } = webmapJsonToMapLibreStyle(webmap);
+    expect(manualGaps.some((g) => g.kind === "dashboard-reference")).toBe(true);
+  });
+
+  it("records a gap for Experience Builder shells and custom widgets", () => {
+    const webmap = {
+      type: "Web Experience",
+      experience: { pages: [] },
+      widgets: [{ name: "my-custom-widget" }],
+      applicationProperties: {
+        viewing: {
+          widgetsOnScreen: { widgets: [{ key: "third-party-1" }] },
+        },
+      },
+      operationalLayers: [],
+    } as unknown as WebMapJson;
+
+    const { manualGaps } = webmapJsonToMapLibreStyle(webmap);
+    const kinds = manualGaps.map((g) => g.kind);
+
+    expect(kinds).toContain("experience-builder-reference");
+    expect(kinds).toContain("custom-widget-reference");
+    // Both the top-level `widgets` array and the
+    // applicationProperties.viewing.widgetsOnScreen branch produce
+    // custom-widget gaps, so we should see at least two.
+    expect(kinds.filter((k) => k === "custom-widget-reference").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("does not record a gap for sprite-required / unknown-property warnings", () => {
+    const webmap: WebMapJson = {
+      operationalLayers: [
+        {
+          id: "pins",
+          url: "https://services.example.com/arcgis/rest/services/Pins/FeatureServer/0",
+          layerType: "ArcGISFeatureLayer",
+          layerDefinition: {
+            drawingInfo: {
+              renderer: {
+                type: "simple",
+                symbol: {
+                  type: "esriPMS",
+                  url: "https://example.com/pin.png",
+                  width: 24,
+                  height: 24,
+                } as never,
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    const { manualGaps } = webmapJsonToMapLibreStyle(webmap);
+    expect(manualGaps).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Slice for #205 (not closing). Adds `webmapJsonToMapLibreStyle(webmap, options)` in `src/map/webmap-maplibre.ts`, a pure WebMap-JSON → MapLibre-style converter for the `honua-maplibre` migration target.

The converter is a thin orchestrator: it delegates the heavy lifting to the existing `src/webmap/` pipeline — `parseWebMap` from `src/webmap/parse.ts` already drives `convertBasemap`, `convertOperationalLayer` (which in turn calls `convertRenderer`, `convertSymbol`, `convertLabelingInfo`, `convertPopupInfo`), and `convertExtent` / `convertInitialViewpoint`. This PR does not re-derive renderer/popup/label/style logic; it reuses what is already shipped. The new code is the structured-gap classifier and the public surface.

The function returns `{ style, manualGaps }`:
- `style` is a `HonuaStyleSpecification` suitable for `map.setStyle(...)` (validated against `validateHonuaStyle` in tests).
- `manualGaps: WebMapMapLibreManualGap[]` is the structured taxonomy of unsupported constructs. Every entry carries `{ kind, reason, path?, layerId?, expression?, context? }`. Unsupported constructs are never silently swallowed: one gap per construct.

`manualGaps` taxonomy (`WebMapMapLibreGapKind`):
- `arcade-expression` — `popupInfo.expressionInfos`, complex Arcade label expressions
- `unsupported-renderer` — heatmap, dotDensity, any other renderer the converter doesn't handle
- `scene-3d` — top-level `ground` / `camera` / `viewingMode`, `ArcGISSceneServiceLayer`, `elevationInfo`, `heightInfo`, `sceneProperties`
- `dashboard-reference` — top-level `dashboard` key or `type: "Dashboard"`
- `experience-builder-reference` — top-level `experience` / `experienceBuilder` keys, or `type: "Web Experience"`
- `custom-widget-reference` — `applicationProperties.viewing.widgetsOnScreen`, top-level `widgets` array
- Pass-throughs: `unsupported-symbol`, `unsupported-layer-type`, `unsupported-feature-collection`, `unsupported-webmap-version`, `other`

Reused modules from `src/webmap/`:
- `parse.ts` (orchestration + 3D top-level + version warnings)
- `convert-basemap.ts`, `convert-extent.ts`, `convert-layer.ts`
- `convert-renderer.ts`, `convert-symbol.ts`, `convert-label.ts`, `convert-popup.ts`
- `warnings.ts` (warning collector + `WebMapWarning` shape)

What is explicitly **not** in this slice:
- The codemod's import-rewriting pass is not wired to call this converter — apps using `new WebMap({ portalItem })` still hit the existing `web-map` compat shim. That's a separate slice.
- No changes to `src/migration/parity-matrix.ts` or `runtime-matrix.ts` (widget-classification slice owns those).
- No changes to `docs/migration-honua-maplibre.md`, `README.md`, or sample-corpus files (in-flight PRs own them).

The migration punch list (`docs/migration-punch-list.md`) gets a new bullet under "Codemod gaps" describing what now works (style derivation, structured `manualGaps`) and what remains manual (codemod wiring, Arcade execution, scene/3D rendering, Dashboard/ExB widget hosts, custom-widget plugins).

## Test plan
- [x] `npx vitest run test/webmap-maplibre-style.test.ts` — 8 tests, all passing (simple happy path, unsupported renderer, Arcade popup, scene-layer, ground/camera, Dashboard, Experience Builder + custom widgets, non-gap warnings)
- [x] `npx vitest run test/migration-codemod.test.ts` — 98 tests, all passing (no regression)
- [x] `npx vitest run test/webmap-parse.test.ts test/webmap-convert-renderer.test.ts test/webmap-convert-symbol.test.ts test/webmap-convert-extent.test.ts` — 50 tests, all passing (existing `src/webmap` suites)
- [x] `npm run typecheck --silent` — clean
- [x] `npx biome check` on touched `.ts` files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)