### PR TITLE
feat(scene-workspace): render Cesium 3D content — 3D Tiles, terrain, glTF + pick (honua-server#1197)

### DIFF
--- a/src/scene-workspace/cesium-adapter.ts
+++ b/src/scene-workspace/cesium-adapter.ts
@@ -386,10 +386,13 @@ export async function addCesiumModel(
 ): Promise<CesiumLayerHandle> {
   const mod = cesium ?? (await loadCesium());
   const placement = modelLayerToCesiumPlacement(primitive);
+  // `placementToModelMatrix` already folds the uniform scale into the model
+  // matrix (alongside translation + rotation). Cesium applies `Model.scale` on
+  // top of `modelMatrix`, so passing it here too would square the scale
+  // (requested 3 → rendered 9). Apply it exactly once, via the matrix.
   const model = await mod.Model.fromGltfAsync({
     url: primitive.uri,
     modelMatrix: placementToModelMatrix(mod, placement),
-    scale: placement.scale,
   });
   scene.primitives.add(model);
   return makeLayerHandle(scene, primitive.id, model, "model-layer", primitive.format);
@@ -425,6 +428,11 @@ export async function applyCesiumTerrain(
       /* terrain is always on once set; visibility is a no-op for the provider. */
     },
     remove() {
+      // Only tear down if *this* handle's provider is still the active one. If a
+      // newer elevation source has since replaced `scene.terrainProvider`,
+      // removing this (now-stale) handle must be a no-op so we don't clobber the
+      // active terrain/exaggeration.
+      if (scene.terrainProvider !== provider) return;
       scene.terrainProvider = undefined;
       scene.verticalExaggeration = 1;
     },

--- a/src/scene-workspace/cesium-adapter.ts
+++ b/src/scene-workspace/cesium-adapter.ts
@@ -6,10 +6,15 @@
  * cost. The CesiumJS runtime is only pulled in lazily (`await import("cesium")`)
  * when a live {@link CesiumSceneRuntimeTarget} is actually driven.
  *
- * Rich layer rendering (3D Tiles / glTF / point clouds / terrain providers) is
- * intentionally minimal here — the capability is *declared* so the workspace
- * routes 3D primitives to this adapter, but the rendering specifics are tracked
- * separately in honua-server#1197. See the `// TODO(#1197)` markers below.
+ * As of honua-server#1197 the adapter renders Honua 3D content end-to-end:
+ * 3D-Tiles tilesets (add/remove/visibility), terrain providers (quantized-mesh
+ * via `CesiumTerrainProvider`, with vertical exaggeration), and glTF/GLB model
+ * layers placed with heading/pitch/roll + scale. It also resolves a picked
+ * 3D-Tiles feature's attributes (batch properties / `EXT_structural_metadata`).
+ *
+ * The provider wiring is still kept Cesium-mockable: every CesiumJS symbol the
+ * adapter touches is read off the lazily-imported module, so the wiring is
+ * exercised against a `vi.mock("cesium")` stub without a live WebGL `Viewer`.
  *
  * @experimental Part of the experimental `scene-workspace` surface; not yet
  *   covered by the SDK's semver contract prior to `1.0.0`.
@@ -17,6 +22,8 @@
  */
 
 import {
+  type SceneElevationSourcePrimitive,
+  type SceneModelLayerPrimitive,
   type ScenePrimitiveApplyResult,
   type SceneRuntimeAdapter,
   type SceneRuntimeCapabilities,
@@ -43,8 +50,10 @@ export const CESIUM_SCENE_CAPABILITIES: SceneRuntimeCapabilities = {
   },
   extrusion: true,
   modelLayer: {
-    // glTF/glb single models, 3D Tiles tilesets (incl. point clouds), and I3S
-    // scene layers are all natively renderable by Cesium.
+    // glTF/glb single models and 3D Tiles tilesets (incl. point clouds) are
+    // rendered live by this adapter as of #1197. I3S scene layers remain
+    // declared-capable (Cesium can consume them) but Honua's server does not yet
+    // emit i3s model-layer primitives, so they fall through to diagnostics only.
     formats: ["gltf", "glb", "3d-tiles", "i3s"],
   },
   sceneLayerMetadata: true,
@@ -96,12 +105,83 @@ export interface CesiumCameraLike {
 }
 
 /**
+ * A 3D-Tiles tileset handle (the bits the adapter mutates). Real Cesium
+ * `Cesium3DTileset` instances satisfy this; tests pass a plain object.
+ */
+export interface CesiumTilesetLike {
+  show: boolean;
+  modelMatrix?: unknown;
+  destroy?(): void;
+  isDestroyed?(): boolean;
+}
+
+/**
+ * A glTF/GLB model handle (the bits the adapter mutates). Real Cesium `Model`
+ * instances satisfy this.
+ */
+export interface CesiumModelLike {
+  show: boolean;
+  modelMatrix?: unknown;
+  destroy?(): void;
+  isDestroyed?(): boolean;
+}
+
+/**
+ * The Cesium `PrimitiveCollection` surface (off `scene.primitives`) the adapter
+ * uses to add/remove tilesets and models.
+ */
+export interface CesiumPrimitiveCollectionLike {
+  add(primitive: unknown, index?: number): unknown;
+  remove(primitive?: unknown): boolean;
+  contains(primitive?: unknown): boolean;
+}
+
+/**
+ * The Cesium `Scene` surface the adapter mutates: a primitive collection for
+ * tilesets/models, a settable `terrainProvider`, vertical exaggeration, and a
+ * `pick` entry point used by {@link pickCesiumFeatureAttributes}.
+ */
+export interface CesiumSceneLike {
+  readonly primitives: CesiumPrimitiveCollectionLike;
+  terrainProvider?: unknown;
+  verticalExaggeration?: number;
+  pick?(windowPosition: unknown, width?: number, height?: number): unknown;
+}
+
+/**
  * The subset of a live Cesium `Viewer`/`Scene` the adapter drives. Supplying
  * this is optional: an adapter created without a target still diagnoses
  * primitives and performs pure camera math, it just cannot mutate a live globe.
+ *
+ * `scene` is optional so a camera-only target (as shipped in #1196) keeps
+ * working unchanged; layer rendering simply no-ops without it.
  */
 export interface CesiumSceneRuntimeTarget {
   readonly camera: CesiumCameraLike;
+  readonly scene?: CesiumSceneLike;
+}
+
+/**
+ * A renderer-neutral plan for placing one model/tileset/terrain provider on a
+ * live scene. Pure (no Cesium import) so the mapping is unit-testable; the live
+ * adapter materializes each plan via the lazily-loaded Cesium module.
+ */
+export interface CesiumModelPlacement {
+  readonly position: { readonly longitude: number; readonly latitude: number; readonly height: number };
+  readonly orientation: CesiumHeadingPitchRollRadians;
+  readonly scale: number;
+}
+
+/**
+ * The handle returned by {@link applyCesiumScenePrimitives} so callers can
+ * later toggle visibility or tear a layer down. Keyed by the primitive id.
+ */
+export interface CesiumLayerHandle {
+  readonly id: string;
+  readonly kind: "model-layer" | "elevation-source";
+  readonly format?: SceneModelLayerPrimitive["format"];
+  setVisible(visible: boolean): void;
+  remove(): void;
 }
 
 const DEG2RAD = Math.PI / 180;
@@ -190,57 +270,294 @@ function normalizeAngleDegrees(degrees: number): number {
 }
 
 /**
+ * Resolve the scale factor for a model layer. The primitive allows a uniform
+ * number or a per-axis triple; Cesium `Model.fromGltfAsync` takes a single
+ * uniform `scale`, so a triple collapses to its first finite component (with a
+ * sane `1` fallback). Non-finite / non-positive values fall back to `1`.
+ */
+export function resolveCesiumModelScale(scale: SceneModelLayerPrimitive["scale"]): number {
+  const candidate = Array.isArray(scale) ? scale[0] : scale;
+  return typeof candidate === "number" && Number.isFinite(candidate) && candidate > 0 ? candidate : 1;
+}
+
+/**
+ * Map a {@link SceneModelLayerPrimitive} onto a renderer-neutral
+ * {@link CesiumModelPlacement} (degrees + metres position, radian orientation,
+ * uniform scale). Pure so the placement math is unit-testable without Cesium.
+ *
+ * `position` defaults to lon/lat 0 at height 0; `rotation` (degrees, in the
+ * workspace contract) defaults to heading/pitch/roll 0.
+ */
+export function modelLayerToCesiumPlacement(primitive: SceneModelLayerPrimitive): CesiumModelPlacement {
+  const [longitude = 0, latitude = 0, height = 0] = primitive.position ?? [];
+  const [heading = 0, pitch = 0, roll = 0] = primitive.rotation ?? [];
+  return {
+    position: { longitude, latitude, height: height ?? 0 },
+    orientation: { heading: toRadians(heading), pitch: toRadians(pitch), roll: toRadians(roll) },
+    scale: resolveCesiumModelScale(primitive.scale),
+  };
+}
+
+/**
+ * The Cesium symbols the live wiring needs. Modelled as the minimal slice of
+ * `typeof import("cesium")` so a `vi.mock("cesium")` stub can satisfy it.
+ */
+type CesiumModule = {
+  readonly Cartesian3: {
+    fromDegrees(longitude: number, latitude: number, height?: number): unknown;
+  };
+  readonly HeadingPitchRoll: new (heading?: number, pitch?: number, roll?: number) => unknown;
+  readonly Transforms: {
+    headingPitchRollToFixedFrame(origin: unknown, headingPitchRoll: unknown): unknown;
+  };
+  readonly Matrix4: {
+    multiplyByUniformScale(matrix: unknown, scale: number, result: unknown): unknown;
+    clone(matrix: unknown, result?: unknown): unknown;
+  };
+  readonly Cesium3DTileset: {
+    fromUrl(url: string, options?: Record<string, unknown>): Promise<CesiumTilesetLike>;
+  };
+  readonly Model: {
+    fromGltfAsync(options: Record<string, unknown>): Promise<CesiumModelLike>;
+  };
+  readonly CesiumTerrainProvider: {
+    fromUrl(url: string, options?: Record<string, unknown>): Promise<unknown>;
+  };
+};
+
+/**
  * Lazily import the CesiumJS runtime. Kept in its own function so the dynamic
  * `import("cesium")` is the *only* reference to the package in `src/`, which is
  * what keeps Cesium out of the 2D bundle.
  */
-async function loadCesium(): Promise<typeof import("cesium")> {
-  return import("cesium");
+async function loadCesium(): Promise<CesiumModule> {
+  return (await import("cesium")) as unknown as CesiumModule;
+}
+
+/**
+ * Build a Cesium `Matrix4` model matrix from a {@link CesiumModelPlacement}
+ * using the supplied (lazily-loaded) Cesium module. Position becomes an
+ * east-north-up fixed frame at the placement origin, then a uniform scale is
+ * folded in. Isolated so the live adapter and tests share one path.
+ */
+function placementToModelMatrix(cesium: CesiumModule, placement: CesiumModelPlacement): unknown {
+  const origin = cesium.Cartesian3.fromDegrees(
+    placement.position.longitude,
+    placement.position.latitude,
+    placement.position.height,
+  );
+  const hpr = new cesium.HeadingPitchRoll(
+    placement.orientation.heading,
+    placement.orientation.pitch,
+    placement.orientation.roll,
+  );
+  const frame = cesium.Transforms.headingPitchRollToFixedFrame(origin, hpr);
+  return placement.scale === 1 ? frame : cesium.Matrix4.multiplyByUniformScale(frame, placement.scale, frame);
+}
+
+/**
+ * Materialize a 3D-Tiles tileset from a model-layer primitive and add it to the
+ * scene's primitive collection, returning a handle for later visibility /
+ * teardown. Exported so consumers (and tests) can drive a single tileset.
+ */
+export async function addCesium3DTileset(
+  scene: CesiumSceneLike,
+  primitive: SceneModelLayerPrimitive,
+  cesium?: CesiumModule,
+): Promise<CesiumLayerHandle> {
+  const mod = cesium ?? (await loadCesium());
+  const tileset = await mod.Cesium3DTileset.fromUrl(primitive.uri);
+  if (primitive.position) {
+    tileset.modelMatrix = placementToModelMatrix(mod, modelLayerToCesiumPlacement(primitive));
+  }
+  scene.primitives.add(tileset);
+  return makeLayerHandle(scene, primitive.id, tileset, "model-layer", primitive.format);
+}
+
+/**
+ * Materialize a glTF/GLB model from a model-layer primitive, placing it at the
+ * primitive's position/rotation/scale, and add it to the scene. Returns a
+ * handle for visibility / teardown.
+ */
+export async function addCesiumModel(
+  scene: CesiumSceneLike,
+  primitive: SceneModelLayerPrimitive,
+  cesium?: CesiumModule,
+): Promise<CesiumLayerHandle> {
+  const mod = cesium ?? (await loadCesium());
+  const placement = modelLayerToCesiumPlacement(primitive);
+  const model = await mod.Model.fromGltfAsync({
+    url: primitive.uri,
+    modelMatrix: placementToModelMatrix(mod, placement),
+    scale: placement.scale,
+  });
+  scene.primitives.add(model);
+  return makeLayerHandle(scene, primitive.id, model, "model-layer", primitive.format);
+}
+
+/**
+ * Wire a terrain provider from an elevation-source primitive onto the scene.
+ *
+ * `quantized-mesh` maps to `CesiumTerrainProvider.fromUrl` natively. `terrain-rgb`
+ * / `raster-dem` (Mapbox/Terrarium-encoded raster DEM tiles) are treated the
+ * same way: Cesium consumes a quantized-mesh-style endpoint at `url`, so we wire
+ * the provider when a `url` is present and otherwise leave the globe on its
+ * default ellipsoid (the diagnostic already flags a missing url). Exaggeration
+ * is applied via the scene's `verticalExaggeration`.
+ */
+export async function applyCesiumTerrain(
+  scene: CesiumSceneLike,
+  primitive: SceneElevationSourcePrimitive,
+  cesium?: CesiumModule,
+): Promise<CesiumLayerHandle | undefined> {
+  const url = typeof primitive.url === "string" && primitive.url.trim() !== "" ? primitive.url : undefined;
+  if (primitive.exaggeration !== undefined && Number.isFinite(primitive.exaggeration)) {
+    scene.verticalExaggeration = primitive.exaggeration;
+  }
+  if (!url) return undefined;
+  const mod = cesium ?? (await loadCesium());
+  const provider = await mod.CesiumTerrainProvider.fromUrl(url);
+  scene.terrainProvider = provider;
+  return {
+    id: primitive.id,
+    kind: "elevation-source",
+    setVisible() {
+      /* terrain is always on once set; visibility is a no-op for the provider. */
+    },
+    remove() {
+      scene.terrainProvider = undefined;
+      scene.verticalExaggeration = 1;
+    },
+  };
+}
+
+function makeLayerHandle(
+  scene: CesiumSceneLike,
+  id: string,
+  primitive: CesiumTilesetLike | CesiumModelLike,
+  kind: "model-layer",
+  format: SceneModelLayerPrimitive["format"],
+): CesiumLayerHandle {
+  return {
+    id,
+    kind,
+    format,
+    setVisible(visible: boolean) {
+      primitive.show = visible;
+    },
+    remove() {
+      if (scene.primitives.contains(primitive)) scene.primitives.remove(primitive);
+    },
+  };
+}
+
+/**
+ * Resolve the attributes of a picked 3D-Tiles feature.
+ *
+ * Cesium returns a `Cesium3DTileFeature` from `scene.pick(...)` for tileset
+ * hits; its batch-table / `EXT_structural_metadata` properties are read via
+ * `getPropertyIds()` + `getProperty(id)`. Anything else (terrain, a glTF model
+ * primitive, empty space) yields `undefined`. Pure given a picked object, so it
+ * is unit-testable with a plain stub.
+ */
+export function resolvePickedFeatureAttributes(picked: unknown): Record<string, unknown> | undefined {
+  if (picked === null || typeof picked !== "object") return undefined;
+  const feature = picked as {
+    getPropertyIds?: (results?: string[]) => string[];
+    getProperty?: (name: string) => unknown;
+  };
+  if (typeof feature.getPropertyIds !== "function" || typeof feature.getProperty !== "function") return undefined;
+  const attributes: Record<string, unknown> = {};
+  for (const propertyId of feature.getPropertyIds()) {
+    attributes[propertyId] = feature.getProperty(propertyId);
+  }
+  return attributes;
+}
+
+/**
+ * Pick a 3D-Tiles feature at the given window position and return its
+ * attributes (or `undefined` for a miss / non-feature hit). Convenience wrapper
+ * over `scene.pick` + {@link resolvePickedFeatureAttributes} for identify flows.
+ */
+export function pickCesiumFeatureAttributes(
+  scene: CesiumSceneLike,
+  windowPosition: unknown,
+): Record<string, unknown> | undefined {
+  if (typeof scene.pick !== "function") return undefined;
+  return resolvePickedFeatureAttributes(scene.pick(windowPosition));
 }
 
 /**
  * Apply scene primitives to a live Cesium target.
  *
- * Today this lands the ENGINE + CAMERA: camera primitives synchronize the live
- * globe via the lazily-loaded Cesium `Cartesian3`. Terrain / model / extrusion
- * rendering is declared-capable (so the workspace routes those primitives here
- * rather than to a non-existent "custom" adapter) but the concrete provider
- * wiring is deferred to honua-server#1197.
+ * As of #1197 this lands the full 3D stack against `target.scene`:
+ *  - `camera` → `Camera.setView` (via the lazily-loaded `Cartesian3`).
+ *  - `elevation-source` → `scene.terrainProvider` + `verticalExaggeration`.
+ *  - `model-layer` (`3d-tiles`) → `Cesium3DTileset.fromUrl` added to
+ *    `scene.primitives`; (`gltf`/`glb`) → `Model.fromGltfAsync` placed by
+ *    position/rotation/scale.
+ *
+ * Returns the diagnostics plus the live layer handles keyed by primitive id so
+ * callers can toggle visibility / tear layers down. Layer rendering is skipped
+ * (gracefully) when no `scene` is attached or when a primitive diagnoses as
+ * unsupported. I3S model layers and extrusions are declared-capable but not yet
+ * materialized here (no Honua server primitives emit them); point clouds ride
+ * the 3D-Tiles path and are gated on server ingest (honua-server#1201).
  */
 export async function applyCesiumScenePrimitives(
   target: CesiumSceneRuntimeTarget,
   primitives: readonly SceneRuntimePrimitive[],
-  state?: SceneWorkspaceState,
-): Promise<ScenePrimitiveApplyResult> {
+  _state?: SceneWorkspaceState,
+): Promise<ScenePrimitiveApplyResult & { readonly layers: ReadonlyMap<string, CesiumLayerHandle> }> {
   const diagnostics = diagnoseScenePrimitives(primitives, CESIUM_SCENE_CAPABILITIES);
   const cesium = await loadCesium();
   const toCartesian = (longitude: number, latitude: number, height: number): unknown =>
     cesium.Cartesian3.fromDegrees(longitude, latitude, height);
+  const unsupportedIds = new Set(
+    diagnostics.filter((diagnostic) => diagnostic.status === "unsupported").map((diagnostic) => diagnostic.primitiveId),
+  );
+  const layers = new Map<string, CesiumLayerHandle>();
+  const scene = target.scene;
 
   for (const primitive of primitives) {
     if (primitive.kind === "camera") {
       applyCameraStateToCesiumCamera(target.camera, primitive.camera, toCartesian);
+      continue;
     }
-    // TODO(#1197): apply terrain (CesiumTerrainProvider / quantized-mesh),
-    // model-layer (Cesium3DTileset / Model.fromGltfAsync), extrusion, and
-    // scene-layer-metadata primitives to the live scene. Capability is declared
-    // above so the workspace routes them here; rich rendering lands in #1197.
+    if (!scene || unsupportedIds.has(primitive.id)) continue;
+
+    if (primitive.kind === "elevation-source") {
+      const handle = await applyCesiumTerrain(scene, primitive, cesium);
+      if (handle) layers.set(handle.id, handle);
+      continue;
+    }
+    if (primitive.kind === "model-layer") {
+      if (primitive.format === "3d-tiles") {
+        layers.set(primitive.id, await addCesium3DTileset(scene, primitive, cesium));
+      } else if (primitive.format === "gltf" || primitive.format === "glb") {
+        layers.set(primitive.id, await addCesiumModel(scene, primitive, cesium));
+      }
+      // i3s / obj / custom: declared-capable but not materialized here.
+    }
   }
 
   return {
     status: summarizeDiagnosticStatus(diagnostics),
     diagnostics,
+    layers,
   };
 }
 
 /**
  * Create a {@link SceneRuntimeAdapter} backed by CesiumJS.
  *
- * When `options.target` (a live Cesium `Viewer`/`Scene` camera surface) is
- * supplied, `apply` drives the live globe (camera today; richer layers in
- * #1197). Without a target the adapter still diagnoses primitives against
- * Cesium's true-3D capabilities — useful for migration analysis before a viewer
- * exists. CesiumJS itself is only imported lazily when `apply` runs.
+ * When `options.target` (a live Cesium `Viewer`/`Scene` surface — a `camera`
+ * plus an optional `scene`) is supplied, `apply` drives the live globe: camera
+ * sync plus, when a `scene` is attached, terrain providers, 3D-Tiles tilesets,
+ * and glTF/GLB model layers (#1197). Without a target the adapter still
+ * diagnoses primitives against Cesium's true-3D capabilities — useful for
+ * migration analysis before a viewer exists. CesiumJS itself is only imported
+ * lazily when `apply` runs.
  */
 export function createCesiumSceneAdapter(
   options: { readonly id?: string; readonly target?: CesiumSceneRuntimeTarget } = {},

--- a/src/scene-workspace/index.ts
+++ b/src/scene-workspace/index.ts
@@ -29,17 +29,30 @@ export {
 } from "./primitives.js";
 export {
   CESIUM_SCENE_CAPABILITIES,
+  addCesium3DTileset,
+  addCesiumModel,
   applyCameraStateToCesiumCamera,
   applyCesiumScenePrimitives,
+  applyCesiumTerrain,
   cameraStateToCesiumView,
   cesiumCameraToSceneState,
   createCesiumSceneAdapter,
+  modelLayerToCesiumPlacement,
+  pickCesiumFeatureAttributes,
+  resolveCesiumModelScale,
+  resolvePickedFeatureAttributes,
 } from "./cesium-adapter.js";
 export type {
   CesiumCameraLike,
   CesiumCameraView,
   CesiumHeadingPitchRollRadians,
+  CesiumLayerHandle,
+  CesiumModelLike,
+  CesiumModelPlacement,
+  CesiumPrimitiveCollectionLike,
+  CesiumSceneLike,
   CesiumSceneRuntimeTarget,
+  CesiumTilesetLike,
 } from "./cesium-adapter.js";
 export { SCENE_WORKSPACE_SLICES } from "./types.js";
 export type {

--- a/test/cesium-scene-adapter.test.ts
+++ b/test/cesium-scene-adapter.test.ts
@@ -1,29 +1,68 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Cesium needs a WebGL context that is unavailable headless, and a real
-// `Cartesian3` is opaque ECEF geometry. Mock only the tiny surface the adapter
-// touches lazily (`Cartesian3.fromDegrees`) so `apply()` stays a fast, pure
-// wiring test. The 2D bundle never loads this module — see the static-import
-// guard test below.
+// `Cartesian3` / model matrix is opaque ECEF geometry. Mock only the surface the
+// adapter touches lazily (`Cartesian3.fromDegrees`, the model-matrix helpers,
+// and the async layer factories) so `apply()` stays a fast, pure wiring test.
+// The 2D bundle never loads this module — see the static-import guard test.
+const tilesetFromUrl = vi.fn(async (url: string) => ({ kind: "tileset", url, show: true, modelMatrix: undefined }));
+const modelFromGltfAsync = vi.fn(async (options: Record<string, unknown>) => ({
+  kind: "model",
+  url: options.url,
+  modelMatrix: options.modelMatrix,
+  scale: options.scale,
+  show: true,
+}));
+const terrainFromUrl = vi.fn(async (url: string) => ({ kind: "terrain-provider", url }));
+
 vi.mock("cesium", () => ({
   Cartesian3: {
-    fromDegrees: (longitude: number, latitude: number, height: number) => ({ longitude, latitude, height }),
+    fromDegrees: (longitude: number, latitude: number, height?: number) => ({ longitude, latitude, height }),
+  },
+  HeadingPitchRoll: class {
+    constructor(
+      public heading = 0,
+      public pitch = 0,
+      public roll = 0,
+    ) {}
+  },
+  Transforms: {
+    headingPitchRollToFixedFrame: (origin: unknown, hpr: unknown) => ({ kind: "frame", origin, hpr }),
+  },
+  Matrix4: {
+    multiplyByUniformScale: (matrix: unknown, scale: number) => ({ kind: "scaled", matrix, scale }),
+    clone: (matrix: unknown) => matrix,
+  },
+  Cesium3DTileset: {
+    fromUrl: (url: string) => tilesetFromUrl(url),
+  },
+  Model: {
+    fromGltfAsync: (options: Record<string, unknown>) => modelFromGltfAsync(options),
+  },
+  CesiumTerrainProvider: {
+    fromUrl: (url: string) => terrainFromUrl(url),
   },
 }));
 
 import {
   CESIUM_SCENE_CAPABILITIES,
   type CesiumCameraLike,
+  type CesiumSceneLike,
   type SceneCameraState,
   type SceneRuntimePrimitive,
   applyCameraStateToCesiumCamera,
+  applyCesiumScenePrimitives,
   cameraStateToCesiumView,
   cesiumCameraToSceneState,
   createCesiumSceneAdapter,
   createSceneWorkspace,
+  modelLayerToCesiumPlacement,
+  pickCesiumFeatureAttributes,
+  resolveCesiumModelScale,
+  resolvePickedFeatureAttributes,
 } from "../src/scene-workspace/index.js";
 
 const DEG2RAD = Math.PI / 180;
@@ -71,6 +110,41 @@ function createMockCesiumCamera(): CesiumCameraLike & {
     },
     setView,
   };
+}
+
+/**
+ * A pure-JS stand-in for the slice of Cesium's `Scene` the adapter mutates: a
+ * primitive collection (tracking adds/removes), a settable `terrainProvider`,
+ * `verticalExaggeration`, and an injectable `pick`. No WebGL required.
+ */
+function createMockCesiumScene(pickResult: unknown = undefined): CesiumSceneLike & {
+  added: unknown[];
+  pick: ReturnType<typeof vi.fn>;
+} {
+  const added: unknown[] = [];
+  const pick = vi.fn(() => pickResult);
+  const scene: CesiumSceneLike & { added: unknown[]; pick: ReturnType<typeof vi.fn> } = {
+    added,
+    verticalExaggeration: 1,
+    terrainProvider: undefined,
+    primitives: {
+      add(primitive: unknown) {
+        added.push(primitive);
+        return primitive;
+      },
+      remove(primitive?: unknown) {
+        const index = added.indexOf(primitive);
+        if (index === -1) return false;
+        added.splice(index, 1);
+        return true;
+      },
+      contains(primitive?: unknown) {
+        return added.includes(primitive);
+      },
+    },
+    pick,
+  };
+  return scene;
 }
 
 describe("cesium scene adapter", () => {
@@ -197,6 +271,175 @@ describe("cesium scene adapter", () => {
   it("omits apply() when no live Cesium target is provided", () => {
     const adapter = createCesiumSceneAdapter();
     expect(adapter.apply).toBeUndefined();
+  });
+
+  describe("3D layer rendering (#1197)", () => {
+    beforeEach(() => {
+      tilesetFromUrl.mockClear();
+      modelFromGltfAsync.mockClear();
+      terrainFromUrl.mockClear();
+    });
+
+    it("loads a 3D-Tiles tileset, adds it to the scene, and toggles visibility", async () => {
+      const camera = createMockCesiumCamera();
+      const scene = createMockCesiumScene();
+      const result = await applyCesiumScenePrimitives({ camera, scene }, [
+        {
+          kind: "model-layer",
+          id: "city-tiles",
+          uri: "https://example.test/tileset.json",
+          format: "3d-tiles",
+        },
+      ]);
+
+      expect(tilesetFromUrl).toHaveBeenCalledWith("https://example.test/tileset.json");
+      expect(scene.added).toHaveLength(1);
+      expect(result.status).toBe("supported");
+
+      const handle = result.layers.get("city-tiles");
+      expect(handle?.kind).toBe("model-layer");
+      expect(handle?.format).toBe("3d-tiles");
+
+      const tileset = scene.added[0] as { show: boolean };
+      handle?.setVisible(false);
+      expect(tileset.show).toBe(false);
+      handle?.setVisible(true);
+      expect(tileset.show).toBe(true);
+    });
+
+    it("removes a tileset from the scene via its handle", async () => {
+      const camera = createMockCesiumCamera();
+      const scene = createMockCesiumScene();
+      const result = await applyCesiumScenePrimitives({ camera, scene }, [
+        { kind: "model-layer", id: "city-tiles", uri: "https://example.test/tileset.json", format: "3d-tiles" },
+      ]);
+
+      expect(scene.added).toHaveLength(1);
+      result.layers.get("city-tiles")?.remove();
+      expect(scene.added).toHaveLength(0);
+    });
+
+    it("wires a quantized-mesh terrain provider and honors exaggeration", async () => {
+      const camera = createMockCesiumCamera();
+      const scene = createMockCesiumScene();
+      const result = await applyCesiumScenePrimitives({ camera, scene }, [
+        {
+          kind: "elevation-source",
+          id: "world-terrain",
+          sourceId: "world-terrain",
+          protocol: "quantized-mesh",
+          url: "https://example.test/terrain",
+          exaggeration: 2.5,
+        },
+      ]);
+
+      expect(terrainFromUrl).toHaveBeenCalledWith("https://example.test/terrain");
+      expect(scene.terrainProvider).toMatchObject({ kind: "terrain-provider" });
+      expect(scene.verticalExaggeration).toBe(2.5);
+      expect(result.layers.has("world-terrain")).toBe(true);
+
+      // Removing the terrain handle resets the globe back to a flat ellipsoid.
+      result.layers.get("world-terrain")?.remove();
+      expect(scene.terrainProvider).toBeUndefined();
+      expect(scene.verticalExaggeration).toBe(1);
+    });
+
+    it("sets exaggeration but skips the provider when terrain url is absent", async () => {
+      const camera = createMockCesiumCamera();
+      const scene = createMockCesiumScene();
+      const result = await applyCesiumScenePrimitives({ camera, scene }, [
+        {
+          kind: "elevation-source",
+          id: "terrain-no-url",
+          sourceId: "terrain-no-url",
+          protocol: "quantized-mesh",
+          exaggeration: 1.5,
+        },
+      ]);
+
+      expect(terrainFromUrl).not.toHaveBeenCalled();
+      expect(scene.terrainProvider).toBeUndefined();
+      expect(scene.verticalExaggeration).toBe(1.5);
+      expect(result.layers.has("terrain-no-url")).toBe(false);
+    });
+
+    it("places a glTF model at its position/rotation/scale", async () => {
+      const camera = createMockCesiumCamera();
+      const scene = createMockCesiumScene();
+      const result = await applyCesiumScenePrimitives({ camera, scene }, [
+        {
+          kind: "model-layer",
+          id: "turbine",
+          uri: "https://example.test/turbine.glb",
+          format: "glb",
+          position: [-122.4, 37.8, 50],
+          rotation: [90, 0, 0],
+          scale: 3,
+        },
+      ]);
+
+      expect(modelFromGltfAsync).toHaveBeenCalledTimes(1);
+      const call = modelFromGltfAsync.mock.calls[0]?.[0] as { url: string; scale: number; modelMatrix: unknown };
+      expect(call.url).toBe("https://example.test/turbine.glb");
+      expect(call.scale).toBe(3);
+      // A non-unit scale folds a uniform-scale matrix into the fixed frame.
+      expect(call.modelMatrix).toMatchObject({ kind: "scaled", scale: 3 });
+      expect(scene.added).toHaveLength(1);
+      expect(result.layers.get("turbine")?.kind).toBe("model-layer");
+    });
+
+    it("maps a model-layer primitive to a placement with radian orientation", () => {
+      const placement = modelLayerToCesiumPlacement({
+        kind: "model-layer",
+        id: "m",
+        uri: "x",
+        format: "gltf",
+        position: [10, 20, 5],
+        rotation: [180, -90, 45],
+        scale: [2, 2, 2],
+      });
+      expect(placement.position).toEqual({ longitude: 10, latitude: 20, height: 5 });
+      expect(placement.orientation.heading).toBeCloseTo(Math.PI, 12);
+      expect(placement.orientation.pitch).toBeCloseTo(-Math.PI / 2, 12);
+      expect(placement.scale).toBe(2);
+    });
+
+    it("collapses scale variants to a positive uniform factor (default 1)", () => {
+      expect(resolveCesiumModelScale(4)).toBe(4);
+      expect(resolveCesiumModelScale([5, 1, 1])).toBe(5);
+      expect(resolveCesiumModelScale(undefined)).toBe(1);
+      expect(resolveCesiumModelScale(0)).toBe(1);
+      expect(resolveCesiumModelScale(Number.NaN)).toBe(1);
+    });
+
+    it("skips layer rendering when the target has no scene (camera-only)", async () => {
+      const camera = createMockCesiumCamera();
+      const result = await applyCesiumScenePrimitives({ camera }, [
+        { kind: "model-layer", id: "city-tiles", uri: "https://example.test/tileset.json", format: "3d-tiles" },
+      ]);
+      expect(tilesetFromUrl).not.toHaveBeenCalled();
+      expect(result.layers.size).toBe(0);
+    });
+
+    it("resolves a picked 3D-Tiles feature's batch/structural-metadata attributes", () => {
+      const feature = {
+        getPropertyIds: () => ["name", "height"],
+        getProperty: (name: string) => (name === "name" ? "Town Hall" : 42),
+      };
+      const scene = createMockCesiumScene(feature);
+      const attributes = pickCesiumFeatureAttributes(scene, { x: 100, y: 200 });
+      expect(attributes).toEqual({ name: "Town Hall", height: 42 });
+      expect(scene.pick).toHaveBeenCalledWith({ x: 100, y: 200 });
+    });
+
+    it("returns undefined for picks that are not 3D-Tiles features", () => {
+      expect(resolvePickedFeatureAttributes(undefined)).toBeUndefined();
+      expect(resolvePickedFeatureAttributes(null)).toBeUndefined();
+      // A glTF model `Model` pick has no batch-property accessors.
+      expect(resolvePickedFeatureAttributes({ primitive: {} })).toBeUndefined();
+      const scene = createMockCesiumScene(undefined);
+      expect(pickCesiumFeatureAttributes(scene, { x: 0, y: 0 })).toBeUndefined();
+    });
   });
 
   it("does not statically import Cesium from the scene-workspace sources", () => {

--- a/test/cesium-scene-adapter.test.ts
+++ b/test/cesium-scene-adapter.test.ts
@@ -55,6 +55,7 @@ import {
   type SceneRuntimePrimitive,
   applyCameraStateToCesiumCamera,
   applyCesiumScenePrimitives,
+  applyCesiumTerrain,
   cameraStateToCesiumView,
   cesiumCameraToSceneState,
   createCesiumSceneAdapter,
@@ -344,6 +345,49 @@ describe("cesium scene adapter", () => {
       expect(scene.verticalExaggeration).toBe(1);
     });
 
+    it("ignores a stale terrain handle's remove() once a newer provider replaced it", async () => {
+      const scene = createMockCesiumScene();
+      // Each `CesiumTerrainProvider.fromUrl` call returns a distinct provider.
+      const cesium = (await import("cesium")) as never;
+
+      const first = await applyCesiumTerrain(
+        scene,
+        {
+          kind: "elevation-source",
+          id: "terrain-a",
+          sourceId: "terrain-a",
+          protocol: "quantized-mesh",
+          url: "https://example.test/terrain-a",
+          exaggeration: 2,
+        },
+        cesium,
+      );
+      const firstProvider = scene.terrainProvider;
+
+      // A newer elevation source replaces the active provider + exaggeration.
+      await applyCesiumTerrain(
+        scene,
+        {
+          kind: "elevation-source",
+          id: "terrain-b",
+          sourceId: "terrain-b",
+          protocol: "quantized-mesh",
+          url: "https://example.test/terrain-b",
+          exaggeration: 3,
+        },
+        cesium,
+      );
+      const secondProvider = scene.terrainProvider;
+      expect(secondProvider).not.toBe(firstProvider);
+      expect(scene.verticalExaggeration).toBe(3);
+
+      // Removing the now-stale first handle must be a no-op: the newer provider
+      // and its exaggeration stay active.
+      first?.remove();
+      expect(scene.terrainProvider).toBe(secondProvider);
+      expect(scene.verticalExaggeration).toBe(3);
+    });
+
     it("sets exaggeration but skips the provider when terrain url is absent", async () => {
       const camera = createMockCesiumCamera();
       const scene = createMockCesiumScene();
@@ -379,9 +423,12 @@ describe("cesium scene adapter", () => {
       ]);
 
       expect(modelFromGltfAsync).toHaveBeenCalledTimes(1);
-      const call = modelFromGltfAsync.mock.calls[0]?.[0] as { url: string; scale: number; modelMatrix: unknown };
+      const call = modelFromGltfAsync.mock.calls[0]?.[0] as { url: string; scale?: number; modelMatrix: unknown };
       expect(call.url).toBe("https://example.test/turbine.glb");
-      expect(call.scale).toBe(3);
+      // Scale must be applied EXACTLY once. Cesium multiplies `Model.scale` on
+      // top of `modelMatrix`, so the scale lives in the matrix only and the
+      // `scale` option must be absent (otherwise a requested 3 renders as 9).
+      expect(call.scale).toBeUndefined();
       // A non-unit scale folds a uniform-scale matrix into the fixed frame.
       expect(call.modelMatrix).toMatchObject({ kind: "scaled", scale: 3 });
       expect(scene.added).toHaveLength(1);


### PR DESCRIPTION
Implements honua-io/honua-server#1197 (Epic honua-io/honua-server#530). **Stacked on** feat/1196-cesium-sceneview.

Extends the Cesium adapter with `addCesium3DTileset`, `applyCesiumTerrain`, `addCesiumModel`, and `resolvePickedFeatureAttributes` — 3D Tiles, quantized-mesh/terrain-rgb terrain, glTF/GLB models, and feature picking.

## Testing
`npm run typecheck` + biome pass; 19 vitest cases (Cesium mocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)