### PR TITLE
Add disconnected replica and sync conflict SDK contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,10 @@
       "types": "./dist/src/console/index.d.ts",
       "default": "./dist/src/console/index.js"
     },
+    "./replica-sync": {
+      "types": "./dist/src/replica-sync/index.d.ts",
+      "default": "./dist/src/replica-sync/index.js"
+    },
     "./exploration": {
       "types": "./dist/src/exploration/index.d.ts",
       "default": "./dist/src/exploration/index.js"

--- a/src/replica-sync/client.ts
+++ b/src/replica-sync/client.ts
@@ -1,0 +1,96 @@
+/**
+ * Disconnected replica and sync-conflict client.
+ *
+ * The client is a thin, ergonomic wrapper over a {@link ReplicaSyncTransport}.
+ * It centralizes validation (e.g. rejecting a `merge` resolution that omits
+ * merged attributes) so every consuming surface — Console, MCP, QGIS, Studio —
+ * gets the same guarantees regardless of the transport behind it.
+ *
+ * @module
+ */
+
+import { HonuaReplicaSyncError } from "./errors.js";
+import type {
+  BatchConflictResolutionResult,
+  DisconnectedReplica,
+  ListConflictsRequest,
+  ListReplicasRequest,
+  ReplicaId,
+  ReplicaSyncCapabilities,
+  ReplicaSyncTransport,
+  SyncConflictDetail,
+  SyncConflictId,
+  SyncConflictResolution,
+  SyncConflictResolutionRecord,
+  SyncConflictSummary,
+  SyncPage,
+} from "./types.js";
+
+export interface HonuaReplicaSyncClientOptions {
+  readonly transport: ReplicaSyncTransport;
+}
+
+export function createHonuaReplicaSync(options: HonuaReplicaSyncClientOptions): HonuaReplicaSyncClient {
+  return new HonuaReplicaSyncClient(options);
+}
+
+export class HonuaReplicaSyncClient {
+  readonly #transport: ReplicaSyncTransport;
+
+  public constructor(options: HonuaReplicaSyncClientOptions) {
+    this.#transport = options.transport;
+  }
+
+  /** Discover replica/sync capabilities for a dataset (or one of its sources). */
+  public capabilities(datasetId: string, sourceId?: string): Promise<ReplicaSyncCapabilities> {
+    return this.#transport.capabilities(datasetId, sourceId);
+  }
+
+  public listReplicas(request: ListReplicasRequest = {}): Promise<SyncPage<DisconnectedReplica>> {
+    return this.#transport.listReplicas(request);
+  }
+
+  public getReplica(
+    replicaId: ReplicaId,
+    options: { readonly signal?: AbortSignal } = {},
+  ): Promise<DisconnectedReplica> {
+    return this.#transport.getReplica(replicaId, options);
+  }
+
+  public listConflicts(request: ListConflictsRequest = {}): Promise<SyncPage<SyncConflictSummary>> {
+    return this.#transport.listConflicts(request);
+  }
+
+  public getConflict(
+    conflictId: SyncConflictId,
+    options: { readonly signal?: AbortSignal } = {},
+  ): Promise<SyncConflictDetail> {
+    return this.#transport.getConflict(conflictId, options);
+  }
+
+  public async resolveConflict(resolution: SyncConflictResolution): Promise<SyncConflictResolutionRecord> {
+    assertResolutionWellFormed(resolution);
+    return this.#transport.resolveConflict(resolution);
+  }
+
+  public async resolveConflicts(
+    resolutions: ReadonlyArray<SyncConflictResolution>,
+  ): Promise<BatchConflictResolutionResult> {
+    for (const resolution of resolutions) assertResolutionWellFormed(resolution);
+    return this.#transport.resolveConflicts(resolutions);
+  }
+}
+
+function assertResolutionWellFormed(resolution: SyncConflictResolution): void {
+  if (
+    resolution.choice === "merge" &&
+    resolution.mergedAttributes === undefined &&
+    resolution.mergedGeometry === undefined
+  ) {
+    throw new HonuaReplicaSyncError(
+      "merge-required",
+      "A merge resolution must supply mergedAttributes and/or mergedGeometry.",
+      { details: { conflictId: resolution.conflictId } },
+    );
+  }
+}

--- a/src/replica-sync/errors.ts
+++ b/src/replica-sync/errors.ts
@@ -1,0 +1,51 @@
+/**
+ * Error contracts for disconnected replica and sync-conflict review.
+ *
+ * Unsupported capabilities are explicit errors so clients can hide manual
+ * conflict review when it is unavailable, instead of inferring it from empty
+ * responses.
+ *
+ * @module
+ */
+
+export type ReplicaSyncErrorCode =
+  | "unsupported-sync"
+  | "unsupported-conflict-review"
+  | "unsupported-conflict-resolution"
+  | "replica-not-found"
+  | "conflict-not-found"
+  | "replica-expired"
+  | "conflict-already-resolved"
+  | "merge-required"
+  | "permission-denied"
+  | "transport-failure";
+
+export class HonuaReplicaSyncError extends Error {
+  public readonly code: ReplicaSyncErrorCode;
+  public readonly details: unknown;
+
+  public constructor(
+    code: ReplicaSyncErrorCode,
+    message: string,
+    options: { readonly details?: unknown; readonly cause?: unknown } = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = "HonuaReplicaSyncError";
+    this.code = code;
+    this.details = options.details;
+  }
+}
+
+export function isHonuaReplicaSyncError(error: unknown): error is HonuaReplicaSyncError {
+  return error instanceof HonuaReplicaSyncError;
+}
+
+/** True for the `unsupported-*` family of codes. */
+export function isUnsupportedReplicaSyncError(error: unknown): error is HonuaReplicaSyncError {
+  return (
+    isHonuaReplicaSyncError(error) &&
+    (error.code === "unsupported-sync" ||
+      error.code === "unsupported-conflict-review" ||
+      error.code === "unsupported-conflict-resolution")
+  );
+}

--- a/src/replica-sync/fixture.ts
+++ b/src/replica-sync/fixture.ts
@@ -1,0 +1,430 @@
+/**
+ * In-memory fixture transport for disconnected replica and sync-conflict
+ * review. It powers Console and Studio temporal/conflict viewer prototypes and
+ * SDK tests without a live server.
+ *
+ * The default seed covers the states the issue calls out: an active replica, an
+ * expired replica, a pending conflict, an already-resolved conflict, a batch of
+ * conflicts, and a dataset where conflict review is unsupported.
+ *
+ * @module
+ */
+
+import { HonuaReplicaSyncError } from "./errors.js";
+import type {
+  BatchConflictResolutionResult,
+  DisconnectedReplica,
+  ListConflictsRequest,
+  ListReplicasRequest,
+  ReplicaId,
+  ReplicaSyncCapabilities,
+  ReplicaSyncTransport,
+  SyncConflictDetail,
+  SyncConflictId,
+  SyncConflictResolution,
+  SyncConflictResolutionRecord,
+  SyncConflictSummary,
+  SyncPage,
+} from "./types.js";
+
+export interface FixtureReplicaSyncSeed {
+  readonly capabilities?: Record<string, ReplicaSyncCapabilities>;
+  readonly replicas?: ReadonlyArray<DisconnectedReplica>;
+  readonly conflicts?: ReadonlyArray<SyncConflictDetail>;
+}
+
+export interface FixtureReplicaSyncTransportOptions {
+  readonly now?: () => Date;
+  readonly seed?: FixtureReplicaSyncSeed;
+}
+
+const FULL_CAPABILITIES: ReplicaSyncCapabilities = {
+  sync: true,
+  createReplica: true,
+  synchronizeReplica: true,
+  conflictReview: true,
+  conflictResolution: true,
+  conflictPolicies: ["server-wins", "client-wins", "manual"],
+  directions: ["bidirectional", "upload", "download"],
+};
+
+const NO_CONFLICT_REVIEW_CAPABILITIES: ReplicaSyncCapabilities = {
+  sync: true,
+  createReplica: true,
+  synchronizeReplica: true,
+  conflictReview: false,
+  conflictResolution: false,
+  conflictPolicies: ["server-wins", "client-wins"],
+  directions: ["bidirectional"],
+};
+
+export function createFixtureReplicaSyncTransport(
+  options: FixtureReplicaSyncTransportOptions = {},
+): FixtureReplicaSyncTransport {
+  return new FixtureReplicaSyncTransport(options);
+}
+
+export class FixtureReplicaSyncTransport implements ReplicaSyncTransport {
+  readonly #now: () => Date;
+  readonly #capabilities = new Map<string, ReplicaSyncCapabilities>();
+  readonly #replicas = new Map<ReplicaId, DisconnectedReplica>();
+  readonly #conflicts = new Map<SyncConflictId, SyncConflictDetail>();
+
+  public constructor(options: FixtureReplicaSyncTransportOptions = {}) {
+    this.#now = options.now ?? (() => new Date());
+    const seed = options.seed ?? defaultSeed();
+    for (const [key, value] of Object.entries(seed.capabilities ?? {})) this.#capabilities.set(key, value);
+    for (const replica of seed.replicas ?? []) this.#replicas.set(replica.id, replica);
+    for (const conflict of seed.conflicts ?? []) this.#conflicts.set(conflict.id, conflict);
+  }
+
+  public async capabilities(datasetId: string, sourceId?: string): Promise<ReplicaSyncCapabilities> {
+    const key = capabilityKey(datasetId, sourceId);
+    const caps = this.#capabilities.get(key) ?? this.#capabilities.get(datasetId);
+    if (!caps) {
+      throw new HonuaReplicaSyncError(
+        "unsupported-sync",
+        `Disconnected sync is not available for dataset "${datasetId}".`,
+      );
+    }
+    return caps;
+  }
+
+  public async listReplicas(request: ListReplicasRequest = {}): Promise<SyncPage<DisconnectedReplica>> {
+    const items = [...this.#replicas.values()].filter((replica) => {
+      if (request.datasetId !== undefined && replica.datasetId !== request.datasetId) return false;
+      if (request.sourceId !== undefined && replica.sourceId !== request.sourceId) return false;
+      if (request.ownerId !== undefined && replica.owner?.id !== request.ownerId) return false;
+      if (request.states !== undefined && !request.states.includes(replica.state)) return false;
+      return true;
+    });
+    return paginate(items, request.limit, request.cursor);
+  }
+
+  public async getReplica(replicaId: ReplicaId): Promise<DisconnectedReplica> {
+    const replica = this.#replicas.get(replicaId);
+    if (!replica) {
+      throw new HonuaReplicaSyncError("replica-not-found", `Replica "${replicaId}" was not found.`);
+    }
+    return replica;
+  }
+
+  public async listConflicts(request: ListConflictsRequest = {}): Promise<SyncPage<SyncConflictSummary>> {
+    const replica = request.replicaId === undefined ? undefined : this.#replicas.get(request.replicaId);
+    if (request.replicaId !== undefined && replica === undefined) {
+      throw new HonuaReplicaSyncError("replica-not-found", `Replica "${request.replicaId}" was not found.`);
+    }
+    this.assertConflictReviewSupported(replica?.datasetId ?? request.datasetId);
+
+    const items = [...this.#conflicts.values()].filter((conflict) => {
+      if (request.replicaId !== undefined && conflict.replicaId !== request.replicaId) return false;
+      if (request.datasetId !== undefined && conflict.datasetId !== request.datasetId) return false;
+      if (request.statuses !== undefined && !request.statuses.includes(conflict.status)) return false;
+      if (request.kinds !== undefined && !request.kinds.includes(conflict.kind)) return false;
+      return true;
+    });
+    return paginate(items.map(toSummary), request.limit, request.cursor);
+  }
+
+  public async getConflict(conflictId: SyncConflictId): Promise<SyncConflictDetail> {
+    const conflict = this.#conflicts.get(conflictId);
+    if (!conflict) {
+      throw new HonuaReplicaSyncError("conflict-not-found", `Sync conflict "${conflictId}" was not found.`);
+    }
+    this.assertConflictReviewSupported(conflict.datasetId);
+    return conflict;
+  }
+
+  public async resolveConflict(resolution: SyncConflictResolution): Promise<SyncConflictResolutionRecord> {
+    const conflict = this.#conflicts.get(resolution.conflictId);
+    if (!conflict) {
+      throw new HonuaReplicaSyncError("conflict-not-found", `Sync conflict "${resolution.conflictId}" was not found.`);
+    }
+    this.assertConflictReviewSupported(conflict.datasetId);
+    if (conflict.status === "resolved" || conflict.status === "discarded") {
+      throw new HonuaReplicaSyncError(
+        "conflict-already-resolved",
+        `Sync conflict "${conflict.id}" is already resolved.`,
+        {
+          details: { status: conflict.status },
+        },
+      );
+    }
+
+    const record: SyncConflictResolutionRecord = {
+      conflictId: conflict.id,
+      choice: resolution.choice,
+      status: resolution.choice === "discard" ? "discarded" : "resolved",
+      resolvedAt: this.#now().toISOString(),
+      resolvedBy: resolution.resolvedBy,
+      serverGen: bumpServerGen(conflict.serverGen),
+      note: resolution.note,
+    };
+    this.#conflicts.set(conflict.id, { ...conflict, status: record.status, resolution: record });
+    return record;
+  }
+
+  public async resolveConflicts(
+    resolutions: ReadonlyArray<SyncConflictResolution>,
+  ): Promise<BatchConflictResolutionResult> {
+    const records: SyncConflictResolutionRecord[] = [];
+    const failures: Array<{ readonly conflictId: SyncConflictId; readonly reason: string }> = [];
+    for (const resolution of resolutions) {
+      try {
+        records.push(await this.resolveConflict(resolution));
+      } catch (error) {
+        failures.push({
+          conflictId: resolution.conflictId,
+          reason: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    return { records, failures };
+  }
+
+  private assertConflictReviewSupported(datasetId: string | undefined): void {
+    if (datasetId === undefined) return;
+    const caps = this.#capabilities.get(datasetId);
+    if (caps && !caps.conflictReview) {
+      throw new HonuaReplicaSyncError(
+        "unsupported-conflict-review",
+        `Manual conflict review is not available for dataset "${datasetId}".`,
+      );
+    }
+  }
+}
+
+function capabilityKey(datasetId: string, sourceId?: string): string {
+  return sourceId === undefined ? datasetId : `${datasetId}::${sourceId}`;
+}
+
+function toSummary(conflict: SyncConflictDetail): SyncConflictSummary {
+  const {
+    base: _base,
+    clientState: _clientState,
+    serverState: _serverState,
+    fieldConflicts: _fieldConflicts,
+    geometryConflict: _geometryConflict,
+    resolutionOptions: _resolutionOptions,
+    resolution: _resolution,
+    serverGen: _serverGen,
+    metadata: _metadata,
+    ...summary
+  } = conflict;
+  return summary;
+}
+
+function paginate<T>(items: ReadonlyArray<T>, limit?: number, cursor?: string): SyncPage<T> {
+  const start = cursor === undefined ? 0 : Math.max(0, Number.parseInt(cursor, 10) || 0);
+  const end = limit === undefined ? items.length : start + limit;
+  const page = items.slice(start, end);
+  const nextCursor = end < items.length ? String(end) : undefined;
+  return { items: page, cursor: nextCursor, totalCount: items.length };
+}
+
+function bumpServerGen(serverGen: string | undefined): string {
+  const current = serverGen === undefined ? 0 : Number.parseInt(serverGen, 10) || 0;
+  return String(current + 1);
+}
+
+/**
+ * Default seed covering every state the issue enumerates. Re-export so apps and
+ * tests can extend it.
+ */
+export function defaultSeed(): FixtureReplicaSyncSeed {
+  const owner = { id: "user-amelia", displayName: "Amelia Stone", kind: "user" as const };
+  const device = { id: "device-field-01", displayName: "Field Tablet 01", platform: "android" };
+
+  const activeReplica: DisconnectedReplica = {
+    id: "replica-active-1",
+    name: "Parcels — North District",
+    datasetId: "parcels",
+    sourceId: "parcels",
+    state: "active",
+    direction: "bidirectional",
+    conflictPolicy: "manual",
+    owner,
+    device,
+    createdAt: "2026-05-20T08:00:00.000Z",
+    expiresAt: "2026-06-20T08:00:00.000Z",
+    status: {
+      serverGen: "42",
+      targetServerGen: "47",
+      lastSyncedAt: "2026-05-28T16:30:00.000Z",
+      lastSyncDirection: "bidirectional",
+      inProgress: false,
+      pendingUploads: 3,
+      pendingDownloads: 5,
+      openConflicts: 2,
+    },
+  };
+
+  const expiredReplica: DisconnectedReplica = {
+    id: "replica-expired-1",
+    name: "Inspections — South District",
+    datasetId: "inspections",
+    sourceId: "inspections",
+    state: "expired",
+    direction: "upload",
+    conflictPolicy: "server-wins",
+    owner: { id: "user-noah", displayName: "Noah Patel", kind: "user" },
+    device: { id: "device-field-07", displayName: "Field Tablet 07", platform: "ios" },
+    createdAt: "2026-03-01T08:00:00.000Z",
+    expiresAt: "2026-04-01T08:00:00.000Z",
+    status: {
+      serverGen: "11",
+      lastSyncedAt: "2026-03-30T12:00:00.000Z",
+      lastSyncDirection: "upload",
+      inProgress: false,
+      pendingUploads: 0,
+      pendingDownloads: 0,
+      openConflicts: 0,
+      lastError: "Replica lease expired before final synchronization.",
+    },
+  };
+
+  const pendingConflict: SyncConflictDetail = {
+    id: "conflict-pending-1",
+    replicaId: "replica-active-1",
+    datasetId: "parcels",
+    sourceId: "parcels",
+    layerId: 0,
+    featureId: "parcel-1024",
+    kind: "replica-sync",
+    status: "pending",
+    clientOperation: "update",
+    serverOperation: "update",
+    detectedAt: "2026-05-28T16:30:05.000Z",
+    fieldConflictCount: 1,
+    hasGeometryConflict: true,
+    client: owner,
+    device,
+    serverGen: "47",
+    base: {
+      operation: "update",
+      attributes: { zoning: "R1", area: 1200 },
+      editedAt: "2026-05-20T08:00:00.000Z",
+    },
+    clientState: {
+      operation: "update",
+      attributes: { zoning: "R2", area: 1200 },
+      geometry: { type: "Polygon", coordinates: [] },
+      editedAt: "2026-05-27T10:15:00.000Z",
+      editedBy: owner,
+      device,
+    },
+    serverState: {
+      operation: "update",
+      attributes: { zoning: "C1", area: 1200 },
+      geometry: { type: "Polygon", coordinates: [] },
+      editedAt: "2026-05-28T09:45:00.000Z",
+      editedBy: { id: "user-office", displayName: "Office Editor", kind: "user" },
+    },
+    fieldConflicts: [{ field: "zoning", baseValue: "R1", clientValue: "R2", serverValue: "C1", diverged: true }],
+    geometryConflict: {
+      changed: true,
+      clientChanged: true,
+      serverChanged: true,
+      geometryType: "Polygon",
+      divergenceMeters: 3.4,
+      note: "Both sides moved a shared vertex.",
+    },
+    resolutionOptions: [
+      { choice: "accept-client", label: "Keep field edit", available: true },
+      { choice: "accept-server", label: "Keep office edit", available: true },
+      { choice: "merge", label: "Merge values", available: true },
+      { choice: "discard", label: "Discard both", available: true },
+    ],
+  };
+
+  const resolvedConflict: SyncConflictDetail = {
+    id: "conflict-resolved-1",
+    replicaId: "replica-active-1",
+    datasetId: "parcels",
+    sourceId: "parcels",
+    layerId: 0,
+    featureId: "parcel-2048",
+    kind: "replica-sync",
+    status: "resolved",
+    clientOperation: "update",
+    serverOperation: "delete",
+    detectedAt: "2026-05-26T11:00:00.000Z",
+    fieldConflictCount: 0,
+    hasGeometryConflict: false,
+    client: owner,
+    device,
+    serverGen: "44",
+    base: { operation: "update", attributes: { owner: "Acme" } },
+    clientState: {
+      operation: "update",
+      attributes: { owner: "Acme Holdings" },
+      editedAt: "2026-05-25T14:00:00.000Z",
+      editedBy: owner,
+      device,
+    },
+    serverState: {
+      operation: "delete",
+      deleted: true,
+      editedAt: "2026-05-26T10:00:00.000Z",
+      editedBy: { id: "user-office", displayName: "Office Editor", kind: "user" },
+    },
+    fieldConflicts: [],
+    resolutionOptions: [
+      { choice: "accept-client", label: "Restore feature", available: true },
+      { choice: "accept-server", label: "Keep deletion", available: true },
+      { choice: "merge", label: "Merge values", available: false, reason: "Server side was deleted." },
+      { choice: "discard", label: "Discard", available: true },
+    ],
+    resolution: {
+      conflictId: "conflict-resolved-1",
+      choice: "accept-client",
+      status: "resolved",
+      resolvedAt: "2026-05-26T12:00:00.000Z",
+      resolvedBy: owner,
+      serverGen: "45",
+      note: "Restored — feature was edited in the field after the office delete.",
+    },
+  };
+
+  // A second pending conflict so batch-resolution scenarios have >1 input.
+  const batchConflict: SyncConflictDetail = {
+    ...pendingConflict,
+    id: "conflict-pending-2",
+    featureId: "parcel-3072",
+    detectedAt: "2026-05-28T16:31:00.000Z",
+    serverGen: "47",
+    fieldConflicts: [{ field: "area", baseValue: 1200, clientValue: 1250, serverValue: 1300, diverged: true }],
+    fieldConflictCount: 1,
+    hasGeometryConflict: false,
+    geometryConflict: undefined,
+  };
+
+  // Dataset that supports sync but not manual conflict review.
+  const unsupportedReviewReplica: DisconnectedReplica = {
+    id: "replica-no-review-1",
+    name: "Hydrants — server-wins",
+    datasetId: "hydrants",
+    sourceId: "hydrants",
+    state: "active",
+    direction: "bidirectional",
+    conflictPolicy: "server-wins",
+    createdAt: "2026-05-22T08:00:00.000Z",
+    status: {
+      serverGen: "9",
+      lastSyncedAt: "2026-05-29T07:00:00.000Z",
+      lastSyncDirection: "bidirectional",
+      inProgress: false,
+      openConflicts: 0,
+    },
+  };
+
+  return {
+    capabilities: {
+      parcels: FULL_CAPABILITIES,
+      inspections: FULL_CAPABILITIES,
+      hydrants: NO_CONFLICT_REVIEW_CAPABILITIES,
+    },
+    replicas: [activeReplica, expiredReplica, unsupportedReviewReplica],
+    conflicts: [pendingConflict, resolvedConflict, batchConflict],
+  };
+}

--- a/src/replica-sync/index.ts
+++ b/src/replica-sync/index.ts
@@ -1,0 +1,62 @@
+/**
+ * Disconnected replica and sync-conflict SDK contracts.
+ *
+ * Console, MCP, QGIS, Studio, and mobile-adjacent tools share one product
+ * contract for disconnected replica metadata and sync conflict review. The
+ * surface is Esri-aligned (Sync, createReplica, synchronizeReplica, replica
+ * names, server generation cursors, conflict behavior) without hard-coding
+ * ArcGIS-only names, and composes with the temporal history contracts in
+ * honua-sdk-js#227.
+ *
+ * @experimental This entrypoint is not yet covered by the SDK's semver
+ *   contract — the surface may change in any minor release prior to `1.0.0`.
+ * @module
+ */
+
+export { HonuaReplicaSyncClient, createHonuaReplicaSync } from "./client.js";
+export type { HonuaReplicaSyncClientOptions } from "./client.js";
+export {
+  HonuaReplicaSyncError,
+  isHonuaReplicaSyncError,
+  isUnsupportedReplicaSyncError,
+} from "./errors.js";
+export type { ReplicaSyncErrorCode } from "./errors.js";
+export {
+  FixtureReplicaSyncTransport,
+  createFixtureReplicaSyncTransport,
+  defaultSeed as defaultReplicaSyncSeed,
+} from "./fixture.js";
+export type {
+  FixtureReplicaSyncSeed,
+  FixtureReplicaSyncTransportOptions,
+} from "./fixture.js";
+export type {
+  BatchConflictResolutionResult,
+  ConflictFeatureState,
+  ConflictResolutionChoice,
+  ConflictResolutionOption,
+  DisconnectedReplica,
+  FieldConflict,
+  GeometryConflictSummary,
+  ListConflictsRequest,
+  ListReplicasRequest,
+  ReplicaConflictPolicy,
+  ReplicaId,
+  ReplicaState,
+  ReplicaSyncCapabilities,
+  ReplicaSyncDirection,
+  ReplicaSyncStatus,
+  ReplicaSyncTransport,
+  ServerGenerationCursor,
+  SyncActor,
+  SyncConflictDetail,
+  SyncConflictId,
+  SyncConflictKind,
+  SyncConflictOperation,
+  SyncConflictResolution,
+  SyncConflictResolutionRecord,
+  SyncConflictStatus,
+  SyncConflictSummary,
+  SyncDevice,
+  SyncPage,
+} from "./types.js";

--- a/src/replica-sync/types.ts
+++ b/src/replica-sync/types.ts
@@ -1,0 +1,282 @@
+/**
+ * Disconnected replica and sync-conflict SDK contracts.
+ *
+ * These types give Console, MCP, QGIS, Studio, and mobile-adjacent tools a
+ * single product-level shape for disconnected replica metadata and sync
+ * conflict review, instead of forcing every client to infer it from low-level
+ * sync responses. The model is Esri-aligned (replicas, server generation
+ * cursors, conflict behavior) but does not hard-code ArcGIS-only names into the
+ * public Honua surface.
+ *
+ * @module
+ */
+
+/** Stable identifier for a disconnected replica. */
+export type ReplicaId = string;
+
+/** Stable identifier for a sync conflict awaiting review. */
+export type SyncConflictId = string;
+
+/**
+ * Monotonic server generation cursor. A replica tracks the server generation it
+ * last synchronized against; the server advances this on every committed edit.
+ * Esri exposes this as `serverGen` on Sync responses — Honua keeps the cursor
+ * opaque so transports can use sequence numbers, hybrid logical clocks, or
+ * vector cursors.
+ */
+export type ServerGenerationCursor = string;
+
+/** Lifecycle state of a disconnected replica. */
+export type ReplicaState = "provisioning" | "active" | "syncing" | "out-of-date" | "expired" | "removed";
+
+/**
+ * How a replica reconciles concurrent edits when synchronizing. Mirrors Esri
+ * `createReplica` conflict behavior without binding to its wire spelling.
+ */
+export type ReplicaConflictPolicy = "server-wins" | "client-wins" | "manual" | "last-writer-wins";
+
+/** Direction(s) of data flow a replica supports. */
+export type ReplicaSyncDirection = "bidirectional" | "upload" | "download";
+
+/** Per-source capability flags advertised for a replica's parent dataset. */
+export interface ReplicaSyncCapabilities {
+  /** Replica creation / disconnected editing is offered at all. */
+  readonly sync: boolean;
+  /** Server can register new replicas (`createReplica`). */
+  readonly createReplica: boolean;
+  /** Existing replicas can be synchronized (`synchronizeReplica`). */
+  readonly synchronizeReplica: boolean;
+  /** Server retains per-conflict detail for manual review. */
+  readonly conflictReview: boolean;
+  /** Conflict resolutions can be submitted back through the SDK. */
+  readonly conflictResolution: boolean;
+  /** Supported reconciliation policies for new replicas. */
+  readonly conflictPolicies: ReadonlyArray<ReplicaConflictPolicy>;
+  /** Supported sync directions. */
+  readonly directions: ReadonlyArray<ReplicaSyncDirection>;
+}
+
+/** Actor (person, service, or agent) attributed to a replica or edit. */
+export interface SyncActor {
+  readonly id: string;
+  readonly displayName?: string;
+  readonly kind?: "user" | "service" | "agent" | (string & {});
+}
+
+/** Device a disconnected replica is checked out to. */
+export interface SyncDevice {
+  readonly id: string;
+  readonly displayName?: string;
+  readonly platform?: string;
+  readonly lastSeenAt?: string;
+}
+
+/** Outcome of the most recent synchronization attempt for a replica. */
+export interface ReplicaSyncStatus {
+  /** Server generation the replica was last reconciled against. */
+  readonly serverGen?: ServerGenerationCursor;
+  /** Server generation the replica is currently aware of (may be ahead). */
+  readonly targetServerGen?: ServerGenerationCursor;
+  readonly lastSyncedAt?: string;
+  readonly lastSyncDirection?: ReplicaSyncDirection;
+  readonly inProgress: boolean;
+  /** Count of edits uploaded but not yet acknowledged by the server. */
+  readonly pendingUploads?: number;
+  /** Count of server edits not yet applied to the replica. */
+  readonly pendingDownloads?: number;
+  /** Open conflicts attributed to this replica. */
+  readonly openConflicts: number;
+  readonly lastError?: string;
+}
+
+/** A disconnected replica registered against a Honua dataset. */
+export interface DisconnectedReplica {
+  readonly id: ReplicaId;
+  /**
+   * Human-facing replica name. Esri parity surfaces a server-assigned replica
+   * name; Honua keeps it optional and informational.
+   */
+  readonly name?: string;
+  readonly datasetId: string;
+  readonly sourceId?: string;
+  readonly state: ReplicaState;
+  readonly direction: ReplicaSyncDirection;
+  readonly conflictPolicy: ReplicaConflictPolicy;
+  readonly owner?: SyncActor;
+  readonly device?: SyncDevice;
+  readonly createdAt: string;
+  /** When the replica's server-side lease expires; absent means no expiry. */
+  readonly expiresAt?: string;
+  readonly status: ReplicaSyncStatus;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+/** Lifecycle of a single sync conflict. */
+export type SyncConflictStatus = "pending" | "resolving" | "resolved" | "discarded";
+
+/** The kind of edit that produced a conflicting side. */
+export type SyncConflictOperation = "create" | "update" | "delete";
+
+/**
+ * Distinguishes a disconnected-replica sync conflict from a named-version
+ * reconcile/post conflict. Clients use this to route review UI correctly and to
+ * avoid mixing the two conflict models (see honua-server#371).
+ */
+export type SyncConflictKind = "replica-sync" | "version-reconcile";
+
+/** A single conflicting attribute value. */
+export interface FieldConflict {
+  readonly field: string;
+  readonly baseValue?: unknown;
+  readonly clientValue?: unknown;
+  readonly serverValue?: unknown;
+  /** True when client and server diverged from the common base. */
+  readonly diverged: boolean;
+}
+
+/** Summary of a geometry-level conflict without shipping full geometries. */
+export interface GeometryConflictSummary {
+  readonly changed: boolean;
+  readonly clientChanged: boolean;
+  readonly serverChanged: boolean;
+  readonly geometryType?: string;
+  /** Hausdorff-style or area-delta hint, when the transport computes one. */
+  readonly divergenceMeters?: number;
+  readonly note?: string;
+}
+
+/** One side of a three-way conflict (base / client / server feature state). */
+export interface ConflictFeatureState {
+  readonly operation: SyncConflictOperation;
+  readonly attributes?: Readonly<Record<string, unknown>>;
+  readonly geometry?: unknown;
+  readonly editedAt?: string;
+  readonly editedBy?: SyncActor;
+  readonly device?: SyncDevice;
+  /** Present when the feature was deleted on this side. */
+  readonly deleted?: boolean;
+}
+
+/** How a single conflict may be resolved. */
+export type ConflictResolutionChoice = "accept-client" | "accept-server" | "merge" | "discard";
+
+/** A resolution option the server is willing to accept for a conflict. */
+export interface ConflictResolutionOption {
+  readonly choice: ConflictResolutionChoice;
+  readonly label?: string;
+  /** False when the option is shown but not currently selectable. */
+  readonly available: boolean;
+  readonly reason?: string;
+}
+
+/** Lightweight conflict record returned by listings. */
+export interface SyncConflictSummary {
+  readonly id: SyncConflictId;
+  readonly replicaId: ReplicaId;
+  readonly datasetId: string;
+  readonly sourceId?: string;
+  readonly layerId?: string | number;
+  readonly featureId: string | number;
+  readonly kind: SyncConflictKind;
+  readonly status: SyncConflictStatus;
+  readonly clientOperation: SyncConflictOperation;
+  readonly serverOperation: SyncConflictOperation;
+  readonly detectedAt: string;
+  /** Number of conflicting fields; geometry counts separately. */
+  readonly fieldConflictCount: number;
+  readonly hasGeometryConflict: boolean;
+  readonly client?: SyncActor;
+  readonly device?: SyncDevice;
+}
+
+/** Full three-way conflict detail for manual review. */
+export interface SyncConflictDetail extends SyncConflictSummary {
+  readonly serverGen?: ServerGenerationCursor;
+  readonly base: ConflictFeatureState;
+  readonly clientState: ConflictFeatureState;
+  readonly serverState: ConflictFeatureState;
+  readonly fieldConflicts: ReadonlyArray<FieldConflict>;
+  readonly geometryConflict?: GeometryConflictSummary;
+  readonly resolutionOptions: ReadonlyArray<ConflictResolutionOption>;
+  /** Resolution recorded once the conflict reaches a terminal state. */
+  readonly resolution?: SyncConflictResolutionRecord;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+/** A resolution submitted by a reviewer. */
+export interface SyncConflictResolution {
+  readonly conflictId: SyncConflictId;
+  readonly choice: ConflictResolutionChoice;
+  /** Required when `choice` is `merge`: the field values to commit. */
+  readonly mergedAttributes?: Readonly<Record<string, unknown>>;
+  readonly mergedGeometry?: unknown;
+  readonly note?: string;
+  readonly resolvedBy?: SyncActor;
+}
+
+/** Server acknowledgement of an applied resolution. */
+export interface SyncConflictResolutionRecord {
+  readonly conflictId: SyncConflictId;
+  readonly choice: ConflictResolutionChoice;
+  readonly status: "resolved" | "discarded";
+  readonly resolvedAt: string;
+  readonly resolvedBy?: SyncActor;
+  /** Server generation produced by committing the resolution. */
+  readonly serverGen?: ServerGenerationCursor;
+  readonly note?: string;
+}
+
+/** Pageable request for the replica listing. */
+export interface ListReplicasRequest {
+  readonly datasetId?: string;
+  readonly sourceId?: string;
+  readonly states?: ReadonlyArray<ReplicaState>;
+  readonly ownerId?: string;
+  readonly limit?: number;
+  readonly cursor?: string;
+  readonly signal?: AbortSignal;
+}
+
+/** Pageable request for conflict listings. */
+export interface ListConflictsRequest {
+  readonly replicaId?: ReplicaId;
+  readonly datasetId?: string;
+  readonly statuses?: ReadonlyArray<SyncConflictStatus>;
+  readonly kinds?: ReadonlyArray<SyncConflictKind>;
+  readonly limit?: number;
+  readonly cursor?: string;
+  readonly signal?: AbortSignal;
+}
+
+/** A page of results plus an optional continuation cursor. */
+export interface SyncPage<T> {
+  readonly items: ReadonlyArray<T>;
+  readonly cursor?: string;
+  readonly totalCount?: number;
+}
+
+/** Result of submitting a batch of resolutions. */
+export interface BatchConflictResolutionResult {
+  readonly records: ReadonlyArray<SyncConflictResolutionRecord>;
+  /** Conflicts that could not be resolved, with a reason. */
+  readonly failures: ReadonlyArray<{
+    readonly conflictId: SyncConflictId;
+    readonly reason: string;
+  }>;
+}
+
+/**
+ * Transport-neutral contract the client drives. A fixture transport ships with
+ * the SDK; a Connect/HTTP adapter can implement the same surface when the
+ * server endpoints land.
+ */
+export interface ReplicaSyncTransport {
+  /** Capabilities for a dataset (or the default source within it). */
+  capabilities(datasetId: string, sourceId?: string): Promise<ReplicaSyncCapabilities>;
+  listReplicas(request?: ListReplicasRequest): Promise<SyncPage<DisconnectedReplica>>;
+  getReplica(replicaId: ReplicaId, options?: { readonly signal?: AbortSignal }): Promise<DisconnectedReplica>;
+  listConflicts(request?: ListConflictsRequest): Promise<SyncPage<SyncConflictSummary>>;
+  getConflict(conflictId: SyncConflictId, options?: { readonly signal?: AbortSignal }): Promise<SyncConflictDetail>;
+  resolveConflict(resolution: SyncConflictResolution): Promise<SyncConflictResolutionRecord>;
+  resolveConflicts(resolutions: ReadonlyArray<SyncConflictResolution>): Promise<BatchConflictResolutionResult>;
+}

--- a/test/entrypoints.test.ts
+++ b/test/entrypoints.test.ts
@@ -224,6 +224,12 @@ import {
   reduceRealtimeFeatureState,
 } from "../src/realtime/index.js";
 import {
+  HonuaReplicaSyncClient,
+  createFixtureReplicaSyncTransport,
+  createHonuaReplicaSync,
+  isUnsupportedReplicaSyncError,
+} from "../src/replica-sync/index.js";
+import {
   HonuaRuntimeDiagnosticError,
   validateRuntimeFilterExpression,
   validateRuntimeStyleExpression,
@@ -482,6 +488,13 @@ describe("entrypoint modules", () => {
     expect(emptyRealtimeFeatureState).toBeTypeOf("function");
     expect(reduceRealtimeFeatureState).toBeTypeOf("function");
     expect(createRealtimeFeatureStore).toBeTypeOf("function");
+  });
+
+  it("exposes the replica-sync entrypoint", () => {
+    expect(HonuaReplicaSyncClient).toBeTypeOf("function");
+    expect(createHonuaReplicaSync).toBeTypeOf("function");
+    expect(createFixtureReplicaSyncTransport).toBeTypeOf("function");
+    expect(isUnsupportedReplicaSyncError).toBeTypeOf("function");
   });
 
   it("exposes the runtime style and interaction helper entrypoint", () => {

--- a/test/replica-sync.test.ts
+++ b/test/replica-sync.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createFixtureReplicaSyncTransport,
+  createHonuaReplicaSync,
+  defaultReplicaSyncSeed,
+  isHonuaReplicaSyncError,
+  isUnsupportedReplicaSyncError,
+} from "../src/replica-sync/index.js";
+
+function client() {
+  return createHonuaReplicaSync({
+    transport: createFixtureReplicaSyncTransport({ now: () => new Date("2026-05-29T12:00:00.000Z") }),
+  });
+}
+
+describe("disconnected replica contracts", () => {
+  it("lists active and expired replicas with sync status and server generation cursors", async () => {
+    const sync = client();
+    const page = await sync.listReplicas({ datasetId: "parcels" });
+
+    const active = page.items.find((replica) => replica.id === "replica-active-1");
+    expect(active?.state).toBe("active");
+    expect(active?.conflictPolicy).toBe("manual");
+    expect(active?.status.serverGen).toBe("42");
+    expect(active?.status.targetServerGen).toBe("47");
+    expect(active?.status.openConflicts).toBe(2);
+  });
+
+  it("represents an expired replica explicitly", async () => {
+    const sync = client();
+    const page = await sync.listReplicas({ states: ["expired"] });
+    expect(page.items.map((replica) => replica.id)).toEqual(["replica-expired-1"]);
+    expect(page.items[0]?.expiresAt).toBe("2026-04-01T08:00:00.000Z");
+    expect(page.items[0]?.status.lastError).toContain("expired");
+  });
+
+  it("reads a single replica and reports replica-not-found as a typed error", async () => {
+    const sync = client();
+    const replica = await sync.getReplica("replica-active-1");
+    expect(replica.device?.platform).toBe("android");
+
+    await expect(sync.getReplica("missing")).rejects.toSatisfy(
+      (error) => isHonuaReplicaSyncError(error) && error.code === "replica-not-found",
+    );
+  });
+
+  it("paginates with a continuation cursor", async () => {
+    const sync = client();
+    const first = await sync.listReplicas({ limit: 1 });
+    expect(first.items).toHaveLength(1);
+    expect(first.cursor).toBeDefined();
+    expect(first.totalCount).toBe(3);
+
+    const second = await sync.listReplicas({ limit: 1, cursor: first.cursor });
+    expect(second.items[0]?.id).not.toBe(first.items[0]?.id);
+  });
+});
+
+describe("sync conflict review contracts", () => {
+  it("lists pending and resolved conflicts as replica-sync (not version-reconcile) conflicts", async () => {
+    const sync = client();
+    const page = await sync.listConflicts({ replicaId: "replica-active-1" });
+    const byId = new Map(page.items.map((conflict) => [conflict.id, conflict]));
+
+    expect(byId.get("conflict-pending-1")?.status).toBe("pending");
+    expect(byId.get("conflict-resolved-1")?.status).toBe("resolved");
+    for (const conflict of page.items) {
+      expect(conflict.kind).toBe("replica-sync");
+    }
+  });
+
+  it("exposes base/client/server states, field + geometry conflicts, actor/device, and resolution options", async () => {
+    const sync = client();
+    const detail = await sync.getConflict("conflict-pending-1");
+
+    expect(detail.base.attributes?.zoning).toBe("R1");
+    expect(detail.clientState.attributes?.zoning).toBe("R2");
+    expect(detail.serverState.attributes?.zoning).toBe("C1");
+    expect(detail.fieldConflicts[0]).toMatchObject({ field: "zoning", diverged: true });
+    expect(detail.geometryConflict?.changed).toBe(true);
+    expect(detail.client?.id).toBe("user-amelia");
+    expect(detail.device?.id).toBe("device-field-01");
+    expect(detail.resolutionOptions.map((option) => option.choice)).toEqual([
+      "accept-client",
+      "accept-server",
+      "merge",
+      "discard",
+    ]);
+  });
+
+  it("resolves a pending conflict and records the resolution with a new server generation", async () => {
+    const sync = client();
+    const record = await sync.resolveConflict({
+      conflictId: "conflict-pending-1",
+      choice: "accept-client",
+      resolvedBy: { id: "user-reviewer" },
+    });
+
+    expect(record.status).toBe("resolved");
+    expect(record.serverGen).toBe("48");
+
+    const detail = await sync.getConflict("conflict-pending-1");
+    expect(detail.status).toBe("resolved");
+    expect(detail.resolution?.choice).toBe("accept-client");
+  });
+
+  it("rejects a merge resolution that omits merged data", async () => {
+    const sync = client();
+    await expect(sync.resolveConflict({ conflictId: "conflict-pending-1", choice: "merge" })).rejects.toSatisfy(
+      (error) => isHonuaReplicaSyncError(error) && error.code === "merge-required",
+    );
+  });
+
+  it("rejects re-resolving an already-resolved conflict", async () => {
+    const sync = client();
+    await expect(
+      sync.resolveConflict({ conflictId: "conflict-resolved-1", choice: "accept-server" }),
+    ).rejects.toSatisfy((error) => isHonuaReplicaSyncError(error) && error.code === "conflict-already-resolved");
+  });
+
+  it("resolves a batch and reports per-conflict failures", async () => {
+    const sync = client();
+    const result = await sync.resolveConflicts([
+      { conflictId: "conflict-pending-1", choice: "accept-server" },
+      { conflictId: "conflict-pending-2", choice: "accept-client" },
+      { conflictId: "missing-conflict", choice: "discard" },
+    ]);
+
+    expect(result.records.map((record) => record.conflictId)).toEqual(["conflict-pending-1", "conflict-pending-2"]);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]?.conflictId).toBe("missing-conflict");
+  });
+});
+
+describe("unsupported capabilities are explicit", () => {
+  it("advertises capabilities per dataset", async () => {
+    const sync = client();
+    expect(await sync.capabilities("parcels")).toMatchObject({ conflictReview: true, conflictResolution: true });
+    expect(await sync.capabilities("hydrants")).toMatchObject({ conflictReview: false, conflictResolution: false });
+  });
+
+  it("surfaces unsupported conflict review so clients can hide manual review", async () => {
+    const sync = client();
+    let caught: unknown;
+    try {
+      await sync.listConflicts({ datasetId: "hydrants", replicaId: "replica-no-review-1" });
+    } catch (error) {
+      caught = error;
+    }
+    expect(isUnsupportedReplicaSyncError(caught)).toBe(true);
+  });
+
+  it("reports unsupported sync for unknown datasets", async () => {
+    const sync = client();
+    await expect(sync.capabilities("does-not-exist")).rejects.toSatisfy((error) =>
+      isUnsupportedReplicaSyncError(error),
+    );
+  });
+});
+
+describe("default seed", () => {
+  it("covers every state the Console/Studio viewers prototype against", () => {
+    const seed = defaultReplicaSyncSeed();
+    expect(seed.replicas?.map((replica) => replica.state).sort()).toEqual(["active", "active", "expired"]);
+    expect(seed.conflicts?.map((conflict) => conflict.status).sort()).toEqual(["pending", "pending", "resolved"]);
+  });
+});


### PR DESCRIPTION
## What

Adds a transport-neutral `replica-sync` module that gives Console, MCP, QGIS, Studio, and mobile-adjacent tools one product-level contract for **disconnected replica metadata** and **sync conflict review**, instead of forcing every client to infer it from low-level sync responses. The surface is Esri-aligned (Sync, createReplica, synchronizeReplica, replica names, server generation cursors, conflict behavior) without hard-coding ArcGIS-only names into the public Honua model.

### Types (`src/replica-sync/types.ts`)
- `DisconnectedReplica`, `ReplicaState`, `ReplicaSyncStatus`, `ReplicaSyncCapabilities`, `ReplicaConflictPolicy`, `ServerGenerationCursor`.
- `SyncConflictSummary` / `SyncConflictDetail` with base/client/server `ConflictFeatureState`, `FieldConflict[]`, `GeometryConflictSummary`, actor/device metadata, and `ConflictResolutionOption[]`.
- `SyncConflictResolution` / `SyncConflictResolutionRecord`, paging types, and the `ReplicaSyncTransport` interface.
- `SyncConflictKind` distinguishes `replica-sync` conflicts from `version-reconcile` (named-version reconcile/post) conflicts per honua-server#371.

### Client (`src/replica-sync/client.ts`)
- `HonuaReplicaSyncClient` / `createHonuaReplicaSync`: capability discovery, list/read replicas, list/read conflicts, single and batch conflict resolution, with merge-resolution validation.

### Errors (`src/replica-sync/errors.ts`)
- `HonuaReplicaSyncError` with an explicit `unsupported-*` family and `isUnsupportedReplicaSyncError` so clients can hide manual conflict review when it is unavailable.

### Fixture (`src/replica-sync/fixture.ts`)
- `FixtureReplicaSyncTransport` + `defaultReplicaSyncSeed` seeded for the states the issue enumerates: active replica, expired replica, pending conflict, resolved conflict, batch conflicts, and an unsupported-conflict-review dataset — ready for Console/Studio temporal/conflict viewer prototypes.

Exposed as the `./replica-sync` subpath export (experimental tier, consistent with `./collaboration`).

## Scope

Full issue for the SDK contracts portion. Server implementation, mobile local storage, and Console UI are explicitly out of scope per the issue. The contracts are designed to compose with the temporal history contracts in honua-sdk-js#227.

## Testing

- `npm run typecheck`, `npm run check` (Biome): clean.
- `npm run verify:split-packages`: split build + smoke ok.
- `npm test`: full suite green (192 files / 2037 tests), including new `test/replica-sync.test.ts` (14 cases covering every required scenario) and an added `./replica-sync` entrypoint assertion in `test/entrypoints.test.ts`.

Refs #228