### PR TITLE
Add Console SDK contracts for content, dashboards, reports, and Vega-Lite

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,10 @@
       "types": "./dist/src/collaboration/index.d.ts",
       "default": "./dist/src/collaboration/index.js"
     },
+    "./console": {
+      "types": "./dist/src/console/index.d.ts",
+      "default": "./dist/src/console/index.js"
+    },
     "./exploration": {
       "types": "./dist/src/exploration/index.d.ts",
       "default": "./dist/src/exploration/index.js"

--- a/scripts/prepare-split-packages.mjs
+++ b/scripts/prepare-split-packages.mjs
@@ -44,6 +44,7 @@ function createSdkPackage() {
   copyDirectory(path.join(DIST_SRC_ROOT, "contract"), path.join(packageRoot, "contract"));
   copyDirectory(path.join(DIST_SRC_ROOT, "control-plane"), path.join(packageRoot, "control-plane"));
   copyDirectory(path.join(DIST_SRC_ROOT, "collaboration"), path.join(packageRoot, "collaboration"));
+  copyDirectory(path.join(DIST_SRC_ROOT, "console"), path.join(packageRoot, "console"));
   copyDirectory(path.join(DIST_SRC_ROOT, "core"), path.join(packageRoot, "core"));
   copyDirectory(path.join(DIST_SRC_ROOT, "agent-tools"), path.join(packageRoot, "agent-tools"));
   copyDirectory(path.join(DIST_SRC_ROOT, "app"), path.join(packageRoot, "app"));
@@ -90,6 +91,10 @@ function createSdkPackage() {
       "./collaboration": {
         types: "./collaboration/index.d.ts",
         default: "./collaboration/index.js",
+      },
+      "./console": {
+        types: "./console/index.d.ts",
+        default: "./console/index.js",
       },
       "./agent-tools": {
         types: "./agent-tools/index.d.ts",

--- a/scripts/verify-split-packages.mjs
+++ b/scripts/verify-split-packages.mjs
@@ -119,6 +119,7 @@ import { validateHonuaStyle } from "@honua/sdk/style";
 import { loadMapPackage, validateRuntimeStyleSpec } from "@honua/sdk/runtime";
 import { defineHonuaWebComponents } from "@honua/sdk/web-components";
 import { projectBuildSpecToGeneratedAppManifest } from "@honua/sdk/generated-app";
+import { chartWidgetToVegaLiteSpec, isVegaLiteSpec } from "@honua/sdk/console";
 import { HONUA_QUERY_PACKAGE_FORMAT_V1, toStudioValidationResponse } from "@honua/sdk/studio";
 import { OPERATOR_EXECUTION_OUTPUT_KEY } from "@honua/sdk/operator";
 import { ChatController } from "@honua/sdk/operator/controllers";
@@ -290,6 +291,10 @@ if (typeof defineHonuaWebComponents !== "function")
   throw new Error("defineHonuaWebComponents export missing from @honua/sdk/web-components");
 if (typeof projectBuildSpecToGeneratedAppManifest !== "function")
   throw new Error("projectBuildSpecToGeneratedAppManifest export missing from @honua/sdk/generated-app");
+if (typeof chartWidgetToVegaLiteSpec !== "function" || typeof isVegaLiteSpec !== "function")
+  throw new Error("console chart spec exports missing from @honua/sdk/console");
+if (!isVegaLiteSpec(chartWidgetToVegaLiteSpec({ chartKind: "categories", groupBy: "status" })))
+  throw new Error("@honua/sdk/console chartWidgetToVegaLiteSpec did not produce a valid Vega-Lite spec");
 if (HONUA_QUERY_PACKAGE_FORMAT_V1 !== "honua_query_package.v1")
   throw new Error("HONUA_QUERY_PACKAGE_FORMAT_V1 export missing from @honua/sdk/studio");
 if (typeof toStudioValidationResponse !== "function")

--- a/src/console/content.ts
+++ b/src/console/content.ts
@@ -1,0 +1,142 @@
+/**
+ * Browser-safe content + metadata-v2 contracts for `honua-console`.
+ *
+ * These types describe the **SDK-projected** view of the shared content model:
+ * the canonical server DTOs (Metadata v2, content items, packages, sharing,
+ * embeds, provenance) remain authoritative, and this module only names the
+ * stable, browser-safe subset Console renders. Every interface keeps an open
+ * index signature so additive server fields survive a round-trip without a
+ * Console-specific copy of the protocol types.
+ *
+ * Ownership legend used across the Console contracts:
+ * - **server-owned**: canonical wire shape produced by `honua-server`.
+ * - **SDK-projected**: the normalized browser-safe view defined here.
+ * - **Console-rendered**: UI state derived from an SDK projection.
+ *
+ * @module
+ */
+
+export const HONUA_CONSOLE_METADATA_FORMAT_V2 = "honua_metadata.v2" as const;
+export type HonuaConsoleMetadataFormat = typeof HONUA_CONSOLE_METADATA_FORMAT_V2;
+
+/**
+ * Discriminator for a Console content item. Unknown server kinds widen to
+ * `string` so the Console browser can still list (and flag) them.
+ */
+export type HonuaConsoleContentKind =
+  | "map"
+  | "map-package"
+  | "app"
+  | "app-package"
+  | "dashboard"
+  | "report"
+  | "dataset"
+  | "connection"
+  | (string & {});
+
+export type HonuaConsoleVisibility = "private" | "workspace" | "public" | (string & {});
+
+/**
+ * Sharing reference for a content item. Mirrors the control-plane share shape
+ * but is content-scoped and embed-aware for Console surfaces.
+ */
+export interface HonuaConsoleSharing {
+  readonly visibility: HonuaConsoleVisibility;
+  readonly principals?: ReadonlyArray<{
+    readonly type: "user" | "group" | "workspace" | (string & {});
+    readonly id: string;
+    readonly role?: "viewer" | "editor" | "owner" | (string & {});
+  }>;
+  readonly embed?: HonuaConsoleEmbed;
+  readonly [extra: string]: unknown;
+}
+
+/**
+ * Embed projection: the browser-safe descriptor Console uses to render an
+ * embed dialog / iframe without re-deriving the server embed policy.
+ */
+export interface HonuaConsoleEmbed {
+  readonly enabled: boolean;
+  readonly url?: string;
+  readonly allowedOrigins?: ReadonlyArray<string>;
+  readonly token?: string;
+  readonly [extra: string]: unknown;
+}
+
+/**
+ * Provenance projection: lineage / authorship Console renders in detail views.
+ */
+export interface HonuaConsoleProvenance {
+  readonly createdBy?: string;
+  readonly createdAt?: string;
+  readonly updatedBy?: string;
+  readonly updatedAt?: string;
+  readonly source?: string;
+  readonly generatedBy?: "user" | "import" | "builder" | "agent" | (string & {});
+  readonly derivedFrom?: ReadonlyArray<{
+    readonly id: string;
+    readonly kind?: HonuaConsoleContentKind;
+    readonly relation?: "source" | "fork" | "import" | (string & {});
+  }>;
+  readonly [extra: string]: unknown;
+}
+
+/**
+ * Metadata v2 projection. `format` pins the contract version so Console can
+ * reject (and surface) an unexpected metadata wire version.
+ */
+export interface HonuaConsoleMetadata {
+  readonly format?: HonuaConsoleMetadataFormat;
+  readonly title?: string;
+  readonly description?: string;
+  readonly summary?: string;
+  readonly tags?: ReadonlyArray<string>;
+  readonly thumbnailUrl?: string;
+  readonly extent?: readonly [number, number, number, number];
+  readonly license?: string;
+  readonly attribution?: string;
+  readonly locale?: string;
+  readonly custom?: Readonly<Record<string, unknown>>;
+  readonly [extra: string]: unknown;
+}
+
+/**
+ * SDK-projected content item. This is the unit a Console content browser lists,
+ * filters, and opens. The package payload (map/app/dashboard/report) is loaded
+ * separately and referenced via {@link HonuaConsoleContentItem.packageId}.
+ */
+export interface HonuaConsoleContentItem {
+  readonly id: string;
+  readonly kind: HonuaConsoleContentKind;
+  readonly title: string;
+  readonly workspaceId?: string;
+  readonly packageId?: string;
+  readonly version?: string;
+  readonly status?: "draft" | "published" | "archived" | "failed" | (string & {});
+  readonly metadata?: HonuaConsoleMetadata;
+  readonly sharing?: HonuaConsoleSharing;
+  readonly provenance?: HonuaConsoleProvenance;
+  readonly etag?: string;
+  readonly [extra: string]: unknown;
+}
+
+/** Recognized Console content kinds with a first-class SDK projection. */
+export const HONUA_CONSOLE_KNOWN_CONTENT_KINDS: ReadonlyArray<HonuaConsoleContentKind> = [
+  "map",
+  "map-package",
+  "app",
+  "app-package",
+  "dashboard",
+  "report",
+  "dataset",
+  "connection",
+];
+
+/**
+ * Returns `true` when the content kind has a first-class SDK projection. Console
+ * can still list unknown kinds, but should flag them as unsupported in detail
+ * views rather than assuming a projection exists.
+ */
+export function isKnownConsoleContentKind(kind: string): kind is HonuaConsoleContentKind {
+  return HONUA_CONSOLE_KNOWN_CONTENT_KINDS.includes(kind as HonuaConsoleContentKind);
+}

--- a/src/console/dashboard.ts
+++ b/src/console/dashboard.ts
@@ -1,0 +1,305 @@
+/**
+ * Browser-safe dashboard + report package contracts for Console.
+ *
+ * A dashboard/report package is a server-owned artifact; this module names the
+ * SDK-projected panel model Console renders and provides projection helpers that
+ * validate Vega-Lite chart specs and surface typed missing-binding errors. It
+ * also bridges the existing generated-app chart widget vocabulary into a
+ * Vega-Lite spec so dashboards reuse the same chart kinds as generated apps.
+ *
+ * @module
+ */
+
+import type { HonuaConsoleMetadata, HonuaConsoleProvenance, HonuaConsoleSharing } from "./content.js";
+import { HonuaConsoleError } from "./errors.js";
+import { HONUA_CONSOLE_VEGA_LITE_SCHEMA, type HonuaVegaLiteSpec, normalizeVegaLiteSpec } from "./vega-lite.js";
+
+export const HONUA_CONSOLE_DASHBOARD_PACKAGE_FORMAT_V1 = "honua_dashboard_package.v1" as const;
+export const HONUA_CONSOLE_REPORT_PACKAGE_FORMAT_V1 = "honua_report_package.v1" as const;
+
+export type HonuaConsoleDashboardPackageFormat = typeof HONUA_CONSOLE_DASHBOARD_PACKAGE_FORMAT_V1;
+export type HonuaConsoleReportPackageFormat = typeof HONUA_CONSOLE_REPORT_PACKAGE_FORMAT_V1;
+
+export type HonuaConsolePanelKind = "chart" | "map" | "metric" | "table" | "text" | (string & {});
+
+/** Data binding a panel resolves against a content/source at render time. */
+export interface HonuaConsolePanelBinding {
+  readonly sourceId?: string;
+  readonly contentId?: string;
+  readonly field?: string;
+  readonly [extra: string]: unknown;
+}
+
+export interface HonuaConsolePanelBase {
+  readonly id: string;
+  readonly kind: HonuaConsolePanelKind;
+  readonly title?: string;
+  readonly binding?: HonuaConsolePanelBinding;
+  readonly layout?: { readonly x?: number; readonly y?: number; readonly w?: number; readonly h?: number };
+  readonly [extra: string]: unknown;
+}
+
+export interface HonuaConsoleChartPanel extends HonuaConsolePanelBase {
+  readonly kind: "chart";
+  /** Inline Vega-Lite spec. Validated by the projection helpers. */
+  readonly chartSpec?: HonuaVegaLiteSpec;
+  readonly [extra: string]: unknown;
+}
+
+export type HonuaConsolePanel = HonuaConsoleChartPanel | HonuaConsolePanelBase;
+
+/**
+ * SDK-projected dashboard package. The server package is authoritative; this
+ * shape is the browser-safe panel set Console hydrates.
+ */
+export interface HonuaConsoleDashboardPackage {
+  readonly format: HonuaConsoleDashboardPackageFormat;
+  readonly id: string;
+  readonly version?: string;
+  readonly title?: string;
+  readonly metadata?: HonuaConsoleMetadata;
+  readonly sharing?: HonuaConsoleSharing;
+  readonly provenance?: HonuaConsoleProvenance;
+  readonly panels: ReadonlyArray<HonuaConsolePanel>;
+  readonly [extra: string]: unknown;
+}
+
+/**
+ * SDK-projected report package. Reports are ordered sections of panels (often
+ * chart panels) intended for print/export rather than an interactive grid.
+ */
+export interface HonuaConsoleReportSection {
+  readonly id: string;
+  readonly title?: string;
+  readonly body?: string;
+  readonly panels?: ReadonlyArray<HonuaConsolePanel>;
+  readonly [extra: string]: unknown;
+}
+
+export interface HonuaConsoleReportPackage {
+  readonly format: HonuaConsoleReportPackageFormat;
+  readonly id: string;
+  readonly version?: string;
+  readonly title?: string;
+  readonly metadata?: HonuaConsoleMetadata;
+  readonly sharing?: HonuaConsoleSharing;
+  readonly provenance?: HonuaConsoleProvenance;
+  readonly sections: ReadonlyArray<HonuaConsoleReportSection>;
+  readonly [extra: string]: unknown;
+}
+
+/** Console-rendered model for a single chart panel. */
+export interface HonuaConsoleChartPanelModel {
+  readonly id: string;
+  readonly kind: "chart";
+  readonly title?: string;
+  readonly chartSpec: HonuaVegaLiteSpec;
+  readonly binding?: HonuaConsolePanelBinding;
+}
+
+export interface HonuaConsoleDashboardRenderModel {
+  readonly id: string;
+  readonly title?: string;
+  readonly charts: ReadonlyArray<HonuaConsoleChartPanelModel>;
+  readonly panels: ReadonlyArray<HonuaConsolePanel>;
+}
+
+function isChartPanel(panel: HonuaConsolePanel): panel is HonuaConsoleChartPanel {
+  return panel.kind === "chart";
+}
+
+/**
+ * Validates a dashboard package and projects it to a Console render model.
+ * Every chart panel must carry a Vega-Lite `chartSpec`; a missing spec raises a
+ * typed `missing-chart-spec` error so Console can flag the broken panel instead
+ * of rendering an empty box.
+ */
+export function projectDashboardPackage(pkg: HonuaConsoleDashboardPackage): HonuaConsoleDashboardRenderModel {
+  if (pkg.format !== HONUA_CONSOLE_DASHBOARD_PACKAGE_FORMAT_V1) {
+    throw new HonuaConsoleError(
+      "unsupported-package-format",
+      `Unsupported dashboard package format "${String(pkg.format)}"`,
+      {
+        stage: "projection",
+        detail: { packageId: pkg.id, path: "format", received: pkg.format },
+      },
+    );
+  }
+  const charts: HonuaConsoleChartPanelModel[] = [];
+  for (const panel of pkg.panels) {
+    if (!isChartPanel(panel)) continue;
+    if (!panel.chartSpec) {
+      throw new HonuaConsoleError("missing-chart-spec", `Chart panel "${panel.id}" is missing a chartSpec`, {
+        stage: "projection",
+        detail: { packageId: pkg.id, panelId: panel.id, path: `panels.${panel.id}.chartSpec` },
+      });
+    }
+    charts.push({
+      id: panel.id,
+      kind: "chart",
+      ...(panel.title !== undefined ? { title: panel.title } : {}),
+      chartSpec: normalizeVegaLiteSpec(panel.chartSpec, { chartId: panel.id, path: `panels.${panel.id}.chartSpec` }),
+      ...(panel.binding ? { binding: panel.binding } : {}),
+    });
+  }
+  return {
+    id: pkg.id,
+    ...(pkg.title !== undefined ? { title: pkg.title } : {}),
+    charts,
+    panels: pkg.panels,
+  };
+}
+
+export interface HonuaConsoleReportRenderModel {
+  readonly id: string;
+  readonly title?: string;
+  readonly sections: ReadonlyArray<{
+    readonly id: string;
+    readonly title?: string;
+    readonly body?: string;
+    readonly charts: ReadonlyArray<HonuaConsoleChartPanelModel>;
+  }>;
+}
+
+/**
+ * Validates a report package and projects each section's chart panels to
+ * Console render models, validating Vega-Lite specs along the way.
+ */
+export function projectReportPackage(pkg: HonuaConsoleReportPackage): HonuaConsoleReportRenderModel {
+  if (pkg.format !== HONUA_CONSOLE_REPORT_PACKAGE_FORMAT_V1) {
+    throw new HonuaConsoleError(
+      "unsupported-package-format",
+      `Unsupported report package format "${String(pkg.format)}"`,
+      {
+        stage: "projection",
+        detail: { packageId: pkg.id, path: "format", received: pkg.format },
+      },
+    );
+  }
+  const sections = pkg.sections.map((section) => {
+    const charts: HonuaConsoleChartPanelModel[] = [];
+    for (const panel of section.panels ?? []) {
+      if (!isChartPanel(panel)) continue;
+      if (!panel.chartSpec) {
+        throw new HonuaConsoleError("missing-chart-spec", `Chart panel "${panel.id}" is missing a chartSpec`, {
+          stage: "projection",
+          detail: {
+            packageId: pkg.id,
+            panelId: panel.id,
+            path: `sections.${section.id}.panels.${panel.id}.chartSpec`,
+          },
+        });
+      }
+      charts.push({
+        id: panel.id,
+        kind: "chart",
+        ...(panel.title !== undefined ? { title: panel.title } : {}),
+        chartSpec: normalizeVegaLiteSpec(panel.chartSpec, {
+          chartId: panel.id,
+          path: `sections.${section.id}.panels.${panel.id}.chartSpec`,
+        }),
+        ...(panel.binding ? { binding: panel.binding } : {}),
+      });
+    }
+    return {
+      id: section.id,
+      ...(section.title !== undefined ? { title: section.title } : {}),
+      ...(section.body !== undefined ? { body: section.body } : {}),
+      charts,
+    };
+  });
+  return {
+    id: pkg.id,
+    ...(pkg.title !== undefined ? { title: pkg.title } : {}),
+    sections,
+  };
+}
+
+/**
+ * Vocabulary shared with the generated-app chart widget. Bridging this into a
+ * Vega-Lite spec lets Console dashboards reuse generated-app chart kinds without
+ * a Console-specific chart engine.
+ */
+export type HonuaConsoleChartKind = "categories" | "histogram" | "time-series";
+
+export interface HonuaConsoleChartWidgetLike {
+  readonly chartKind?: HonuaConsoleChartKind;
+  readonly groupBy?: string;
+  readonly field?: string;
+  readonly title?: string;
+  readonly bins?: number;
+  readonly [extra: string]: unknown;
+}
+
+/**
+ * Projects a generated-app-style chart widget into an SDK Vega-Lite spec.
+ * A missing required field for the chosen chart kind raises a typed
+ * `missing-binding` error.
+ */
+export function chartWidgetToVegaLiteSpec(
+  widget: HonuaConsoleChartWidgetLike,
+  context: { readonly chartId?: string } = {},
+): HonuaVegaLiteSpec {
+  const chartKind = widget.chartKind ?? "categories";
+  const title = widget.title;
+  const base = {
+    $schema: HONUA_CONSOLE_VEGA_LITE_SCHEMA,
+    ...(title !== undefined ? { title } : {}),
+    width: "container" as const,
+    height: "container" as const,
+  };
+
+  if (chartKind === "categories") {
+    if (!widget.groupBy) {
+      throw new HonuaConsoleError("missing-binding", 'Chart kind "categories" requires a groupBy field', {
+        stage: "chart",
+        detail: { ...context, path: "groupBy" },
+      });
+    }
+    return {
+      ...base,
+      mark: "bar",
+      encoding: {
+        x: { field: widget.groupBy, type: "nominal", sort: "descending" },
+        y: { aggregate: "count", type: "quantitative", title: "Count" },
+      },
+    };
+  }
+
+  if (chartKind === "histogram") {
+    if (!widget.field) {
+      throw new HonuaConsoleError("missing-binding", 'Chart kind "histogram" requires a field', {
+        stage: "chart",
+        detail: { ...context, path: "field" },
+      });
+    }
+    return {
+      ...base,
+      mark: "bar",
+      encoding: {
+        x: {
+          field: widget.field,
+          type: "quantitative",
+          bin: widget.bins ? { maxbins: widget.bins } : true,
+        },
+        y: { aggregate: "count", type: "quantitative", title: "Count" },
+      },
+    };
+  }
+
+  // time-series
+  if (!widget.field) {
+    throw new HonuaConsoleError("missing-binding", 'Chart kind "time-series" requires a time field', {
+      stage: "chart",
+      detail: { ...context, path: "field" },
+    });
+  }
+  return {
+    ...base,
+    mark: "line",
+    encoding: {
+      x: { field: widget.field, type: "temporal" },
+      y: { aggregate: "count", type: "quantitative", title: "Count" },
+    },
+  };
+}

--- a/src/console/errors.ts
+++ b/src/console/errors.ts
@@ -1,0 +1,91 @@
+/**
+ * Typed error surface for the Console SDK contracts.
+ *
+ * Console UI surfaces (content browser, dashboard/report viewers, embed hosts)
+ * need serializable, code-tagged diagnostics rather than thrown strings so they
+ * can render an explicit "unsupported" or "missing binding" state instead of a
+ * blank panel. The canonical server objects remain authoritative; these errors
+ * only describe the browser-side projection failures the SDK can detect.
+ *
+ * @module
+ */
+
+export type HonuaConsoleErrorCode =
+  | "unsupported-content-kind"
+  | "unsupported-package-format"
+  | "unsupported-chart-spec"
+  | "missing-binding"
+  | "missing-panel"
+  | "missing-chart-spec"
+  | "invalid-vega-lite-spec"
+  | "projection-failed";
+
+export type HonuaConsoleErrorStage = "content" | "metadata" | "projection" | "chart" | "render";
+
+export interface HonuaConsoleErrorDetail {
+  readonly contentId?: string;
+  readonly packageId?: string;
+  readonly panelId?: string;
+  readonly chartId?: string;
+  readonly path?: string;
+  readonly expected?: unknown;
+  readonly received?: unknown;
+  readonly [extra: string]: unknown;
+}
+
+export interface HonuaConsoleDiagnostic {
+  readonly name: "HonuaConsoleError";
+  readonly code: HonuaConsoleErrorCode;
+  readonly stage: HonuaConsoleErrorStage;
+  readonly message: string;
+  readonly detail?: HonuaConsoleErrorDetail;
+}
+
+/**
+ * Structured error raised by Console contract projection helpers. Console hosts
+ * should catch this class and call {@link HonuaConsoleError.toJSON} (or
+ * {@link toConsoleDiagnostic}) to obtain a serializable diagnostic for the UI.
+ */
+export class HonuaConsoleError extends Error {
+  public readonly code: HonuaConsoleErrorCode;
+  public readonly stage: HonuaConsoleErrorStage;
+  public readonly detail: HonuaConsoleErrorDetail | undefined;
+  public override readonly cause: unknown;
+
+  public constructor(
+    code: HonuaConsoleErrorCode,
+    message: string,
+    options: {
+      readonly stage: HonuaConsoleErrorStage;
+      readonly detail?: HonuaConsoleErrorDetail;
+      readonly cause?: unknown;
+    },
+  ) {
+    super(message);
+    this.name = "HonuaConsoleError";
+    this.code = code;
+    this.stage = options.stage;
+    this.detail = options.detail;
+    this.cause = options.cause;
+  }
+
+  public toJSON(): HonuaConsoleDiagnostic {
+    return {
+      name: "HonuaConsoleError",
+      code: this.code,
+      stage: this.stage,
+      message: this.message,
+      ...(this.detail ? { detail: this.detail } : {}),
+    };
+  }
+}
+
+export function toConsoleDiagnostic(error: unknown): HonuaConsoleDiagnostic {
+  if (error instanceof HonuaConsoleError) return error.toJSON();
+  return {
+    name: "HonuaConsoleError",
+    code: "projection-failed",
+    stage: "projection",
+    message: error instanceof Error ? error.message : String(error),
+  };
+}

--- a/src/console/index.ts
+++ b/src/console/index.ts
@@ -1,0 +1,93 @@
+/**
+ * `@honua/sdk-js/console` — browser-safe SDK contracts for `honua-console`.
+ *
+ * This subpath exposes the SDK-projected view of the shared content/metadata
+ * model (content items, Metadata v2, sharing, embeds, provenance) and the
+ * dashboard/report package projections with Vega-Lite chart spec support, so
+ * Console can consume stable contracts without copying server DTOs or Portal
+ * types.
+ *
+ * Contract ownership:
+ * - **server-owned**: canonical wire shapes in `honua-server` (Metadata v2,
+ *   content items, packages, sharing, embeds, provenance). Not defined here.
+ * - **SDK-projected**: the browser-safe types and projection helpers in this
+ *   module, plus `@honua/sdk-js/runtime` (`MapPackage`), `./control-plane`
+ *   (admin resources, sharing), and `./generated-app` (generated-app runtime).
+ * - **Console-rendered**: render models (`*RenderModel`) derived from the
+ *   projections above.
+ *
+ * MCP / QGIS / Console parity: these contracts describe the same package
+ * artifacts the MCP server and QGIS plugin consume. The chart-kind vocabulary
+ * (`categories` / `histogram` / `time-series`) is shared with
+ * `./generated-app`; {@link chartWidgetToVegaLiteSpec} is the canonical bridge
+ * so every consumer renders identical charts.
+ *
+ * @experimental This entrypoint is not yet covered by the SDK's semver contract
+ *   — the surface may change in any minor release prior to `1.0.0`.
+ * @module
+ */
+
+export {
+  HONUA_CONSOLE_METADATA_FORMAT_V2,
+  HONUA_CONSOLE_KNOWN_CONTENT_KINDS,
+  isKnownConsoleContentKind,
+} from "./content.js";
+export type {
+  HonuaConsoleContentItem,
+  HonuaConsoleContentKind,
+  HonuaConsoleEmbed,
+  HonuaConsoleMetadata,
+  HonuaConsoleMetadataFormat,
+  HonuaConsoleProvenance,
+  HonuaConsoleSharing,
+  HonuaConsoleVisibility,
+} from "./content.js";
+
+export {
+  assertVegaLiteSpec,
+  isVegaLiteSpec,
+  normalizeVegaLiteSpec,
+  HONUA_CONSOLE_VEGA_LITE_SCHEMA,
+} from "./vega-lite.js";
+export type {
+  HonuaVegaLiteAggregate,
+  HonuaVegaLiteData,
+  HonuaVegaLiteEncoding,
+  HonuaVegaLiteFieldDef,
+  HonuaVegaLiteFieldType,
+  HonuaVegaLiteMark,
+  HonuaVegaLiteSpec,
+} from "./vega-lite.js";
+
+export {
+  chartWidgetToVegaLiteSpec,
+  projectDashboardPackage,
+  projectReportPackage,
+  HONUA_CONSOLE_DASHBOARD_PACKAGE_FORMAT_V1,
+  HONUA_CONSOLE_REPORT_PACKAGE_FORMAT_V1,
+} from "./dashboard.js";
+export type {
+  HonuaConsoleChartKind,
+  HonuaConsoleChartPanel,
+  HonuaConsoleChartPanelModel,
+  HonuaConsoleChartWidgetLike,
+  HonuaConsoleDashboardPackage,
+  HonuaConsoleDashboardPackageFormat,
+  HonuaConsoleDashboardRenderModel,
+  HonuaConsolePanel,
+  HonuaConsolePanelBase,
+  HonuaConsolePanelBinding,
+  HonuaConsolePanelKind,
+  HonuaConsoleReportPackage,
+  HonuaConsoleReportPackageFormat,
+  HonuaConsoleReportRenderModel,
+  HonuaConsoleReportSection,
+} from "./dashboard.js";
+
+export { HonuaConsoleError, toConsoleDiagnostic } from "./errors.js";
+export type {
+  HonuaConsoleDiagnostic,
+  HonuaConsoleErrorCode,
+  HonuaConsoleErrorDetail,
+  HonuaConsoleErrorStage,
+} from "./errors.js";

--- a/src/console/vega-lite.ts
+++ b/src/console/vega-lite.ts
@@ -1,0 +1,188 @@
+/**
+ * Browser-safe Vega-Lite chart spec contract for Console dashboards/reports.
+ *
+ * Console renders dashboard and report charts with Vega-Lite. The SDK does not
+ * bundle Vega — it only owns the **portable, validated spec shape** so dashboard
+ * and report packages can carry chart specs that round-trip cleanly between the
+ * server, the SDK projection, and the Console renderer. This is a deliberately
+ * narrow subset of the Vega-Lite grammar (single-view, encoding-based marks)
+ * sufficient for the operations-dashboard chart kinds.
+ *
+ * @module
+ */
+
+import { HonuaConsoleError } from "./errors.js";
+
+export const HONUA_CONSOLE_VEGA_LITE_SCHEMA = "https://vega.github.io/schema/vega-lite/v5.json" as const;
+
+export type HonuaVegaLiteMark = "bar" | "line" | "point" | "area" | "arc" | "rect" | "tick";
+
+export type HonuaVegaLiteFieldType = "quantitative" | "temporal" | "ordinal" | "nominal";
+
+export type HonuaVegaLiteAggregate = "count" | "sum" | "mean" | "median" | "min" | "max" | (string & {});
+
+export interface HonuaVegaLiteFieldDef {
+  readonly field?: string;
+  readonly type: HonuaVegaLiteFieldType;
+  readonly aggregate?: HonuaVegaLiteAggregate;
+  readonly timeUnit?: string;
+  readonly bin?: boolean | { readonly maxbins?: number };
+  readonly title?: string;
+  readonly sort?: "ascending" | "descending" | null;
+  readonly [extra: string]: unknown;
+}
+
+export interface HonuaVegaLiteEncoding {
+  readonly x?: HonuaVegaLiteFieldDef;
+  readonly y?: HonuaVegaLiteFieldDef;
+  readonly color?: HonuaVegaLiteFieldDef;
+  readonly theta?: HonuaVegaLiteFieldDef;
+  readonly tooltip?: HonuaVegaLiteFieldDef | ReadonlyArray<HonuaVegaLiteFieldDef>;
+  readonly [channel: string]: HonuaVegaLiteFieldDef | ReadonlyArray<HonuaVegaLiteFieldDef> | undefined;
+}
+
+/**
+ * Inline data values. Console may instead bind a named data source at render
+ * time; when `values` is omitted the spec is a template the host populates.
+ */
+export interface HonuaVegaLiteData {
+  readonly name?: string;
+  readonly values?: ReadonlyArray<Readonly<Record<string, unknown>>>;
+  readonly [extra: string]: unknown;
+}
+
+/**
+ * SDK-projected Vega-Lite chart spec. Carries the SDK schema marker so the
+ * renderer can confirm the contract version. Extra Vega-Lite properties survive
+ * via the open index signature.
+ */
+export interface HonuaVegaLiteSpec {
+  readonly $schema?: typeof HONUA_CONSOLE_VEGA_LITE_SCHEMA | (string & {});
+  readonly title?: string;
+  readonly description?: string;
+  readonly width?: number | "container";
+  readonly height?: number | "container";
+  readonly mark: HonuaVegaLiteMark | { readonly type: HonuaVegaLiteMark; readonly [extra: string]: unknown };
+  readonly encoding: HonuaVegaLiteEncoding;
+  readonly data?: HonuaVegaLiteData;
+  readonly [extra: string]: unknown;
+}
+
+const VEGA_LITE_MARKS: ReadonlySet<string> = new Set<HonuaVegaLiteMark>([
+  "bar",
+  "line",
+  "point",
+  "area",
+  "arc",
+  "rect",
+  "tick",
+]);
+
+const VEGA_LITE_FIELD_TYPES: ReadonlySet<string> = new Set<HonuaVegaLiteFieldType>([
+  "quantitative",
+  "temporal",
+  "ordinal",
+  "nominal",
+]);
+
+function markType(mark: HonuaVegaLiteSpec["mark"]): string | undefined {
+  if (typeof mark === "string") return mark;
+  if (mark && typeof mark === "object" && typeof mark.type === "string") return mark.type;
+  return undefined;
+}
+
+/**
+ * Validates the SDK Vega-Lite subset and narrows an unknown value to
+ * {@link HonuaVegaLiteSpec}. Throws a typed {@link HonuaConsoleError} with code
+ * `invalid-vega-lite-spec` (or `unsupported-chart-spec` for an out-of-subset
+ * mark/type) so Console can render a precise failure state.
+ */
+export function assertVegaLiteSpec(
+  value: unknown,
+  context: { readonly chartId?: string; readonly path?: string } = {},
+): asserts value is HonuaVegaLiteSpec {
+  const path = context.path ?? "spec";
+  if (!value || typeof value !== "object") {
+    throw new HonuaConsoleError("invalid-vega-lite-spec", "Vega-Lite spec must be an object", {
+      stage: "chart",
+      detail: { ...context, path, received: value },
+    });
+  }
+  const spec = value as Record<string, unknown>;
+  const mark = markType(spec.mark as HonuaVegaLiteSpec["mark"]);
+  if (!mark) {
+    throw new HonuaConsoleError("invalid-vega-lite-spec", "Vega-Lite spec is missing a mark", {
+      stage: "chart",
+      detail: { ...context, path: `${path}.mark` },
+    });
+  }
+  if (!VEGA_LITE_MARKS.has(mark)) {
+    throw new HonuaConsoleError("unsupported-chart-spec", `Unsupported Vega-Lite mark "${mark}"`, {
+      stage: "chart",
+      detail: { ...context, path: `${path}.mark`, received: mark, expected: [...VEGA_LITE_MARKS] },
+    });
+  }
+  const encoding = spec.encoding;
+  if (!encoding || typeof encoding !== "object") {
+    throw new HonuaConsoleError("invalid-vega-lite-spec", "Vega-Lite spec is missing encoding", {
+      stage: "chart",
+      detail: { ...context, path: `${path}.encoding` },
+    });
+  }
+  for (const [channel, def] of Object.entries(encoding as Record<string, unknown>)) {
+    if (def === undefined) continue;
+    const defs = Array.isArray(def) ? def : [def];
+    for (const fieldDef of defs) {
+      if (!fieldDef || typeof fieldDef !== "object") {
+        throw new HonuaConsoleError("invalid-vega-lite-spec", `Encoding channel "${channel}" must be a field def`, {
+          stage: "chart",
+          detail: { ...context, path: `${path}.encoding.${channel}`, received: fieldDef },
+        });
+      }
+      const type = (fieldDef as Record<string, unknown>).type;
+      if (typeof type !== "string" || !VEGA_LITE_FIELD_TYPES.has(type)) {
+        throw new HonuaConsoleError(
+          "unsupported-chart-spec",
+          `Encoding channel "${channel}" has unsupported type "${String(type)}"`,
+          {
+            stage: "chart",
+            detail: {
+              ...context,
+              path: `${path}.encoding.${channel}.type`,
+              received: type,
+              expected: [...VEGA_LITE_FIELD_TYPES],
+            },
+          },
+        );
+      }
+    }
+  }
+}
+
+/** Returns `true` when `value` is a valid SDK-subset Vega-Lite spec. */
+export function isVegaLiteSpec(value: unknown): value is HonuaVegaLiteSpec {
+  try {
+    assertVegaLiteSpec(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Normalizes an SDK-subset Vega-Lite spec to a stable, validated shape: pins the
+ * SDK `$schema`, coerces a string mark to a `{ type }` object only when extra
+ * mark props are absent (string form is preserved otherwise), and validates the
+ * result. The output round-trips through {@link assertVegaLiteSpec}.
+ */
+export function normalizeVegaLiteSpec(
+  value: unknown,
+  context: { readonly chartId?: string; readonly path?: string } = {},
+): HonuaVegaLiteSpec {
+  assertVegaLiteSpec(value, context);
+  const spec = value as HonuaVegaLiteSpec;
+  return {
+    ...spec,
+    $schema: spec.$schema ?? HONUA_CONSOLE_VEGA_LITE_SCHEMA,
+  };
+}

--- a/test/console-contracts.test.ts
+++ b/test/console-contracts.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HONUA_CONSOLE_DASHBOARD_PACKAGE_FORMAT_V1,
+  HONUA_CONSOLE_REPORT_PACKAGE_FORMAT_V1,
+  HONUA_CONSOLE_VEGA_LITE_SCHEMA,
+  type HonuaConsoleDashboardPackage,
+  HonuaConsoleError,
+  type HonuaConsoleReportPackage,
+  type HonuaVegaLiteSpec,
+  assertVegaLiteSpec,
+  chartWidgetToVegaLiteSpec,
+  isKnownConsoleContentKind,
+  isVegaLiteSpec,
+  normalizeVegaLiteSpec,
+  projectDashboardPackage,
+  projectReportPackage,
+  toConsoleDiagnostic,
+} from "../src/console/index.js";
+
+const validSpec: HonuaVegaLiteSpec = {
+  mark: "bar",
+  encoding: {
+    x: { field: "status", type: "nominal" },
+    y: { aggregate: "count", type: "quantitative" },
+  },
+};
+
+describe("console content contracts", () => {
+  it("recognizes known content kinds and flags unknown ones", () => {
+    expect(isKnownConsoleContentKind("dashboard")).toBe(true);
+    expect(isKnownConsoleContentKind("report")).toBe(true);
+    expect(isKnownConsoleContentKind("map-package")).toBe(true);
+    expect(isKnownConsoleContentKind("totally-new-kind")).toBe(false);
+  });
+});
+
+describe("vega-lite chart spec", () => {
+  it("accepts a valid SDK-subset spec", () => {
+    expect(isVegaLiteSpec(validSpec)).toBe(true);
+  });
+
+  it("normalize pins the SDK $schema and round-trips through assert", () => {
+    const normalized = normalizeVegaLiteSpec(validSpec);
+    expect(normalized.$schema).toBe(HONUA_CONSOLE_VEGA_LITE_SCHEMA);
+    // Round-trip: a normalized spec must still validate, and re-normalizing is stable.
+    expect(() => assertVegaLiteSpec(normalized)).not.toThrow();
+    expect(normalizeVegaLiteSpec(normalized)).toEqual(normalized);
+  });
+
+  it("preserves an explicit $schema and extra properties on round-trip", () => {
+    const withExtras: HonuaVegaLiteSpec = {
+      ...validSpec,
+      $schema: HONUA_CONSOLE_VEGA_LITE_SCHEMA,
+      title: "Incidents by status",
+      width: "container",
+      mark: { type: "bar", cornerRadius: 2 },
+    };
+    const normalized = normalizeVegaLiteSpec(withExtras);
+    expect(normalized).toEqual(withExtras);
+  });
+
+  it("rejects an unsupported mark with a typed error", () => {
+    expect(() => assertVegaLiteSpec({ mark: "geoshape", encoding: { x: { type: "nominal" } } })).toThrowError(
+      HonuaConsoleError,
+    );
+    try {
+      assertVegaLiteSpec({ mark: "geoshape", encoding: { x: { type: "nominal" } } }, { chartId: "c1" });
+    } catch (error) {
+      const diag = toConsoleDiagnostic(error);
+      expect(diag.code).toBe("unsupported-chart-spec");
+      expect(diag.stage).toBe("chart");
+      expect(diag.detail?.chartId).toBe("c1");
+    }
+  });
+
+  it("rejects an unsupported encoding type", () => {
+    expect(() => assertVegaLiteSpec({ mark: "bar", encoding: { x: { field: "a", type: "geojson" } } })).toThrowError(
+      /unsupported type/,
+    );
+  });
+
+  it("rejects a non-object / missing-encoding spec", () => {
+    expect(() => assertVegaLiteSpec(null)).toThrowError(HonuaConsoleError);
+    expect(() => assertVegaLiteSpec({ mark: "bar" })).toThrowError(/missing encoding/);
+  });
+});
+
+describe("chartWidgetToVegaLiteSpec bridge", () => {
+  it("projects a categories widget to a bar chart spec", () => {
+    const spec = chartWidgetToVegaLiteSpec({ chartKind: "categories", groupBy: "status", title: "By status" });
+    expect(spec.mark).toBe("bar");
+    expect(spec.title).toBe("By status");
+    expect(spec.encoding.x?.field).toBe("status");
+    expect(isVegaLiteSpec(spec)).toBe(true);
+  });
+
+  it("projects a histogram widget with bins", () => {
+    const spec = chartWidgetToVegaLiteSpec({ chartKind: "histogram", field: "magnitude", bins: 20 });
+    expect(spec.mark).toBe("bar");
+    expect(spec.encoding.x?.bin).toEqual({ maxbins: 20 });
+    expect(isVegaLiteSpec(spec)).toBe(true);
+  });
+
+  it("projects a time-series widget to a line chart spec", () => {
+    const spec = chartWidgetToVegaLiteSpec({ chartKind: "time-series", field: "reportedAt" });
+    expect(spec.mark).toBe("line");
+    expect(spec.encoding.x?.type).toBe("temporal");
+    expect(isVegaLiteSpec(spec)).toBe(true);
+  });
+
+  it("raises a typed missing-binding error when a required field is absent", () => {
+    try {
+      chartWidgetToVegaLiteSpec({ chartKind: "histogram" }, { chartId: "w9" });
+      throw new Error("expected throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(HonuaConsoleError);
+      const diag = toConsoleDiagnostic(error);
+      expect(diag.code).toBe("missing-binding");
+      expect(diag.detail?.chartId).toBe("w9");
+      expect(diag.detail?.path).toBe("field");
+    }
+  });
+});
+
+describe("dashboard package projection", () => {
+  const dashboard: HonuaConsoleDashboardPackage = {
+    format: HONUA_CONSOLE_DASHBOARD_PACKAGE_FORMAT_V1,
+    id: "dash-1",
+    title: "Operations",
+    panels: [
+      { id: "p-map", kind: "map" },
+      { id: "p-chart", kind: "chart", title: "Status", chartSpec: validSpec, binding: { sourceId: "incidents" } },
+    ],
+  };
+
+  it("projects chart panels and round-trips Vega-Lite specs", () => {
+    const model = projectDashboardPackage(dashboard);
+    expect(model.id).toBe("dash-1");
+    expect(model.charts).toHaveLength(1);
+    expect(model.charts[0]?.id).toBe("p-chart");
+    expect(model.charts[0]?.chartSpec.$schema).toBe(HONUA_CONSOLE_VEGA_LITE_SCHEMA);
+    expect(model.charts[0]?.binding?.sourceId).toBe("incidents");
+    // Non-chart panels are preserved on the model for layout.
+    expect(model.panels).toHaveLength(2);
+  });
+
+  it("raises a typed missing-chart-spec error for a chart panel without a spec", () => {
+    const broken: HonuaConsoleDashboardPackage = {
+      ...dashboard,
+      panels: [{ id: "p-broken", kind: "chart" }],
+    };
+    try {
+      projectDashboardPackage(broken);
+      throw new Error("expected throw");
+    } catch (error) {
+      const diag = toConsoleDiagnostic(error);
+      expect(diag.code).toBe("missing-chart-spec");
+      expect(diag.detail?.panelId).toBe("p-broken");
+    }
+  });
+
+  it("rejects an unsupported package format", () => {
+    const bad = { ...dashboard, format: "honua_dashboard_package.v2" } as unknown as HonuaConsoleDashboardPackage;
+    try {
+      projectDashboardPackage(bad);
+      throw new Error("expected throw");
+    } catch (error) {
+      expect(toConsoleDiagnostic(error).code).toBe("unsupported-package-format");
+    }
+  });
+});
+
+describe("report package projection", () => {
+  const report: HonuaConsoleReportPackage = {
+    format: HONUA_CONSOLE_REPORT_PACKAGE_FORMAT_V1,
+    id: "rep-1",
+    title: "Quarterly",
+    sections: [
+      {
+        id: "s1",
+        title: "Summary",
+        body: "Overview text",
+        panels: [{ id: "c1", kind: "chart", chartSpec: validSpec }],
+      },
+      { id: "s2", title: "Notes" },
+    ],
+  };
+
+  it("projects each section's chart panels", () => {
+    const model = projectReportPackage(report);
+    expect(model.sections).toHaveLength(2);
+    expect(model.sections[0]?.charts).toHaveLength(1);
+    expect(model.sections[0]?.charts[0]?.chartSpec.$schema).toBe(HONUA_CONSOLE_VEGA_LITE_SCHEMA);
+    expect(model.sections[0]?.body).toBe("Overview text");
+    expect(model.sections[1]?.charts).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What this does

Adds a browser-safe `@honua/sdk-js/console` subpath so `honua-console` can consume the shared metadata/content/package model without duplicating server DTOs or Portal-only types.

New module `src/console/`:
- **content.ts** — SDK-projected `HonuaConsoleContentItem`, Metadata v2 (`HonuaConsoleMetadata`), sharing, embed, and provenance projections. Every interface keeps an open index signature so additive server fields survive a round-trip without a Console-specific copy of the protocol types. Includes `isKnownConsoleContentKind` so Console can flag unsupported kinds.
- **vega-lite.ts** — portable Vega-Lite chart spec subset (`HonuaVegaLiteSpec`) with `assertVegaLiteSpec` / `isVegaLiteSpec` / `normalizeVegaLiteSpec`. Out-of-subset marks or encoding types raise typed errors; `normalize` pins the SDK `$schema` and round-trips.
- **dashboard.ts** — dashboard and report package contracts plus `projectDashboardPackage` / `projectReportPackage`, which validate Vega-Lite chart specs and surface typed missing-binding / missing-chart-spec / unsupported-format errors. `chartWidgetToVegaLiteSpec` bridges the existing generated-app chart-kind vocabulary (`categories` / `histogram` / `time-series`) into Vega-Lite so dashboards and generated apps render identical charts.
- **errors.ts** — `HonuaConsoleError` with serializable diagnostics for Console UI surfaces.

Wiring: `./console` added to `package.json` exports and to the split-package prepare/verify scripts (verify now asserts the chart-spec bridge produces a valid Vega-Lite spec).

The module documents contract ownership (server-owned / SDK-projected / Console-rendered) and MCP/QGIS/Console parity expectations in its module docs.

## Scope

**First slice** of #225 (labeled effort/XL). It deliberately builds on, rather than duplicates, the existing `./control-plane` client (hosted maps, map packages, imports, tokens, sharing) and `./generated-app` runtime, and establishes the new content/metadata/dashboard/report/Vega-Lite contract surface and typed Console error model. Existing generated-app runtime behavior is unchanged.

Recommended follow-up slices (separate PRs): a content/metadata-v2 client on the control-plane base path; `MapPackage`/`AppPackage` projection normalizers for Console; embed/provenance client surfaces; and public docs enumerating each contract's ownership.

## Testing

- `npm run typecheck` — passes.
- `npm run check` (Biome) — clean on changed files.
- `npx vitest run test/console-contracts.test.ts` — 15 tests pass, covering dashboard/report/app-chart projection and Vega-Lite chart spec round-tripping (acceptance criteria).
- `npm run build` emits `dist/src/console`; the split-package prepare step copies it into `@honua/sdk/console`. The full `verify:split-packages` CI gate exercises the new export assertion.

Refs #225