### PR TITLE
Add Operate observability SDK contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,10 @@
     "./operator/i18n": {
       "types": "./dist/src/operator/i18n/index.d.ts",
       "default": "./dist/src/operator/i18n/index.js"
+    },
+    "./operate": {
+      "types": "./dist/src/operate/index.d.ts",
+      "default": "./dist/src/operate/index.js"
     }
   },
   "scripts": {

--- a/scripts/prepare-split-packages.mjs
+++ b/scripts/prepare-split-packages.mjs
@@ -60,6 +60,7 @@ function createSdkPackage() {
   copyDirectory(path.join(DIST_SRC_ROOT, "app-workspace"), path.join(packageRoot, "app-workspace"));
   copyDirectory(path.join(DIST_SRC_ROOT, "map"), path.join(packageRoot, "map"));
   copyDirectory(path.join(DIST_SRC_ROOT, "operator"), path.join(packageRoot, "operator"));
+  copyDirectory(path.join(DIST_SRC_ROOT, "operate"), path.join(packageRoot, "operate"));
   copyDirectory(path.join(DIST_SRC_ROOT, "realtime"), path.join(packageRoot, "realtime"));
   copyDirectory(path.join(DIST_SRC_ROOT, "runtime"), path.join(packageRoot, "runtime"));
   copyDirectory(path.join(DIST_SRC_ROOT, "scene-workspace"), path.join(packageRoot, "scene-workspace"));
@@ -130,6 +131,10 @@ function createSdkPackage() {
       "./operator/i18n": {
         types: "./operator/i18n/index.d.ts",
         default: "./operator/i18n/index.js",
+      },
+      "./operate": {
+        types: "./operate/index.d.ts",
+        default: "./operate/index.js",
       },
       "./exploration": {
         types: "./exploration/index.d.ts",

--- a/src/operate/client.ts
+++ b/src/operate/client.ts
@@ -1,0 +1,563 @@
+import { honuaCacheValidatorFromHeaders } from "../core/cache-state.js";
+import type { HonuaClient } from "../core/client.js";
+import { HonuaHttpError } from "../core/errors.js";
+import type { QueryMethod } from "../core/types.js";
+import {
+  HONUA_OPERATE_BASE_PATH,
+  type HonuaAlert,
+  type HonuaAlertActionRequest,
+  type HonuaAlertRule,
+  type HonuaAlertRuleTestResult,
+  type HonuaAlertRuleWriteRequest,
+  type HonuaGeofenceZone,
+  type HonuaGeofenceZoneWriteRequest,
+  type HonuaInvestigation,
+  type HonuaInvestigationCreateRequest,
+  type HonuaInvestigationPinRequest,
+  type HonuaJobActionRequest,
+  type HonuaJobArtifact,
+  type HonuaJobLog,
+  type HonuaJobRunDetail,
+  type HonuaJobRunSummary,
+  type HonuaLogRecord,
+  type HonuaObservabilityTarget,
+  type HonuaOperateCapability,
+  type HonuaOperateListOptions,
+  type HonuaOperatePage,
+  type HonuaOperateRawRequest,
+  type HonuaOperateRequestOptions,
+  type HonuaOperateResult,
+  type HonuaOperationalEvent,
+  type HonuaProblemDetails,
+  type HonuaServerTelemetryStatus,
+} from "./types.js";
+
+export interface HonuaOperateClientOptions {
+  readonly client: HonuaClient;
+  readonly basePath?: string;
+}
+
+export function createHonuaOperate(options: HonuaOperateClientOptions): HonuaOperateClient {
+  return new HonuaOperateClient(options);
+}
+
+/**
+ * Experimental Operate observability client.
+ *
+ * Exposes telemetry status, the event/log viewers, alerts and realtime alert
+ * rules, geofence zones, investigations, and the job viewer over `/api/v1/operate`.
+ * Missing providers degrade to typed {@link HonuaOperateUnsupported} results.
+ */
+export class HonuaOperateClient {
+  readonly #client: HonuaClient;
+  readonly #basePath: string;
+
+  public readonly telemetry: HonuaTelemetryClient;
+  public readonly events: HonuaEventsClient;
+  public readonly logs: HonuaLogsClient;
+  public readonly alerts: HonuaAlertsClient;
+  public readonly alertRules: HonuaAlertRulesClient;
+  public readonly geofences: HonuaGeofencesClient;
+  public readonly investigations: HonuaInvestigationsClient;
+  public readonly jobs: HonuaJobsClient;
+
+  public constructor(options: HonuaOperateClientOptions) {
+    this.#client = options.client;
+    this.#basePath = normalizeBasePath(options.basePath ?? HONUA_OPERATE_BASE_PATH);
+    this.telemetry = new HonuaTelemetryClient(this);
+    this.events = new HonuaEventsClient(this);
+    this.logs = new HonuaLogsClient(this);
+    this.alerts = new HonuaAlertsClient(this);
+    this.alertRules = new HonuaAlertRulesClient(this);
+    this.geofences = new HonuaGeofencesClient(this);
+    this.investigations = new HonuaInvestigationsClient(this);
+    this.jobs = new HonuaJobsClient(this);
+  }
+
+  public get basePath(): string {
+    return this.#basePath;
+  }
+
+  public async raw<T = unknown>(request: HonuaOperateRawRequest): Promise<HonuaOperateResult<T>> {
+    return this.requestJson<T>("raw", request.method ?? "GET", request.path, request.body, {
+      signal: request.signal,
+      headers: request.headers,
+      okStatuses: request.okStatuses,
+    });
+  }
+
+  public async requestJson<T>(
+    capability: HonuaOperateCapability,
+    method: QueryMethod,
+    path: string,
+    body?: unknown,
+    options: HonuaOperateRequestOptions & { okStatuses?: readonly number[] } = {},
+  ): Promise<HonuaOperateResult<T>> {
+    try {
+      const response = await this.#client.pipelineFetch(
+        method,
+        this.resolvePath(path),
+        {
+          headers: jsonHeaders(options.headers),
+          body: body === undefined ? null : JSON.stringify(body),
+        },
+        options.signal,
+        options.okStatuses ? { okStatuses: options.okStatuses } : {},
+      );
+      if (response.status === 204) return supported(undefined as T);
+      const value = (await readJson(response)) as T;
+      return supported(value);
+    } catch (error) {
+      return unsupportedFromError(capability, error);
+    }
+  }
+
+  public async requestPage<T>(
+    capability: HonuaOperateCapability,
+    path: string,
+    options: HonuaOperateListOptions = {},
+  ): Promise<HonuaOperateResult<HonuaOperatePage<T>>> {
+    try {
+      const hasValidator = Boolean(options.validator?.etag || options.validator?.lastModified);
+      const response = await this.#client.pipelineFetch(
+        "GET",
+        this.resolvePath(withListQuery(path, options)),
+        { headers: listHeaders(options) },
+        options.signal,
+        { okStatuses: hasValidator ? [304, 404, 501] : [404, 501] },
+      );
+      if (response.status === 404 || response.status === 501) {
+        return unsupportedFromStatus(capability, response.status, await readJson(response));
+      }
+      const value = normalizePage<T>(response.status === 304 ? undefined : await readJson(response), response, {
+        fallbackValidator: options.validator,
+      });
+      return supported(value);
+    } catch (error) {
+      return unsupportedFromError(capability, error);
+    }
+  }
+
+  public resolvePath(path: string): string {
+    if (path.startsWith("http://") || path.startsWith("https://")) return path;
+    const normalized = path.startsWith("/") ? path : `/${path}`;
+    if (normalized === this.#basePath || normalized.startsWith(`${this.#basePath}/`)) return normalized;
+    return `${this.#basePath}${normalized}`;
+  }
+}
+
+export class HonuaTelemetryClient {
+  readonly #operate: HonuaOperateClient;
+
+  public constructor(operate: HonuaOperateClient) {
+    this.#operate = operate;
+  }
+
+  public listTargets(
+    options: HonuaOperateListOptions = {},
+  ): Promise<HonuaOperateResult<HonuaOperatePage<HonuaObservabilityTarget>>> {
+    return this.#operate.requestPage("telemetry", "/targets", options);
+  }
+
+  public status(
+    targetId: string,
+    options: HonuaOperateRequestOptions = {},
+  ): Promise<HonuaOperateResult<HonuaServerTelemetryStatus>> {
+    return this.#operate.requestJson(
+      "telemetry",
+      "GET",
+      `/targets/${encodeURIComponent(targetId)}/telemetry`,
+      undefined,
+      options,
+    );
+  }
+}
+
+export class HonuaEventsClient {
+  readonly #operate: HonuaOperateClient;
+
+  public constructor(operate: HonuaOperateClient) {
+    this.#operate = operate;
+  }
+
+  public query(
+    options: HonuaOperateListOptions = {},
+  ): Promise<HonuaOperateResult<HonuaOperatePage<HonuaOperationalEvent>>> {
+    return this.#operate.requestPage("events", "/events", options);
+  }
+}
+
+export class HonuaLogsClient {
+  readonly #operate: HonuaOperateClient;
+
+  public constructor(operate: HonuaOperateClient) {
+    this.#operate = operate;
+  }
+
+  public query(options: HonuaOperateListOptions = {}): Promise<HonuaOperateResult<HonuaOperatePage<HonuaLogRecord>>> {
+    return this.#operate.requestPage("logs", "/logs", options);
+  }
+}
+
+export class HonuaAlertsClient {
+  readonly #operate: HonuaOperateClient;
+
+  public constructor(operate: HonuaOperateClient) {
+    this.#operate = operate;
+  }
+
+  public query(options: HonuaOperateListOptions = {}): Promise<HonuaOperateResult<HonuaOperatePage<HonuaAlert>>> {
+    return this.#operate.requestPage("alerts", "/alerts", options);
+  }
+
+  public get(alertId: string, options: HonuaOperateRequestOptions = {}): Promise<HonuaOperateResult<HonuaAlert>> {
+    return this.#operate.requestJson("alerts", "GET", `/alerts/${encodeURIComponent(alertId)}`, undefined, options);
+  }
+
+  public act(
+    alertId: string,
+    request: HonuaAlertActionRequest,
+    options: HonuaOperateRequestOptions = {},
+  ): Promise<HonuaOperateResult<HonuaAlert>> {
+    const { ifMatch, ...body } = request;
+    return this.#operate.requestJson("alerts", "POST", `/alerts/${encodeURIComponent(alertId)}/actions`, body, {
+      ...options,
+      headers: withIfMatch(options.headers, ifMatch),
+    });
+  }
+}
+
+export class HonuaAlertRulesClient {
+  readonly #operate: HonuaOperateClient;
+
+  public constructor(operate: HonuaOperateClient) {
+    this.#operate = operate;
+  }
+
+  public list(options: HonuaOperateListOptions = {}): Promise<HonuaOperateResult<HonuaOperatePage<HonuaAlertRule>>> {
+    return this.#operate.requestPage("alert-rules", "/alert-rules", options);
+  }
+
+  public get(ruleId: string, options: HonuaOperateRequestOptions = {}): Promise<HonuaOperateResult<HonuaAlertRule>> {
+    return this.#operate.requestJson(
+      "alert-rules",
+      "GET",
+      `/alert-rules/${encodeURIComponent(ruleId)}`,
+      undefined,
+      options,
+    );
+  }
+
+  public create(
+    request: HonuaAlertRuleWriteRequest,
+    options: HonuaOperateRequestOptions = {},
+  ): Promise<HonuaOperateResult<HonuaAlertRule>> {
+    const { ifMatch, ...body } = request;
+    return this.#operate.requestJson("alert-rules", "POST", "/alert-rules", body, {
+      ...options,
+      headers: withIfMatch(options.headers, ifMatch),
+    });
+  }
+
+  public update(
+    ruleId: string,
+    request: HonuaAlertRuleWriteRequest,
+    options: HonuaOperateRequestOptions = {},
+  ): Promise<HonuaOperateResult<HonuaAlertRule>> {
+    const { ifMatch, ...body } = request;
+    return this.#operate.requestJson("alert-rules", "PUT", `/alert-rules/${encodeURIComponent(ruleId)}`, body, {
+      ...options,
+      headers: withIfMatch(options.headers, ifMatch),
+    });
+  }
+
+  public delete(ruleId: string, options: HonuaOperateRequestOptions = {}): Promise<HonuaOperateResult<void>> {
+    return this.#operate.requestJson("alert-rules", "DELETE", `/alert-rules/${encodeURIComponent(ruleId)}`, undefined, {
+      ...options,
+      okStatuses: [204],
+    });
+  }
+
+  public test(
+    ruleId: string,
+    options: HonuaOperateRequestOptions = {},
+  ): Promise<HonuaOperateResult<HonuaAlertRuleTestResult>> {
+    return this.#operate.requestJson(
+      "alert-rules",
+      "POST",
+      `/alert-rules/${encodeURIComponent(ruleId)}/test`,
+      {},
+      options,
+    );
+  }
+}
+
+export class HonuaGeofencesClient {
+  readonly #operate: HonuaOperateClient;
+
+  public constructor(operate: HonuaOperateClient) {
+    this.#operate = operate;
+  }
+
+  public list(options: HonuaOperateListOptions = {}): Promise<HonuaOperateResult<HonuaOperatePage<HonuaGeofenceZone>>> {
+    return this.#operate.requestPage("geofences", "/geofences", options);
+  }
+
+  public get(zoneId: string, options: HonuaOperateRequestOptions = {}): Promise<HonuaOperateResult<HonuaGeofenceZone>> {
+    return this.#operate.requestJson(
+      "geofences",
+      "GET",
+      `/geofences/${encodeURIComponent(zoneId)}`,
+      undefined,
+      options,
+    );
+  }
+
+  public create(
+    request: HonuaGeofenceZoneWriteRequest,
+    options: HonuaOperateRequestOptions = {},
+  ): Promise<HonuaOperateResult<HonuaGeofenceZone>> {
+    const { ifMatch, ...body } = request;
+    return this.#operate.requestJson("geofences", "POST", "/geofences", body, {
+      ...options,
+      headers: withIfMatch(options.headers, ifMatch),
+    });
+  }
+
+  public update(
+    zoneId: string,
+    request: HonuaGeofenceZoneWriteRequest,
+    options: HonuaOperateRequestOptions = {},
+  ): Promise<HonuaOperateResult<HonuaGeofenceZone>> {
+    const { ifMatch, ...body } = request;
+    return this.#operate.requestJson("geofences", "PUT", `/geofences/${encodeURIComponent(zoneId)}`, body, {
+      ...options,
+      headers: withIfMatch(options.headers, ifMatch),
+    });
+  }
+
+  public delete(zoneId: string, options: HonuaOperateRequestOptions = {}): Promise<HonuaOperateResult<void>> {
+    return this.#operate.requestJson("geofences", "DELETE", `/geofences/${encodeURIComponent(zoneId)}`, undefined, {
+      ...options,
+      okStatuses: [204],
+    });
+  }
+}
+
+export class HonuaInvestigationsClient {
+  readonly #operate: HonuaOperateClient;
+
+  public constructor(operate: HonuaOperateClient) {
+    this.#operate = operate;
+  }
+
+  public list(
+    options: HonuaOperateListOptions = {},
+  ): Promise<HonuaOperateResult<HonuaOperatePage<HonuaInvestigation>>> {
+    return this.#operate.requestPage("investigations", "/investigations", options);
+  }
+
+  public get(
+    investigationId: string,
+    options: HonuaOperateRequestOptions = {},
+  ): Promise<HonuaOperateResult<HonuaInvestigation>> {
+    return this.#operate.requestJson(
+      "investigations",
+      "GET",
+      `/investigations/${encodeURIComponent(investigationId)}`,
+      undefined,
+      options,
+    );
+  }
+
+  public create(
+    request: HonuaInvestigationCreateRequest,
+    options: HonuaOperateRequestOptions = {},
+  ): Promise<HonuaOperateResult<HonuaInvestigation>> {
+    return this.#operate.requestJson("investigations", "POST", "/investigations", request, options);
+  }
+
+  public pin(
+    investigationId: string,
+    request: HonuaInvestigationPinRequest,
+    options: HonuaOperateRequestOptions = {},
+  ): Promise<HonuaOperateResult<HonuaInvestigation>> {
+    const { ifMatch, ...body } = request;
+    return this.#operate.requestJson(
+      "investigations",
+      "POST",
+      `/investigations/${encodeURIComponent(investigationId)}/pins`,
+      body,
+      { ...options, headers: withIfMatch(options.headers, ifMatch) },
+    );
+  }
+}
+
+export class HonuaJobsClient {
+  readonly #operate: HonuaOperateClient;
+
+  public constructor(operate: HonuaOperateClient) {
+    this.#operate = operate;
+  }
+
+  public query(
+    options: HonuaOperateListOptions = {},
+  ): Promise<HonuaOperateResult<HonuaOperatePage<HonuaJobRunSummary>>> {
+    return this.#operate.requestPage("jobs", "/jobs", options);
+  }
+
+  public get(jobId: string, options: HonuaOperateRequestOptions = {}): Promise<HonuaOperateResult<HonuaJobRunDetail>> {
+    return this.#operate.requestJson("jobs", "GET", `/jobs/${encodeURIComponent(jobId)}`, undefined, options);
+  }
+
+  public logs(
+    jobId: string,
+    options: HonuaOperateListOptions = {},
+  ): Promise<HonuaOperateResult<HonuaOperatePage<HonuaJobLog>>> {
+    return this.#operate.requestPage("jobs", `/jobs/${encodeURIComponent(jobId)}/logs`, options);
+  }
+
+  public artifacts(
+    jobId: string,
+    options: HonuaOperateListOptions = {},
+  ): Promise<HonuaOperateResult<HonuaOperatePage<HonuaJobArtifact>>> {
+    return this.#operate.requestPage("jobs", `/jobs/${encodeURIComponent(jobId)}/artifacts`, options);
+  }
+
+  public act(
+    jobId: string,
+    request: HonuaJobActionRequest,
+    options: HonuaOperateRequestOptions = {},
+  ): Promise<HonuaOperateResult<HonuaJobRunDetail>> {
+    const { ifMatch, ...body } = request;
+    return this.#operate.requestJson("jobs", "POST", `/jobs/${encodeURIComponent(jobId)}/actions`, body, {
+      ...options,
+      headers: withIfMatch(options.headers, ifMatch),
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeBasePath(basePath: string): string {
+  const normalized = basePath.startsWith("/") ? basePath : `/${basePath}`;
+  return normalized.replace(/\/+$/, "");
+}
+
+function supported<T>(value: T): HonuaOperateResult<T> {
+  return { supported: true, value };
+}
+
+function unsupportedFromError<T>(capability: HonuaOperateCapability, error: unknown): HonuaOperateResult<T> {
+  if (error instanceof HonuaHttpError && (error.statusCode === 404 || error.statusCode === 501)) {
+    return unsupportedFromStatus(capability, error.statusCode, error.body);
+  }
+  throw error;
+}
+
+function unsupportedFromStatus<T>(
+  capability: HonuaOperateCapability,
+  statusCode: number,
+  body: unknown,
+): HonuaOperateResult<T> {
+  const problem = toProblemDetails(body);
+  return {
+    supported: false,
+    capability,
+    statusCode,
+    reason:
+      problem?.detail ?? problem?.title ?? `Operate capability "${capability}" is not available on this deployment.`,
+    ...(problem ? { problem } : {}),
+  };
+}
+
+function withListQuery(path: string, options: HonuaOperateListOptions): string {
+  const params = new URLSearchParams();
+  if (options.cursor) params.set("cursor", options.cursor);
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  if (options.targetId) params.set("targetId", options.targetId);
+  if (options.q) params.set("q", options.q);
+  if (options.since) params.set("since", options.since);
+  if (options.until) params.set("until", options.until);
+  const query = params.toString();
+  return query ? `${path}${path.includes("?") ? "&" : "?"}${query}` : path;
+}
+
+function jsonHeaders(headers: HeadersInit | undefined): HeadersInit {
+  return {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    ...headersToRecord(headers),
+  };
+}
+
+function listHeaders(options: HonuaOperateListOptions): HeadersInit {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    ...headersToRecord(options.headers),
+  };
+  if (options.validator?.etag) headers["If-None-Match"] = options.validator.etag;
+  if (options.validator?.lastModified) headers["If-Modified-Since"] = options.validator.lastModified;
+  return headers;
+}
+
+function withIfMatch(headers: HeadersInit | undefined, ifMatch: string | undefined): HeadersInit | undefined {
+  if (!ifMatch) return headers;
+  return { ...headersToRecord(headers), "If-Match": ifMatch };
+}
+
+function headersToRecord(headers: HeadersInit | undefined): Record<string, string> {
+  if (!headers) return {};
+  if (headers instanceof Headers) return Object.fromEntries(headers.entries());
+  if (Array.isArray(headers)) return Object.fromEntries(headers);
+  return { ...headers };
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return undefined;
+  return JSON.parse(text);
+}
+
+function normalizePage<T>(
+  body: unknown,
+  response: Response,
+  options: { readonly fallbackValidator?: HonuaOperateListOptions["validator"] } = {},
+): HonuaOperatePage<T> {
+  const value = isRecord(body) ? body : {};
+  const items = (Array.isArray(value.items) ? value.items : Array.isArray(value.data) ? value.data : []) as T[];
+  const pagination = isRecord(value.pagination) ? value.pagination : value;
+  const validator = honuaCacheValidatorFromHeaders(response.headers) ?? options.fallbackValidator;
+  const sourceUpdatedAt = response.headers.get("last-modified") ?? undefined;
+  return {
+    items,
+    pagination: {
+      nextCursor: stringValue(pagination.nextCursor ?? pagination.next),
+      previousCursor: stringValue(pagination.previousCursor ?? pagination.previous),
+      limit: numberValue(pagination.limit),
+      total: numberValue(pagination.total),
+    },
+    ...(validator ? { validator } : {}),
+    ...(sourceUpdatedAt ? { sourceUpdatedAt } : {}),
+  };
+}
+
+function toProblemDetails(body: unknown): HonuaProblemDetails | undefined {
+  if (!isRecord(body)) return undefined;
+  const candidate = isRecord(body.problem) ? body.problem : body;
+  return candidate as HonuaProblemDetails;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}

--- a/src/operate/index.ts
+++ b/src/operate/index.ts
@@ -1,0 +1,79 @@
+/**
+ * Experimental Operate observability client and contracts.
+ *
+ * Shared, protocol-neutral SDK surface for the Console / MCP / Studio "Operate"
+ * screens: server telemetry status, the event and log viewers, alerts and
+ * realtime alert rules, geofence zones, delivery channel bindings,
+ * investigations, and the job viewer (runs, stages, logs, artifacts).
+ *
+ * Designed so fixture data can drive Console Operate screens before live
+ * endpoints land. Missing providers (no OTLP, no logs, no realtime, no alert
+ * delivery, no job controls, no investigation store) degrade to typed
+ * {@link HonuaOperateUnsupported} results instead of empty data or thrown errors.
+ *
+ * @experimental This entrypoint is not yet covered by the SDK's semver contract
+ *   — the surface may change in any minor release prior to `1.0.0`.
+ * @module
+ */
+
+export {
+  HonuaAlertRulesClient,
+  HonuaAlertsClient,
+  HonuaEventsClient,
+  HonuaGeofencesClient,
+  HonuaInvestigationsClient,
+  HonuaJobsClient,
+  HonuaLogsClient,
+  HonuaOperateClient,
+  HonuaTelemetryClient,
+  createHonuaOperate,
+} from "./client.js";
+export type { HonuaOperateClientOptions } from "./client.js";
+export { HONUA_OPERATE_BASE_PATH } from "./types.js";
+export type {
+  HonuaAlert,
+  HonuaAlertAction,
+  HonuaAlertActionRequest,
+  HonuaAlertDeliveryStatus,
+  HonuaAlertRule,
+  HonuaAlertRuleKind,
+  HonuaAlertRuleTestResult,
+  HonuaAlertRuleWriteRequest,
+  HonuaAlertSeverity,
+  HonuaAlertStatus,
+  HonuaDeliveryChannelBinding,
+  HonuaGeofenceZone,
+  HonuaGeofenceZoneWriteRequest,
+  HonuaInvestigation,
+  HonuaInvestigationCreateRequest,
+  HonuaInvestigationPinRequest,
+  HonuaInvestigationTimelineEntry,
+  HonuaJobAction,
+  HonuaJobActionRequest,
+  HonuaJobArtifact,
+  HonuaJobLog,
+  HonuaJobRunDetail,
+  HonuaJobRunSummary,
+  HonuaJobStage,
+  HonuaJobState,
+  HonuaLogLevel,
+  HonuaLogRecord,
+  HonuaMetricSnapshot,
+  HonuaObservabilityTarget,
+  HonuaOperateCapability,
+  HonuaOperateEntityValidators,
+  HonuaOperateLinks,
+  HonuaOperateListOptions,
+  HonuaOperatePage,
+  HonuaOperateRawRequest,
+  HonuaOperateRequestOptions,
+  HonuaOperateResult,
+  HonuaOperateSuccess,
+  HonuaOperateUnsupported,
+  HonuaOperationalEvent,
+  HonuaOperationalEventSeverity,
+  HonuaProblemDetails,
+  HonuaServerTelemetryStatus,
+  HonuaTelemetryHealth,
+  HonuaTelemetryProviderStatus,
+} from "./types.js";

--- a/src/operate/types.ts
+++ b/src/operate/types.ts
@@ -1,0 +1,481 @@
+import type { HonuaCacheValidator } from "../core/cache-state.js";
+import type { QueryMethod } from "../core/types.js";
+
+/**
+ * Operate observability SDK contracts.
+ *
+ * Shared, protocol-neutral shapes for the Console / MCP / Studio "Operate"
+ * surfaces: server telemetry status, operational events, logs, alerts, realtime
+ * alert rules, geofence zones, delivery channel bindings, investigations, and the
+ * job viewer (runs, stages, logs, artifacts).
+ *
+ * These mirror honua-server#1168 / #1169 / #1170 and are designed so fixture data
+ * can drive Console Operate screens before live endpoints land. Capability gaps
+ * are represented as typed degraded results (see {@link HonuaOperateUnsupported})
+ * rather than thrown errors, and action availability is carried explicitly by the
+ * resource state/policy rather than inferred by the UI.
+ *
+ * @module
+ */
+
+export const HONUA_OPERATE_BASE_PATH = "/api/v1/operate" as const;
+
+/**
+ * Observability sub-capabilities a deployment may or may not provide.
+ * Absent providers are surfaced as {@link HonuaOperateUnsupported} so clients can
+ * disable the matching Console panel instead of rendering empty data.
+ */
+export type HonuaOperateCapability =
+  | "telemetry"
+  | "events"
+  | "logs"
+  | "metrics"
+  | "alerts"
+  | "alert-rules"
+  | "geofences"
+  | "delivery-channels"
+  | "investigations"
+  | "jobs"
+  | "raw";
+
+export interface HonuaProblemDetails {
+  readonly type?: string;
+  readonly title?: string;
+  readonly status?: number;
+  readonly detail?: string;
+  readonly instance?: string;
+  readonly code?: string;
+  readonly errors?: Record<string, readonly string[]>;
+  readonly [extra: string]: unknown;
+}
+
+export interface HonuaOperateUnsupported {
+  readonly supported: false;
+  readonly capability: HonuaOperateCapability;
+  readonly statusCode?: number;
+  readonly reason: string;
+  readonly problem?: HonuaProblemDetails;
+}
+
+export interface HonuaOperateSuccess<T> {
+  readonly supported: true;
+  readonly value: T;
+}
+
+export type HonuaOperateResult<T> = HonuaOperateSuccess<T> | HonuaOperateUnsupported;
+
+export interface HonuaOperateRequestOptions {
+  readonly signal?: AbortSignal;
+  readonly headers?: HeadersInit;
+}
+
+export interface HonuaOperateListOptions extends HonuaOperateRequestOptions {
+  readonly cursor?: string;
+  readonly limit?: number;
+  readonly targetId?: string;
+  readonly q?: string;
+  readonly since?: string;
+  readonly until?: string;
+  readonly refresh?: boolean;
+  readonly validator?: HonuaCacheValidator;
+}
+
+export interface HonuaOperatePage<T> {
+  readonly items: readonly T[];
+  readonly pagination: {
+    readonly nextCursor?: string;
+    readonly previousCursor?: string;
+    readonly limit?: number;
+    readonly total?: number;
+  };
+  readonly validator?: HonuaCacheValidator;
+  readonly sourceUpdatedAt?: string;
+}
+
+export interface HonuaOperateEntityValidators {
+  readonly etag?: string;
+  readonly lastModified?: string;
+}
+
+/** Hyperlinks attached to Operate resources for follow-on navigation. */
+export interface HonuaOperateLinks {
+  readonly self?: string;
+  readonly logs?: string;
+  readonly artifacts?: string;
+  readonly stages?: string;
+  readonly investigation?: string;
+  readonly alert?: string;
+  readonly rule?: string;
+  readonly [rel: string]: string | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Observability target + telemetry status
+// ---------------------------------------------------------------------------
+
+/** A monitored unit (server, deployment, region) the Operate surfaces report on. */
+export interface HonuaObservabilityTarget extends HonuaOperateEntityValidators {
+  readonly id: string;
+  readonly name: string;
+  readonly kind: "server" | "deployment" | "region" | "cluster" | (string & {});
+  readonly environment?: "production" | "staging" | "development" | (string & {});
+  readonly region?: string;
+  readonly labels?: Record<string, string>;
+  readonly links?: HonuaOperateLinks;
+  readonly [extra: string]: unknown;
+}
+
+export type HonuaTelemetryHealth = "healthy" | "degraded" | "unhealthy" | "unknown" | (string & {});
+
+/** Provider availability for a target. `enabled: false` means telemetry is off, not failing. */
+export interface HonuaTelemetryProviderStatus {
+  readonly id: string;
+  readonly kind: "otlp" | "logs" | "metrics" | "alerts" | "jobs" | (string & {});
+  readonly enabled: boolean;
+  readonly connected?: boolean;
+  readonly detail?: string;
+  readonly lastSeenAt?: string;
+}
+
+export interface HonuaServerTelemetryStatus extends HonuaOperateEntityValidators {
+  readonly targetId: string;
+  readonly health: HonuaTelemetryHealth;
+  /** True when an OTLP/telemetry pipeline is configured and active for the target. */
+  readonly telemetryEnabled: boolean;
+  readonly version?: string;
+  readonly uptimeSeconds?: number;
+  readonly startedAt?: string;
+  readonly observedAt?: string;
+  readonly providers?: readonly HonuaTelemetryProviderStatus[];
+  readonly metrics?: readonly HonuaMetricSnapshot[];
+  readonly message?: string;
+  readonly problem?: HonuaProblemDetails;
+  readonly [extra: string]: unknown;
+}
+
+export interface HonuaMetricSnapshot {
+  readonly name: string;
+  readonly value: number;
+  readonly unit?: string;
+  readonly observedAt?: string;
+  readonly labels?: Record<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// Operational events vs audit events
+// ---------------------------------------------------------------------------
+
+export type HonuaOperationalEventSeverity = "info" | "notice" | "warning" | "error" | "critical" | (string & {});
+
+/**
+ * An operational event in the event viewer. The {@link HonuaOperationalEvent.category}
+ * discriminates `audit` events from operational ones so the UI never conflates them.
+ */
+export interface HonuaOperationalEvent {
+  readonly id: string;
+  readonly targetId?: string;
+  readonly category: "operational" | "audit" | "security" | (string & {});
+  readonly type: string;
+  readonly severity: HonuaOperationalEventSeverity;
+  readonly summary: string;
+  readonly detail?: string;
+  readonly occurredAt: string;
+  readonly actor?: string;
+  readonly resource?: string;
+  readonly correlationId?: string;
+  readonly attributes?: Record<string, unknown>;
+  readonly links?: HonuaOperateLinks;
+}
+
+export type HonuaLogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal" | (string & {});
+
+/** A single structured log line. Distinct from {@link HonuaOperationalEvent} audit records. */
+export interface HonuaLogRecord {
+  readonly id: string;
+  readonly targetId?: string;
+  readonly level: HonuaLogLevel;
+  readonly message: string;
+  readonly timestamp: string;
+  readonly source?: string;
+  readonly traceId?: string;
+  readonly spanId?: string;
+  readonly jobId?: string;
+  readonly attributes?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Alerts
+// ---------------------------------------------------------------------------
+
+export type HonuaAlertSeverity = "info" | "warning" | "error" | "critical" | (string & {});
+export type HonuaAlertStatus = "firing" | "acknowledged" | "resolved" | "suppressed" | (string & {});
+
+/** Actions a viewer may take on an alert; presence reflects state + policy, not the UI's guess. */
+export type HonuaAlertAction = "acknowledge" | "resolve" | "suppress" | "unsuppress" | "escalate" | (string & {});
+
+export interface HonuaAlert extends HonuaOperateEntityValidators {
+  readonly id: string;
+  readonly targetId?: string;
+  readonly ruleId?: string;
+  readonly title: string;
+  readonly description?: string;
+  readonly severity: HonuaAlertSeverity;
+  readonly status: HonuaAlertStatus;
+  readonly firedAt: string;
+  readonly updatedAt?: string;
+  readonly resolvedAt?: string;
+  readonly acknowledgedAt?: string;
+  readonly acknowledgedBy?: string;
+  /** When `status === "suppressed"`, the reason/window the suppression was applied for. */
+  readonly suppression?: {
+    readonly reason?: string;
+    readonly until?: string;
+    readonly by?: string;
+  };
+  /** Outcome of the most recent delivery attempt across bound channels. */
+  readonly delivery?: HonuaAlertDeliveryStatus;
+  /** Actions currently permitted for this alert given its state and the caller's policy. */
+  readonly availableActions: readonly HonuaAlertAction[];
+  readonly labels?: Record<string, string>;
+  readonly links?: HonuaOperateLinks;
+  readonly [extra: string]: unknown;
+}
+
+export interface HonuaAlertDeliveryStatus {
+  readonly state: "pending" | "delivered" | "failed" | "not-configured" | (string & {});
+  readonly channelId?: string;
+  readonly attemptedAt?: string;
+  readonly error?: HonuaProblemDetails;
+}
+
+export interface HonuaAlertActionRequest {
+  readonly action: HonuaAlertAction;
+  readonly reason?: string;
+  /** For `suppress`: how long the suppression should last. */
+  readonly suppressUntil?: string;
+  readonly ifMatch?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Realtime alert rules + geofence zones + delivery channels
+// ---------------------------------------------------------------------------
+
+export type HonuaAlertRuleKind = "threshold" | "rate" | "absence" | "geofence" | (string & {});
+
+export interface HonuaAlertRule extends HonuaOperateEntityValidators {
+  readonly id: string;
+  readonly name: string;
+  readonly kind: HonuaAlertRuleKind;
+  readonly enabled: boolean;
+  readonly targetId?: string;
+  readonly description?: string;
+  readonly severity?: HonuaAlertSeverity;
+  /** True when the rule is evaluated against a live stream rather than batched. */
+  readonly realtime: boolean;
+  readonly expression?: string;
+  readonly geofenceZoneId?: string;
+  readonly windowSeconds?: number;
+  readonly threshold?: number;
+  /** Delivery channel bindings this rule fires through, with per-binding errors. */
+  readonly channelBindings?: readonly HonuaDeliveryChannelBinding[];
+  readonly createdAt?: string;
+  readonly updatedAt?: string;
+  readonly links?: HonuaOperateLinks;
+  readonly [extra: string]: unknown;
+}
+
+export interface HonuaAlertRuleWriteRequest {
+  readonly name: string;
+  readonly kind: HonuaAlertRuleKind;
+  readonly enabled?: boolean;
+  readonly targetId?: string;
+  readonly description?: string;
+  readonly severity?: HonuaAlertSeverity;
+  readonly realtime?: boolean;
+  readonly expression?: string;
+  readonly geofenceZoneId?: string;
+  readonly windowSeconds?: number;
+  readonly threshold?: number;
+  readonly channelIds?: readonly string[];
+  readonly ifMatch?: string;
+}
+
+/** Result of a dry-run rule evaluation; no alert is persisted. */
+export interface HonuaAlertRuleTestResult {
+  readonly matched: boolean;
+  readonly evaluatedAt: string;
+  readonly observedValue?: number;
+  readonly sampleEventIds?: readonly string[];
+  readonly message?: string;
+  readonly problem?: HonuaProblemDetails;
+}
+
+/** A polygon/circle geofence zone an alert rule of kind `geofence` references. */
+export interface HonuaGeofenceZone extends HonuaOperateEntityValidators {
+  readonly id: string;
+  readonly name: string;
+  readonly enabled: boolean;
+  readonly trigger: "enter" | "exit" | "dwell" | (string & {});
+  /** GeoJSON Polygon/MultiPolygon geometry, kept opaque to avoid a geometry dep here. */
+  readonly geometry: Record<string, unknown>;
+  readonly dwellSeconds?: number;
+  readonly description?: string;
+  readonly createdAt?: string;
+  readonly updatedAt?: string;
+  readonly links?: HonuaOperateLinks;
+  readonly [extra: string]: unknown;
+}
+
+export interface HonuaGeofenceZoneWriteRequest {
+  readonly name: string;
+  readonly enabled?: boolean;
+  readonly trigger: "enter" | "exit" | "dwell" | (string & {});
+  readonly geometry: Record<string, unknown>;
+  readonly dwellSeconds?: number;
+  readonly description?: string;
+  readonly ifMatch?: string;
+}
+
+/** Binding of an alert rule to a delivery channel, carrying the last delivery error if any. */
+export interface HonuaDeliveryChannelBinding {
+  readonly channelId: string;
+  readonly kind: "email" | "webhook" | "slack" | "pagerduty" | "sms" | (string & {});
+  readonly enabled: boolean;
+  readonly target?: string;
+  readonly lastDeliveryState?: HonuaAlertDeliveryStatus["state"];
+  readonly lastError?: HonuaProblemDetails;
+}
+
+// ---------------------------------------------------------------------------
+// Investigations
+// ---------------------------------------------------------------------------
+
+export interface HonuaInvestigation extends HonuaOperateEntityValidators {
+  readonly id: string;
+  readonly title: string;
+  readonly status: "open" | "investigating" | "resolved" | "closed" | (string & {});
+  readonly summary?: string;
+  readonly targetId?: string;
+  readonly createdAt: string;
+  readonly updatedAt?: string;
+  readonly createdBy?: string;
+  readonly pinnedItemIds?: readonly string[];
+  readonly timeline?: readonly HonuaInvestigationTimelineEntry[];
+  readonly links?: HonuaOperateLinks;
+  readonly [extra: string]: unknown;
+}
+
+export interface HonuaInvestigationTimelineEntry {
+  readonly id: string;
+  readonly kind: "note" | "event" | "alert" | "log" | "job" | (string & {});
+  readonly at: string;
+  readonly summary: string;
+  readonly refId?: string;
+  readonly pinned?: boolean;
+  readonly author?: string;
+}
+
+export interface HonuaInvestigationCreateRequest {
+  readonly title: string;
+  readonly summary?: string;
+  readonly targetId?: string;
+  readonly seedItemIds?: readonly string[];
+}
+
+export interface HonuaInvestigationPinRequest {
+  readonly itemId: string;
+  readonly pinned: boolean;
+  readonly ifMatch?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Job viewer
+// ---------------------------------------------------------------------------
+
+export type HonuaJobState = "queued" | "running" | "succeeded" | "failed" | "cancelled" | "retrying" | (string & {});
+
+/** Job lifecycle controls; availability is state/policy-driven, never inferred by the UI. */
+export type HonuaJobAction = "cancel" | "retry" | "rerun" | "pause" | "resume" | (string & {});
+
+export interface HonuaJobRunSummary extends HonuaOperateEntityValidators {
+  readonly id: string;
+  readonly name: string;
+  readonly type?: string;
+  readonly targetId?: string;
+  readonly state: HonuaJobState;
+  readonly queuedAt?: string;
+  readonly startedAt?: string;
+  readonly finishedAt?: string;
+  readonly durationMs?: number;
+  readonly attempt?: number;
+  readonly maxAttempts?: number;
+  readonly progress?: {
+    readonly completed?: number;
+    readonly total?: number;
+    readonly message?: string;
+  };
+  /** Actions currently permitted for this run given its state and the caller's policy. */
+  readonly availableActions: readonly HonuaJobAction[];
+  readonly problem?: HonuaProblemDetails;
+  readonly links?: HonuaOperateLinks;
+  readonly [extra: string]: unknown;
+}
+
+export interface HonuaJobRunDetail extends HonuaJobRunSummary {
+  readonly stages?: readonly HonuaJobStage[];
+  readonly artifacts?: readonly HonuaJobArtifact[];
+  readonly parameters?: Record<string, unknown>;
+  readonly triggeredBy?: string;
+  /** Id of the prior run this run retried, when `state === "retrying"` or after a retry. */
+  readonly retryOfRunId?: string;
+}
+
+export interface HonuaJobStage {
+  readonly id: string;
+  readonly name: string;
+  readonly state: HonuaJobState;
+  readonly startedAt?: string;
+  readonly finishedAt?: string;
+  readonly durationMs?: number;
+  readonly message?: string;
+  readonly problem?: HonuaProblemDetails;
+}
+
+export interface HonuaJobLog {
+  readonly id: string;
+  readonly jobId: string;
+  readonly stageId?: string;
+  readonly level: HonuaLogLevel;
+  readonly message: string;
+  readonly timestamp: string;
+  readonly attributes?: Record<string, unknown>;
+}
+
+export interface HonuaJobArtifact {
+  readonly id: string;
+  readonly jobId: string;
+  readonly name: string;
+  readonly contentType?: string;
+  readonly sizeBytes?: number;
+  readonly createdAt?: string;
+  readonly href?: string;
+  readonly checksum?: string;
+  readonly metadata?: Record<string, unknown>;
+}
+
+export interface HonuaJobActionRequest {
+  readonly action: HonuaJobAction;
+  readonly reason?: string;
+  readonly ifMatch?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Raw escape hatch
+// ---------------------------------------------------------------------------
+
+export interface HonuaOperateRawRequest extends HonuaOperateRequestOptions {
+  readonly method?: QueryMethod;
+  readonly path: string;
+  readonly body?: unknown;
+  readonly okStatuses?: readonly number[];
+}

--- a/test/fixtures/operate/README.md
+++ b/test/fixtures/operate/README.md
@@ -1,0 +1,40 @@
+# Operate Observability Contract Fixtures
+
+These fixtures document the experimental `/api/v1/operate` SDK contract for the
+Console / MCP / Studio "Operate" surfaces (server telemetry, event/log viewers,
+alerts and realtime alert rules, geofences, delivery channels, investigations,
+and the job viewer). They let Console Operate screens be built and tested before
+live endpoints land. Each file is a `{ request, response }` pair keyed by
+`schemaVersion`.
+
+Telemetry status:
+
+- `telemetry-status-healthy.v1.json` — healthy server with OTLP/logs/alerts providers and metrics, plus `ETag`/`Last-Modified` validators.
+- `telemetry-status-degraded.v1.json` — degraded health with a disconnected metrics provider.
+- `telemetry-disabled.v1.json` — `telemetryEnabled: false` (no OTLP pipeline configured); distinct from a failing target.
+
+Alerts and rules:
+
+- `alert-critical-active.v1.json` — firing critical alert page with explicit `availableActions` (action availability is state/policy-driven, not inferred).
+- `alert-suppressed.v1.json` — suppressed alert carrying the suppression reason/window and reduced action set.
+- `alert-rule-geofence.v1.json` — realtime geofence alert rule referencing a geofence zone and a Slack channel binding.
+- `delivery-failure.v1.json` — realtime rate rule whose webhook channel binding reports an explicit `lastError` delivery-channel error.
+
+Job viewer:
+
+- `job-running.v1.json` — running job with stages and progress; only `cancel` is available.
+- `job-failed.v1.json` — failed job with a stage-level problem; `retry`/`rerun` available.
+- `job-retried.v1.json` — retry run (`state: retrying`) linked to the prior run via `retryOfRunId`.
+- `job-artifacts.v1.json` — artifact listing page for an artifact-producing job.
+
+Investigations:
+
+- `investigation-timeline.v1.json` — investigation with a pinned alert and a mixed (alert/note/job) timeline.
+
+Capability gaps (typed degraded results, not empty data):
+
+- `unsupported-logs.v1.json` — `501` when no log store is configured.
+- `unsupported-investigations.v1.json` — `404` when no investigation store is provisioned.
+
+Operational events/logs distinguish audit records from operational ones via the
+event `category` field; secret-bearing values must never appear in fixtures.

--- a/test/fixtures/operate/alert-critical-active.v1.json
+++ b/test/fixtures/operate/alert-critical-active.v1.json
@@ -1,0 +1,34 @@
+{
+  "schemaVersion": 1,
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/operate/alerts?limit=2&targetId=server-prod"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "etag": "\"alerts-v1\"",
+      "last-modified": "Thu, 28 May 2026 09:05:00 GMT"
+    },
+    "body": {
+      "items": [
+        {
+          "id": "alert-cpu-001",
+          "targetId": "server-prod",
+          "ruleId": "rule-cpu-sat",
+          "title": "CPU saturation on server-prod",
+          "description": "CPU usage above 95% for 5 minutes.",
+          "severity": "critical",
+          "status": "firing",
+          "firedAt": "2026-05-28T09:00:00Z",
+          "updatedAt": "2026-05-28T09:05:00Z",
+          "delivery": { "state": "delivered", "channelId": "chan-pagerduty", "attemptedAt": "2026-05-28T09:00:05Z" },
+          "availableActions": ["acknowledge", "resolve", "suppress", "escalate"],
+          "labels": { "service": "tiles", "region": "us-east" },
+          "links": { "self": "/api/v1/operate/alerts/alert-cpu-001", "rule": "/api/v1/operate/alert-rules/rule-cpu-sat" }
+        }
+      ],
+      "pagination": { "nextCursor": "cursor-alerts-2", "limit": 2, "total": 1 }
+    }
+  }
+}

--- a/test/fixtures/operate/alert-rule-geofence.v1.json
+++ b/test/fixtures/operate/alert-rule-geofence.v1.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": 1,
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/operate/alert-rules/rule-fleet-geofence"
+  },
+  "response": {
+    "status": 200,
+    "headers": { "etag": "\"rule-fleet-geofence-v2\"" },
+    "body": {
+      "id": "rule-fleet-geofence",
+      "name": "Fleet left service area",
+      "kind": "geofence",
+      "enabled": true,
+      "targetId": "server-prod",
+      "description": "Fire when a tracked asset exits the service-area zone.",
+      "severity": "warning",
+      "realtime": true,
+      "geofenceZoneId": "zone-service-area",
+      "channelBindings": [
+        { "channelId": "chan-slack-ops", "kind": "slack", "enabled": true, "target": "#ops-alerts", "lastDeliveryState": "delivered" }
+      ],
+      "createdAt": "2026-05-01T00:00:00Z",
+      "updatedAt": "2026-05-20T12:00:00Z",
+      "links": { "self": "/api/v1/operate/alert-rules/rule-fleet-geofence" }
+    }
+  }
+}

--- a/test/fixtures/operate/alert-suppressed.v1.json
+++ b/test/fixtures/operate/alert-suppressed.v1.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": 1,
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/operate/alerts/alert-disk-014"
+  },
+  "response": {
+    "status": 200,
+    "headers": { "etag": "\"alert-disk-014-v3\"" },
+    "body": {
+      "id": "alert-disk-014",
+      "targetId": "server-eu",
+      "ruleId": "rule-disk-low",
+      "title": "Disk space low on server-eu",
+      "severity": "warning",
+      "status": "suppressed",
+      "firedAt": "2026-05-28T06:00:00Z",
+      "updatedAt": "2026-05-28T08:30:00Z",
+      "suppression": {
+        "reason": "Planned storage expansion in progress.",
+        "until": "2026-05-28T18:00:00Z",
+        "by": "ops@honua.io"
+      },
+      "delivery": { "state": "delivered", "channelId": "chan-email" },
+      "availableActions": ["unsuppress", "resolve"],
+      "links": { "self": "/api/v1/operate/alerts/alert-disk-014" }
+    }
+  }
+}

--- a/test/fixtures/operate/delivery-failure.v1.json
+++ b/test/fixtures/operate/delivery-failure.v1.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/operate/alert-rules/rule-webhook-prod"
+  },
+  "response": {
+    "status": 200,
+    "body": {
+      "id": "rule-webhook-prod",
+      "name": "Production error spike",
+      "kind": "rate",
+      "enabled": true,
+      "targetId": "server-prod",
+      "severity": "error",
+      "realtime": true,
+      "expression": "error_rate > 0.05",
+      "windowSeconds": 300,
+      "threshold": 0.05,
+      "channelBindings": [
+        {
+          "channelId": "chan-webhook-pd",
+          "kind": "webhook",
+          "enabled": true,
+          "target": "https://hooks.example.test/honua",
+          "lastDeliveryState": "failed",
+          "lastError": {
+            "title": "Delivery failed",
+            "status": 502,
+            "detail": "Webhook endpoint returned 502 Bad Gateway.",
+            "code": "delivery_channel_error"
+          }
+        }
+      ],
+      "links": { "self": "/api/v1/operate/alert-rules/rule-webhook-prod" }
+    }
+  }
+}

--- a/test/fixtures/operate/investigation-timeline.v1.json
+++ b/test/fixtures/operate/investigation-timeline.v1.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": 1,
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/operate/investigations/inv-outage-42"
+  },
+  "response": {
+    "status": 200,
+    "headers": { "etag": "\"inv-42-v5\"" },
+    "body": {
+      "id": "inv-outage-42",
+      "title": "Tile service outage 2026-05-28",
+      "status": "investigating",
+      "summary": "Investigating elevated 5xx on the tile service starting 09:00Z.",
+      "targetId": "server-prod",
+      "createdAt": "2026-05-28T09:06:00Z",
+      "updatedAt": "2026-05-28T09:20:00Z",
+      "createdBy": "ops@honua.io",
+      "pinnedItemIds": ["alert-cpu-001"],
+      "timeline": [
+        { "id": "tl-1", "kind": "alert", "at": "2026-05-28T09:00:00Z", "summary": "CPU saturation alert fired", "refId": "alert-cpu-001", "pinned": true },
+        { "id": "tl-2", "kind": "note", "at": "2026-05-28T09:08:00Z", "summary": "Scaled tile workers from 4 to 8", "author": "ops@honua.io" },
+        { "id": "tl-3", "kind": "job", "at": "2026-05-28T09:12:00Z", "summary": "Tile bake retried", "refId": "job-tile-bake-101" }
+      ],
+      "links": { "self": "/api/v1/operate/investigations/inv-outage-42" }
+    }
+  }
+}

--- a/test/fixtures/operate/job-artifacts.v1.json
+++ b/test/fixtures/operate/job-artifacts.v1.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/operate/jobs/job-export-300/artifacts"
+  },
+  "response": {
+    "status": 200,
+    "headers": { "etag": "\"job-300-artifacts-v1\"" },
+    "body": {
+      "items": [
+        {
+          "id": "artifact-export-geojson",
+          "jobId": "job-export-300",
+          "name": "parcels-export.geojson",
+          "contentType": "application/geo+json",
+          "sizeBytes": 4823211,
+          "createdAt": "2026-05-28T08:10:00Z",
+          "href": "/api/v1/operate/jobs/job-export-300/artifacts/artifact-export-geojson",
+          "checksum": "sha256:5b3f...e1a9"
+        },
+        {
+          "id": "artifact-export-report",
+          "jobId": "job-export-300",
+          "name": "export-report.json",
+          "contentType": "application/json",
+          "sizeBytes": 1842,
+          "createdAt": "2026-05-28T08:10:01Z",
+          "href": "/api/v1/operate/jobs/job-export-300/artifacts/artifact-export-report"
+        }
+      ],
+      "pagination": { "limit": 50, "total": 2 }
+    }
+  }
+}

--- a/test/fixtures/operate/job-failed.v1.json
+++ b/test/fixtures/operate/job-failed.v1.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/operate/jobs/job-import-200"
+  },
+  "response": {
+    "status": 200,
+    "body": {
+      "id": "job-import-200",
+      "name": "Import: parcels-2026",
+      "type": "import",
+      "targetId": "server-prod",
+      "state": "failed",
+      "queuedAt": "2026-05-28T07:00:00Z",
+      "startedAt": "2026-05-28T07:00:05Z",
+      "finishedAt": "2026-05-28T07:04:12Z",
+      "durationMs": 247000,
+      "attempt": 1,
+      "maxAttempts": 3,
+      "availableActions": ["retry", "rerun"],
+      "problem": {
+        "title": "Import failed",
+        "status": 422,
+        "detail": "Row 8821 has an invalid geometry (self-intersection).",
+        "code": "invalid_geometry"
+      },
+      "stages": [
+        { "id": "fetch", "name": "Fetch", "state": "succeeded", "durationMs": 12000 },
+        { "id": "validate", "name": "Validate", "state": "failed", "durationMs": 235000, "message": "Invalid geometry at row 8821", "problem": { "code": "invalid_geometry", "status": 422 } }
+      ],
+      "links": { "self": "/api/v1/operate/jobs/job-import-200", "logs": "/api/v1/operate/jobs/job-import-200/logs" }
+    }
+  }
+}

--- a/test/fixtures/operate/job-retried.v1.json
+++ b/test/fixtures/operate/job-retried.v1.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/operate/jobs/job-import-201"
+  },
+  "response": {
+    "status": 200,
+    "body": {
+      "id": "job-import-201",
+      "name": "Import: parcels-2026",
+      "type": "import",
+      "targetId": "server-prod",
+      "state": "retrying",
+      "queuedAt": "2026-05-28T07:05:00Z",
+      "startedAt": "2026-05-28T07:05:05Z",
+      "attempt": 2,
+      "maxAttempts": 3,
+      "retryOfRunId": "job-import-200",
+      "progress": { "completed": 8821, "total": 50000, "message": "Re-validating from last good row" },
+      "availableActions": ["cancel"],
+      "links": { "self": "/api/v1/operate/jobs/job-import-201" }
+    }
+  }
+}

--- a/test/fixtures/operate/job-running.v1.json
+++ b/test/fixtures/operate/job-running.v1.json
@@ -1,0 +1,34 @@
+{
+  "schemaVersion": 1,
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/operate/jobs/job-tile-bake-101"
+  },
+  "response": {
+    "status": 200,
+    "headers": { "etag": "\"job-101-v4\"" },
+    "body": {
+      "id": "job-tile-bake-101",
+      "name": "Tile bake: basemap-eu",
+      "type": "tile-bake",
+      "targetId": "server-prod",
+      "state": "running",
+      "queuedAt": "2026-05-28T09:00:00Z",
+      "startedAt": "2026-05-28T09:00:10Z",
+      "attempt": 1,
+      "maxAttempts": 3,
+      "progress": { "completed": 6400, "total": 16384, "message": "Baking zoom 12" },
+      "availableActions": ["cancel"],
+      "triggeredBy": "scheduler",
+      "stages": [
+        { "id": "plan", "name": "Plan", "state": "succeeded", "startedAt": "2026-05-28T09:00:10Z", "finishedAt": "2026-05-28T09:00:20Z", "durationMs": 10000 },
+        { "id": "bake", "name": "Bake", "state": "running", "startedAt": "2026-05-28T09:00:20Z" }
+      ],
+      "links": {
+        "self": "/api/v1/operate/jobs/job-tile-bake-101",
+        "logs": "/api/v1/operate/jobs/job-tile-bake-101/logs",
+        "artifacts": "/api/v1/operate/jobs/job-tile-bake-101/artifacts"
+      }
+    }
+  }
+}

--- a/test/fixtures/operate/telemetry-disabled.v1.json
+++ b/test/fixtures/operate/telemetry-disabled.v1.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": 1,
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/operate/targets/server-edge/telemetry"
+  },
+  "response": {
+    "status": 200,
+    "body": {
+      "targetId": "server-edge",
+      "health": "unknown",
+      "telemetryEnabled": false,
+      "observedAt": "2026-05-28T09:02:00Z",
+      "message": "No OTLP pipeline is configured for this target.",
+      "providers": [{ "id": "otlp", "kind": "otlp", "enabled": false }]
+    }
+  }
+}

--- a/test/fixtures/operate/telemetry-status-degraded.v1.json
+++ b/test/fixtures/operate/telemetry-status-degraded.v1.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": 1,
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/operate/targets/server-eu/telemetry"
+  },
+  "response": {
+    "status": 200,
+    "body": {
+      "targetId": "server-eu",
+      "health": "degraded",
+      "telemetryEnabled": true,
+      "version": "2026.5.1",
+      "observedAt": "2026-05-28T09:01:00Z",
+      "message": "Metrics provider is reporting elevated error rate.",
+      "providers": [
+        { "id": "otlp", "kind": "otlp", "enabled": true, "connected": true },
+        { "id": "metrics", "kind": "metrics", "enabled": true, "connected": false, "detail": "scrape timeout" }
+      ],
+      "metrics": [{ "name": "error_rate", "value": 0.087, "unit": "ratio", "observedAt": "2026-05-28T09:01:00Z" }]
+    }
+  }
+}

--- a/test/fixtures/operate/telemetry-status-healthy.v1.json
+++ b/test/fixtures/operate/telemetry-status-healthy.v1.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": 1,
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/operate/targets/server-prod/telemetry"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "etag": "\"telemetry-prod-v1\"",
+      "last-modified": "Thu, 28 May 2026 09:00:00 GMT"
+    },
+    "body": {
+      "targetId": "server-prod",
+      "health": "healthy",
+      "telemetryEnabled": true,
+      "version": "2026.5.1",
+      "uptimeSeconds": 864000,
+      "startedAt": "2026-05-18T09:00:00Z",
+      "observedAt": "2026-05-28T09:00:00Z",
+      "providers": [
+        { "id": "otlp", "kind": "otlp", "enabled": true, "connected": true, "lastSeenAt": "2026-05-28T08:59:55Z" },
+        { "id": "logs", "kind": "logs", "enabled": true, "connected": true },
+        { "id": "alerts", "kind": "alerts", "enabled": true, "connected": true }
+      ],
+      "metrics": [
+        { "name": "request_rate", "value": 412.5, "unit": "rps", "observedAt": "2026-05-28T09:00:00Z" },
+        { "name": "error_rate", "value": 0.002, "unit": "ratio", "observedAt": "2026-05-28T09:00:00Z" }
+      ]
+    }
+  }
+}

--- a/test/fixtures/operate/unsupported-investigations.v1.json
+++ b/test/fixtures/operate/unsupported-investigations.v1.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "request": {
+    "method": "POST",
+    "path": "/api/v1/operate/investigations"
+  },
+  "response": {
+    "status": 404,
+    "body": {
+      "title": "Investigation store not available",
+      "status": 404,
+      "detail": "No investigation store is provisioned for this deployment.",
+      "code": "capability_unavailable"
+    }
+  }
+}

--- a/test/fixtures/operate/unsupported-logs.v1.json
+++ b/test/fixtures/operate/unsupported-logs.v1.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/operate/logs"
+  },
+  "response": {
+    "status": 501,
+    "body": {
+      "title": "Logs provider not configured",
+      "status": 501,
+      "detail": "This deployment has no log store configured.",
+      "code": "capability_unavailable"
+    }
+  }
+}

--- a/test/operate.test.ts
+++ b/test/operate.test.ts
@@ -1,0 +1,225 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { HonuaClient } from "../src/index.js";
+import { HONUA_OPERATE_BASE_PATH, HonuaOperateClient, createHonuaOperate } from "../src/operate/index.js";
+
+const fixturesDir = resolve(dirname(fileURLToPath(import.meta.url)), "fixtures/operate");
+
+interface Fixture {
+  request: { method: string; path: string; headers?: Record<string, string>; body?: unknown };
+  response: { status: number; headers?: Record<string, string>; body?: unknown };
+}
+
+function fixture(name: string): Fixture {
+  return JSON.parse(readFileSync(resolve(fixturesDir, name), "utf8"));
+}
+
+function clientForFixture(contract: Fixture, capture?: Array<{ method: string; path: string }>): HonuaOperateClient {
+  return createHonuaOperate({
+    client: new HonuaClient({
+      baseUrl: "https://example.test",
+      fetchFn: async (input, init) => {
+        const url = new URL(String(input));
+        capture?.push({ method: String(init?.method ?? "GET"), path: `${url.pathname}${url.search}` });
+        const body = contract.response.body === undefined ? null : JSON.stringify(contract.response.body);
+        return new Response(body, { status: contract.response.status, headers: contract.response.headers });
+      },
+    }),
+  });
+}
+
+describe("operate observability client", () => {
+  it("exports the experimental subpath constants and factory", () => {
+    expect(HONUA_OPERATE_BASE_PATH).toBe("/api/v1/operate");
+    expect(createHonuaOperate).toBeTypeOf("function");
+    expect(HonuaOperateClient).toBeTypeOf("function");
+  });
+
+  it("reads healthy server telemetry status with validators", async () => {
+    const contract = fixture("telemetry-status-healthy.v1.json");
+    const requests: Array<{ method: string; path: string }> = [];
+    const operate = clientForFixture(contract, requests);
+
+    const result = await operate.telemetry.status("server-prod");
+
+    expect(requests[0]).toEqual({ method: "GET", path: contract.request.path });
+    expect(result.supported).toBe(true);
+    if (!result.supported) return;
+    expect(result.value.health).toBe("healthy");
+    expect(result.value.telemetryEnabled).toBe(true);
+    expect(result.value.providers?.some((provider) => provider.kind === "otlp" && provider.connected)).toBe(true);
+  });
+
+  it("represents disabled telemetry distinctly from a failing target", async () => {
+    const contract = fixture("telemetry-disabled.v1.json");
+    const operate = clientForFixture(contract);
+
+    const result = await operate.telemetry.status("server-edge");
+
+    expect(result.supported).toBe(true);
+    if (!result.supported) return;
+    expect(result.value.telemetryEnabled).toBe(false);
+    expect(result.value.health).toBe("unknown");
+  });
+
+  it("queries alerts and exposes state-driven available actions", async () => {
+    const contract = fixture("alert-critical-active.v1.json");
+    const requests: Array<{ method: string; path: string }> = [];
+    const operate = clientForFixture(contract, requests);
+
+    const result = await operate.alerts.query({ limit: 2, targetId: "server-prod" });
+
+    expect(requests[0]?.path).toBe(contract.request.path);
+    expect(result.supported).toBe(true);
+    if (!result.supported) return;
+    const alert = result.value.items[0];
+    expect(alert?.severity).toBe("critical");
+    expect(alert?.status).toBe("firing");
+    expect(alert?.availableActions).toContain("acknowledge");
+    expect(alert?.availableActions).not.toContain("unsuppress");
+    expect(result.value.validator?.etag).toBe('"alerts-v1"');
+  });
+
+  it("carries suppression metadata and a reduced action set for suppressed alerts", async () => {
+    const contract = fixture("alert-suppressed.v1.json");
+    const operate = clientForFixture(contract);
+
+    const result = await operate.alerts.get("alert-disk-014");
+
+    expect(result.supported).toBe(true);
+    if (!result.supported) return;
+    expect(result.value.status).toBe("suppressed");
+    expect(result.value.suppression?.until).toBe("2026-05-28T18:00:00Z");
+    expect(result.value.availableActions).toContain("unsuppress");
+    expect(result.value.availableActions).not.toContain("suppress");
+  });
+
+  it("sends If-Match when acting on an alert", async () => {
+    const headers: Array<Headers> = [];
+    const operate = createHonuaOperate({
+      client: new HonuaClient({
+        baseUrl: "https://example.test",
+        fetchFn: async (_input, init) => {
+          headers.push(new Headers(init?.headers));
+          return new Response(JSON.stringify({ id: "alert-cpu-001", status: "acknowledged", availableActions: [] }), {
+            status: 200,
+          });
+        },
+      }),
+    });
+
+    const result = await operate.alerts.act("alert-cpu-001", { action: "acknowledge", ifMatch: '"alert-v9"' });
+
+    expect(headers[0]?.get("If-Match")).toBe('"alert-v9"');
+    expect(result.supported).toBe(true);
+  });
+
+  it("exposes realtime geofence alert rules with channel bindings", async () => {
+    const contract = fixture("alert-rule-geofence.v1.json");
+    const operate = clientForFixture(contract);
+
+    const result = await operate.alertRules.get("rule-fleet-geofence");
+
+    expect(result.supported).toBe(true);
+    if (!result.supported) return;
+    expect(result.value.kind).toBe("geofence");
+    expect(result.value.realtime).toBe(true);
+    expect(result.value.geofenceZoneId).toBe("zone-service-area");
+  });
+
+  it("surfaces explicit delivery-channel errors on rule bindings", async () => {
+    const contract = fixture("delivery-failure.v1.json");
+    const operate = clientForFixture(contract);
+
+    const result = await operate.alertRules.get("rule-webhook-prod");
+
+    expect(result.supported).toBe(true);
+    if (!result.supported) return;
+    const binding = result.value.channelBindings?.[0];
+    expect(binding?.lastDeliveryState).toBe("failed");
+    expect(binding?.lastError?.status).toBe(502);
+    expect(binding?.lastError?.code).toBe("delivery_channel_error");
+  });
+
+  it("reads job detail with stages and state-driven actions", async () => {
+    const contract = fixture("job-running.v1.json");
+    const operate = clientForFixture(contract);
+
+    const result = await operate.jobs.get("job-tile-bake-101");
+
+    expect(result.supported).toBe(true);
+    if (!result.supported) return;
+    expect(result.value.state).toBe("running");
+    expect(result.value.availableActions).toEqual(["cancel"]);
+    expect(result.value.stages?.find((s) => s.id === "bake")?.state).toBe("running");
+  });
+
+  it("links a retried job back to its prior run", async () => {
+    const contract = fixture("job-retried.v1.json");
+    const operate = clientForFixture(contract);
+
+    const result = await operate.jobs.get("job-import-201");
+
+    expect(result.supported).toBe(true);
+    if (!result.supported) return;
+    expect(result.value.state).toBe("retrying");
+    expect(result.value.retryOfRunId).toBe("job-import-200");
+  });
+
+  it("lists artifacts for an artifact-producing job", async () => {
+    const contract = fixture("job-artifacts.v1.json");
+    const requests: Array<{ method: string; path: string }> = [];
+    const operate = clientForFixture(contract, requests);
+
+    const result = await operate.jobs.artifacts("job-export-300");
+
+    expect(requests[0]?.path).toBe(contract.request.path);
+    expect(result.supported).toBe(true);
+    if (!result.supported) return;
+    expect(result.value.items).toHaveLength(2);
+    expect(result.value.items[0]?.contentType).toBe("application/geo+json");
+  });
+
+  it("reads an investigation timeline with pinned items", async () => {
+    const contract = fixture("investigation-timeline.v1.json");
+    const operate = clientForFixture(contract);
+
+    const result = await operate.investigations.get("inv-outage-42");
+
+    expect(result.supported).toBe(true);
+    if (!result.supported) return;
+    expect(result.value.pinnedItemIds).toContain("alert-cpu-001");
+    expect(result.value.timeline?.[0]?.kind).toBe("alert");
+    expect(result.value.timeline?.[0]?.pinned).toBe(true);
+  });
+
+  it("degrades to a typed unsupported result when logs are not configured (501)", async () => {
+    const contract = fixture("unsupported-logs.v1.json");
+    const operate = clientForFixture(contract);
+
+    const result = await operate.logs.query();
+
+    expect(result.supported).toBe(false);
+    if (result.supported) return;
+    expect(result.capability).toBe("logs");
+    expect(result.statusCode).toBe(501);
+    expect(result.reason).toContain("no log store");
+  });
+
+  it("degrades to a typed unsupported result when investigations are not provisioned (404)", async () => {
+    const contract = fixture("unsupported-investigations.v1.json");
+    const operate = clientForFixture(contract);
+
+    const result = await operate.investigations.create({ title: "New investigation" });
+
+    expect(result.supported).toBe(false);
+    if (result.supported) return;
+    expect(result.capability).toBe("investigations");
+    expect(result.statusCode).toBe(404);
+    expect(result.problem?.code).toBe("capability_unavailable");
+  });
+});


### PR DESCRIPTION
## What

Adds an experimental `@honua/sdk-js/operate` subpath with shared, protocol-neutral SDK contracts for the Console / MCP / Studio "Operate" observability surfaces, mirroring honua-server#1168 / #1169 / #1170. The goal is that fixture data can drive Console Operate screens before live endpoints land.

### Types (`src/operate/types.ts`)
Observability target, server telemetry status (with provider statuses + metric snapshots), operational events (explicitly distinguished from audit events via `category`), log records, alerts, realtime alert rules, geofence zones, delivery channel bindings, investigations + timeline, and the job viewer (run summary/detail, stage, log, artifact). Typed degraded-result model (`HonuaOperateResult` / `HonuaOperateUnsupported`) and a `HonuaOperateCapability` union.

### Client (`src/operate/client.ts`)
`HonuaOperateClient` (factory `createHonuaOperate`) following the existing `control-plane` client pattern, with sub-clients for:
- `telemetry` — list targets, status
- `events` / `logs` — query
- `alerts` — query, get, act (acknowledge/resolve/suppress/...)
- `alertRules` — list/get/create/update/delete/test
- `geofences` — list/get/create/update/delete
- `investigations` — list/get/create/pin
- `jobs` — query/get/logs/artifacts/act (cancel/retry/...)

Optimistic concurrency via `If-Match`, cursor pagination with `ETag`/`Last-Modified` validators, and a `raw` escape hatch.

### Behavior the acceptance criteria call for
- Capability gaps (no OTLP, no logs, no realtime, no alert delivery, no job controls, no investigation store) degrade to typed `HonuaOperateUnsupported` results (HTTP 404/501) rather than empty data or thrown errors.
- Action availability is carried explicitly by resource state + policy (`availableActions` on alerts and jobs), not inferred by the UI.
- Realtime alert-rule capability (`realtime`) and delivery-channel errors (`lastError` on bindings, `delivery` on alerts) are explicit.
- Operational events vs audit events are distinguished by `category`.

### Fixtures (`test/fixtures/operate/`)
Healthy/degraded/disabled telemetry, active critical alert, suppressed alert, geofence alert rule, delivery failure, running/failed/retried/artifact-producing jobs, investigation timeline, and unsupported-capability (404/501) responses. Plus a README documenting each.

## Scope

First slice of an XL contract issue, but self-contained: it delivers the full contract surface (types + client + fixtures + capability flags) named in the issue Scope. Server implementation, Console UI, and external provider SDKs remain out of scope (as the issue states).

## Testing

- `npm run typecheck` — green
- `npm run check` (Biome) — green
- `test/operate.test.ts` (14 cases via Vitest) — green
- `npm run verify:split-packages` — green (new `./operate` subpath ships in `@honua/sdk`)

Refs #229