### PR TITLE
test(playwright): browser smoke for honua-maplibre codemod target

### DIFF
--- a/package.json
+++ b/package.json
@@ -263,7 +263,7 @@
     "test:migration:real-samples": "vitest run test/migration-real-sample-runtime.test.ts test/migration-feature-table-demo-runtime.test.ts",
     "test:playwright": "npm run build --silent && node scripts/ensure-kepler-demo-deps.mjs && playwright test",
     "test:playwright:25d": "playwright test test/playwright/storytelling-25d-map.spec.mjs",
-    "test:playwright:migration": "npm run build --silent && playwright test test/playwright/migration-browser-smoke.spec.mjs test/playwright/migration-browser-real-sample.spec.mjs",
+    "test:playwright:migration": "npm run build --silent && playwright test test/playwright/migration-browser-smoke.spec.mjs test/playwright/migration-browser-real-sample.spec.mjs test/playwright/migration-browser-maplibre.spec.mjs",
     "report:migration:demo-target": "npm run build --silent && node dist/src/migration/cli.js fixtures --target honua --fixtures esri-demo-feature-table-relates-app --report reports/demo-featuretable-primary-metrics.json",
     "gate:migration:demo-target": "npm run build --silent && node dist/src/migration/cli.js fixtures --target honua --fixtures esri-demo-feature-table-relates-app --fail-on-manual --fail-on-unhandled --fail-on-blocked --max-manual-ratio 0 --max-manual-intervention-ratio 0 --report reports/demo-featuretable-primary-metrics.json",
     "report:migration:esri-leaflet-target": "npm run build --silent && node dist/src/migration/cli.js fixtures --target esri-leaflet --fixtures esri-demo-feature-table-popup-interaction-app --report reports/demo-featuretable-fallback-esri-leaflet-metrics.json",

--- a/test/playwright/migration-browser-maplibre.spec.mjs
+++ b/test/playwright/migration-browser-maplibre.spec.mjs
@@ -1,0 +1,288 @@
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+const require = createRequire(import.meta.url);
+
+function getProjectRoot() {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+}
+
+async function importCodemod(projectRoot) {
+  const codemodPath = path.join(projectRoot, "dist", "src", "migration", "codemod.js");
+  return import(pathToFileURL(codemodPath).href);
+}
+
+function createTempRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "honua-playwright-maplibre-"));
+}
+
+function writeFixtureApp(appRoot) {
+  fs.mkdirSync(appRoot, { recursive: true });
+  const appFile = path.join(appRoot, "main.js");
+  fs.writeFileSync(
+    appFile,
+    [
+      "import Map from '@arcgis/core/Map';",
+      "import FeatureLayer from '@arcgis/core/layers/FeatureLayer';",
+      "import MapImageLayer from '@arcgis/core/layers/MapImageLayer';",
+      "import TileLayer from '@arcgis/core/layers/TileLayer';",
+      "import MapView from '@arcgis/core/views/MapView';",
+      "const incidents = new FeatureLayer({",
+      "  id: 'incidents',",
+      "  title: 'Incidents',",
+      "  url: 'https://example.test/rest/services/incidents/FeatureServer/0',",
+      "  outFields: ['*'],",
+      "  definitionExpression: \"status = 'open'\",",
+      "  opacity: 0.8,",
+      "});",
+      "const districts = new MapImageLayer({",
+      "  id: 'districts',",
+      "  url: 'https://example.test/rest/services/districts/MapServer',",
+      "  visible: true,",
+      "});",
+      "const basemapTiles = new TileLayer({",
+      "  id: 'basemap-tiles',",
+      "  url: 'https://example.test/rest/services/basemap/MapServer',",
+      "});",
+      "const map = new Map({",
+      "  basemap: 'streets-vector',",
+      "  layers: [basemapTiles, districts, incidents],",
+      "});",
+      "const view = new MapView({",
+      "  map,",
+      "  container: 'viewDiv',",
+      "  center: [-157.8, 21.3],",
+      "  zoom: 12,",
+      "});",
+      "void view;",
+    ].join("\n"),
+    "utf8",
+  );
+  return appFile;
+}
+
+function createIndexHtml() {
+  // The migrated module emitted by the `honua-maplibre` codemod target
+  // references the bare specifiers `maplibre-gl` and `@honua/sdk-js/map`,
+  // which the browser cannot resolve directly. We deliberately do not
+  // execute the migrated module in the browser here — the source-level
+  // assertions below prove the codemod produced the correct shape. The
+  // page below instead exercises the Honua MapLibre helpers (served from
+  // the built `dist/src/map/maplibre-target.js`) end-to-end against a
+  // real MapLibre runtime so we can assert that a `<canvas>` renders and
+  // the derived style retains the migrated layer.
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Honua MapLibre Migration Browser Smoke</title>
+    <link rel="stylesheet" href="/maplibre-gl.css" />
+    <style>
+      html, body, #viewDiv { margin: 0; padding: 0; height: 100%; width: 100%; }
+    </style>
+  </head>
+  <body>
+    <div id="viewDiv"></div>
+    <script src="/maplibre-gl.js"></script>
+    <script type="module">
+      window.__migrationDone = false;
+      window.__migrationResult = null;
+      window.__migrationError = null;
+
+      import("/honua/maplibre-target.js")
+        .then(async (mod) => {
+          const tileLayer = mod.createHonuaTileServiceLayer({
+            id: "basemap-tiles",
+            url: "https://example.test/rest/services/basemap/MapServer",
+          });
+          const style = mod.createHonuaMapLibreStyle({
+            basemap: "streets-vector",
+            layers: [tileLayer],
+            center: [-157.8, 21.3],
+            zoom: 12,
+          });
+          const mapOptions = mod.createHonuaMapLibreMapOptions({
+            map: style,
+            container: "viewDiv",
+            center: [-157.8, 21.3],
+            zoom: 12,
+          });
+
+          const map = new window.maplibregl.Map(mapOptions);
+          // Don't let upstream tile-fetch errors fail the smoke test —
+          // we only care that MapLibre accepted the style and produced
+          // a canvas. Surface the error to the test runner instead.
+          map.on("error", (event) => {
+            window.__migrationTileError = event?.error?.message ?? String(event);
+          });
+          map.on("load", () => {
+            const liveStyle = map.getStyle();
+            window.__migrationResult = {
+              mapLibreVersion: window.maplibregl?.version ?? null,
+              styleVersion: style.version,
+              styleLayerCount: style.layers.length,
+              liveLayerCount: liveStyle?.layers?.length ?? 0,
+              liveLayerIds: (liveStyle?.layers ?? []).map((layer) => layer.id),
+              basemapMetadata: style.metadata?.["honua:arcgis-basemap"] ?? null,
+              tileSourceType: liveStyle?.sources?.[tileLayer.sourceId]?.type ?? null,
+            };
+            window.__migrationDone = true;
+          });
+        })
+        .catch((error) => {
+          window.__migrationError = String(error);
+          window.__migrationDone = true;
+          console.error(error);
+        });
+    </script>
+  </body>
+</html>`;
+}
+
+function startServer(projectRoot, appMain) {
+  const distSourceRoot = path.join(projectRoot, "dist", "src");
+  const maplibreModuleRoot = path.dirname(
+    require.resolve("maplibre-gl/package.json", { paths: [projectRoot] }),
+  );
+  const maplibreJs = path.join(maplibreModuleRoot, "dist", "maplibre-gl.js");
+  const maplibreCss = path.join(maplibreModuleRoot, "dist", "maplibre-gl.css");
+
+  const server = http.createServer((req, res) => {
+    const requestUrl = new URL(req.url ?? "/", "http://127.0.0.1");
+    if (requestUrl.pathname === "/") {
+      res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      res.end(createIndexHtml());
+      return;
+    }
+
+    if (requestUrl.pathname === "/app/main.js") {
+      res.writeHead(200, { "content-type": "text/javascript; charset=utf-8" });
+      res.end(fs.readFileSync(appMain, "utf8"));
+      return;
+    }
+
+    if (requestUrl.pathname === "/maplibre-gl.js") {
+      res.writeHead(200, { "content-type": "text/javascript; charset=utf-8" });
+      res.end(fs.readFileSync(maplibreJs, "utf8"));
+      return;
+    }
+
+    if (requestUrl.pathname === "/maplibre-gl.css") {
+      res.writeHead(200, { "content-type": "text/css; charset=utf-8" });
+      res.end(fs.readFileSync(maplibreCss, "utf8"));
+      return;
+    }
+
+    if (requestUrl.pathname === "/honua/maplibre-target.js") {
+      const target = path.join(distSourceRoot, "map", "maplibre-target.js");
+      res.writeHead(200, { "content-type": "text/javascript; charset=utf-8" });
+      res.end(fs.readFileSync(target, "utf8"));
+      return;
+    }
+
+    const distModulePath = path.join(distSourceRoot, requestUrl.pathname.slice(1));
+    if (distModulePath.startsWith(distSourceRoot) && fs.existsSync(distModulePath)) {
+      res.writeHead(200, { "content-type": "text/javascript; charset=utf-8" });
+      res.end(fs.readFileSync(distModulePath, "utf8"));
+      return;
+    }
+
+    res.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+    res.end("Not found");
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve(server);
+    });
+  });
+}
+
+async function getServerUrl(server) {
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to bind maplibre migration smoke server.");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+test("honua-maplibre codemod target produces a runnable MapLibre app", async ({ page }) => {
+  const projectRoot = getProjectRoot();
+  const tempRoot = createTempRoot();
+  const appRoot = path.join(tempRoot, "app");
+  const appMain = writeFixtureApp(appRoot);
+
+  const { runEsriCompatCodemod } = await importCodemod(projectRoot);
+  const codemodResult = runEsriCompatCodemod({
+    rootDir: tempRoot,
+    target: "honua-maplibre",
+    write: true,
+  });
+
+  // Source-level acceptance: the codemod fully migrated every supported
+  // constructor for the honua-maplibre target without leaving any manual
+  // todos for the simple-app shape.
+  expect(codemodResult.target).toBe("honua-maplibre");
+  expect(codemodResult.filesChanged).toBe(1);
+  expect(codemodResult.metrics.totalCodemodScopedCallSites).toBe(5);
+  expect(codemodResult.metrics.autoMigratedCallSites).toBe(5);
+  expect(codemodResult.metrics.manualCallSites).toBe(0);
+
+  const migratedSource = fs.readFileSync(appMain, "utf8");
+  expect(migratedSource).not.toContain("@arcgis/core");
+  expect(migratedSource).not.toContain("@honua/sdk-esri-compat");
+  expect(migratedSource).toContain('import * as maplibregl from "maplibre-gl";');
+  expect(migratedSource).toContain('from "@honua/sdk-js/map"');
+  expect(migratedSource).toContain("createHonuaFeatureServiceLayer");
+  expect(migratedSource).toContain("createHonuaMapServiceLayer");
+  expect(migratedSource).toContain("createHonuaTileServiceLayer");
+  expect(migratedSource).toContain("createHonuaMapLibreStyle");
+  expect(migratedSource).toContain("createHonuaMapLibreMapOptions");
+  expect(migratedSource).toContain("new maplibregl.Map(");
+
+  const pageErrors = [];
+  page.on("pageerror", (error) => {
+    pageErrors.push(error.message);
+  });
+
+  const server = await startServer(projectRoot, appMain);
+  try {
+    const serverUrl = await getServerUrl(server);
+    await page.goto(serverUrl);
+
+    // Browser-level acceptance: the Honua MapLibre helpers wire a real
+    // MapLibre runtime that renders to a canvas and registers at least
+    // the migrated tile layer in the live style.
+    await page.waitForSelector("canvas.maplibregl-canvas", { timeout: 20_000 });
+
+    await expect
+      .poll(async () => page.evaluate(() => window.__migrationDone === true), {
+        timeout: 20_000,
+      })
+      .toBe(true);
+
+    const migrationError = await page.evaluate(() => window.__migrationError);
+    const migrationResult = await page.evaluate(() => window.__migrationResult);
+
+    expect(migrationError).toBeNull();
+    expect(pageErrors).toEqual([]);
+    expect(migrationResult).not.toBeNull();
+    expect(migrationResult).toMatchObject({
+      styleVersion: 8,
+      styleLayerCount: 1,
+      liveLayerCount: 1,
+      basemapMetadata: "streets-vector",
+      tileSourceType: "raster",
+    });
+    expect(migrationResult.liveLayerIds).toContain("basemap-tiles-raster");
+  } finally {
+    await new Promise((resolve) => server.close(() => resolve(undefined)));
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
Adds a Playwright slice for the `honua-maplibre` codemod target. This is a slice toward #205 and #206 — it does not close either issue.

`test/playwright/migration-browser-maplibre.spec.mjs`:
- Copies an ArcGIS Map / MapView / FeatureLayer / MapImageLayer / TileLayer fixture into a temp dir.
- Runs `runEsriCompatCodemod` with `target: "honua-maplibre"` (`write: true`).
- Asserts on the migrated source:
  - No `@arcgis/core` or `@honua/sdk-esri-compat` imports remain.
  - Emits `import * as maplibregl from "maplibre-gl";`.
  - Emits a named import from `@honua/sdk-js/map` referencing every helper the target wires up (`createHonuaFeatureServiceLayer`, `createHonuaMapServiceLayer`, `createHonuaTileServiceLayer`, `createHonuaMapLibreStyle`, `createHonuaMapLibreMapOptions`).
  - Emits `new maplibregl.Map(...)` for the MapView migration.
  - Metrics report `totalCodemodScopedCallSites === autoMigratedCallSites === 5`, `manualCallSites === 0`.
- Serves a tiny HTML harness over `http.createServer` (same pattern as `migration-browser-smoke.spec.mjs` / `migration-browser-real-sample.spec.mjs`) that loads the MapLibre UMD build, imports the built `dist/src/map/maplibre-target.js` directly, builds a style via `createHonuaTileServiceLayer` + `createHonuaMapLibreStyle`, instantiates a real `new maplibregl.Map(createHonuaMapLibreMapOptions(...))`, and reports the live style back.
- Asserts in the browser:
  - `<canvas.maplibregl-canvas>` is present (waits up to 20s).
  - No `pageerror`s.
  - The live style retains `basemap-tiles-raster` as a layer, the source is `type: "raster"`, and `metadata["honua:arcgis-basemap"]` is `"streets-vector"`.

Extends the existing `test:playwright:migration` npm script to include the new spec alongside the two existing migration browser specs.

## Scoped-down assertions (follow-up)
The migrated module itself is not executed in the browser. It contains the bare specifiers `maplibre-gl` and `@honua/sdk-js/map`, which would need an importmap or a bundler (Vite) for the browser to resolve directly. Instead, the spec proves the codemod output shape and proves the helpers it emits actually drive a real MapLibre runtime end-to-end. Follow-ups (not in this slice):
- Wire an importmap / bundler so the migrated module itself runs unmodified in the browser.
- Drive a Honua-hosted FeatureServer fixture through `createHonuaFeatureServiceLayer` and assert popup / query / selection behaviour (the live-query slice for #206).

## Test plan
- [x] `npm run build --silent`
- [x] `npx playwright install chromium`
- [x] `npx playwright test test/playwright/migration-browser-maplibre.spec.mjs` (passes locally in ~1s)
- [x] `npx playwright test test/playwright/migration-browser-smoke.spec.mjs test/playwright/migration-browser-real-sample.spec.mjs test/playwright/migration-browser-maplibre.spec.mjs` (all 6 pass)
- [x] `npm run typecheck --silent` (clean)

Refs #205, #206 (slice — does not close).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>