### PR TITLE
feat(sdk-js): apply attribute-driven 3D Tiles styling in the Cesium SceneView (#1206 client)

### DIFF
--- a/src/scene-workspace/cesium-adapter.ts
+++ b/src/scene-workspace/cesium-adapter.ts
@@ -107,10 +107,17 @@ export interface CesiumCameraLike {
 /**
  * A 3D-Tiles tileset handle (the bits the adapter mutates). Real Cesium
  * `Cesium3DTileset` instances satisfy this; tests pass a plain object.
+ *
+ * `extras` mirrors Cesium's `Cesium3DTileset.extras` — the parsed `extras`
+ * object from the tileset.json root, available once the tileset is ready. The
+ * server advertises its attribute-driven styling there under `honua_style`
+ * (honua-server#1206). `style` is the settable `Cesium3DTileStyle` slot.
  */
 export interface CesiumTilesetLike {
   show: boolean;
   modelMatrix?: unknown;
+  extras?: unknown;
+  style?: unknown;
   destroy?(): void;
   isDestroyed?(): boolean;
 }
@@ -317,6 +324,7 @@ type CesiumModule = {
   readonly Cesium3DTileset: {
     fromUrl(url: string, options?: Record<string, unknown>): Promise<CesiumTilesetLike>;
   };
+  readonly Cesium3DTileStyle: new (style?: Record<string, unknown>) => unknown;
   readonly Model: {
     fromGltfAsync(options: Record<string, unknown>): Promise<CesiumModelLike>;
   };
@@ -356,19 +364,235 @@ function placementToModelMatrix(cesium: CesiumModule, placement: CesiumModelPlac
 }
 
 /**
+ * A condition block of a 3D-Tiles styling expression. Each entry is an
+ * `[expression, result]` pair evaluated in priority order, where `expression`
+ * is a Cesium styling-language string (`${attr}` references feature attributes)
+ * and `result` is the value applied when the expression is the first to match.
+ * A trailing `["true", <default>]` entry supplies the fallback.
+ *
+ * This is shaped EXACTLY as a CesiumJS `Cesium3DTileStyle` `color`/`show`
+ * block, so a spec can be handed straight to `new Cesium3DTileStyle({ ... })`.
+ */
+export interface Honua3DStyleConditions {
+  readonly conditions: ReadonlyArray<readonly [string, string]>;
+}
+
+/**
+ * The attribute-driven 3D-Tiles styling contract the Honua server emits as a
+ * `style.json` sidecar next to `tileset.json` (honua-server#1206). The server
+ * advertises it in the tileset's root `extras.honua_style`; the `style.color`
+ * / `style.show` blocks are pre-shaped for `Cesium3DTileStyle`.
+ *
+ * `style.color` and `style.show` are each optional — when a block is omitted
+ * the corresponding aspect of the Cesium style is left untouched.
+ */
+export interface Honua3DStyleSpec {
+  readonly encoding: "3d-tiles-styling";
+  readonly version: string;
+  readonly defaultMaterial?: {
+    readonly color?: string;
+    readonly opacity?: number;
+  };
+  readonly style: {
+    readonly color?: Honua3DStyleConditions;
+    readonly show?: Honua3DStyleConditions;
+  };
+}
+
+/**
+ * The descriptor the server places at `extras.honua_style` on the tileset.json
+ * root to advertise its styling sidecar. `uri` is RELATIVE to the tileset.json
+ * URL and is resolved against the tileset's base URL before fetching.
+ */
+export interface Honua3DStyleDescriptor {
+  readonly encoding: "3d-tiles-styling";
+  readonly version: string;
+  readonly uri: string;
+}
+
+/**
+ * Read the `honua_style` descriptor off a tileset's (or tileset.json's)
+ * `extras`, if present and well-formed. Returns `undefined` when the tileset
+ * carries no Honua styling metadata (the common case for plain tilesets), so
+ * the auto-apply path can no-op silently.
+ */
+export function readHonua3DStyleDescriptor(extras: unknown): Honua3DStyleDescriptor | undefined {
+  if (extras === null || typeof extras !== "object") return undefined;
+  const candidate = (extras as { honua_style?: unknown }).honua_style;
+  if (candidate === null || typeof candidate !== "object") return undefined;
+  const descriptor = candidate as { encoding?: unknown; version?: unknown; uri?: unknown };
+  if (descriptor.encoding !== "3d-tiles-styling") return undefined;
+  if (typeof descriptor.uri !== "string" || descriptor.uri.trim() === "") return undefined;
+  return {
+    encoding: "3d-tiles-styling",
+    version: typeof descriptor.version === "string" ? descriptor.version : "1.0",
+    uri: descriptor.uri,
+  };
+}
+
+/**
+ * Resolve a sidecar `uri` (relative, per the contract) against the
+ * `tileset.json` URL it was advertised in. Falls back to returning the raw
+ * `uri` unchanged when `tilesetUrl` is not a parseable absolute/base URL (e.g.
+ * a bare relative path in a test), which keeps a plain `fetch` workable.
+ */
+export function resolveHonua3DStyleUri(uri: string, tilesetUrl: string): string {
+  try {
+    return new URL(uri, tilesetUrl).toString();
+  } catch {
+    return uri;
+  }
+}
+
+/**
+ * Fetch + parse the `style.json` sidecar at `styleUrl`.
+ *
+ * The sidecar is a STATIC asset served next to `tileset.json` (not a Honua API
+ * call), so it is fetched with a plain global `fetch` rather than routed
+ * through the SDK's authenticated request path — this keeps the styling module
+ * free of a client dependency and mirrors how Cesium itself loads tileset
+ * assets. A custom `fetchImpl` can be injected (tests pass a mock).
+ */
+export async function fetchHonua3DStyleSpec(
+  styleUrl: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Honua3DStyleSpec> {
+  const response = await fetchImpl(styleUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Honua 3D style "${styleUrl}": ${response.status} ${response.statusText}`);
+  }
+  return (await response.json()) as Honua3DStyleSpec;
+}
+
+/**
+ * Discover and load the Honua 3D styling spec advertised by a tileset.
+ *
+ * Reads `extras.honua_style` (off either a loaded `Cesium3DTileset` or a parsed
+ * tileset.json `extras` object), resolves the sidecar `uri` against
+ * `tilesetUrl`, and fetches the `style.json`. Returns `undefined` when the
+ * tileset advertises no Honua styling, so callers can treat "no style" as a
+ * silent no-op rather than an error.
+ */
+export async function loadHonua3DStyle(
+  extras: unknown,
+  tilesetUrl: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Honua3DStyleSpec | undefined> {
+  const descriptor = readHonua3DStyleDescriptor(extras);
+  if (!descriptor) return undefined;
+  const styleUrl = resolveHonua3DStyleUri(descriptor.uri, tilesetUrl);
+  return fetchHonua3DStyleSpec(styleUrl, fetchImpl);
+}
+
+/**
+ * Build a Cesium `Cesium3DTileStyle` options object from a spec, including only
+ * the blocks (`color` / `show`) that are present. The spec's blocks are already
+ * `Cesium3DTileStyle`-shaped, so they are passed through verbatim. Pure (no
+ * Cesium import) so the block-selection logic is unit-testable.
+ */
+export function honua3DStyleToCesiumStyleOptions(spec: Honua3DStyleSpec): Record<string, unknown> {
+  const options: Record<string, unknown> = {};
+  if (spec.style.color) options.color = spec.style.color;
+  if (spec.style.show) options.show = spec.style.show;
+  return options;
+}
+
+/**
+ * Apply a Honua 3D styling spec to a tileset by constructing a
+ * `Cesium3DTileStyle` (only from the present `color` / `show` blocks) and
+ * assigning it to `tileset.style`. Lazily loads Cesium the same way the rest of
+ * the adapter does, so no static `import("cesium")` leaks into the 2D bundle.
+ *
+ * When the spec carries neither a `color` nor a `show` block, the tileset's
+ * `style` is left untouched (nothing to apply).
+ */
+export async function applyHonua3DStyle(
+  tileset: CesiumTilesetLike,
+  spec: Honua3DStyleSpec,
+  cesium?: CesiumModule,
+): Promise<void> {
+  const options = honua3DStyleToCesiumStyleOptions(spec);
+  if (Object.keys(options).length === 0) return;
+  const mod = cesium ?? (await loadCesium());
+  tileset.style = new mod.Cesium3DTileStyle(options);
+}
+
+/**
+ * Programmatic override for a tileset's styling: apply a (typically
+ * server-discovered, but possibly hand-authored) {@link Honua3DStyleSpec} to a
+ * live tileset. Thin alias over {@link applyHonua3DStyle} that reads as an
+ * intentional manual set at the call site.
+ */
+export function setTilesetStyle(
+  tileset: CesiumTilesetLike,
+  spec: Honua3DStyleSpec,
+  cesium?: CesiumModule,
+): Promise<void> {
+  return applyHonua3DStyle(tileset, spec, cesium);
+}
+
+/**
+ * Discover and apply the server's attribute-driven styling to an already-loaded
+ * tileset, if it advertises any (`extras.honua_style`). Returns the applied
+ * spec (or `undefined` when the tileset carries no Honua styling). Used by
+ * {@link addCesium3DTileset}'s auto-apply path and exposed for callers that
+ * load a tileset themselves.
+ */
+export async function applyTilesetServerStyle(
+  tileset: CesiumTilesetLike,
+  tilesetUrl: string,
+  cesium?: CesiumModule,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Honua3DStyleSpec | undefined> {
+  const spec = await loadHonua3DStyle(tileset.extras, tilesetUrl, fetchImpl);
+  if (!spec) return undefined;
+  await applyHonua3DStyle(tileset, spec, cesium);
+  return spec;
+}
+
+/**
+ * Options controlling {@link addCesium3DTileset}.
+ */
+export interface AddCesium3DTilesetOptions {
+  /**
+   * When `true` (the default), a tileset that advertises Honua styling metadata
+   * (`extras.honua_style`) has its `style.json` sidecar fetched and applied
+   * automatically after the tileset loads. Set to `false` to add the tileset
+   * unstyled (e.g. to apply a custom style via {@link setTilesetStyle}).
+   */
+  readonly applyServerStyle?: boolean;
+  /**
+   * Override the `fetch` used to load the styling sidecar. Defaults to the
+   * global `fetch`. Primarily a test seam.
+   */
+  readonly fetchImpl?: typeof fetch;
+}
+
+/**
  * Materialize a 3D-Tiles tileset from a model-layer primitive and add it to the
  * scene's primitive collection, returning a handle for later visibility /
  * teardown. Exported so consumers (and tests) can drive a single tileset.
+ *
+ * If the loaded tileset advertises the server's attribute-driven styling
+ * contract (`extras.honua_style`, honua-server#1206) the sidecar style is
+ * fetched and applied automatically (honua-server#1206). Pass
+ * `{ applyServerStyle: false }` to skip that and style the tileset manually via
+ * {@link setTilesetStyle}. A tileset without `honua_style` is added unchanged
+ * (no fetch), so existing callers are unaffected.
  */
 export async function addCesium3DTileset(
   scene: CesiumSceneLike,
   primitive: SceneModelLayerPrimitive,
   cesium?: CesiumModule,
+  options: AddCesium3DTilesetOptions = {},
 ): Promise<CesiumLayerHandle> {
   const mod = cesium ?? (await loadCesium());
   const tileset = await mod.Cesium3DTileset.fromUrl(primitive.uri);
   if (primitive.position) {
     tileset.modelMatrix = placementToModelMatrix(mod, modelLayerToCesiumPlacement(primitive));
+  }
+  if (options.applyServerStyle !== false) {
+    await applyTilesetServerStyle(tileset, primitive.uri, mod, options.fetchImpl ?? fetch);
   }
   scene.primitives.add(tileset);
   return makeLayerHandle(scene, primitive.id, tileset, "model-layer", primitive.format);

--- a/src/scene-workspace/index.ts
+++ b/src/scene-workspace/index.ts
@@ -34,15 +34,24 @@ export {
   applyCameraStateToCesiumCamera,
   applyCesiumScenePrimitives,
   applyCesiumTerrain,
+  applyHonua3DStyle,
+  applyTilesetServerStyle,
   cameraStateToCesiumView,
   cesiumCameraToSceneState,
   createCesiumSceneAdapter,
+  fetchHonua3DStyleSpec,
+  honua3DStyleToCesiumStyleOptions,
+  loadHonua3DStyle,
   modelLayerToCesiumPlacement,
   pickCesiumFeatureAttributes,
+  readHonua3DStyleDescriptor,
   resolveCesiumModelScale,
+  resolveHonua3DStyleUri,
   resolvePickedFeatureAttributes,
+  setTilesetStyle,
 } from "./cesium-adapter.js";
 export type {
+  AddCesium3DTilesetOptions,
   CesiumCameraLike,
   CesiumCameraView,
   CesiumHeadingPitchRollRadians,
@@ -53,6 +62,9 @@ export type {
   CesiumSceneLike,
   CesiumSceneRuntimeTarget,
   CesiumTilesetLike,
+  Honua3DStyleConditions,
+  Honua3DStyleDescriptor,
+  Honua3DStyleSpec,
 } from "./cesium-adapter.js";
 export { SCENE_WORKSPACE_SLICES } from "./types.js";
 export type {

--- a/test/cesium-3d-symbology.test.ts
+++ b/test/cesium-3d-symbology.test.ts
@@ -1,0 +1,369 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// As with `cesium-scene-adapter.test.ts`, Cesium needs a WebGL context that is
+// unavailable headless, so we mock only the surface the styling path touches:
+// `Cesium3DTileset.fromUrl` (to feed `extras` into the auto-apply flow) and a
+// `Cesium3DTileStyle` stub that records the options it was constructed with so
+// we can assert which blocks were forwarded. The 2D bundle never loads this
+// module — the static-import guard in `cesium-scene-adapter.test.ts` covers it.
+const tilesetFromUrl = vi.fn(async (url: string) => ({
+  kind: "tileset",
+  url,
+  show: true,
+  modelMatrix: undefined,
+  extras: undefined as unknown,
+  style: undefined as unknown,
+}));
+
+class Cesium3DTileStyleStub {
+  constructor(public readonly options: Record<string, unknown> = {}) {}
+}
+
+vi.mock("cesium", () => ({
+  Cartesian3: {
+    fromDegrees: (longitude: number, latitude: number, height?: number) => ({ longitude, latitude, height }),
+  },
+  HeadingPitchRoll: class {
+    constructor(
+      public heading = 0,
+      public pitch = 0,
+      public roll = 0,
+    ) {}
+  },
+  Transforms: {
+    headingPitchRollToFixedFrame: (origin: unknown, hpr: unknown) => ({ kind: "frame", origin, hpr }),
+  },
+  Matrix4: {
+    multiplyByUniformScale: (matrix: unknown, scale: number) => ({ kind: "scaled", matrix, scale }),
+    clone: (matrix: unknown) => matrix,
+  },
+  Cesium3DTileset: {
+    fromUrl: (url: string) => tilesetFromUrl(url),
+  },
+  Cesium3DTileStyle: Cesium3DTileStyleStub,
+  Model: {
+    fromGltfAsync: vi.fn(async (options: Record<string, unknown>) => ({ ...options, kind: "model", show: true })),
+  },
+  CesiumTerrainProvider: {
+    fromUrl: vi.fn(async (url: string) => ({ kind: "terrain-provider", url })),
+  },
+}));
+
+import {
+  type CesiumSceneLike,
+  type CesiumTilesetLike,
+  type Honua3DStyleSpec,
+  addCesium3DTileset,
+  applyHonua3DStyle,
+  applyTilesetServerStyle,
+  fetchHonua3DStyleSpec,
+  honua3DStyleToCesiumStyleOptions,
+  loadHonua3DStyle,
+  readHonua3DStyleDescriptor,
+  resolveHonua3DStyleUri,
+  setTilesetStyle,
+} from "../src/scene-workspace/index.js";
+
+const COLOR_AND_SHOW: Honua3DStyleSpec = {
+  encoding: "3d-tiles-styling",
+  version: "1.0",
+  defaultMaterial: { color: "#ffffff", opacity: 0.5 },
+  style: {
+    color: {
+      conditions: [
+        ["${height} > 30", "color('#ff0000', 1)"],
+        ["true", "color('#ffffff', 0.5)"],
+      ],
+    },
+    show: {
+      conditions: [
+        ["${demolished} === 'true'", "false"],
+        ["true", "true"],
+      ],
+    },
+  },
+};
+
+function styleSidecarResponse(spec: Honua3DStyleSpec): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => spec,
+  } as unknown as Response;
+}
+
+function createMockScene(): CesiumSceneLike & { added: unknown[] } {
+  const added: unknown[] = [];
+  return {
+    added,
+    verticalExaggeration: 1,
+    terrainProvider: undefined,
+    primitives: {
+      add(primitive: unknown) {
+        added.push(primitive);
+        return primitive;
+      },
+      remove() {
+        return true;
+      },
+      contains(primitive?: unknown) {
+        return added.includes(primitive);
+      },
+    },
+  };
+}
+
+/** A loaded tileset stub that exposes `extras` + a settable `style`. */
+function createTileset(extras?: unknown): CesiumTilesetLike & { style: unknown } {
+  return { show: true, extras, style: undefined };
+}
+
+describe("honua 3d symbology — descriptor discovery", () => {
+  it("reads a well-formed honua_style descriptor off extras", () => {
+    const descriptor = readHonua3DStyleDescriptor({
+      honua_style: { encoding: "3d-tiles-styling", version: "1.0", uri: "style.json" },
+    });
+    expect(descriptor).toEqual({ encoding: "3d-tiles-styling", version: "1.0", uri: "style.json" });
+  });
+
+  it("defaults version to 1.0 when the descriptor omits it", () => {
+    const descriptor = readHonua3DStyleDescriptor({
+      honua_style: { encoding: "3d-tiles-styling", uri: "style.json" },
+    });
+    expect(descriptor?.version).toBe("1.0");
+  });
+
+  it("returns undefined when no honua_style is present or the shape is wrong", () => {
+    expect(readHonua3DStyleDescriptor(undefined)).toBeUndefined();
+    expect(readHonua3DStyleDescriptor(null)).toBeUndefined();
+    expect(readHonua3DStyleDescriptor({})).toBeUndefined();
+    // Wrong encoding.
+    expect(readHonua3DStyleDescriptor({ honua_style: { encoding: "other", uri: "style.json" } })).toBeUndefined();
+    // Missing / empty uri.
+    expect(readHonua3DStyleDescriptor({ honua_style: { encoding: "3d-tiles-styling" } })).toBeUndefined();
+    expect(readHonua3DStyleDescriptor({ honua_style: { encoding: "3d-tiles-styling", uri: "  " } })).toBeUndefined();
+  });
+});
+
+describe("honua 3d symbology — relative-uri resolution", () => {
+  it("resolves a relative sidecar uri against the tileset.json url", () => {
+    expect(resolveHonua3DStyleUri("style.json", "https://example.test/tiles/city/tileset.json")).toBe(
+      "https://example.test/tiles/city/style.json",
+    );
+    expect(resolveHonua3DStyleUri("./styles/style.json", "https://example.test/tiles/city/tileset.json")).toBe(
+      "https://example.test/tiles/city/styles/style.json",
+    );
+  });
+
+  it("falls back to the raw uri when the tileset url is not absolute", () => {
+    expect(resolveHonua3DStyleUri("style.json", "tileset.json")).toBe("style.json");
+  });
+});
+
+describe("honua 3d symbology — fetch + load", () => {
+  it("fetches and parses the style.json sidecar", async () => {
+    const fetchImpl = vi.fn(async () => styleSidecarResponse(COLOR_AND_SHOW));
+    const spec = await fetchHonua3DStyleSpec("https://example.test/tiles/city/style.json", fetchImpl);
+    expect(fetchImpl).toHaveBeenCalledWith("https://example.test/tiles/city/style.json");
+    expect(spec.encoding).toBe("3d-tiles-styling");
+    expect(spec.style.color?.conditions).toHaveLength(2);
+  });
+
+  it("throws on a non-ok sidecar response", async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 404, statusText: "Not Found" }) as unknown as Response);
+    await expect(fetchHonua3DStyleSpec("https://example.test/style.json", fetchImpl)).rejects.toThrow(/404/);
+  });
+
+  it("discovers + loads via extras, resolving the relative sidecar uri", async () => {
+    const fetchImpl = vi.fn(async () => styleSidecarResponse(COLOR_AND_SHOW));
+    const spec = await loadHonua3DStyle(
+      { honua_style: { encoding: "3d-tiles-styling", version: "1.0", uri: "style.json" } },
+      "https://example.test/tiles/city/tileset.json",
+      fetchImpl,
+    );
+    expect(fetchImpl).toHaveBeenCalledWith("https://example.test/tiles/city/style.json");
+    expect(spec).toEqual(COLOR_AND_SHOW);
+  });
+
+  it("returns undefined (no fetch) when extras carry no honua_style", async () => {
+    const fetchImpl = vi.fn();
+    const spec = await loadHonua3DStyle({}, "https://example.test/tileset.json", fetchImpl);
+    expect(spec).toBeUndefined();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe("honua 3d symbology — option building + apply", () => {
+  it("includes only the blocks present in the spec", () => {
+    expect(honua3DStyleToCesiumStyleOptions(COLOR_AND_SHOW)).toEqual({
+      color: COLOR_AND_SHOW.style.color,
+      show: COLOR_AND_SHOW.style.show,
+    });
+    expect(
+      honua3DStyleToCesiumStyleOptions({
+        encoding: "3d-tiles-styling",
+        version: "1.0",
+        style: { color: COLOR_AND_SHOW.style.color },
+      }),
+    ).toEqual({ color: COLOR_AND_SHOW.style.color });
+    expect(
+      honua3DStyleToCesiumStyleOptions({
+        encoding: "3d-tiles-styling",
+        version: "1.0",
+        style: { show: COLOR_AND_SHOW.style.show },
+      }),
+    ).toEqual({ show: COLOR_AND_SHOW.style.show });
+  });
+
+  it("applies a color+show spec, building a Cesium3DTileStyle with both blocks", async () => {
+    const tileset = createTileset();
+    await applyHonua3DStyle(tileset, COLOR_AND_SHOW);
+    const style = tileset.style as Cesium3DTileStyleStub;
+    expect(style).toBeInstanceOf(Cesium3DTileStyleStub);
+    expect(style.options).toEqual({
+      color: COLOR_AND_SHOW.style.color,
+      show: COLOR_AND_SHOW.style.show,
+    });
+  });
+
+  it("applies a color-only spec (no show key in the style options)", async () => {
+    const tileset = createTileset();
+    await applyHonua3DStyle(tileset, {
+      encoding: "3d-tiles-styling",
+      version: "1.0",
+      style: { color: COLOR_AND_SHOW.style.color },
+    });
+    const style = tileset.style as Cesium3DTileStyleStub;
+    expect(Object.keys(style.options)).toEqual(["color"]);
+  });
+
+  it("applies a show-only spec (no color key in the style options)", async () => {
+    const tileset = createTileset();
+    await applyHonua3DStyle(tileset, {
+      encoding: "3d-tiles-styling",
+      version: "1.0",
+      style: { show: COLOR_AND_SHOW.style.show },
+    });
+    const style = tileset.style as Cesium3DTileStyleStub;
+    expect(Object.keys(style.options)).toEqual(["show"]);
+  });
+
+  it("leaves tileset.style untouched when neither block is present", async () => {
+    const tileset = createTileset();
+    await applyHonua3DStyle(tileset, { encoding: "3d-tiles-styling", version: "1.0", style: {} });
+    expect(tileset.style).toBeUndefined();
+  });
+
+  it("setTilesetStyle applies a spec as a programmatic override", async () => {
+    const tileset = createTileset();
+    await setTilesetStyle(tileset, COLOR_AND_SHOW);
+    expect(tileset.style).toBeInstanceOf(Cesium3DTileStyleStub);
+  });
+
+  it("applyTilesetServerStyle discovers, fetches, and applies; returns the spec", async () => {
+    const fetchImpl = vi.fn(async () => styleSidecarResponse(COLOR_AND_SHOW));
+    const tileset = createTileset({
+      honua_style: { encoding: "3d-tiles-styling", version: "1.0", uri: "style.json" },
+    });
+    const spec = await applyTilesetServerStyle(
+      tileset,
+      "https://example.test/tiles/city/tileset.json",
+      undefined,
+      fetchImpl,
+    );
+    expect(spec).toEqual(COLOR_AND_SHOW);
+    expect(fetchImpl).toHaveBeenCalledWith("https://example.test/tiles/city/style.json");
+    expect(tileset.style).toBeInstanceOf(Cesium3DTileStyleStub);
+  });
+
+  it("applyTilesetServerStyle no-ops (no fetch, undefined) for an unstyled tileset", async () => {
+    const fetchImpl = vi.fn();
+    const tileset = createTileset();
+    const spec = await applyTilesetServerStyle(tileset, "https://example.test/tileset.json", undefined, fetchImpl);
+    expect(spec).toBeUndefined();
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(tileset.style).toBeUndefined();
+  });
+});
+
+describe("honua 3d symbology — auto-apply on tileset add", () => {
+  beforeEach(() => {
+    tilesetFromUrl.mockClear();
+  });
+
+  it("auto-applies server style when the added tileset advertises honua_style", async () => {
+    tilesetFromUrl.mockImplementationOnce(async (url: string) => ({
+      kind: "tileset",
+      url,
+      show: true,
+      modelMatrix: undefined,
+      extras: { honua_style: { encoding: "3d-tiles-styling", version: "1.0", uri: "style.json" } },
+      style: undefined,
+    }));
+    const fetchImpl = vi.fn(async () => styleSidecarResponse(COLOR_AND_SHOW));
+    const scene = createMockScene();
+
+    const handle = await addCesium3DTileset(
+      scene,
+      {
+        kind: "model-layer",
+        id: "city-tiles",
+        uri: "https://example.test/tiles/city/tileset.json",
+        format: "3d-tiles",
+      },
+      undefined,
+      { fetchImpl },
+    );
+
+    expect(handle.id).toBe("city-tiles");
+    expect(scene.added).toHaveLength(1);
+    expect(fetchImpl).toHaveBeenCalledWith("https://example.test/tiles/city/style.json");
+    const tileset = scene.added[0] as { style: unknown };
+    expect(tileset.style).toBeInstanceOf(Cesium3DTileStyleStub);
+  });
+
+  it("skips the server style when applyServerStyle is false", async () => {
+    tilesetFromUrl.mockImplementationOnce(async (url: string) => ({
+      kind: "tileset",
+      url,
+      show: true,
+      modelMatrix: undefined,
+      extras: { honua_style: { encoding: "3d-tiles-styling", version: "1.0", uri: "style.json" } },
+      style: undefined,
+    }));
+    const fetchImpl = vi.fn(async () => styleSidecarResponse(COLOR_AND_SHOW));
+    const scene = createMockScene();
+
+    await addCesium3DTileset(
+      scene,
+      {
+        kind: "model-layer",
+        id: "city-tiles",
+        uri: "https://example.test/tiles/city/tileset.json",
+        format: "3d-tiles",
+      },
+      undefined,
+      { applyServerStyle: false, fetchImpl },
+    );
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    const tileset = scene.added[0] as { style: unknown };
+    expect(tileset.style).toBeUndefined();
+  });
+
+  it("adds an unstyled tileset (no fetch) when it carries no honua_style", async () => {
+    const fetchImpl = vi.fn();
+    const scene = createMockScene();
+
+    await addCesium3DTileset(
+      scene,
+      { kind: "model-layer", id: "plain", uri: "https://example.test/tiles/plain/tileset.json", format: "3d-tiles" },
+      undefined,
+      { fetchImpl },
+    );
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(scene.added).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Implements the **client side** of honua-io/honua-server#1206 (Epic honua-io/honua-server#530). **Stacked on** feat/1197-cesium-3d-content. Server side: honua-server feat/1206-3d-symbology-server.

When a tileset carries `extras.honua_style`, `addCesium3DTileset` now resolves the relative `style.json`, fetches it, and assigns `new Cesium3DTileStyle({ color?, show? })` to `tileset.style`. Adds `setTilesetStyle` for programmatic overrides. Consumes the exact `TileStyleSpec` contract the server emits.

## Testing
`npm run typecheck` + biome pass; 20 vitest cases (Cesium + fetch mocked): discovery, relative-URI resolution, color-only/show-only/both, auto-apply on add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)