### PR TITLE
feat(migration): corpus-evidence CLI for Esri sample corpus

### DIFF
--- a/docs/esri-sample-corpus.md
+++ b/docs/esri-sample-corpus.md
@@ -87,6 +87,19 @@ API-key, premium-service, etc.) appear in the evidence record with
 aggregate, but never as `migrated`. No live Esri services are contacted; the
 helper operates entirely on the committed fixture corpus.
 
+The same evidence can be persisted to disk via the migration CLI subcommand
+`corpus-evidence`. It writes one JSON artifact per sample to
+`<out>/samples/<sampleId>.json` and a single aggregate document to
+`<out>/corpus-evidence.json`. `--corpus` defaults to
+`test/fixtures/esri-sample-corpus`, and `--target` defaults to
+`honua-maplibre`:
+
+```bash
+node dist/src/migration/cli.js corpus-evidence \
+  --corpus test/fixtures/esri-sample-corpus \
+  --out ./corpus-evidence
+```
+
 ## Live Evidence Lanes
 
 Live Esri sample/service evidence is reserved for scheduled or manual runs. A

--- a/src/migration/cli.ts
+++ b/src/migration/cli.ts
@@ -19,6 +19,7 @@ import { getJsParityMatrix, summarizeJsParityMatrix } from "./parity-matrix.js";
 import { runLayerReconciliation, summarizeLayerReconciliation } from "./reconcile.js";
 import { buildJsMigrationReport } from "./report.js";
 import { getJsRuntimeParityMatrix, summarizeJsRuntimeParity } from "./runtime-matrix.js";
+import { emitEsriSampleCorpusEvidence } from "./sample-corpus-evidence.js";
 import { scanArcGisUsage, summarizeArcGisScan } from "./scanner.js";
 
 interface ParsedArgs {
@@ -31,7 +32,8 @@ interface ParsedArgs {
     | "fixtures"
     | "demo"
     | "content-webmap"
-    | "content";
+    | "content"
+    | "corpus-evidence";
   target: string;
   contentAction?: "scan" | "export" | "import" | "reconcile";
   codemodTarget: CodemodTarget;
@@ -76,6 +78,8 @@ interface ParsedArgs {
   contentIncludeFeatures: boolean;
   contentIncludeWebMaps: boolean;
   contentIncludeHostedLayers: boolean;
+  corpusPath?: string;
+  corpusOutputDir?: string;
 }
 
 interface FixtureMetricSnapshot {
@@ -179,6 +183,13 @@ if (!parsed) {
       process.stderr.write(`reconcileError=${error instanceof Error ? error.message : String(error)}\n`);
       process.exitCode = 1;
     });
+  } else if (parsed.command === "corpus-evidence") {
+    try {
+      runCorpusEvidence(parsed);
+    } catch (error) {
+      process.stderr.write(`corpusEvidenceError=${error instanceof Error ? error.message : String(error)}\n`);
+      process.exitCode = 1;
+    }
   } else {
     runCodemod(parsed);
   }
@@ -236,6 +247,51 @@ function runRuntimeMatrix(reportPath?: string): void {
     fs.writeFileSync(reportPath, `${JSON.stringify({ summary, matrix }, null, 2)}\n`, "utf8");
     process.stdout.write(`reportWritten=${reportPath}\n`);
   }
+}
+
+function runCorpusEvidence(args: ParsedArgs): void {
+  const corpusRoot = path.resolve(
+    args.corpusPath ?? path.join(process.cwd(), "test", "fixtures", "esri-sample-corpus"),
+  );
+  if (!args.corpusOutputDir) {
+    throw new Error("corpus-evidence requires --out <dir>");
+  }
+  const outputDir = path.resolve(args.corpusOutputDir);
+
+  const manifestPath = path.join(corpusRoot, "manifest.json");
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error(`corpus manifest not found at ${manifestPath}`);
+  }
+
+  const evidence = emitEsriSampleCorpusEvidence({
+    manifestPath,
+    codemodTarget: args.codemodTarget,
+  });
+
+  const samplesDir = path.join(outputDir, "samples");
+  fs.mkdirSync(samplesDir, { recursive: true });
+  for (const sample of evidence.samples) {
+    const samplePath = path.join(samplesDir, `${sample.sampleId}.json`);
+    fs.writeFileSync(samplePath, `${JSON.stringify(sample, null, 2)}\n`, "utf8");
+  }
+
+  const aggregatePath = path.join(outputDir, "corpus-evidence.json");
+  fs.writeFileSync(aggregatePath, `${JSON.stringify(evidence, null, 2)}\n`, "utf8");
+
+  process.stdout.write(
+    [
+      "corpusEvidence",
+      `samples=${evidence.aggregate.sampleCount}`,
+      `migrated=${evidence.aggregate.statusCounts.migrated}`,
+      `skipped=${evidence.aggregate.statusCounts.skipped}`,
+      `error=${evidence.aggregate.statusCounts.error}`,
+      `target=${evidence.codemodTarget}`,
+      `out=${outputDir}`,
+    ].join(" "),
+  );
+  process.stdout.write("\n");
+  process.stdout.write(`aggregateWritten=${aggregatePath}\n`);
+  process.stdout.write(`samplesDir=${samplesDir}\n`);
 }
 
 function runScan(target: string, reportPath?: string): void {
@@ -1063,7 +1119,8 @@ function parseArgs(argv: string[]): ParsedArgs | undefined {
     | "fixtures"
     | "demo"
     | "content-webmap"
-    | "content" =
+    | "content"
+    | "corpus-evidence" =
     maybeCommand === "scan" ||
     maybeCommand === "codemod" ||
     maybeCommand === "reconcile" ||
@@ -1072,7 +1129,8 @@ function parseArgs(argv: string[]): ParsedArgs | undefined {
     maybeCommand === "fixtures" ||
     maybeCommand === "demo" ||
     maybeCommand === "content-webmap" ||
-    maybeCommand === "content"
+    maybeCommand === "content" ||
+    maybeCommand === "corpus-evidence"
       ? maybeCommand
       : "scan";
   const positional = command === maybeCommand ? argv.slice(1) : argv.slice(0);
@@ -1081,6 +1139,7 @@ function parseArgs(argv: string[]): ParsedArgs | undefined {
   let fixtureNames: string[] | undefined;
   let reportPath: string | undefined;
   let codemodTarget: CodemodTarget = "honua-compat";
+  let codemodTargetExplicit = false;
   let write = false;
   let annotateTodos = false;
   let failOnManual = false;
@@ -1121,6 +1180,8 @@ function parseArgs(argv: string[]): ParsedArgs | undefined {
   let contentIncludeFeatures = true;
   let contentIncludeWebMaps = true;
   let contentIncludeHostedLayers = true;
+  let corpusPath: string | undefined;
+  let corpusOutputDir: string | undefined;
 
   for (let i = 0; i < positional.length; i += 1) {
     const token = positional[i];
@@ -1209,6 +1270,7 @@ function parseArgs(argv: string[]): ParsedArgs | undefined {
         return undefined;
       }
       codemodTarget = next === "honua" ? "honua-compat" : next;
+      codemodTargetExplicit = true;
       i += 1;
       continue;
     }
@@ -1335,6 +1397,24 @@ function parseArgs(argv: string[]): ParsedArgs | undefined {
         return undefined;
       }
       contentInputPath = next;
+      i += 1;
+      continue;
+    }
+    if (token === "--corpus") {
+      const next = positional[i + 1];
+      if (!next) {
+        return undefined;
+      }
+      corpusPath = next;
+      i += 1;
+      continue;
+    }
+    if (token === "--out") {
+      const next = positional[i + 1];
+      if (!next) {
+        return undefined;
+      }
+      corpusOutputDir = next;
       i += 1;
       continue;
     }
@@ -1528,6 +1608,13 @@ function parseArgs(argv: string[]): ParsedArgs | undefined {
       }
       return undefined;
     }
+    if (command === "corpus-evidence") {
+      if (!corpusPath) {
+        corpusPath = token;
+        continue;
+      }
+      return undefined;
+    }
     if (!target) {
       target = token;
       continue;
@@ -1562,6 +1649,9 @@ function parseArgs(argv: string[]): ParsedArgs | undefined {
     }
   }
 
+  const resolvedCodemodTarget: CodemodTarget =
+    command === "corpus-evidence" && !codemodTargetExplicit ? "honua-maplibre" : codemodTarget;
+
   return {
     command,
     target:
@@ -1569,7 +1659,7 @@ function parseArgs(argv: string[]): ParsedArgs | undefined {
       (command === "fixtures" || command === "demo" ? path.join(process.cwd(), "test", "fixtures") : process.cwd()),
     contentAction,
     write,
-    codemodTarget,
+    codemodTarget: resolvedCodemodTarget,
     annotateTodos,
     failOnManual,
     failOnUnhandled,
@@ -1610,6 +1700,8 @@ function parseArgs(argv: string[]): ParsedArgs | undefined {
     contentIncludeFeatures,
     contentIncludeWebMaps,
     contentIncludeHostedLayers,
+    corpusPath,
+    corpusOutputDir,
   };
 }
 
@@ -1658,6 +1750,7 @@ function printUsage(): void {
       "  honua-migrate content import --source <dir> --target <url> [--admin-api-key <key>] [--output-dir <dir>] [--table-prefix <prefix>] [--source-url-prefix <url>] [--target-url-prefix <url>] [--exclude-webmaps] [--exclude-hosted-layers] [--report <file>]",
       "  honua-migrate content reconcile --source <dir> [--import-report <file>] [--output-dir <file>] [--report <file>]",
       "  honua-migrate content-webmap --input <webmap.json> [--output <file>] [--source-url-prefix <url>] [--target-url-prefix <url>] [--exclude-basemap] [--report <file>]",
+      "  honua-migrate corpus-evidence [--corpus <dir>] --out <dir> [--target <honua|honua-compat|honua-maplibre|esri-leaflet>]",
       "",
       "Examples:",
       "  node dist/src/migration/cli.js scan ./src",
@@ -1676,6 +1769,7 @@ function printUsage(): void {
       "  node dist/src/migration/cli.js content import --source ./export --target https://honua.example.com --admin-api-key $HONUA_ADMIN_API_KEY --report ./content/import.json",
       "  node dist/src/migration/cli.js content reconcile --source ./export --report ./content/reconcile.json",
       "  node dist/src/migration/cli.js content-webmap --input ./export/map.json --output ./export/map.honua.json --source-url-prefix https://org.maps.arcgis.com --target-url-prefix https://honua.example.com --report ./export/map.report.json",
+      "  node dist/src/migration/cli.js corpus-evidence --corpus test/fixtures/esri-sample-corpus --out ./corpus-evidence",
       "",
       "Target semantics:",
       "  honua: alias of honua-compat.",

--- a/test/migration-cli-corpus-evidence.test.ts
+++ b/test/migration-cli-corpus-evidence.test.ts
@@ -1,0 +1,164 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+import { getProjectRoot, withCliLock } from "./migration-cli-lock.js";
+
+const tempDirs: string[] = [];
+let builtOnce = false;
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "honua-cli-corpus-evidence-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function ensureBuiltCliArtifacts(): void {
+  withCliLock(() => {
+    const cliPath = path.join(getProjectRoot(), "dist", "src", "migration", "cli.js");
+    if (builtOnce && fs.existsSync(cliPath)) {
+      return;
+    }
+
+    const buildResult = spawnSync("npm", ["run", "build", "--silent"], {
+      cwd: getProjectRoot(),
+      encoding: "utf8",
+    });
+    if (buildResult.status !== 0) {
+      throw new Error(buildResult.stderr || buildResult.stdout || "failed to build migration CLI");
+    }
+    builtOnce = true;
+  });
+}
+
+function runCli(args: readonly string[], cwd: string): { status: number | null; stdout: string; stderr: string } {
+  return withCliLock(() => {
+    const cliPath = path.join(getProjectRoot(), "dist", "src", "migration", "cli.js");
+    const result = spawnSync("node", [cliPath, ...args], {
+      cwd,
+      encoding: "utf8",
+    });
+
+    return {
+      status: result.status,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  });
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const fixtureCorpusRoot = path.join(getProjectRoot(), "test", "fixtures", "esri-sample-corpus");
+const fixtureManifestPath = path.join(fixtureCorpusRoot, "manifest.json");
+
+interface AggregateEvidence {
+  codemodTarget: string;
+  manifestPath?: string;
+  samples: Array<{
+    sampleId: string;
+    status: "migrated" | "skipped" | "error";
+    codemodTarget: string;
+  }>;
+  aggregate: {
+    sampleCount: number;
+    codemodTarget: string;
+    statusCounts: { migrated: number; skipped: number; error: number };
+    totals: { auto: number; manual: number; unsupported: number };
+    manualTodoTotal: number;
+    uniqueUnsupportedApis: string[];
+  };
+}
+
+describe("migration cli corpus-evidence", () => {
+  it("writes per-sample and aggregate evidence artifacts for the fixture corpus", () => {
+    ensureBuiltCliArtifacts();
+    const outRoot = makeTempDir();
+    const outDir = path.join(outRoot, "evidence");
+
+    const result = runCli(["corpus-evidence", "--corpus", fixtureCorpusRoot, "--out", outDir], getProjectRoot());
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("corpusEvidence");
+    expect(result.stdout).toContain("target=honua-maplibre");
+    expect(result.stdout).toContain(`out=${outDir}`);
+
+    const aggregatePath = path.join(outDir, "corpus-evidence.json");
+    const samplesDir = path.join(outDir, "samples");
+    expect(fs.existsSync(aggregatePath)).toBe(true);
+    expect(fs.existsSync(samplesDir)).toBe(true);
+
+    const aggregate = JSON.parse(fs.readFileSync(aggregatePath, "utf8")) as AggregateEvidence;
+    expect(aggregate.codemodTarget).toBe("honua-maplibre");
+    expect(aggregate.aggregate.codemodTarget).toBe("honua-maplibre");
+
+    const manifest = JSON.parse(fs.readFileSync(fixtureManifestPath, "utf8")) as {
+      samples: Array<{ id: string }>;
+    };
+    expect(aggregate.aggregate.sampleCount).toBe(manifest.samples.length);
+    expect(aggregate.samples).toHaveLength(manifest.samples.length);
+
+    const summed =
+      aggregate.aggregate.statusCounts.migrated +
+      aggregate.aggregate.statusCounts.skipped +
+      aggregate.aggregate.statusCounts.error;
+    expect(summed).toBe(manifest.samples.length);
+    expect(aggregate.aggregate.statusCounts.migrated).toBeGreaterThanOrEqual(1);
+    expect(aggregate.aggregate.statusCounts.skipped).toBeGreaterThanOrEqual(2);
+    expect(aggregate.aggregate.statusCounts.error).toBe(0);
+
+    for (const sample of manifest.samples) {
+      const samplePath = path.join(samplesDir, `${sample.id}.json`);
+      expect(fs.existsSync(samplePath)).toBe(true);
+      const written = JSON.parse(fs.readFileSync(samplePath, "utf8")) as {
+        sampleId: string;
+        codemodTarget: string;
+      };
+      expect(written.sampleId).toBe(sample.id);
+      expect(written.codemodTarget).toBe("honua-maplibre");
+    }
+  }, 240_000);
+
+  it("respects an explicit --target flag in the aggregate output", () => {
+    ensureBuiltCliArtifacts();
+    const outRoot = makeTempDir();
+    const outDir = path.join(outRoot, "evidence");
+
+    const result = runCli(
+      ["corpus-evidence", "--corpus", fixtureCorpusRoot, "--out", outDir, "--target", "honua-compat"],
+      getProjectRoot(),
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("target=honua-compat");
+
+    const aggregate = JSON.parse(
+      fs.readFileSync(path.join(outDir, "corpus-evidence.json"), "utf8"),
+    ) as AggregateEvidence;
+    expect(aggregate.codemodTarget).toBe("honua-compat");
+    expect(aggregate.aggregate.codemodTarget).toBe("honua-compat");
+    for (const sample of aggregate.samples) {
+      expect(sample.codemodTarget).toBe("honua-compat");
+    }
+  }, 240_000);
+
+  it("exits non-zero with a clear stderr message when the corpus manifest is missing", () => {
+    ensureBuiltCliArtifacts();
+    const outRoot = makeTempDir();
+    const missingCorpus = path.join(outRoot, "does-not-exist");
+    const outDir = path.join(outRoot, "evidence");
+
+    const result = runCli(["corpus-evidence", "--corpus", missingCorpus, "--out", outDir], getProjectRoot());
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("corpusEvidenceError=");
+    expect(result.stderr).toContain("manifest.json");
+    expect(fs.existsSync(path.join(outDir, "corpus-evidence.json"))).toBe(false);
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

Slice of #206 — does not close the issue.

- Adds `honua-migrate corpus-evidence [--corpus <dir>] --out <dir> [--target <honua|honua-compat|honua-maplibre|esri-leaflet>]` to the migration CLI. The subcommand calls the existing `emitEsriSampleCorpusEvidence` helper (shipped in #217) — it does not reimplement evidence shape.
- Writes one JSON file per sample to `<out>/samples/<sampleId>.json` plus an aggregate `<out>/corpus-evidence.json` document. `--target` defaults to `honua-maplibre` to match the in-memory helper, and the corpus root defaults to `test/fixtures/esri-sample-corpus` when `--corpus` is omitted.
- Prints a one-line `corpusEvidence samples=… migrated=… skipped=… error=… target=… out=…` summary, then `aggregateWritten=` / `samplesDir=`. On missing/unreadable manifests the CLI exits non-zero with a `corpusEvidenceError=` stderr message.

## Files touched

- `src/migration/cli.ts` — new `corpus-evidence` subcommand, `--corpus` / `--out` flags, per-command default of `honua-maplibre` when `--target` is not explicit, usage entry + example.
- `test/migration-cli-corpus-evidence.test.ts` — happy path (default `honua-maplibre`, per-sample + aggregate written, status counts sum to manifest length), explicit `--target honua-compat` propagation, and missing-corpus error path.
- `docs/esri-sample-corpus.md` — extended "Per-sample evidence" section with the new CLI usage + example block. No other sections touched.

Public surface (`src/migration-entry.ts`) was not changed — `emitEsriSampleCorpusEvidence` was already exported by #217. `src/migration/sample-corpus.ts`, `src/migration/sample-corpus-evidence.ts`, `src/migration/codemod.ts`, `src/map/webmap-maplibre.ts`, `runtime-matrix.ts`, and `parity-matrix.ts` are untouched.

## Test plan

- [x] `npm test -- --run test/migration-cli-corpus-evidence.test.ts test/migration-cli-target.test.ts test/migration-cli-fixtures.test.ts test/migration-sample-corpus-evidence.test.ts test/entrypoints.test.ts` (5 files / 31 tests pass)
- [x] `npm run typecheck --silent`
- [x] `npx biome check src/migration/cli.ts test/migration-cli-corpus-evidence.test.ts docs/esri-sample-corpus.md`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>