### PR TITLE
feat(scene-workspace): Cesium 3D SceneRuntimeAdapter (honua-server#1196)

### DIFF
--- a/src/scene-workspace/cesium-adapter.ts
+++ b/src/scene-workspace/cesium-adapter.ts
@@ -1,0 +1,259 @@
+/**
+ * Cesium 3D `SceneRuntimeAdapter` for the renderer-neutral scene workspace.
+ *
+ * This module deliberately keeps the camera-state mapping pure and free of any
+ * static Cesium import so that 2D-only consumers never pay the CesiumJS bundle
+ * cost. The CesiumJS runtime is only pulled in lazily (`await import("cesium")`)
+ * when a live {@link CesiumSceneRuntimeTarget} is actually driven.
+ *
+ * Rich layer rendering (3D Tiles / glTF / point clouds / terrain providers) is
+ * intentionally minimal here — the capability is *declared* so the workspace
+ * routes 3D primitives to this adapter, but the rendering specifics are tracked
+ * separately in honua-server#1197. See the `// TODO(#1197)` markers below.
+ *
+ * @experimental Part of the experimental `scene-workspace` surface; not yet
+ *   covered by the SDK's semver contract prior to `1.0.0`.
+ * @module
+ */
+
+import {
+  type ScenePrimitiveApplyResult,
+  type SceneRuntimeAdapter,
+  type SceneRuntimeCapabilities,
+  type SceneRuntimePrimitive,
+  createSceneRuntimeAdapter,
+  diagnoseScenePrimitives,
+  summarizeDiagnosticStatus,
+} from "./primitives.js";
+import type { SceneCameraState, SceneWorkspaceState } from "./types.js";
+
+/**
+ * Capabilities advertised by the Cesium adapter. Unlike the MapLibre 2.5D
+ * adapter, Cesium is a true globe renderer: full 3D camera with
+ * heading/pitch/roll/height, terrain across the common elevation protocols, and
+ * model layers for 3D Tiles / glTF / I3S / point clouds.
+ */
+export const CESIUM_SCENE_CAPABILITIES: SceneRuntimeCapabilities = {
+  renderer: "cesium",
+  camera: true,
+  ground: true,
+  terrain: {
+    protocols: ["quantized-mesh", "terrain-rgb", "raster-dem", "image-service", "custom"],
+    supportsExaggeration: true,
+  },
+  extrusion: true,
+  modelLayer: {
+    // glTF/glb single models, 3D Tiles tilesets (incl. point clouds), and I3S
+    // scene layers are all natively renderable by Cesium.
+    formats: ["gltf", "glb", "3d-tiles", "i3s"],
+  },
+  sceneLayerMetadata: true,
+};
+
+/**
+ * Cesium camera orientation, expressed in radians (Cesium's native unit).
+ */
+export interface CesiumHeadingPitchRollRadians {
+  readonly heading: number;
+  readonly pitch: number;
+  readonly roll: number;
+}
+
+/**
+ * A renderer-neutral description of a Cesium `Camera.setView` call. Longitude /
+ * latitude / height are kept in degrees + metres (the workspace contract) and
+ * the orientation is pre-converted to radians so a live adapter can hand it
+ * straight to Cesium without re-deriving units.
+ */
+export interface CesiumCameraView {
+  readonly destination: {
+    readonly longitude: number;
+    readonly latitude: number;
+    readonly height: number;
+  };
+  readonly orientation: CesiumHeadingPitchRollRadians;
+}
+
+/**
+ * The minimal slice of Cesium's `Camera` that the adapter reads from. Cesium
+ * exposes `positionCartographic` (lon/lat/height in radians + metres) and
+ * heading/pitch/roll getters in radians. Modelling only this surface keeps the
+ * state mapping unit-testable without a live WebGL `Viewer`.
+ */
+export interface CesiumCameraLike {
+  readonly positionCartographic: {
+    readonly longitude: number;
+    readonly latitude: number;
+    readonly height: number;
+  };
+  readonly heading: number;
+  readonly pitch: number;
+  readonly roll: number;
+  setView(options: {
+    destination?: unknown;
+    orientation?: { heading?: number; pitch?: number; roll?: number };
+  }): void;
+}
+
+/**
+ * The subset of a live Cesium `Viewer`/`Scene` the adapter drives. Supplying
+ * this is optional: an adapter created without a target still diagnoses
+ * primitives and performs pure camera math, it just cannot mutate a live globe.
+ */
+export interface CesiumSceneRuntimeTarget {
+  readonly camera: CesiumCameraLike;
+}
+
+const DEG2RAD = Math.PI / 180;
+const RAD2DEG = 180 / Math.PI;
+
+function toRadians(degrees: number): number {
+  return degrees * DEG2RAD;
+}
+
+function toDegrees(radians: number): number {
+  return radians * RAD2DEG;
+}
+
+/**
+ * Map a renderer-neutral {@link SceneCameraState} (degrees + metres) onto a
+ * Cesium `setView` description (degrees destination + radian orientation).
+ *
+ * Heading/pitch/roll default to Cesium's own defaults — heading 0 (north),
+ * pitch -90 (looking straight down), roll 0 — when the workspace omits them.
+ */
+export function cameraStateToCesiumView(camera: SceneCameraState): CesiumCameraView {
+  return {
+    destination: {
+      longitude: camera.longitude,
+      latitude: camera.latitude,
+      height: camera.height,
+    },
+    orientation: {
+      heading: toRadians(camera.heading ?? 0),
+      pitch: toRadians(camera.pitch ?? -90),
+      roll: toRadians(camera.roll ?? 0),
+    },
+  };
+}
+
+/**
+ * Read a live (or mocked) Cesium camera back into a renderer-neutral
+ * {@link SceneCameraState}. This is the inverse of
+ * {@link cameraStateToCesiumView} and is the load-bearing half of the
+ * camera-state round-trip through the workspace.
+ */
+export function cesiumCameraToSceneState(camera: CesiumCameraLike): SceneCameraState {
+  return {
+    longitude: toDegrees(camera.positionCartographic.longitude),
+    latitude: toDegrees(camera.positionCartographic.latitude),
+    height: camera.positionCartographic.height,
+    heading: normalizeAngleDegrees(toDegrees(camera.heading)),
+    pitch: toDegrees(camera.pitch),
+    roll: toDegrees(camera.roll),
+  };
+}
+
+/**
+ * Apply a {@link SceneCameraState} to a live (or mocked) Cesium camera.
+ *
+ * The destination is left as degrees + height on the `setView` call; a live
+ * adapter (see {@link applyCesiumScenePrimitives}) converts it to a
+ * `Cartesian3` via the lazily-loaded Cesium module before calling `setView`.
+ * Tests can pass a mock camera and assert the orientation (in radians) directly.
+ */
+export function applyCameraStateToCesiumCamera(
+  camera: CesiumCameraLike,
+  state: SceneCameraState,
+  toCartesian: (lon: number, lat: number, height: number) => unknown = (longitude, latitude, height) => ({
+    longitude,
+    latitude,
+    height,
+  }),
+): void {
+  const view = cameraStateToCesiumView(state);
+  camera.setView({
+    destination: toCartesian(view.destination.longitude, view.destination.latitude, view.destination.height),
+    orientation: view.orientation,
+  });
+}
+
+/**
+ * Normalize a heading in degrees into the `[0, 360)` range so a round-trip
+ * through Cesium (which wraps headings) compares cleanly. Pitch and roll are
+ * left untouched because Cesium keeps them in their natural signed ranges.
+ */
+function normalizeAngleDegrees(degrees: number): number {
+  if (!Number.isFinite(degrees)) return degrees;
+  const wrapped = degrees % 360;
+  return wrapped < 0 ? wrapped + 360 : wrapped;
+}
+
+/**
+ * Lazily import the CesiumJS runtime. Kept in its own function so the dynamic
+ * `import("cesium")` is the *only* reference to the package in `src/`, which is
+ * what keeps Cesium out of the 2D bundle.
+ */
+async function loadCesium(): Promise<typeof import("cesium")> {
+  return import("cesium");
+}
+
+/**
+ * Apply scene primitives to a live Cesium target.
+ *
+ * Today this lands the ENGINE + CAMERA: camera primitives synchronize the live
+ * globe via the lazily-loaded Cesium `Cartesian3`. Terrain / model / extrusion
+ * rendering is declared-capable (so the workspace routes those primitives here
+ * rather than to a non-existent "custom" adapter) but the concrete provider
+ * wiring is deferred to honua-server#1197.
+ */
+export async function applyCesiumScenePrimitives(
+  target: CesiumSceneRuntimeTarget,
+  primitives: readonly SceneRuntimePrimitive[],
+  state?: SceneWorkspaceState,
+): Promise<ScenePrimitiveApplyResult> {
+  const diagnostics = diagnoseScenePrimitives(primitives, CESIUM_SCENE_CAPABILITIES);
+  const cesium = await loadCesium();
+  const toCartesian = (longitude: number, latitude: number, height: number): unknown =>
+    cesium.Cartesian3.fromDegrees(longitude, latitude, height);
+
+  for (const primitive of primitives) {
+    if (primitive.kind === "camera") {
+      applyCameraStateToCesiumCamera(target.camera, primitive.camera, toCartesian);
+    }
+    // TODO(#1197): apply terrain (CesiumTerrainProvider / quantized-mesh),
+    // model-layer (Cesium3DTileset / Model.fromGltfAsync), extrusion, and
+    // scene-layer-metadata primitives to the live scene. Capability is declared
+    // above so the workspace routes them here; rich rendering lands in #1197.
+  }
+
+  return {
+    status: summarizeDiagnosticStatus(diagnostics),
+    diagnostics,
+  };
+}
+
+/**
+ * Create a {@link SceneRuntimeAdapter} backed by CesiumJS.
+ *
+ * When `options.target` (a live Cesium `Viewer`/`Scene` camera surface) is
+ * supplied, `apply` drives the live globe (camera today; richer layers in
+ * #1197). Without a target the adapter still diagnoses primitives against
+ * Cesium's true-3D capabilities — useful for migration analysis before a viewer
+ * exists. CesiumJS itself is only imported lazily when `apply` runs.
+ */
+export function createCesiumSceneAdapter(
+  options: { readonly id?: string; readonly target?: CesiumSceneRuntimeTarget } = {},
+): SceneRuntimeAdapter {
+  const { id = "cesium-scene", target } = options;
+  return createSceneRuntimeAdapter({
+    id,
+    capabilities: CESIUM_SCENE_CAPABILITIES,
+    ...(target
+      ? {
+          apply: (primitives: readonly SceneRuntimePrimitive[], state?: SceneWorkspaceState) =>
+            applyCesiumScenePrimitives(target, primitives, state),
+        }
+      : {}),
+  });
+}

--- a/src/scene-workspace/index.ts
+++ b/src/scene-workspace/index.ts
@@ -27,6 +27,20 @@ export {
   toMapLibreExtrusionLayer,
   toMapLibreTerrainPatch,
 } from "./primitives.js";
+export {
+  CESIUM_SCENE_CAPABILITIES,
+  applyCameraStateToCesiumCamera,
+  applyCesiumScenePrimitives,
+  cameraStateToCesiumView,
+  cesiumCameraToSceneState,
+  createCesiumSceneAdapter,
+} from "./cesium-adapter.js";
+export type {
+  CesiumCameraLike,
+  CesiumCameraView,
+  CesiumHeadingPitchRollRadians,
+  CesiumSceneRuntimeTarget,
+} from "./cesium-adapter.js";
 export { SCENE_WORKSPACE_SLICES } from "./types.js";
 export type {
   MapLibreExtrusionLayerSpecification,

--- a/test/cesium-scene-adapter.test.ts
+++ b/test/cesium-scene-adapter.test.ts
@@ -1,0 +1,212 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+// Cesium needs a WebGL context that is unavailable headless, and a real
+// `Cartesian3` is opaque ECEF geometry. Mock only the tiny surface the adapter
+// touches lazily (`Cartesian3.fromDegrees`) so `apply()` stays a fast, pure
+// wiring test. The 2D bundle never loads this module — see the static-import
+// guard test below.
+vi.mock("cesium", () => ({
+  Cartesian3: {
+    fromDegrees: (longitude: number, latitude: number, height: number) => ({ longitude, latitude, height }),
+  },
+}));
+
+import {
+  CESIUM_SCENE_CAPABILITIES,
+  type CesiumCameraLike,
+  type SceneCameraState,
+  type SceneRuntimePrimitive,
+  applyCameraStateToCesiumCamera,
+  cameraStateToCesiumView,
+  cesiumCameraToSceneState,
+  createCesiumSceneAdapter,
+  createSceneWorkspace,
+} from "../src/scene-workspace/index.js";
+
+const DEG2RAD = Math.PI / 180;
+
+/**
+ * A pure-JS stand-in for Cesium's `Camera`. It mirrors the real getter contract
+ * (`positionCartographic` + heading/pitch/roll in radians) so the adapter's
+ * camera math can be exercised without a WebGL `Viewer`, which is unavailable
+ * headless. `setView` mutates internal radian state exactly as Cesium would.
+ */
+function createMockCesiumCamera(): CesiumCameraLike & {
+  setView: ReturnType<typeof vi.fn>;
+} {
+  const position = { longitude: 0, latitude: 0, height: 0 };
+  const orientation = { heading: 0, pitch: -Math.PI / 2, roll: 0 };
+  const setView = vi.fn(
+    (options: {
+      destination?: { longitude: number; latitude: number; height: number };
+      orientation?: { heading?: number; pitch?: number; roll?: number };
+    }) => {
+      if (options.destination) {
+        position.longitude = options.destination.longitude * DEG2RAD;
+        position.latitude = options.destination.latitude * DEG2RAD;
+        position.height = options.destination.height;
+      }
+      if (options.orientation) {
+        if (options.orientation.heading !== undefined) orientation.heading = options.orientation.heading;
+        if (options.orientation.pitch !== undefined) orientation.pitch = options.orientation.pitch;
+        if (options.orientation.roll !== undefined) orientation.roll = options.orientation.roll;
+      }
+    },
+  );
+  return {
+    get positionCartographic() {
+      return { ...position };
+    },
+    get heading() {
+      return orientation.heading;
+    },
+    get pitch() {
+      return orientation.pitch;
+    },
+    get roll() {
+      return orientation.roll;
+    },
+    setView,
+  };
+}
+
+describe("cesium scene adapter", () => {
+  it("declares true-3D capabilities distinct from the MapLibre 2.5D adapter", () => {
+    expect(CESIUM_SCENE_CAPABILITIES.renderer).toBe("cesium");
+    expect(CESIUM_SCENE_CAPABILITIES.camera).toBe(true);
+    expect(CESIUM_SCENE_CAPABILITIES.terrain?.protocols).toContain("quantized-mesh");
+    expect(CESIUM_SCENE_CAPABILITIES.terrain?.supportsExaggeration).toBe(true);
+    expect(CESIUM_SCENE_CAPABILITIES.modelLayer?.formats).toEqual(
+      expect.arrayContaining(["gltf", "glb", "3d-tiles", "i3s"]),
+    );
+    expect(CESIUM_SCENE_CAPABILITIES.sceneLayerMetadata).toBe(true);
+
+    const adapter = createCesiumSceneAdapter();
+    expect(adapter.id).toBe("cesium-scene");
+    expect(adapter.capabilities).toBe(CESIUM_SCENE_CAPABILITIES);
+  });
+
+  it("maps a scene camera state to a Cesium setView description in radians", () => {
+    const view = cameraStateToCesiumView({
+      longitude: -157.8583,
+      latitude: 21.3069,
+      height: 700,
+      heading: 45,
+      pitch: -35,
+      roll: 10,
+    });
+
+    expect(view.destination).toEqual({ longitude: -157.8583, latitude: 21.3069, height: 700 });
+    expect(view.orientation.heading).toBeCloseTo(45 * DEG2RAD, 12);
+    expect(view.orientation.pitch).toBeCloseTo(-35 * DEG2RAD, 12);
+    expect(view.orientation.roll).toBeCloseTo(10 * DEG2RAD, 12);
+  });
+
+  it("defaults heading/pitch/roll to Cesium's top-down defaults when omitted", () => {
+    const view = cameraStateToCesiumView({ longitude: 10, latitude: 20, height: 1000 });
+    expect(view.orientation.heading).toBe(0);
+    expect(view.orientation.pitch).toBeCloseTo(-90 * DEG2RAD, 12);
+    expect(view.orientation.roll).toBe(0);
+  });
+
+  it("round-trips camera state set -> read back through a Cesium camera", () => {
+    const camera = createMockCesiumCamera();
+    const original: SceneCameraState = {
+      longitude: -157.8583,
+      latitude: 21.3069,
+      height: 1234.5,
+      heading: 312,
+      pitch: -42.5,
+      roll: 7.25,
+    };
+
+    applyCameraStateToCesiumCamera(camera, original);
+    const readBack = cesiumCameraToSceneState(camera);
+
+    expect(readBack.longitude).toBeCloseTo(-157.8583, 9);
+    expect(readBack.latitude).toBeCloseTo(21.3069, 9);
+    expect(readBack.height).toBeCloseTo(1234.5, 6);
+    expect(readBack.heading).toBeCloseTo(312, 9);
+    expect(readBack.pitch).toBeCloseTo(-42.5, 9);
+    expect(readBack.roll).toBeCloseTo(7.25, 9);
+  });
+
+  it("normalizes a negative heading into the [0, 360) range on read back", () => {
+    const camera = createMockCesiumCamera();
+    camera.setView({ orientation: { heading: -90 * DEG2RAD, pitch: 0, roll: 0 } });
+    expect(cesiumCameraToSceneState(camera).heading).toBeCloseTo(270, 9);
+  });
+
+  it("diagnoses 3D primitives (terrain, 3D-tiles model layer) as supported", () => {
+    const adapter = createCesiumSceneAdapter();
+    const primitives: SceneRuntimePrimitive[] = [
+      {
+        kind: "elevation-source",
+        id: "world-terrain",
+        sourceId: "world-terrain",
+        protocol: "quantized-mesh",
+        url: "https://example.test/terrain",
+        exaggeration: 1.5,
+      },
+      {
+        kind: "model-layer",
+        id: "city-tiles",
+        uri: "https://example.test/tileset.json",
+        format: "3d-tiles",
+      },
+    ];
+
+    const diagnostics = adapter.diagnose(primitives);
+    expect(diagnostics.map((diagnostic) => diagnostic.status)).toEqual(["supported", "supported"]);
+    expect(diagnostics.every((diagnostic) => diagnostic.renderer === "cesium")).toBe(true);
+  });
+
+  it("drives the adapter from a workspace camera dispatch via apply()", async () => {
+    const camera = createMockCesiumCamera();
+    const adapter = createCesiumSceneAdapter({ target: { camera } });
+    const workspace = createSceneWorkspace();
+
+    const cameraState: SceneCameraState = {
+      longitude: 12.4924,
+      latitude: 41.8902,
+      height: 850,
+      heading: 90,
+      pitch: -25,
+      roll: 0,
+    };
+    workspace.dispatch({ kind: "set-camera", camera: cameraState });
+
+    expect(adapter.apply).toBeTypeOf("function");
+    const result = await adapter.apply?.(
+      [{ kind: "camera", id: "primary", camera: workspace.state.camera as SceneCameraState }],
+      workspace.state,
+    );
+
+    expect(result?.status).toBe("supported");
+    expect(camera.setView).toHaveBeenCalledTimes(1);
+    // After apply, reading the live camera back reproduces the workspace state.
+    const readBack = cesiumCameraToSceneState(camera);
+    expect(readBack.longitude).toBeCloseTo(12.4924, 9);
+    expect(readBack.heading).toBeCloseTo(90, 9);
+    expect(readBack.pitch).toBeCloseTo(-25, 9);
+  });
+
+  it("omits apply() when no live Cesium target is provided", () => {
+    const adapter = createCesiumSceneAdapter();
+    expect(adapter.apply).toBeUndefined();
+  });
+
+  it("does not statically import Cesium from the scene-workspace sources", () => {
+    const sceneWorkspaceRoot = path.resolve(process.cwd(), "src", "scene-workspace");
+    const files = fs.readdirSync(sceneWorkspaceRoot).filter((file) => file.endsWith(".ts"));
+    const source = files.map((file) => fs.readFileSync(path.join(sceneWorkspaceRoot, file), "utf8")).join("\n");
+
+    // Static `import ... from "cesium"` would eagerly pull Cesium into the 2D
+    // bundle. Only the lazy dynamic `import("cesium")` is allowed.
+    expect(source).not.toMatch(/from\s+["']cesium["']/);
+    expect(source).toMatch(/import\(["']cesium["']\)/);
+  });
+});

--- a/test/entrypoints.test.ts
+++ b/test/entrypoints.test.ts
@@ -205,6 +205,22 @@ import {
   wmtsSource as rootWmtsSource,
   syncFeatureStateSelection,
 } from "../src/index.js";
+// Experimental subpaths are no longer re-exported from the root barrel —
+// importing them keeps this test honest about the stable / experimental tier.
+import {
+  createHonuaController,
+} from "../src/app-controller/index.js";
+import {
+  createHonuaAppWorkspace,
+  selectHonuaAppWorkspaceMetadataCacheModel,
+} from "../src/app-workspace/index.js";
+import {
+  createMapLibreSceneAdapter as rootCreateMapLibreSceneAdapter,
+  createSceneWorkspace as rootCreateSceneWorkspace,
+} from "../src/scene-workspace/index.js";
+import {
+  HonuaControlPlaneClient as RootHonuaControlPlaneClient,
+} from "../src/control-plane/index.js";
 import {
   bindChartToExploration as interactionsBindChartToExploration,
   selectLinkedViewQueryProjection as interactionsSelectLinkedViewQueryProjection,

--- a/test/entrypoints.test.ts
+++ b/test/entrypoints.test.ts
@@ -205,22 +205,6 @@ import {
   wmtsSource as rootWmtsSource,
   syncFeatureStateSelection,
 } from "../src/index.js";
-// Experimental subpaths are no longer re-exported from the root barrel —
-// importing them keeps this test honest about the stable / experimental tier.
-import {
-  createHonuaController,
-} from "../src/app-controller/index.js";
-import {
-  createHonuaAppWorkspace,
-  selectHonuaAppWorkspaceMetadataCacheModel,
-} from "../src/app-workspace/index.js";
-import {
-  createMapLibreSceneAdapter as rootCreateMapLibreSceneAdapter,
-  createSceneWorkspace as rootCreateSceneWorkspace,
-} from "../src/scene-workspace/index.js";
-import {
-  HonuaControlPlaneClient as RootHonuaControlPlaneClient,
-} from "../src/control-plane/index.js";
 import {
   bindChartToExploration as interactionsBindChartToExploration,
   selectLinkedViewQueryProjection as interactionsSelectLinkedViewQueryProjection,


### PR DESCRIPTION
Implements honua-io/honua-server#1196 (Epic honua-io/honua-server#530).

A Cesium-backed `SceneRuntimeAdapter` for the experimental `scene-workspace`: `createCesiumSceneAdapter`, `CESIUM_SCENE_CAPABILITIES`, camera/viewpoint mapping. Cesium is pulled in lazily via `import("cesium")` so 2D-only consumers never pay the bundle cost.

## Testing
`npm run typecheck` + biome pass; 9 vitest cases (Cesium mocked, incl. a static-import guard).

## Note
This PR also carries the scene-workspace example/alias + barrel/biome setup commits from the same landing line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)