### PR TITLE
MCP/QGIS/Studio package parity for generated map, dashboard, report, and app packages

### DIFF
--- a/docs/studio-package-contracts.md
+++ b/docs/studio-package-contracts.md
@@ -170,6 +170,14 @@ re-exported from the root barrels), so it is outside the SDK semver contract
 until the matching server contracts land. The format constants follow the
 `HONUA_X_PACKAGE_FORMAT_V1 = "honua_x_package.v1"` pattern.
 
+## Cross-surface parity (MCP / QGIS)
+
+The parity layer that makes packages portable across Console, MCP, and QGIS —
+a shared `provenance` envelope, a family-agnostic `validateStudioPackage`
+helper, a documented Vega-Lite chart subset, and cross-surface fixtures — is
+documented in [`studio-package-parity.md`](./studio-package-parity.md)
+(`honua-sdk-js#226`).
+
 ## Open questions (pending server contracts)
 
 These are tracked for follow-up once the server shapes are finalized:

--- a/docs/studio-package-parity.md
+++ b/docs/studio-package-parity.md
@@ -1,0 +1,115 @@
+# Studio package parity: MCP, QGIS, and Console (`honua-sdk-js#226`)
+
+Status: experimental, implemented for ticket `honua-sdk-js#226` (parity layer on
+top of the package contracts from `honua-sdk-js#225`, see
+[`studio-package-contracts.md`](./studio-package-contracts.md)).
+
+The goal is that an AI-generated spatial output — a map, dashboard, report, or
+app package — is **portable across Honua Studio/Console, MCP clients, and the
+QGIS plugin** because all three use the same package contracts and the same
+provenance shape, rather than surface-specific output formats. A package
+produced through MCP or QGIS is validated by the SDK with one envelope and can
+be opened in Console once Console supports the route.
+
+```ts
+import {
+  validateStudioPackage,
+  validatePackageProvenance,
+  getPackageProvenance,
+  chartWidgetToVegaLiteSpec,
+} from "@honua/sdk-js/studio";
+```
+
+## Provenance carried consistently
+
+Every generated package may carry a `provenance` envelope
+(`honua_package_provenance.v1`) under its open `[extra]` index signature. The
+envelope records the same fields regardless of which surface generated it:
+
+| Field | Meaning |
+| --- | --- |
+| `origin` | `console` / `studio` / `mcp` / `qgis` / `sdk` — the producing surface. |
+| `prompt` | The natural-language prompt + model + capturing surface. |
+| `plan` | The ordered generation steps and rationale the agent followed. |
+| `dataBindings` | Which sources (and optionally query/layer) the output reads. |
+| `permissions` | Capabilities required, each flagged `clientSide` true/false. |
+
+`getPackageProvenance(pkg)` reads it off any package value (returns `undefined`
+when absent or malformed); `validatePackageProvenance(pkg, { required })`
+validates just the envelope. MCP- and QGIS-origin packages must satisfy the
+same provenance shape as Console — there is no surface-specific variant.
+
+## One validation envelope for packages produced outside Console
+
+`validateStudioPackage(family, pkg, options)` validates a package of any family
+produced by an MCP client, the QGIS plugin, or the SDK, returning the unified
+`StudioPackageValidationResponse<T>` from `#225`. For the `map` family it
+delegates to the established structural `validateMapPackage`; for the other
+families it runs the shared base checks (identity field, `format`, lifecycle)
+plus provenance checks when an envelope is present. Pass
+`{ requireProvenance: true }` to make provenance mandatory.
+
+```ts
+const response = validateStudioPackage("dashboard", mcpDashboardPackage);
+if (!response.valid) {
+  for (const d of response.diagnostics) console.warn(d.code, d.message);
+}
+```
+
+Fixtures for all four package variants — map-only, dashboard, report, app — live
+in [`test/fixtures/studio-packages/`](../test/fixtures/studio-packages/) and are
+shaped exactly as MCP/QGIS would emit them (`provenance.origin` of `mcp`/`qgis`).
+They are openable by Console and exercised by
+`test/studio/studio-package-parity.test.ts`.
+
+## Charts use a documented Vega-Lite subset
+
+Dashboard and report charts use a documented, compatible subset of Vega-Lite v5
+(`HonuaVegaLiteChartSpec`) so a chart renders identically across surfaces. The
+subset is `bar` / `line` / `point` / `arc` marks over a single positional
+encoding pair plus an optional color channel — a structural subset of a real
+Vega-Lite `TopLevelSpec`, consumable directly by `vega-embed` without
+translation. `chartWidgetToVegaLiteSpec(widget, rows?)` derives a spec from a
+generated-app chart widget:
+
+| Generated-app `chartKind` | Vega-Lite mark | Encoding |
+| --- | --- | --- |
+| `categories` | `bar` | `x`: nominal group field, `y`: count |
+| `histogram` | `bar` | `x`: binned quantitative field, `y`: count |
+| `time-series` | `line` | `x`: temporal field, `y`: count or metric aggregate |
+
+Anything outside the subset is not silently downgraded: when a widget lacks the
+field its chart kind needs, `chartWidgetToVegaLiteSpec` returns `undefined` so a
+host degrades cleanly instead of emitting a broken spec.
+
+## Client-side preview vs. server execution
+
+The SDK can preview the client-renderable parts of a package in a browser
+without a server. Capabilities that need server execution are flagged on each
+permission (`clientSide: false`) so a host reports an unsupported state cleanly
+rather than rendering a silent partial.
+
+| Capability | Client-side preview (SDK) | Requires server execution |
+| --- | --- | --- |
+| Validate any package (`validateStudioPackage`) | ✅ | — |
+| Read/validate provenance | ✅ | — |
+| Render a `map` package (MapLibre runtime) | ✅ | — |
+| Derive a chart spec (`chartWidgetToVegaLiteSpec`) | ✅ | — |
+| Hydrate a dashboard/app manifest preview | ✅ (with a feature loader) | — |
+| Run live queries against a hosted/protected source | — | ✅ (auth, hosting) |
+| Render a report to PDF / static artifact | — | ✅ (`report:render`) |
+| Execute a GP / ETL / workflow package | — | ✅ |
+| Publish / share / embed a package | — | ✅ (control-plane) |
+
+A host should gate UI on this matrix together with the server's
+`StudioCapabilityManifest` (`hasCapability` / `getCapability`): the manifest says
+what the connected server supports; this table says what the SDK can do without
+one.
+
+## Versioning
+
+Every new export is tagged `@experimental` and is subpath-only under
+`@honua/sdk-js/studio`, outside the SDK semver contract until the matching
+server contracts land. The provenance format follows the established
+`HONUA_X_PACKAGE_FORMAT_V1 = "honua_x_package.v1"` pattern
+(`HONUA_PACKAGE_PROVENANCE_FORMAT_V1 = "honua_package_provenance.v1"`).

--- a/src/studio/chart-spec.ts
+++ b/src/studio/chart-spec.ts
@@ -1,0 +1,165 @@
+/**
+ * A documented, compatible subset of the Vega-Lite v5 spec used by Studio
+ * dashboard and report charts. The acceptance criterion for cross-surface
+ * parity is that "dashboard/report charts use Vega-Lite specs or an explicitly
+ * documented compatible subset" — this module is that documented subset, plus
+ * a pure helper that derives a spec from a generated-app chart widget so MCP,
+ * QGIS, Console, and the SDK preview runtime all render the same chart.
+ *
+ * The subset is intentionally narrow: bar / arc / line / point marks over a
+ * single positional encoding pair plus an optional color channel. It is a
+ * structural subset of a real Vega-Lite `TopLevelSpec`, so a host may hand the
+ * object directly to `vega-embed` / `vega-lite` without translation, while the
+ * SDK stays free of a Vega dependency (these are plain data types).
+ *
+ * @experimental Not yet covered by the SDK's semver contract — these shapes
+ *   may change in any minor release prior to `1.0.0`.
+ * @module
+ */
+
+import type { HonuaGeneratedAppChartWidget } from "../generated-app/manifest.js";
+
+/** Vega-Lite schema URL this subset targets. */
+export const HONUA_VEGA_LITE_SCHEMA_V5 = "https://vega.github.io/schema/vega-lite/v5.json" as const;
+
+/** Mark types in the supported subset. */
+export type HonuaChartMark = "bar" | "line" | "point" | "arc";
+
+/** Encoding field type in the supported subset. */
+export type HonuaChartFieldType = "quantitative" | "nominal" | "ordinal" | "temporal";
+
+/**
+ * One positional / visual encoding channel. A structural subset of a
+ * Vega-Lite `FieldDef`.
+ *
+ * @experimental
+ */
+export interface HonuaChartEncodingChannel {
+  readonly field: string;
+  readonly type: HonuaChartFieldType;
+  readonly title?: string;
+  readonly aggregate?: "count" | "sum" | "mean" | "min" | "max" | "median";
+  readonly timeUnit?: string;
+  readonly bin?: boolean | { readonly maxbins?: number };
+}
+
+/**
+ * The encoding block. `x`/`y` are the positional pair; `color` is optional.
+ *
+ * @experimental
+ */
+export interface HonuaChartEncoding {
+  readonly x?: HonuaChartEncodingChannel;
+  readonly y?: HonuaChartEncodingChannel;
+  readonly color?: HonuaChartEncodingChannel;
+}
+
+/**
+ * The documented Vega-Lite-compatible chart spec. Inline `data.values` carry
+ * the rows; a host may instead point `data.name` at a named dataset. The
+ * `$schema` and structural layout make this directly consumable by Vega-Lite.
+ *
+ * @experimental
+ */
+export interface HonuaVegaLiteChartSpec {
+  readonly $schema: typeof HONUA_VEGA_LITE_SCHEMA_V5;
+  readonly title?: string;
+  readonly description?: string;
+  readonly mark: HonuaChartMark | { readonly type: HonuaChartMark; readonly tooltip?: boolean };
+  readonly encoding: HonuaChartEncoding;
+  readonly data?: {
+    readonly values?: ReadonlyArray<Record<string, unknown>>;
+    readonly name?: string;
+  };
+  readonly width?: number | "container";
+  readonly height?: number | "container";
+}
+
+/**
+ * Map a generated-app chart widget kind to a Vega-Lite mark and the encoding
+ * shape the subset expects.
+ */
+const CHART_KIND_MARK: Record<NonNullable<HonuaGeneratedAppChartWidget["chartKind"]>, HonuaChartMark> = {
+  categories: "bar",
+  histogram: "bar",
+  "time-series": "line",
+};
+
+/**
+ * Derive a {@link HonuaVegaLiteChartSpec} from a generated-app chart widget so
+ * dashboard and report charts render identically across surfaces. `rows`, when
+ * supplied, become inline `data.values`; otherwise the host binds a named
+ * dataset. Returns `undefined` when the widget lacks the field needed for its
+ * chart kind (so a caller can degrade cleanly rather than emit a broken spec).
+ *
+ * @experimental
+ */
+export function chartWidgetToVegaLiteSpec(
+  widget: HonuaGeneratedAppChartWidget,
+  rows?: ReadonlyArray<Record<string, unknown>>,
+): HonuaVegaLiteChartSpec | undefined {
+  const chartKind = widget.chartKind ?? "categories";
+  const mark = CHART_KIND_MARK[chartKind];
+
+  let encoding: HonuaChartEncoding | undefined;
+  if (chartKind === "categories") {
+    const category = widget.groupBy ?? widget.field;
+    if (!category) return undefined;
+    encoding = {
+      x: { field: category, type: "nominal", title: widget.title },
+      y: { field: "count", type: "quantitative", aggregate: "count", title: "Count" },
+    };
+  } else if (chartKind === "histogram") {
+    if (!widget.field) return undefined;
+    encoding = {
+      x: {
+        field: widget.field,
+        type: "quantitative",
+        bin: widget.bins ? { maxbins: widget.bins } : true,
+        title: widget.title ?? widget.field,
+      },
+      y: { field: "count", type: "quantitative", aggregate: "count", title: "Count" },
+    };
+  } else {
+    // time-series
+    const timeField = widget.field ?? widget.groupBy;
+    if (!timeField) return undefined;
+    const valueChannel: HonuaChartEncodingChannel = widget.metric
+      ? {
+          field: widget.metric.field === "*" ? "count" : widget.metric.field,
+          type: "quantitative",
+          aggregate: metricToAggregate(widget.metric.fn),
+          title: widget.metric.alias ?? widget.metric.field,
+        }
+      : { field: "count", type: "quantitative", aggregate: "count", title: "Count" };
+    encoding = {
+      x: { field: timeField, type: "temporal", title: widget.title ?? timeField },
+      y: valueChannel,
+    };
+  }
+
+  return {
+    $schema: HONUA_VEGA_LITE_SCHEMA_V5,
+    ...(widget.title ? { title: widget.title } : {}),
+    mark: { type: mark, tooltip: true },
+    encoding,
+    width: "container",
+    ...(rows ? { data: { values: rows } } : {}),
+  };
+}
+
+function metricToAggregate(metric: string): NonNullable<HonuaChartEncodingChannel["aggregate"]> {
+  switch (metric) {
+    case "sum":
+      return "sum";
+    case "avg":
+    case "mean":
+      return "mean";
+    case "min":
+      return "min";
+    case "max":
+      return "max";
+    default:
+      return "count";
+  }
+}

--- a/src/studio/index.ts
+++ b/src/studio/index.ts
@@ -64,6 +64,30 @@ export type {
   StudioPreviewArtifactRef,
 } from "./validation.js";
 
+export { validatePackageProvenance, validateStudioPackage } from "./validate.js";
+export type { ValidateStudioPackageOptions } from "./validate.js";
+
+export { HONUA_PACKAGE_PROVENANCE_FORMAT_V1, getPackageProvenance } from "./provenance.js";
+export type {
+  HonuaPackageOrigin,
+  HonuaPackagePermission,
+  HonuaPackageProvenance,
+  HonuaPackageProvenanceFormat,
+  HonuaPlanProvenance,
+  HonuaPlanStep,
+  HonuaPromptProvenance,
+  HonuaProvenanceDataBinding,
+} from "./provenance.js";
+
+export { HONUA_VEGA_LITE_SCHEMA_V5, chartWidgetToVegaLiteSpec } from "./chart-spec.js";
+export type {
+  HonuaChartEncoding,
+  HonuaChartEncodingChannel,
+  HonuaChartFieldType,
+  HonuaChartMark,
+  HonuaVegaLiteChartSpec,
+} from "./chart-spec.js";
+
 export { getCapability, hasCapability } from "./capability-manifest.js";
 export type {
   StudioCapabilityConstraint,

--- a/src/studio/provenance.ts
+++ b/src/studio/provenance.ts
@@ -1,0 +1,155 @@
+/**
+ * Shared provenance contract carried by AI-generated Studio packages
+ * (map, dashboard, report, app, and the stub families) regardless of which
+ * surface produced them — Honua Studio/Console, an MCP client, or the QGIS
+ * plugin.
+ *
+ * Parity goal: a package generated through MCP or QGIS records the same
+ * prompt / plan / data-binding / permission / origin provenance as one
+ * generated in Console, so the SDK can validate, attribute, and preview it
+ * with one contract. The shape is intentionally additive and open-ended —
+ * unknown fields are preserved through `[extra: string]: unknown` so a newer
+ * generator never breaks an older client.
+ *
+ * @experimental Not yet covered by the SDK's semver contract — these shapes
+ *   may change in any minor release prior to `1.0.0` and before the matching
+ *   server contracts ship.
+ * @module
+ */
+
+/** Canonical format string for the v1 package-provenance shape. */
+export const HONUA_PACKAGE_PROVENANCE_FORMAT_V1 = "honua_package_provenance.v1" as const;
+
+export type HonuaPackageProvenanceFormat = typeof HONUA_PACKAGE_PROVENANCE_FORMAT_V1;
+
+/**
+ * The surface that produced a package. Used to attribute generation and to
+ * gate which capabilities a host may assume (e.g. QGIS-origin packages cannot
+ * assume Console-only server execution).
+ *
+ * @experimental
+ */
+export type HonuaPackageOrigin = "console" | "studio" | "mcp" | "qgis" | "sdk" | (string & {});
+
+/**
+ * The natural-language prompt and any structured instructions that drove an
+ * AI generation. `surface` records which client captured the prompt so MCP
+ * and QGIS flows carry the same shape as Console.
+ *
+ * @experimental
+ */
+export interface HonuaPromptProvenance {
+  readonly text?: string;
+  readonly system?: string;
+  readonly surface?: HonuaPackageOrigin;
+  readonly model?: string;
+  readonly capturedAt?: string;
+  readonly [extra: string]: unknown;
+}
+
+/**
+ * One step in the generation plan the agent followed to produce the package.
+ *
+ * @experimental
+ */
+export interface HonuaPlanStep {
+  readonly id?: string;
+  readonly kind?: string;
+  readonly summary?: string;
+  readonly toolName?: string;
+  readonly status?: "planned" | "succeeded" | "failed" | "skipped" | (string & {});
+  readonly [extra: string]: unknown;
+}
+
+/**
+ * The plan an agent executed — an ordered list of steps plus an optional
+ * free-text rationale. Mirrors what Console records so MCP/QGIS-generated
+ * packages can be inspected identically.
+ *
+ * @experimental
+ */
+export interface HonuaPlanProvenance {
+  readonly steps?: readonly HonuaPlanStep[];
+  readonly rationale?: string;
+  readonly [extra: string]: unknown;
+}
+
+/**
+ * One data binding referenced by a package's provenance: which source (and
+ * optionally which query/layer) the generated output reads. This duplicates
+ * just enough of the per-family binding to let a validator confirm the
+ * package's declared inputs without loading every family-specific spec.
+ *
+ * @experimental
+ */
+export interface HonuaProvenanceDataBinding {
+  readonly sourceId: string;
+  readonly title?: string;
+  readonly protocol?: string;
+  readonly queryId?: string;
+  readonly layerId?: string;
+  readonly role?: "primary" | "secondary" | "lookup" | (string & {});
+  readonly [extra: string]: unknown;
+}
+
+/**
+ * A single permission the package requires to render or execute. `scope`
+ * names the capability (e.g. `"source:read"`, `"server:execute"`) and
+ * `clientSide` records whether the SDK can satisfy it in a browser preview
+ * (`true`) or whether it requires server execution (`false`).
+ *
+ * @experimental
+ */
+export interface HonuaPackagePermission {
+  readonly scope: string;
+  readonly resource?: string;
+  readonly clientSide?: boolean;
+  readonly description?: string;
+  readonly [extra: string]: unknown;
+}
+
+/**
+ * Provenance envelope attached to a generated package, consistently shaped
+ * across Console, MCP, and QGIS. Attach it under a package's `provenance`
+ * field (every family carries an open `[extra]` index signature) so the SDK
+ * validator and preview helpers can read one contract.
+ *
+ * @experimental
+ */
+export interface HonuaPackageProvenance {
+  readonly format: HonuaPackageProvenanceFormat;
+  readonly origin: HonuaPackageOrigin;
+  /** Stable id of the package this provenance describes, when known. */
+  readonly packageId?: string;
+  readonly generatedAt?: string;
+  /** Generator/tool identifier, e.g. `"honua-mcp@1.4.0"` or `"qgis-plugin@0.3"`. */
+  readonly generator?: string;
+  readonly prompt?: HonuaPromptProvenance;
+  readonly plan?: HonuaPlanProvenance;
+  readonly dataBindings?: readonly HonuaProvenanceDataBinding[];
+  readonly permissions?: readonly HonuaPackagePermission[];
+  readonly [extra: string]: unknown;
+}
+
+/** A package value that may carry a {@link HonuaPackageProvenance}. */
+interface MaybeProvenanced {
+  readonly provenance?: unknown;
+}
+
+/**
+ * Read the provenance envelope off any package value, or `undefined` when it
+ * is absent or malformed. Does not throw on untrusted input.
+ *
+ * @experimental
+ */
+export function getPackageProvenance(pkg: unknown): HonuaPackageProvenance | undefined {
+  if (!isRecord(pkg)) return undefined;
+  const provenance = (pkg as MaybeProvenanced).provenance;
+  if (!isRecord(provenance)) return undefined;
+  if (provenance.format !== HONUA_PACKAGE_PROVENANCE_FORMAT_V1) return undefined;
+  return provenance as unknown as HonuaPackageProvenance;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/studio/validate.ts
+++ b/src/studio/validate.ts
@@ -1,0 +1,294 @@
+/**
+ * Family-agnostic validation for Studio packages produced outside Console —
+ * by an MCP client, the QGIS plugin, or the SDK itself. It returns the same
+ * unified {@link StudioPackageValidationResponse} envelope as the per-family
+ * validators, so a package generated through any surface is validated against
+ * one contract.
+ *
+ * For the `map` family this delegates to the established
+ * {@link validateMapPackage} (no duplication). For every other family it runs
+ * the shared base checks (`packageId`/`format`, lifecycle) and, when present,
+ * the shared {@link HonuaPackageProvenance} checks. Provenance is optional, but
+ * when a package carries it, MCP- and QGIS-origin packages must satisfy the
+ * same provenance shape as Console.
+ *
+ * @experimental Not yet covered by the SDK's semver contract — these shapes
+ *   may change in any minor release prior to `1.0.0`.
+ * @module
+ */
+
+import { validateMapPackage } from "../runtime/map-package-validation.js";
+import { HONUA_MAP_PACKAGE_FORMAT_V1 } from "../runtime/map-package.js";
+import { HONUA_PACKAGE_PROVENANCE_FORMAT_V1, type HonuaPackageProvenance, getPackageProvenance } from "./provenance.js";
+import { STUDIO_PACKAGE_FAMILIES, isStudioPackageFamily } from "./types.js";
+import { fromMapPackageValidation } from "./validation.js";
+import type { StudioPackageDiagnostic, StudioPackageValidationResponse } from "./validation.js";
+
+/**
+ * Expected `format` string for each family whose projection carries a single
+ * `format` discriminant. `map` and `dashboard` reuse their established
+ * constants; the `app` family is identified by `version` rather than `format`
+ * and is therefore not in this table.
+ */
+const FAMILY_FORMAT: Partial<Record<string, string>> = {
+  query: "honua_query_package.v1",
+  analysis: "honua_analysis_package.v1",
+  map: HONUA_MAP_PACKAGE_FORMAT_V1,
+  dashboard: "honua_generated_app_manifest.v1",
+  report: "honua_report_package.v1",
+  form: "honua_form_package.v1",
+  workflow: "honua_workflow_package.v1",
+  gp: "honua_gp_package.v1",
+  etl: "honua_etl_package.v1",
+};
+
+/** The package-identity field each family uses. */
+function packageIdOf(family: string, value: Record<string, unknown>): string | undefined {
+  if (family === "map") return typeof value.mapPackageId === "string" ? value.mapPackageId : undefined;
+  if (family === "dashboard") return typeof value.appId === "string" ? value.appId : undefined;
+  if (family === "app") return typeof value.id === "string" ? value.id : undefined;
+  return typeof value.packageId === "string" ? value.packageId : undefined;
+}
+
+export interface ValidateStudioPackageOptions {
+  /** Wall-clock for lifecycle (expired) diagnostics. Defaults to `Date.now()`. */
+  readonly now?: number | Date;
+  /** Require a {@link HonuaPackageProvenance} envelope to be present. */
+  readonly requireProvenance?: boolean;
+}
+
+/**
+ * Validate a package of any Studio family produced outside Console. Dispatches
+ * to the map validator for the `map` family and applies shared base +
+ * provenance checks for every family.
+ *
+ * @experimental
+ */
+export function validateStudioPackage<T = unknown>(
+  family: string,
+  value: unknown,
+  options: ValidateStudioPackageOptions = {},
+): StudioPackageValidationResponse<T> {
+  const diagnostics: StudioPackageDiagnostic[] = [];
+
+  if (!isStudioPackageFamily(family)) {
+    diagnostics.push({
+      code: "unknown-family",
+      severity: "error",
+      message: `Unknown Studio package family "${family}". Expected one of: ${STUDIO_PACKAGE_FAMILIES.join(", ")}.`,
+      path: "packageFamily",
+    });
+    return { valid: false, diagnostics };
+  }
+
+  if (!isRecord(value)) {
+    diagnostics.push({
+      code: "invalid-package",
+      severity: "error",
+      message: `${family} package must be a JSON object.`,
+    });
+    return { valid: false, diagnostics };
+  }
+
+  // The map family has a full structural validator already — reuse it so MCP
+  // and QGIS map packages validate identically to Console's.
+  if (family === "map") {
+    const mapResponse = fromMapPackageValidation(validateMapPackage(value, { now: options.now }));
+    const merged: StudioPackageDiagnostic[] = [...mapResponse.diagnostics];
+    appendProvenanceDiagnostics(merged, value, options);
+    return {
+      valid: mapResponse.valid && !hasErrors(merged),
+      diagnostics: merged,
+      ...(mapResponse.pkg === undefined ? {} : { pkg: mapResponse.pkg as unknown as T }),
+    };
+  }
+
+  const packageId = packageIdOf(family, value);
+  if (!packageId) {
+    diagnostics.push({
+      code: "missing-package-id",
+      severity: "error",
+      message: `${family} package must carry a non-empty identity field.`,
+      path: family === "dashboard" ? "appId" : family === "app" ? "id" : "packageId",
+    });
+  }
+
+  const expectedFormat = FAMILY_FORMAT[family];
+  if (expectedFormat !== undefined && family !== "app" && value.format !== expectedFormat) {
+    diagnostics.push({
+      code: "unsupported-format",
+      severity: "error",
+      message: `${family} package format must be "${expectedFormat}".`,
+      path: "format",
+      detail: { expected: expectedFormat, received: value.format },
+    });
+  }
+
+  appendLifecycleDiagnostics(diagnostics, value, options);
+  appendProvenanceDiagnostics(diagnostics, value, options);
+
+  return {
+    valid: !hasErrors(diagnostics),
+    diagnostics,
+    pkg: value as unknown as T,
+  };
+}
+
+/**
+ * Validate just the {@link HonuaPackageProvenance} envelope on a package value.
+ * Useful when a host (MCP/QGIS) wants to confirm attribution without running
+ * the full family validation.
+ *
+ * @experimental
+ */
+export function validatePackageProvenance(
+  value: unknown,
+  options: { readonly required?: boolean } = {},
+): StudioPackageValidationResponse<HonuaPackageProvenance> {
+  const diagnostics: StudioPackageDiagnostic[] = [];
+  appendProvenanceDiagnostics(diagnostics, value, { requireProvenance: options.required });
+  const provenance = getPackageProvenance(value);
+  return {
+    valid: !hasErrors(diagnostics),
+    diagnostics,
+    ...(provenance === undefined ? {} : { pkg: provenance }),
+  };
+}
+
+const KNOWN_ORIGINS = new Set(["console", "studio", "mcp", "qgis", "sdk"]);
+
+function appendProvenanceDiagnostics(
+  diagnostics: StudioPackageDiagnostic[],
+  value: unknown,
+  options: ValidateStudioPackageOptions | { requireProvenance?: boolean },
+): void {
+  const raw = isRecord(value) ? (value as { provenance?: unknown }).provenance : undefined;
+  if (raw === undefined) {
+    if (options.requireProvenance) {
+      diagnostics.push({
+        code: "missing-provenance",
+        severity: "error",
+        message: "Package provenance is required but absent.",
+        path: "provenance",
+      });
+    }
+    return;
+  }
+
+  if (!isRecord(raw)) {
+    diagnostics.push({
+      code: "invalid-provenance",
+      severity: "error",
+      message: "Package provenance must be a JSON object.",
+      path: "provenance",
+    });
+    return;
+  }
+
+  if (raw.format !== HONUA_PACKAGE_PROVENANCE_FORMAT_V1) {
+    diagnostics.push({
+      code: "unsupported-provenance-format",
+      severity: "error",
+      message: `Package provenance.format must be "${HONUA_PACKAGE_PROVENANCE_FORMAT_V1}".`,
+      path: "provenance.format",
+      detail: { expected: HONUA_PACKAGE_PROVENANCE_FORMAT_V1, received: raw.format },
+    });
+    return;
+  }
+
+  if (typeof raw.origin !== "string" || raw.origin.length === 0) {
+    diagnostics.push({
+      code: "missing-provenance-origin",
+      severity: "error",
+      message: "Package provenance.origin must be a non-empty string.",
+      path: "provenance.origin",
+    });
+  } else if (!KNOWN_ORIGINS.has(raw.origin)) {
+    diagnostics.push({
+      code: "unknown-provenance-origin",
+      severity: "warning",
+      message: `Package provenance.origin "${raw.origin}" is not a known surface.`,
+      path: "provenance.origin",
+      detail: { origin: raw.origin, known: [...KNOWN_ORIGINS] },
+    });
+  }
+
+  if (raw.dataBindings !== undefined && !Array.isArray(raw.dataBindings)) {
+    diagnostics.push({
+      code: "invalid-provenance-data-bindings",
+      severity: "error",
+      message: "Package provenance.dataBindings must be an array when present.",
+      path: "provenance.dataBindings",
+    });
+  } else if (Array.isArray(raw.dataBindings)) {
+    raw.dataBindings.forEach((binding, i) => {
+      if (!isRecord(binding) || typeof binding.sourceId !== "string" || binding.sourceId.length === 0) {
+        diagnostics.push({
+          code: "invalid-provenance-data-binding",
+          severity: "error",
+          message: "Each provenance dataBinding must carry a non-empty sourceId.",
+          path: `provenance.dataBindings[${i}].sourceId`,
+        });
+      }
+    });
+  }
+
+  if (raw.permissions !== undefined && !Array.isArray(raw.permissions)) {
+    diagnostics.push({
+      code: "invalid-provenance-permissions",
+      severity: "error",
+      message: "Package provenance.permissions must be an array when present.",
+      path: "provenance.permissions",
+    });
+  } else if (Array.isArray(raw.permissions)) {
+    raw.permissions.forEach((permission, i) => {
+      if (!isRecord(permission) || typeof permission.scope !== "string" || permission.scope.length === 0) {
+        diagnostics.push({
+          code: "invalid-provenance-permission",
+          severity: "error",
+          message: "Each provenance permission must carry a non-empty scope.",
+          path: `provenance.permissions[${i}].scope`,
+        });
+      }
+    });
+  }
+}
+
+function appendLifecycleDiagnostics(
+  diagnostics: StudioPackageDiagnostic[],
+  value: Record<string, unknown>,
+  options: ValidateStudioPackageOptions,
+): void {
+  const nowMs = options.now instanceof Date ? options.now.getTime() : (options.now ?? Date.now());
+  if (value.status === "Expired") {
+    diagnostics.push({
+      code: "expired-package",
+      severity: "error",
+      message: "Package status is Expired.",
+      path: "status",
+    });
+  }
+  const expiresAt = parseTimestamp(value.expiresAt);
+  if (expiresAt !== undefined && expiresAt <= nowMs) {
+    diagnostics.push({
+      code: "expired-package",
+      severity: "error",
+      message: "Package expiresAt is in the past.",
+      path: "expiresAt",
+    });
+  }
+}
+
+function parseTimestamp(value: unknown): number | undefined {
+  if (typeof value !== "string" && typeof value !== "number") return undefined;
+  const parsed = typeof value === "number" ? value : Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function hasErrors(diagnostics: readonly StudioPackageDiagnostic[]): boolean {
+  return diagnostics.some((d) => d.severity === "error");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/test/fixtures/studio-packages/README.md
+++ b/test/fixtures/studio-packages/README.md
@@ -1,0 +1,25 @@
+# Studio package fixtures (cross-surface parity)
+
+These fixtures are AI-generated Studio packages that exercise the cross-surface
+parity contract from `honua-sdk-js#226`: each is shaped exactly as it would be
+when produced through an MCP client or the QGIS plugin (note the
+`provenance.origin` of `"mcp"` / `"qgis"`), and each can be opened by Console
+and inspected by SDK tests through `@honua/sdk-js/studio`.
+
+| Fixture | Family | Origin | Notes |
+| --- | --- | --- | --- |
+| `map-only.v1.json` | `map` | `mcp` | Minimal valid `HonuaMapPackage` with provenance. |
+| `dashboard.v1.json` | `dashboard` | `qgis` | `HonuaGeneratedAppManifest` with category + time-series charts. |
+| `report.v1.json` | `report` | `mcp` | `HonuaReportPackage`; declares a server-side `report:render` permission. |
+| `app.v1.json` | `app` | `mcp` | `HonuaGeneratedAppPackage` wrapping a manifest artifact. |
+
+Every fixture carries a `provenance` envelope (`honua_package_provenance.v1`)
+recording prompt, plan, data bindings, and permissions consistently — the same
+shape regardless of which surface generated it. `validateStudioPackage(family,
+pkg)` from `@honua/sdk-js/studio` validates all four against one envelope; see
+`test/studio/studio-package-parity.test.ts`.
+
+Permissions flag client-vs-server execution via `clientSide`: a `true`
+permission can be satisfied by an SDK browser preview, a `false` one (e.g. the
+report's `report:render`) requires server execution. See
+`docs/studio-package-parity.md` for the full capability matrix.

--- a/test/fixtures/studio-packages/app.v1.json
+++ b/test/fixtures/studio-packages/app.v1.json
@@ -1,0 +1,52 @@
+{
+  "id": "app-pkg-mcp-004",
+  "version": "1.2.0",
+  "assets": [
+    { "id": "manifest", "kind": "manifest", "mediaType": "application/json" },
+    { "id": "map", "kind": "map-package", "url": "honua://packages/pkg-map-mcp-001" }
+  ],
+  "manifest_artifact": {
+    "artifactKind": "honua.generated-app.manifest",
+    "artifactVersion": 1,
+    "createdAt": "2026-05-23T10:00:00Z",
+    "source": "mcp",
+    "manifest": {
+      "format": "honua_generated_app_manifest.v1",
+      "profile": "operations-dashboard.v1",
+      "appId": "app-pkg-mcp-004",
+      "title": "Field operations app",
+      "version": "1.2.0",
+      "data": { "sourceId": "assets", "previewLimit": 250 },
+      "mapPackageId": "pkg-map-mcp-001",
+      "layout": {
+        "kind": "operations-dashboard",
+        "widgets": [
+          { "id": "map", "kind": "map", "sourceId": "assets" },
+          { "id": "list", "kind": "list", "sourceId": "assets", "titleField": "name", "subtitleField": "status" }
+        ]
+      }
+    }
+  },
+  "provenance": {
+    "format": "honua_package_provenance.v1",
+    "origin": "mcp",
+    "packageId": "app-pkg-mcp-004",
+    "generatedAt": "2026-05-23T10:00:00Z",
+    "generator": "honua-mcp@1.4.0",
+    "prompt": {
+      "text": "Make a field operations app with a map and an asset list",
+      "surface": "mcp"
+    },
+    "plan": {
+      "steps": [
+        { "id": "scaffold", "kind": "app-scaffold", "summary": "Scaffold map + list app", "status": "succeeded" }
+      ]
+    },
+    "dataBindings": [
+      { "sourceId": "assets", "role": "primary" }
+    ],
+    "permissions": [
+      { "scope": "source:read", "resource": "assets", "clientSide": true }
+    ]
+  }
+}

--- a/test/fixtures/studio-packages/dashboard.v1.json
+++ b/test/fixtures/studio-packages/dashboard.v1.json
@@ -1,0 +1,44 @@
+{
+  "format": "honua_generated_app_manifest.v1",
+  "profile": "operations-dashboard.v1",
+  "appId": "app-dash-qgis-002",
+  "title": "Active incidents dashboard",
+  "version": "1.0.0",
+  "data": { "sourceId": "incidents", "previewLimit": 500 },
+  "mapPackageId": "pkg-map-mcp-001",
+  "layout": {
+    "kind": "operations-dashboard",
+    "widgets": [
+      { "id": "map", "kind": "map", "sourceId": "incidents", "showLegend": true },
+      { "id": "by-status", "kind": "chart", "chartKind": "categories", "title": "Incidents by status", "sourceId": "incidents", "groupBy": "status" },
+      { "id": "over-time", "kind": "chart", "chartKind": "time-series", "title": "Incidents over time", "sourceId": "incidents", "field": "reported_at", "interval": "day" },
+      { "id": "total", "kind": "count", "label": "Total incidents", "sourceId": "incidents" }
+    ]
+  },
+  "bindings": { "sourceId": "incidents", "primaryKey": "id", "titleField": "name", "categoryField": "status" },
+  "provenance": {
+    "format": "honua_package_provenance.v1",
+    "origin": "qgis",
+    "packageId": "app-dash-qgis-002",
+    "generatedAt": "2026-05-21T09:30:00Z",
+    "generator": "qgis-plugin@0.3.1",
+    "prompt": {
+      "text": "Build an operations dashboard for active incidents with a status chart and a daily trend",
+      "surface": "qgis"
+    },
+    "plan": {
+      "rationale": "Map plus categorical and temporal charts cover status mix and trend.",
+      "steps": [
+        { "id": "bind", "kind": "source-binding", "summary": "Bind incidents source", "status": "succeeded" },
+        { "id": "charts", "kind": "chart-derivation", "summary": "Derive status and trend charts", "status": "succeeded" }
+      ]
+    },
+    "dataBindings": [
+      { "sourceId": "incidents", "role": "primary" }
+    ],
+    "permissions": [
+      { "scope": "source:read", "resource": "incidents", "clientSide": true },
+      { "scope": "aggregate:client", "resource": "incidents", "clientSide": true }
+    ]
+  }
+}

--- a/test/fixtures/studio-packages/map-only.v1.json
+++ b/test/fixtures/studio-packages/map-only.v1.json
@@ -1,0 +1,49 @@
+{
+  "mapPackageId": "pkg-map-mcp-001",
+  "format": "honua_map_package.v1",
+  "status": "Ready",
+  "title": "Honolulu flood zones",
+  "createdAt": "2026-05-20T12:00:00Z",
+  "updatedAt": "2026-05-20T12:00:00Z",
+  "sourceBindings": [
+    {
+      "sourceId": "flood-zones",
+      "protocol": "ogc_features",
+      "locator": { "url": "https://example.test/collections/flood-zones" }
+    }
+  ],
+  "mapSpec": {
+    "version": 8,
+    "sources": {
+      "flood-zones": { "type": "geojson", "data": { "type": "FeatureCollection", "features": [] } }
+    },
+    "layers": [
+      { "id": "flood-fill", "type": "fill", "source": "flood-zones", "paint": { "fill-color": "#1d6fb8", "fill-opacity": 0.4 } }
+    ]
+  },
+  "initialView": { "center": [-157.86, 21.31], "zoom": 11 },
+  "provenance": {
+    "format": "honua_package_provenance.v1",
+    "origin": "mcp",
+    "packageId": "pkg-map-mcp-001",
+    "generatedAt": "2026-05-20T12:00:00Z",
+    "generator": "honua-mcp@1.4.0",
+    "prompt": {
+      "text": "Map the flood zones for Honolulu",
+      "surface": "mcp",
+      "model": "claude-opus-4"
+    },
+    "plan": {
+      "steps": [
+        { "id": "discover", "kind": "source-discovery", "summary": "Resolve flood-zones collection", "status": "succeeded" },
+        { "id": "compose", "kind": "map-compose", "summary": "Compose fill layer", "status": "succeeded" }
+      ]
+    },
+    "dataBindings": [
+      { "sourceId": "flood-zones", "protocol": "ogc_features", "role": "primary", "layerId": "flood-fill" }
+    ],
+    "permissions": [
+      { "scope": "source:read", "resource": "flood-zones", "clientSide": true }
+    ]
+  }
+}

--- a/test/fixtures/studio-packages/report.v1.json
+++ b/test/fixtures/studio-packages/report.v1.json
@@ -1,0 +1,38 @@
+{
+  "packageId": "pkg-report-mcp-003",
+  "format": "honua_report_package.v1",
+  "status": "Ready",
+  "title": "Quarterly flood exposure report",
+  "templateId": "standard-report.v1",
+  "mapPackageId": "pkg-map-mcp-001",
+  "sections": [
+    { "id": "summary", "kind": "text", "title": "Executive summary" },
+    { "id": "exposure-map", "kind": "map", "title": "Exposure map" },
+    { "id": "by-zone", "kind": "chart", "title": "Parcels by flood zone" }
+  ],
+  "provenance": {
+    "format": "honua_package_provenance.v1",
+    "origin": "mcp",
+    "packageId": "pkg-report-mcp-003",
+    "generatedAt": "2026-05-22T16:00:00Z",
+    "generator": "honua-mcp@1.4.0",
+    "prompt": {
+      "text": "Generate a quarterly flood exposure report with a map and a chart of parcels by zone",
+      "surface": "mcp"
+    },
+    "plan": {
+      "steps": [
+        { "id": "outline", "kind": "report-outline", "summary": "Outline summary, map, chart sections", "status": "succeeded" }
+      ]
+    },
+    "dataBindings": [
+      { "sourceId": "flood-zones", "protocol": "ogc_features", "role": "primary" },
+      { "sourceId": "parcels", "protocol": "ogc_features", "role": "secondary" }
+    ],
+    "permissions": [
+      { "scope": "source:read", "resource": "flood-zones", "clientSide": true },
+      { "scope": "source:read", "resource": "parcels", "clientSide": true },
+      { "scope": "report:render", "resource": "pkg-report-mcp-003", "clientSide": false, "description": "PDF rendering runs server-side" }
+    ]
+  }
+}

--- a/test/studio/studio-package-parity.test.ts
+++ b/test/studio/studio-package-parity.test.ts
@@ -1,0 +1,202 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { HONUA_GENERATED_APP_MANIFEST_FORMAT_V1 } from "../../src/generated-app/manifest.js";
+import type { HonuaGeneratedAppChartWidget } from "../../src/generated-app/manifest.js";
+import { HONUA_MAP_PACKAGE_FORMAT_V1 } from "../../src/runtime/map-package.js";
+import {
+  HONUA_PACKAGE_PROVENANCE_FORMAT_V1,
+  HONUA_VEGA_LITE_SCHEMA_V5,
+  chartWidgetToVegaLiteSpec,
+  getPackageProvenance,
+  validatePackageProvenance,
+  validateStudioPackage,
+} from "../../src/studio/index.js";
+
+const FIXTURE_DIR = path.join(process.cwd(), "test", "fixtures", "studio-packages");
+
+function loadFixture(name: string): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(path.join(FIXTURE_DIR, name), "utf8")) as Record<string, unknown>;
+}
+
+describe("cross-surface package fixtures", () => {
+  const cases: ReadonlyArray<[string, string]> = [
+    ["map", "map-only.v1.json"],
+    ["dashboard", "dashboard.v1.json"],
+    ["report", "report.v1.json"],
+    ["app", "app.v1.json"],
+  ];
+
+  it.each(cases)("%s fixture validates through the unified envelope", (family, file) => {
+    const pkg = loadFixture(file);
+    const response = validateStudioPackage(family, pkg);
+    expect(response.valid, JSON.stringify(response.diagnostics)).toBe(true);
+    expect(response.diagnostics.filter((d) => d.severity === "error")).toEqual([]);
+  });
+
+  it.each(cases)("%s fixture carries a parity provenance envelope", (_family, file) => {
+    const pkg = loadFixture(file);
+    const provenance = getPackageProvenance(pkg);
+    expect(provenance).toBeDefined();
+    expect(provenance?.format).toBe(HONUA_PACKAGE_PROVENANCE_FORMAT_V1);
+    expect(["mcp", "qgis"]).toContain(provenance?.origin);
+    expect(provenance?.prompt?.text).toBeTruthy();
+    expect(provenance?.dataBindings?.length).toBeGreaterThan(0);
+    expect(provenance?.permissions?.length).toBeGreaterThan(0);
+  });
+
+  it("report fixture declares a server-side render permission", () => {
+    const provenance = getPackageProvenance(loadFixture("report.v1.json"));
+    const render = provenance?.permissions?.find((p) => p.scope === "report:render");
+    expect(render?.clientSide).toBe(false);
+  });
+});
+
+describe("validateStudioPackage", () => {
+  it("delegates the map family to the structural map validator", () => {
+    const response = validateStudioPackage("map", { format: HONUA_MAP_PACKAGE_FORMAT_V1 });
+    // Missing id / sourceBindings / mapSpec all surface from the map validator.
+    expect(response.valid).toBe(false);
+    expect(response.diagnostics.some((d) => d.code === "missing-map-package-id")).toBe(true);
+    expect(response.diagnostics.some((d) => d.code === "missing-source-bindings")).toBe(true);
+  });
+
+  it("rejects an unknown family", () => {
+    const response = validateStudioPackage("not-a-family", {});
+    expect(response.valid).toBe(false);
+    expect(response.diagnostics[0]?.code).toBe("unknown-family");
+  });
+
+  it("flags a wrong format string for a stub family", () => {
+    const response = validateStudioPackage("report", { packageId: "r1", format: "wrong" });
+    expect(response.valid).toBe(false);
+    expect(response.diagnostics.some((d) => d.code === "unsupported-format")).toBe(true);
+  });
+
+  it("flags a missing identity field", () => {
+    const response = validateStudioPackage("report", { format: "honua_report_package.v1" });
+    expect(response.diagnostics.some((d) => d.code === "missing-package-id")).toBe(true);
+  });
+
+  it("uses appId for the dashboard family and id for the app family", () => {
+    expect(
+      validateStudioPackage("dashboard", {
+        format: HONUA_GENERATED_APP_MANIFEST_FORMAT_V1,
+        appId: "a1",
+      }).valid,
+    ).toBe(true);
+    expect(validateStudioPackage("app", { id: "app1", version: "1.0.0" }).valid).toBe(true);
+  });
+
+  it("can require provenance to be present", () => {
+    const response = validateStudioPackage(
+      "report",
+      { packageId: "r1", format: "honua_report_package.v1" },
+      { requireProvenance: true },
+    );
+    expect(response.diagnostics.some((d) => d.code === "missing-provenance")).toBe(true);
+  });
+
+  it("treats an expired package as invalid", () => {
+    const response = validateStudioPackage("report", {
+      packageId: "r1",
+      format: "honua_report_package.v1",
+      expiresAt: "2000-01-01T00:00:00Z",
+    });
+    expect(response.diagnostics.some((d) => d.code === "expired-package")).toBe(true);
+  });
+});
+
+describe("validatePackageProvenance", () => {
+  it("accepts a well-formed envelope from any origin", () => {
+    const response = validatePackageProvenance({
+      provenance: {
+        format: HONUA_PACKAGE_PROVENANCE_FORMAT_V1,
+        origin: "qgis",
+        dataBindings: [{ sourceId: "s1" }],
+        permissions: [{ scope: "source:read" }],
+      },
+    });
+    expect(response.valid).toBe(true);
+    expect(response.pkg?.origin).toBe("qgis");
+  });
+
+  it("rejects an unsupported provenance format", () => {
+    const response = validatePackageProvenance({ provenance: { format: "nope", origin: "mcp" } });
+    expect(response.valid).toBe(false);
+    expect(response.diagnostics.some((d) => d.code === "unsupported-provenance-format")).toBe(true);
+  });
+
+  it("warns on an unknown origin but stays valid", () => {
+    const response = validatePackageProvenance({
+      provenance: { format: HONUA_PACKAGE_PROVENANCE_FORMAT_V1, origin: "spreadsheet" },
+    });
+    expect(response.valid).toBe(true);
+    expect(response.diagnostics.some((d) => d.code === "unknown-provenance-origin" && d.severity === "warning")).toBe(
+      true,
+    );
+  });
+
+  it("flags data bindings missing a sourceId", () => {
+    const response = validatePackageProvenance({
+      provenance: { format: HONUA_PACKAGE_PROVENANCE_FORMAT_V1, origin: "mcp", dataBindings: [{}] },
+    });
+    expect(response.valid).toBe(false);
+    expect(response.diagnostics.some((d) => d.code === "invalid-provenance-data-binding")).toBe(true);
+  });
+});
+
+describe("chartWidgetToVegaLiteSpec", () => {
+  it("derives a bar spec for a categories chart", () => {
+    const widget: HonuaGeneratedAppChartWidget = {
+      id: "c1",
+      kind: "chart",
+      chartKind: "categories",
+      title: "By status",
+      groupBy: "status",
+    };
+    const spec = chartWidgetToVegaLiteSpec(widget);
+    expect(spec?.$schema).toBe(HONUA_VEGA_LITE_SCHEMA_V5);
+    expect(typeof spec?.mark === "object" && spec?.mark.type).toBe("bar");
+    expect(spec?.encoding.x?.field).toBe("status");
+    expect(spec?.encoding.y?.aggregate).toBe("count");
+  });
+
+  it("derives a binned histogram spec", () => {
+    const spec = chartWidgetToVegaLiteSpec({
+      id: "c2",
+      kind: "chart",
+      chartKind: "histogram",
+      field: "magnitude",
+      bins: 12,
+    });
+    expect(spec?.encoding.x?.field).toBe("magnitude");
+    expect(spec?.encoding.x?.bin).toEqual({ maxbins: 12 });
+  });
+
+  it("derives a temporal line spec for time-series", () => {
+    const spec = chartWidgetToVegaLiteSpec({
+      id: "c3",
+      kind: "chart",
+      chartKind: "time-series",
+      field: "reported_at",
+    });
+    expect(typeof spec?.mark === "object" && spec?.mark.type).toBe("line");
+    expect(spec?.encoding.x?.type).toBe("temporal");
+  });
+
+  it("inlines provided rows as data.values", () => {
+    const rows = [{ status: "open", count: 3 }];
+    const spec = chartWidgetToVegaLiteSpec(
+      { id: "c4", kind: "chart", chartKind: "categories", groupBy: "status" },
+      rows,
+    );
+    expect(spec?.data?.values).toEqual(rows);
+  });
+
+  it("returns undefined when a categories chart has no grouping field", () => {
+    expect(chartWidgetToVegaLiteSpec({ id: "c5", kind: "chart", chartKind: "categories" })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What this does

Adds the cross-surface **parity layer** on top of the Studio package contracts from #225, so AI-generated **map, dashboard, report, and app** packages are portable across Honua Studio/Console, MCP clients, and the QGIS plugin via one set of contracts rather than surface-specific output formats.

All additions are subpath-only under `@honua/sdk-js/studio`, tagged `@experimental` (outside the SDK semver contract until the matching server contracts land), and stay MCP/QGIS-safe (no MapLibre/DOM/Console-coupled imports — enforced by the existing source-scan test).

### New contracts and helpers

- **`src/studio/provenance.ts`** — a shared `HonuaPackageProvenance` envelope (`honua_package_provenance.v1`) carrying `origin` (console/studio/mcp/qgis/sdk), `prompt`, `plan`, `dataBindings`, and `permissions` consistently regardless of producing surface, plus `getPackageProvenance()`. Permissions flag `clientSide` true/false so a host can tell client-preview from server-execution.
- **`src/studio/validate.ts`** — `validateStudioPackage(family, pkg, options)`, family-agnostic validation for packages produced **outside Console** (MCP/QGIS flows). It delegates the `map` family to the established structural `validateMapPackage` (no duplication), applies shared base/lifecycle checks for the other families, validates the provenance envelope when present, and returns the unified `StudioPackageValidationResponse` from #225. Plus `validatePackageProvenance()`.
- **`src/studio/chart-spec.ts`** — a documented, compatible subset of Vega-Lite v5 (`HonuaVegaLiteChartSpec`) for dashboard/report charts, and `chartWidgetToVegaLiteSpec(widget, rows?)` to derive a spec from a generated-app chart widget (categories→bar, histogram→binned bar, time-series→line). Returns `undefined` rather than emitting a broken spec when a widget lacks its required field.

### Fixtures

- **`test/fixtures/studio-packages/`** — `map-only`, `dashboard`, `report`, and `app` package variants shaped exactly as MCP/QGIS would emit them (`provenance.origin` of `mcp`/`qgis`), openable by Console and inspected by SDK tests. The report fixture declares a server-side `report:render` permission to exercise the unsupported-state path.

### Docs

- **`docs/studio-package-parity.md`** — provenance shape, the one validation envelope, the Vega-Lite chart subset, and a **client-preview-vs-server-execution capability matrix** that identifies unsupported states cleanly instead of allowing silent partial renders. Cross-linked from `docs/studio-package-contracts.md`.

## Acceptance criteria mapping

- Package produced via MCP validated by SDK / openable in Console → `validateStudioPackage` + fixtures (origin `mcp`).
- Package produced via QGIS uses the same validation/provenance shape → dashboard fixture (origin `qgis`); one `HonuaPackageProvenance` contract.
- Dashboard/report charts use Vega-Lite or a documented compatible subset → `chart-spec.ts` + doc table.
- Fixtures cover map-only, dashboard, report, app → `test/fixtures/studio-packages/`.
- Docs identify unsupported states cleanly → capability matrix in `docs/studio-package-parity.md`.

Out of scope (per issue): QGIS plugin UI changes; live model endpoints.

## Scope

Full issue scope for the SDK side. No server, build-config, or root-barrel changes — subpath-only and additive.

## How it was tested

Validated in an isolated clean checkout of `origin/trunk` (this shared worktree carries unrelated in-flight work from sibling tickets):

- `npm run typecheck` — clean.
- `npm run check` (Biome) — clean after `check:fix`.
- `npx vitest run test/studio/` — 37 passing (25 new in `studio-package-parity.test.ts` + 12 existing `studio-contracts.test.ts`).

Closes #226