### PR TITLE
feat(migration): WebMap literal codemod wiring for honua-maplibre

### DIFF
--- a/docs/migration-punch-list.md
+++ b/docs/migration-punch-list.md
@@ -242,17 +242,26 @@ known constructors" into "automated app conversion":
    top-level `widgets` array used by host shells), plus
    pass-throughs for `unsupported-symbol`,
    `unsupported-layer-type`, `unsupported-feature-collection`, and
-   `unsupported-webmap-version`. **What still requires manual
-   review:** the codemod does **not** yet wire this converter into
-   its import-rewriting pass — apps that call ArcGIS WebMap
-   loaders (`WebMap.load()`, `WebMap({ portalItem })`) still hit
-   the existing `web-map` compat shim, not the MapLibre style
-   path; the gap surface is also intentionally honest about its
-   ceiling, since Arcade execution, scene/3D rendering, Dashboard
-   widget hosts, Experience Builder pages, and custom-widget
-   plugins all require runtime support the JS SDK cannot
-   synthesize from JSON alone. Each emitted gap is a `// TODO`
-   anchor for an app author, not a promise of automated
+   `unsupported-webmap-version`. The migration codemod now wires
+   this converter into its `honua-maplibre` constructor-rewriting
+   pass: any `new WebMap({ ... })` call whose argument is a static
+   WebMap JSON object literal (top-level `operationalLayers` and/or
+   `baseMap`, fully literal values, no `portalItem`) is rewritten
+   to `webmapJsonToMapLibreStyle({ ... })` from
+   `@honua/sdk-js/map`, and the helper's `manualGaps` array is
+   propagated into the migration report as per-gap `web-map`
+   manual TODOs (Arcade, unsupported renderer, scene/3D, dashboard
+   shell, …). **What still requires manual review:** dynamic /
+   portal-loaded WebMaps (`new WebMap({ portalItem: { id: someId }
+   })`, `WebMap.load()`, identifier references, computed
+   properties, spreads) still emit a `web-map` manual TODO with
+   no rewrite — they need a runtime fetch the codemod cannot
+   synthesize. The gap surface is also intentionally honest about
+   its ceiling, since Arcade execution, scene/3D rendering,
+   Dashboard widget hosts, Experience Builder pages, and
+   custom-widget plugins all require runtime support the JS SDK
+   cannot synthesize from JSON alone. Each emitted gap is a `//
+   TODO` anchor for an app author, not a promise of automated
    migration.
 6. **End-to-end demo conversion.** Shipped at
    `examples/arcgis-source-app/` + `test/migration-e2e.test.ts`.

--- a/src/migration/codemod.ts
+++ b/src/migration/codemod.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import ts from "typescript";
+import { type WebMapMapLibreManualGap, webmapJsonToMapLibreStyle } from "../map/webmap-maplibre.js";
+import type { WebMapJson } from "../webmap/types.js";
 
 const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
 const SKIP_DIRS = new Set(["node_modules", "dist", ".git"]);
@@ -23,6 +25,10 @@ const HONUA_MAPLIBRE_UNSUPPORTED_DYNAMIC_IMPORT_REASON =
   "Dynamic import has no deterministic Honua MapLibre mapping; requires manual migration.";
 const HONUA_MAPLIBRE_UNSUPPORTED_IMPORT_REASON =
   "No deterministic Honua MapLibre mapping for this import; requires manual migration.";
+const HONUA_MAPLIBRE_WEBMAP_DYNAMIC_REASON =
+  "Dynamic / portal-loaded WebMap has no deterministic Honua MapLibre style derivation; requires manual migration.";
+const HONUA_MAPLIBRE_WEBMAP_UNSUPPORTED_SHAPE_REASON =
+  "WebMap constructor argument is not a static WebMap JSON literal; requires manual migration.";
 const REACTIVE_UTILS_IMPORT_UNSUPPORTED_REASON = "ReactiveUtils import shape is unsupported for automatic migration.";
 const ESRI_CONFIG_IMPORT_UNSUPPORTED_REASON = "esriConfig import shape is unsupported for automatic migration.";
 const IDENTITY_MANAGER_IMPORT_UNSUPPORTED_REASON =
@@ -1209,6 +1215,65 @@ function codemodFile(
         }
         return;
       }
+    }
+
+    if (target === "honua-maplibre" && importBinding.kind === "web-map") {
+      const webmapOutcome = handleHonuaMapLibreWebMapNewExpression(node, sourceFile);
+      if (webmapOutcome.kind === "rewrite") {
+        constructorEdits.push({
+          start: node.getStart(sourceFile),
+          end: node.getEnd(),
+          text: webmapOutcome.text,
+        });
+        requiredHonuaMapLibreSymbols.add("webmapJsonToMapLibreStyle");
+        rewrittenKinds.push("web-map");
+        for (const gap of webmapOutcome.manualGaps) {
+          const nodeStart = node.getStart(sourceFile);
+          const location = sourceFile.getLineAndCharacterOfPosition(nodeStart);
+          const gapReason = formatWebMapMapLibreGapReason(gap);
+          manualTodos.push({
+            kind: "web-map",
+            file,
+            line: location.line + 1,
+            column: location.character + 1,
+            reason: gapReason,
+            difficulty: "complex",
+          });
+          if (annotateTodos) {
+            const lineStart = findLineStartOffset(source, nodeStart);
+            if (shouldInsertTodoComment(source, lineStart, nodeStart)) {
+              todoCommentEdits.push({
+                start: lineStart,
+                end: lineStart,
+                text: `// ${TODO_MARKER}[web-map]: ${gapReason}\n`,
+              });
+            }
+          }
+        }
+        return;
+      }
+
+      const nodeStart = node.getStart(sourceFile);
+      const location = sourceFile.getLineAndCharacterOfPosition(nodeStart);
+      manualTodos.push({
+        kind: "web-map",
+        file,
+        line: location.line + 1,
+        column: location.character + 1,
+        reason: webmapOutcome.reason,
+        difficulty: "complex",
+      });
+      if (annotateTodos) {
+        const lineStart = findLineStartOffset(source, nodeStart);
+        if (shouldInsertTodoComment(source, lineStart, nodeStart)) {
+          todoCommentEdits.push({
+            start: lineStart,
+            end: lineStart,
+            text: `// ${TODO_MARKER}[web-map]: ${webmapOutcome.reason}\n`,
+          });
+        }
+      }
+      return;
     }
 
     const safeCheck = isSafeConstructorCall(importBinding.kind, node, target);
@@ -2945,6 +3010,150 @@ function buildOptionalObjectOptionsText(node: ts.NewExpression, sourceFile: ts.S
     return "{}";
   }
   return arg.getText(sourceFile);
+}
+
+type HonuaMapLibreWebMapOutcome =
+  | { kind: "rewrite"; text: string; manualGaps: readonly WebMapMapLibreManualGap[] }
+  | { kind: "manual"; reason: string };
+
+/**
+ * Decide how to migrate a `new WebMap({...})` call for the `honua-maplibre`
+ * target. Safe WebMap JSON object literals are rewritten to a
+ * `webmapJsonToMapLibreStyle({...})` call; any other shape (string portal
+ * item id, identifier references, computed properties, spreads, …)
+ * falls through to a manual TODO carrying a clear reason.
+ */
+function handleHonuaMapLibreWebMapNewExpression(
+  node: ts.NewExpression,
+  sourceFile: ts.SourceFile,
+): HonuaMapLibreWebMapOutcome {
+  const args = node.arguments;
+  if (!args || args.length === 0) {
+    return { kind: "manual", reason: HONUA_MAPLIBRE_WEBMAP_DYNAMIC_REASON };
+  }
+  if (args.length !== 1) {
+    return { kind: "manual", reason: HONUA_MAPLIBRE_WEBMAP_UNSUPPORTED_SHAPE_REASON };
+  }
+
+  const [arg] = args;
+  if (!ts.isObjectLiteralExpression(arg)) {
+    return { kind: "manual", reason: HONUA_MAPLIBRE_WEBMAP_UNSUPPORTED_SHAPE_REASON };
+  }
+
+  // Reject portal-loaded / dynamic shapes outright — they have no static
+  // JSON to feed into webmapJsonToMapLibreStyle.
+  if (objectLiteralHasProperty(arg, "portalItem")) {
+    return { kind: "manual", reason: HONUA_MAPLIBRE_WEBMAP_DYNAMIC_REASON };
+  }
+
+  const evaluated = evaluateObjectLiteralAsJson(arg);
+  if (!evaluated.ok) {
+    return { kind: "manual", reason: HONUA_MAPLIBRE_WEBMAP_UNSUPPORTED_SHAPE_REASON };
+  }
+
+  // Require at least one WebMap-JSON-specific top-level key so we don't
+  // mistake an ArcGIS JS API constructor literal (e.g. `{ basemap:
+  // 'streets' }`) for a WebMap JSON document. WebMap JSON uses
+  // `baseMap` (capital M) and/or `operationalLayers`.
+  const json = evaluated.value as Record<string, unknown>;
+  const looksLikeWebMapJson =
+    Object.prototype.hasOwnProperty.call(json, "operationalLayers") ||
+    Object.prototype.hasOwnProperty.call(json, "baseMap");
+  if (!looksLikeWebMapJson) {
+    return { kind: "manual", reason: HONUA_MAPLIBRE_WEBMAP_DYNAMIC_REASON };
+  }
+
+  let result: { manualGaps: readonly WebMapMapLibreManualGap[] };
+  try {
+    result = webmapJsonToMapLibreStyle(json as WebMapJson);
+  } catch {
+    return { kind: "manual", reason: HONUA_MAPLIBRE_WEBMAP_UNSUPPORTED_SHAPE_REASON };
+  }
+
+  return {
+    kind: "rewrite",
+    text: `webmapJsonToMapLibreStyle(${arg.getText(sourceFile)})`,
+    manualGaps: result.manualGaps,
+  };
+}
+
+function formatWebMapMapLibreGapReason(gap: WebMapMapLibreManualGap): string {
+  const pathSuffix = gap.path ? ` at ${gap.path}` : "";
+  return `WebMap → MapLibre style derivation [${gap.kind}]${pathSuffix}: ${gap.reason}`;
+}
+
+/**
+ * Evaluate a TypeScript object literal as a JSON value. Returns ok:false
+ * if any node is non-literal (identifier, call, template expression,
+ * computed property, spread, method shorthand, etc.). Used by the
+ * WebMap → MapLibre style derivation rewrite to gate which constructor
+ * arguments can be statically converted.
+ */
+function evaluateObjectLiteralAsJson(
+  node: ts.ObjectLiteralExpression,
+): { ok: true; value: Record<string, unknown> } | { ok: false } {
+  const result: Record<string, unknown> = {};
+  for (const property of node.properties) {
+    if (!ts.isPropertyAssignment(property)) {
+      return { ok: false };
+    }
+    const name = getPropertyNameText(property.name);
+    if (!name) {
+      return { ok: false };
+    }
+    const value = evaluateExpressionAsJson(property.initializer);
+    if (!value.ok) {
+      return { ok: false };
+    }
+    result[name] = value.value;
+  }
+  return { ok: true, value: result };
+}
+
+function evaluateExpressionAsJson(node: ts.Expression): { ok: true; value: unknown } | { ok: false } {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return { ok: true, value: node.text };
+  }
+  if (ts.isNumericLiteral(node)) {
+    return { ok: true, value: Number(node.text) };
+  }
+  if (node.kind === ts.SyntaxKind.TrueKeyword) {
+    return { ok: true, value: true };
+  }
+  if (node.kind === ts.SyntaxKind.FalseKeyword) {
+    return { ok: true, value: false };
+  }
+  if (node.kind === ts.SyntaxKind.NullKeyword) {
+    return { ok: true, value: null };
+  }
+  if (ts.isPrefixUnaryExpression(node) && node.operator === ts.SyntaxKind.MinusToken) {
+    const inner = evaluateExpressionAsJson(node.operand);
+    if (!inner.ok || typeof inner.value !== "number") {
+      return { ok: false };
+    }
+    return { ok: true, value: -inner.value };
+  }
+  if (ts.isArrayLiteralExpression(node)) {
+    const values: unknown[] = [];
+    for (const element of node.elements) {
+      if (ts.isOmittedExpression(element) || ts.isSpreadElement(element)) {
+        return { ok: false };
+      }
+      const evaluated = evaluateExpressionAsJson(element);
+      if (!evaluated.ok) {
+        return { ok: false };
+      }
+      values.push(evaluated.value);
+    }
+    return { ok: true, value: values };
+  }
+  if (ts.isObjectLiteralExpression(node)) {
+    return evaluateObjectLiteralAsJson(node);
+  }
+  if (ts.isParenthesizedExpression(node)) {
+    return evaluateExpressionAsJson(node.expression);
+  }
+  return { ok: false };
 }
 
 function esriLeafletMethodForKind(kind: CodemodConstructorKind): string | undefined {

--- a/src/migration/parity-matrix.ts
+++ b/src/migration/parity-matrix.ts
@@ -76,6 +76,8 @@ const HONUA_MAPLIBRE_NOTE_OVERRIDES: Readonly<Partial<Record<CodemodConstructorK
     "Search requires a Locator-equivalent backend (HonuaGeocodeService); blocked on migration-punch-list Task C.",
   "feature-table-widget":
     "FeatureTableCompat renders through the Honua widget host; MapLibre apps must wire layout/columns manually.",
+  "web-map":
+    "Static WebMap JSON literals are auto-rewritten to webmapJsonToMapLibreStyle({...}); dynamic / portal-loaded WebMaps still fall through to manual TODO.",
 });
 
 const BASE_MATRIX_ROWS: JsParityMatrixEntry[] = (Object.keys(CANONICAL_MODULE_BY_KIND) as CodemodConstructorKind[])

--- a/test/migration-codemod.test.ts
+++ b/test/migration-codemod.test.ts
@@ -1879,6 +1879,111 @@ describe("runEsriCompatCodemod", () => {
     expect(nextSource).not.toContain("@honua/sdk-esri-compat");
   });
 
+  it("rewrites safe WebMap JSON literal to webmapJsonToMapLibreStyle for honua-maplibre target", () => {
+    const root = makeTempProject();
+    const file = path.join(root, "honua-maplibre-webmap.ts");
+    fs.writeFileSync(
+      file,
+      [
+        "import WebMap from '@arcgis/core/WebMap';",
+        "const webmap = new WebMap({ operationalLayers: [{ id: 'roads', title: 'Roads', url: 'https://services.example.com/Roads/FeatureServer/0', layerType: 'ArcGISFeatureLayer', layerDefinition: { drawingInfo: { renderer: { type: 'simple', symbol: { type: 'esriSLS', color: [0, 0, 0, 255], width: 1 } } } } }], baseMap: { baseMapLayers: [{ id: 'base', url: 'https://tiles.example.com/tile/{z}/{y}/{x}', layerType: 'ArcGISTiledMapServiceLayer' }] } });",
+        "void webmap;",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = runEsriCompatCodemod({
+      rootDir: root,
+      target: "honua-maplibre",
+      write: true,
+    });
+
+    expect(result.filesChanged).toBe(1);
+    expect(result.metrics.byKind["web-map"]).toMatchObject({ total: 1, autoMigrated: 1, manual: 0 });
+    expect(result.metrics.manualCallSites).toBe(0);
+    expect(result.manualTodos).toEqual([]);
+
+    const nextSource = fs.readFileSync(file, "utf8");
+    expect(nextSource).toContain('import { webmapJsonToMapLibreStyle } from "@honua/sdk-js/map";');
+    expect(nextSource).toContain("const webmap = webmapJsonToMapLibreStyle({ operationalLayers:");
+    expect(nextSource).not.toContain("@arcgis/core/WebMap");
+    expect(nextSource).not.toContain("@honua/sdk-esri-compat");
+  });
+
+  it("rewrites WebMap JSON literal with arcade expression and emits arcade-expression manual todo for honua-maplibre target", () => {
+    const root = makeTempProject();
+    const file = path.join(root, "honua-maplibre-webmap-arcade.ts");
+    fs.writeFileSync(
+      file,
+      [
+        "import WebMap from '@arcgis/core/WebMap';",
+        "const webmap = new WebMap({ operationalLayers: [{ id: 'facilities', url: 'https://services.example.com/Facilities/FeatureServer/0', layerType: 'ArcGISFeatureLayer', layerDefinition: { drawingInfo: { renderer: { type: 'simple', symbol: { type: 'esriSFS', style: 'esriSFSSolid', color: [180, 180, 200, 255] } } } }, popupInfo: { title: '{NAME}', expressionInfos: [{ name: 'statusText', expression: \"IIF($feature.STATUS == 1, 'Open', 'Closed')\" }] } }] });",
+        "void webmap;",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = runEsriCompatCodemod({
+      rootDir: root,
+      target: "honua-maplibre",
+      write: true,
+      annotateTodos: true,
+    });
+
+    expect(result.filesChanged).toBe(1);
+    // Auto-migrated AND manual TODO are independent: the rewrite still
+    // happens, but each manualGaps entry is also recorded in the report.
+    expect(result.metrics.byKind["web-map"].autoMigrated).toBe(1);
+    expect(result.metrics.byKind["web-map"].manual).toBeGreaterThan(0);
+    const arcadeTodos = result.manualTodos.filter(
+      (todo) => todo.kind === "web-map" && todo.reason.includes("arcade-expression"),
+    );
+    expect(arcadeTodos.length).toBeGreaterThan(0);
+    expect(arcadeTodos[0]?.reason).toContain("arcade-expression");
+
+    const nextSource = fs.readFileSync(file, "utf8");
+    expect(nextSource).toContain("webmapJsonToMapLibreStyle(");
+    expect(nextSource).toContain("// TODO(honua-migrate)[web-map]:");
+    expect(nextSource).toContain("arcade-expression");
+    expect(nextSource).not.toContain("@arcgis/core/WebMap");
+  });
+
+  it("emits manual todo without rewrite for dynamic / portal-loaded WebMap under honua-maplibre target", () => {
+    const root = makeTempProject();
+    const file = path.join(root, "honua-maplibre-webmap-portal.ts");
+    fs.writeFileSync(
+      file,
+      [
+        "import WebMap from '@arcgis/core/WebMap';",
+        "declare const someId: string;",
+        "const webmap = new WebMap({ portalItem: { id: someId } });",
+        "void webmap;",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = runEsriCompatCodemod({
+      rootDir: root,
+      target: "honua-maplibre",
+      write: true,
+      annotateTodos: true,
+    });
+
+    expect(result.metrics.byKind["web-map"]).toMatchObject({ total: 1, autoMigrated: 0, manual: 1 });
+    expect(result.metrics.manualCallSites).toBe(1);
+    expect(result.manualTodos).toEqual([
+      expect.objectContaining({
+        kind: "web-map",
+        reason: expect.stringContaining("Dynamic / portal-loaded WebMap"),
+      }),
+    ]);
+
+    const nextSource = fs.readFileSync(file, "utf8");
+    expect(nextSource).toContain("new WebMap({ portalItem: { id: someId } })");
+    expect(nextSource).toContain("// TODO(honua-migrate)[web-map]:");
+    expect(nextSource).not.toContain("webmapJsonToMapLibreStyle");
+  });
+
   it("rewrites map/view/widget constructors to compat fallbacks for esri-leaflet target", () => {
     const root = makeTempProject();
     const file = path.join(root, "esri-leaflet-compat-fallbacks.ts");


### PR DESCRIPTION
## Issue Link

Related to #205 (slice — not closing). Builds directly on PR #220 (`webmapJsonToMapLibreStyle` helper).

## Summary

Under `target=honua-maplibre`, the codemod now rewrites safe `new WebMap({...})` literals to `webmapJsonToMapLibreStyle({...})` from `@honua/sdk-js/map`. The helper's `manualGaps` array is propagated into the migration report as per-gap `web-map` manual TODOs (arcade-expression, unsupported-renderer, scene-3d, dashboard-reference, experience-builder-reference, custom-widget-reference, …).

Dynamic / portal-loaded WebMaps (`new WebMap({ portalItem: { id: someId } })`, identifier references, computed properties, spreads) emit a manual TODO with no rewrite — they need a runtime fetch the codemod cannot synthesize.

`honua-compat` and `esri-leaflet` targets are unchanged.

## Changes

- `src/migration/codemod.ts` — new `handleHonuaMapLibreWebMapNewExpression` + safe-JSON literal evaluator (`evaluateObjectLiteralAsJson` / `evaluateExpressionAsJson`); dispatch under `target === "honua-maplibre" && kind === "web-map"`; manualGaps propagated as `web-map` manualTodos with `complex` difficulty.
- `src/migration/parity-matrix.ts` — `HONUA_MAPLIBRE_NOTE_OVERRIDES["web-map"]` note clarifying static-vs-dynamic split.
- `test/migration-codemod.test.ts` — 3 new tests: safe literal rewrite, literal-with-Arcade rewrite + TODO, dynamic portalItem manual TODO without rewrite.
- `docs/migration-punch-list.md` — updated the existing WebMap paragraph to reflect that codemod wiring is now done; dynamic/portal-loaded WebMaps still call out as manual.

## Validation

- `npx vitest run test/migration-codemod.test.ts test/migration-report.test.ts test/migration-runtime-matrix.test.ts test/migration-parity-matrix.test.ts test/webmap-maplibre-style.test.ts` — 124/124 passing
- `npm run typecheck --silent` — clean
- `npx biome check src/migration/codemod.ts src/migration/parity-matrix.ts test/migration-codemod.test.ts docs/migration-punch-list.md` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>