### PR TITLE
Add browser-safe Share, embed, and open-data contracts (#233)

### DIFF
--- a/docs/share-embed-open-data-contracts.md
+++ b/docs/share-embed-open-data-contracts.md
@@ -1,0 +1,112 @@
+# Share, Embed, and Open-Data Browser Contracts
+
+`@honua/sdk-js/share` is a browser-safe projection of the canonical honua-server
+Console Share contracts and the `honua-sdk-dotnet` console clients. The long-term
+Console runtime is .NET/Blazor, but generated apps and embeddable map surfaces
+need browser-safe types and helpers so they consume Share, embed-token,
+public-link, and open-data state without inventing a second vocabulary.
+
+This subpath owns **no transport**: it consumes server responses that are
+already available. Admin/write share operations (mint links, enable embedding)
+live on [`@honua/sdk-js/control-plane`](./split-packages.md).
+
+```ts
+import {
+  denialFromHttpStatus,
+  grantShareAccess,
+  parseEmbedTokenFromFragment,
+  toSchemaOrgDataset,
+} from "@honua/sdk-js/share";
+import type {
+  HonuaEmbedRedemption,
+  HonuaShareProjection,
+} from "@honua/sdk-js/share";
+```
+
+## Contract vocabulary
+
+The TypeScript names and string-literal values mirror the server JSON wire
+contracts exactly, so a parsed `fetch` body assigns straight into the SDK type
+with no remapping:
+
+| SDK type | honua-server contract |
+|----------|-----------------------|
+| `HonuaShareAccessTier` (`private`/`organization`/`public-link`/`public-indexed`) | `ConsoleShareAccessTier` |
+| `HonuaEmbedAudience` (`map`/`content`) | `ConsoleEmbedAudience` |
+| `HonuaShareItemType` | `ConsoleContentItemType` |
+| `HonuaPublicLinkToken` / `HonuaEmbedToken` | `ConsolePublicLinkToken` / `ConsoleEmbedToken` |
+| `HonuaShareProjection` | `ConsoleShareProjection` |
+| `HonuaPublicLinkResolution` | `ConsolePublicLinkResolutionResponse` |
+| `HonuaEmbedRedemption` | `ConsoleEmbedRedeemResponse` |
+| `HonuaShareDependencyConflict` | `ConsoleShareDependencyConflict` |
+
+Each known string union stays open with `(string & {})` so a future server tier
+or audience round-trips without a type error while keeping autocomplete on the
+known members. `HONUA_SHARE_ACCESS_TIERS` and `HONUA_EMBED_AUDIENCES` export the
+known members for validation/iteration.
+
+## Fragment-only embed tokens
+
+Embed bearer tokens MUST travel in the URL **fragment** (`#…`), never the query
+string. The fragment is not sent to the origin, is not written to server access
+logs or the `Referer` header, and is not captured by most proxy/CDN logging — so
+a fragment-borne token has a much smaller disclosure surface.
+
+`parseEmbedTokenFromFragment` enforces this. It **rejects** a query-string token
+outright (even when a fragment token is also present) so a leak-prone placement
+is never silently accepted:
+
+```ts
+parseEmbedTokenFromFragment("https://app/embed#embed_token=abc");
+// → { ok: true, token: "abc", param: "embed_token" }
+
+parseEmbedTokenFromFragment("https://app/embed?embed_token=abc");
+// → { ok: false, reason: "query-string-token" }
+```
+
+Rejection reasons: `query-string-token`, `missing`, `empty`, `malformed`. In a
+browser, pass `window.location.href`. `hasQueryStringEmbedToken(url)` is a guard
+for asserting a redirect stripped a token before it reached a logged surface.
+
+## Anonymous-safe denial states
+
+The server's anonymous Share endpoints collapse unknown, expired, revoked,
+forbidden, and no-longer-covered tokens into a single, identical denial that
+never discloses item identity, title, or existence. `HonuaShareAccessState` is
+the discriminated browser mirror:
+
+```ts
+async function resolvePublicLink(token: string): Promise<HonuaPublicLinkAccessState> {
+  const res = await fetch(`/api/v1/console/share/link/${token}`);
+  if (!res.ok) return denialFromHttpStatus("public-link", res.status);
+  const body = (await res.json()) as { data: HonuaPublicLinkResolution };
+  return grantShareAccess("public-link", body.data);
+}
+```
+
+A denied state carries only a coarse `reason` (`not-found`/`expired`/`forbidden`)
+and a constant, identity-free `message` sourced from
+`HONUA_SHARE_DENIAL_MESSAGES` — never from caller-supplied item data — so private
+titles cannot leak through this path. The message content is identical across
+reasons for a given kind, so it is not an existence oracle.
+
+## Open-data read projections
+
+For an open-data landing card, `HonuaOpenDataReadProjection` is the
+anonymous-safe read model. `toDcatDataset` and `toSchemaOrgDataset` project a
+held read model into standards-aligned metadata (W3C DCAT / DCAT-AP and a
+Schema.org `Dataset` JSON-LD node) for injection into an open-data page:
+
+```ts
+const ld = toSchemaOrgDataset(projection);
+// <script type="application/ld+json">{ "@context": "https://schema.org", ... }</script>
+```
+
+Both helpers omit unset/empty fields. When honua-server's open-data publication
+API ships its own DCAT/STAC projection, prefer the server-emitted document; these
+helpers remain the browser fallback for responses that only carry the read model.
+
+## Status
+
+Experimental — not yet covered by the SDK's semver contract; the surface may
+change in any minor release prior to `1.0.0`.

--- a/package.json
+++ b/package.json
@@ -86,6 +86,10 @@
       "types": "./dist/src/replica-sync/index.d.ts",
       "default": "./dist/src/replica-sync/index.js"
     },
+    "./share": {
+      "types": "./dist/src/share/index.d.ts",
+      "default": "./dist/src/share/index.js"
+    },
     "./exploration": {
       "types": "./dist/src/exploration/index.d.ts",
       "default": "./dist/src/exploration/index.js"

--- a/scripts/prepare-split-packages.mjs
+++ b/scripts/prepare-split-packages.mjs
@@ -45,6 +45,7 @@ function createSdkPackage() {
   copyDirectory(path.join(DIST_SRC_ROOT, "control-plane"), path.join(packageRoot, "control-plane"));
   copyDirectory(path.join(DIST_SRC_ROOT, "collaboration"), path.join(packageRoot, "collaboration"));
   copyDirectory(path.join(DIST_SRC_ROOT, "console"), path.join(packageRoot, "console"));
+  copyDirectory(path.join(DIST_SRC_ROOT, "share"), path.join(packageRoot, "share"));
   copyDirectory(path.join(DIST_SRC_ROOT, "core"), path.join(packageRoot, "core"));
   copyDirectory(path.join(DIST_SRC_ROOT, "agent-tools"), path.join(packageRoot, "agent-tools"));
   copyDirectory(path.join(DIST_SRC_ROOT, "app"), path.join(packageRoot, "app"));
@@ -96,6 +97,10 @@ function createSdkPackage() {
       "./console": {
         types: "./console/index.d.ts",
         default: "./console/index.js",
+      },
+      "./share": {
+        types: "./share/index.d.ts",
+        default: "./share/index.js",
       },
       "./agent-tools": {
         types: "./agent-tools/index.d.ts",

--- a/scripts/verify-split-packages.mjs
+++ b/scripts/verify-split-packages.mjs
@@ -73,6 +73,10 @@ import {
   createHonuaSavedMapCollaboration,
 } from "@honua/sdk/collaboration";
 import {
+  parseEmbedTokenFromFragment,
+  toDcatDataset,
+} from "@honua/sdk/share";
+import {
   CAPABILITIES,
   PROTOCOLS,
   createDataset,
@@ -231,6 +235,10 @@ if (typeof createHonuaSavedMapCollaboration !== "function")
   throw new Error("createHonuaSavedMapCollaboration export missing from @honua/sdk/collaboration");
 if (typeof createFixtureSavedMapCollaborationTransport !== "function")
   throw new Error("createFixtureSavedMapCollaborationTransport export missing from @honua/sdk/collaboration");
+if (typeof parseEmbedTokenFromFragment !== "function" || typeof toDcatDataset !== "function")
+  throw new Error("share contract exports missing from @honua/sdk/share");
+if (parseEmbedTokenFromFragment("https://app.example/embed?embed_token=leaked").ok)
+  throw new Error("share embed-token helper accepted a query-string bearer token");
 if (!Array.isArray(HONUA_AGENT_TOOL_NAMES) || !HONUA_AGENT_TOOL_NAMES.includes("explainCapabilityGap"))
   throw new Error("agent tool exports missing from @honua/sdk/agent-tools");
 if (explainHonuaCapabilityGap({ protocol: "wmts", capability: "query" }).supported)

--- a/src/share/denial.ts
+++ b/src/share/denial.ts
@@ -1,0 +1,119 @@
+/**
+ * Anonymous-safe Share access states and denial helpers.
+ *
+ * Mirrors the server's anonymous Share endpoints: unknown, expired, revoked,
+ * forbidden, or no-longer-covered tokens all collapse to a single, identical
+ * denial that never discloses item identity, title, or existence. Browser code
+ * consumes one explicit state model rather than inferring access from HTTP
+ * status codes or—worse—leaking a private title into a "not allowed" message.
+ *
+ * @module
+ */
+
+import type { HonuaEmbedRedemption, HonuaPublicLinkResolution } from "./types.js";
+
+/**
+ * Why an anonymous Share read was denied. These are intentionally coarse so the
+ * reason never acts as an existence/identity oracle: `not-found` covers unknown
+ * items, revoked/unknown tokens, and items whose tier no longer covers the
+ * access path; `expired` covers tokens past their TTL; `forbidden` covers a
+ * surface that exists but is not anonymously readable through the attempted
+ * mechanism.
+ */
+export type HonuaShareDenialReason = "not-found" | "expired" | "forbidden";
+
+/** The mechanism an anonymous read was attempted through. */
+export type HonuaShareAccessKind = "public-link" | "public-content" | "embed";
+
+/**
+ * Granted anonymous Share state — the resolved presentation projection plus the
+ * access kind it was reached through.
+ */
+export interface HonuaShareAccessGranted<TResolution> {
+  readonly status: "granted";
+  readonly kind: HonuaShareAccessKind;
+  readonly resolution: TResolution;
+}
+
+/**
+ * Denied anonymous Share state. Carries only a coarse {@link reason} and an
+ * opaque, identity-free {@link message}. It deliberately exposes no item id,
+ * title, or any field that could confirm a private item exists.
+ */
+export interface HonuaShareAccessDenied {
+  readonly status: "denied";
+  readonly kind: HonuaShareAccessKind;
+  readonly reason: HonuaShareDenialReason;
+  /** Opaque, anonymous-safe denial message. Never includes item identity. */
+  readonly message: string;
+}
+
+/** Discriminated anonymous Share access state. */
+export type HonuaShareAccessState<TResolution> = HonuaShareAccessGranted<TResolution> | HonuaShareAccessDenied;
+
+/** Anonymous Share access state for a public-link / public-content read. */
+export type HonuaPublicLinkAccessState = HonuaShareAccessState<HonuaPublicLinkResolution>;
+
+/** Anonymous Share access state for an embed redemption. */
+export type HonuaEmbedAccessState = HonuaShareAccessState<HonuaEmbedRedemption>;
+
+/**
+ * Constant, identity-free denial messages keyed by access kind. These mirror
+ * the server's fixed denial bodies so the browser never has to synthesize a
+ * message from item data. They are byte-stable per kind so a denial response
+ * cannot be distinguished by message content.
+ */
+export const HONUA_SHARE_DENIAL_MESSAGES: Readonly<Record<HonuaShareAccessKind, string>> = {
+  "public-link": "Link not found or expired.",
+  "public-content": "Shared item not found.",
+  embed: "Embed token not found or expired.",
+} as const;
+
+/**
+ * Builds an anonymous-safe denial state. The message is always sourced from
+ * {@link HONUA_SHARE_DENIAL_MESSAGES} and never from caller-supplied item data,
+ * so private titles cannot leak through this path.
+ */
+export function denyShareAccess(kind: HonuaShareAccessKind, reason: HonuaShareDenialReason): HonuaShareAccessDenied {
+  return {
+    status: "denied",
+    kind,
+    reason,
+    message: HONUA_SHARE_DENIAL_MESSAGES[kind] ?? HONUA_SHARE_DENIAL_MESSAGES["public-content"],
+  };
+}
+
+/** Builds a granted Share access state from a resolved presentation projection. */
+export function grantShareAccess<TResolution>(
+  kind: HonuaShareAccessKind,
+  resolution: TResolution,
+): HonuaShareAccessGranted<TResolution> {
+  return { status: "granted", kind, resolution };
+}
+
+/** Narrowing guard for the denied state. */
+export function isShareAccessDenied<TResolution>(
+  state: HonuaShareAccessState<TResolution>,
+): state is HonuaShareAccessDenied {
+  return state.status === "denied";
+}
+
+/** Narrowing guard for the granted state. */
+export function isShareAccessGranted<TResolution>(
+  state: HonuaShareAccessState<TResolution>,
+): state is HonuaShareAccessGranted<TResolution> {
+  return state.status === "granted";
+}
+
+/**
+ * Maps an anonymous Share endpoint HTTP status to a denial state. The server
+ * collapses unknown/expired/revoked/forbidden into a uniform `404`, so any
+ * non-2xx status becomes a `not-found` denial unless it is a `403`
+ * (`forbidden`) or `410` (`expired`). This keeps browser callers from leaking
+ * an existence oracle by branching on richer statuses.
+ */
+export function denialFromHttpStatus(kind: HonuaShareAccessKind, status: number): HonuaShareAccessDenied {
+  if (status === 403) return denyShareAccess(kind, "forbidden");
+  if (status === 410) return denyShareAccess(kind, "expired");
+  return denyShareAccess(kind, "not-found");
+}

--- a/src/share/embed-token.ts
+++ b/src/share/embed-token.ts
@@ -1,0 +1,143 @@
+/**
+ * Fragment-only embed-token parsing.
+ *
+ * Embed bearer tokens MUST travel in the URL fragment (`#...`), never the query
+ * string. The fragment is not sent to the origin server, is not written to
+ * server access logs or the `Referer` header, and is not captured by most
+ * proxy/CDN request logging — so a fragment-borne bearer token has a much
+ * smaller disclosure surface than a query-string one. This helper extracts a
+ * token from the fragment and *rejects* query-string bearer patterns outright
+ * so a generated app or embed never silently accepts a leak-prone placement.
+ *
+ * @module
+ */
+
+/** Default fragment parameter name an embed token is read from. */
+export const HONUA_EMBED_TOKEN_FRAGMENT_PARAM = "embed_token" as const;
+
+/** Why an embed-token parse rejected an input. */
+export type HonuaEmbedTokenRejectionReason =
+  /** No token was present in the fragment. */
+  | "missing"
+  /** The token appeared in the query string — a forbidden, leak-prone placement. */
+  | "query-string-token"
+  /** The fragment held a token-shaped value but it was empty/blank. */
+  | "empty"
+  /** The input was not a parseable URL or fragment. */
+  | "malformed";
+
+/** Successful fragment-only token parse. */
+export interface HonuaEmbedTokenParseOk {
+  readonly ok: true;
+  /** The extracted opaque token value (trimmed, never empty). */
+  readonly token: string;
+  /** The fragment parameter the token was read from. */
+  readonly param: string;
+}
+
+/** Rejected token parse — carries a reason but never the offending value. */
+export interface HonuaEmbedTokenParseRejected {
+  readonly ok: false;
+  readonly reason: HonuaEmbedTokenRejectionReason;
+}
+
+/** Result of {@link parseEmbedTokenFromFragment}. */
+export type HonuaEmbedTokenParseResult = HonuaEmbedTokenParseOk | HonuaEmbedTokenParseRejected;
+
+/** Options for {@link parseEmbedTokenFromFragment}. */
+export interface ParseEmbedTokenOptions {
+  /**
+   * Fragment parameter name(s) to read the token from. Defaults to
+   * {@link HONUA_EMBED_TOKEN_FRAGMENT_PARAM}. The same name(s) are also the
+   * query-string keys that are rejected if a token is found there.
+   */
+  readonly param?: string | readonly string[];
+}
+
+function normalizeParams(param: ParseEmbedTokenOptions["param"]): readonly string[] {
+  if (param === undefined) return [HONUA_EMBED_TOKEN_FRAGMENT_PARAM];
+  const list = typeof param === "string" ? [param] : param;
+  const names = list.map((name) => name.trim()).filter((name) => name.length > 0);
+  return names.length > 0 ? names : [HONUA_EMBED_TOKEN_FRAGMENT_PARAM];
+}
+
+/**
+ * Splits an arbitrary URL or location-like string into its query and fragment
+ * components without requiring an absolute base. Accepts a full URL
+ * (`https://host/path?q#frag`), a relative URL (`/path?q#frag`), a bare query
+ * (`?q`), or a bare fragment (`#frag`).
+ */
+function splitLocation(input: string): { query: string; fragment: string } | null {
+  if (typeof input !== "string") return null;
+  const hashIndex = input.indexOf("#");
+  const fragment = hashIndex >= 0 ? input.slice(hashIndex + 1) : "";
+  const beforeFragment = hashIndex >= 0 ? input.slice(0, hashIndex) : input;
+  const queryIndex = beforeFragment.indexOf("?");
+  const query = queryIndex >= 0 ? beforeFragment.slice(queryIndex + 1) : "";
+  return { query, fragment };
+}
+
+/**
+ * Reads a named parameter out of a `&`/`=` encoded component (query or
+ * fragment). Returns the first match's decoded value, or `null` if absent. A
+ * present-but-empty parameter (`embed_token=`) returns an empty string so the
+ * caller can distinguish "absent" from "blank".
+ */
+function readParam(component: string, names: readonly string[]): string | null {
+  if (component.length === 0) return null;
+  const params = new URLSearchParams(component);
+  for (const name of names) {
+    if (params.has(name)) return params.get(name) ?? "";
+  }
+  return null;
+}
+
+/**
+ * Extracts an embed bearer token from a URL/location fragment, rejecting any
+ * token placed in the query string.
+ *
+ * Resolution order:
+ * 1. If a token parameter is present in the **query string**, reject with
+ *    `query-string-token` — even if a fragment token also exists — so a
+ *    leak-prone placement is never silently tolerated.
+ * 2. Otherwise read the token from the **fragment**. A blank fragment token
+ *    rejects with `empty`; a missing one rejects with `missing`.
+ *
+ * @param input A full or relative URL, a bare query, or a bare fragment. In a
+ *   browser, pass `window.location.href` (or `location.search + location.hash`).
+ */
+export function parseEmbedTokenFromFragment(
+  input: string,
+  options: ParseEmbedTokenOptions = {},
+): HonuaEmbedTokenParseResult {
+  const names = normalizeParams(options.param);
+  const parts = splitLocation(input);
+  if (parts === null) return { ok: false, reason: "malformed" };
+
+  // (1) Reject query-string bearer tokens unconditionally.
+  const queryToken = readParam(parts.query, names);
+  if (queryToken !== null) {
+    return { ok: false, reason: "query-string-token" };
+  }
+
+  // (2) Read from the fragment.
+  const fragmentToken = readParam(parts.fragment, names);
+  if (fragmentToken === null) return { ok: false, reason: "missing" };
+
+  const trimmed = fragmentToken.trim();
+  if (trimmed.length === 0) return { ok: false, reason: "empty" };
+
+  return { ok: true, token: trimmed, param: names[0] };
+}
+
+/**
+ * Convenience guard: `true` when `input` carries an embed-token parameter in the
+ * query string (any leak-prone placement). Useful for asserting a redirect
+ * stripped the token before it reached a logged surface.
+ */
+export function hasQueryStringEmbedToken(input: string, options: ParseEmbedTokenOptions = {}): boolean {
+  const names = normalizeParams(options.param);
+  const parts = splitLocation(input);
+  if (parts === null) return false;
+  return readParam(parts.query, names) !== null;
+}

--- a/src/share/index.ts
+++ b/src/share/index.ts
@@ -1,0 +1,86 @@
+/**
+ * `@honua/sdk-js/share` — browser-safe Share, embed-token, public-link, and
+ * open-data contract types and helpers.
+ *
+ * The long-term Console runtime is .NET/Blazor, but generated apps and
+ * embeddable map surfaces need browser-safe contracts that match honua-server
+ * and `honua-sdk-dotnet`. This subpath projects that shared vocabulary into
+ * TypeScript so browser code consumes Share/embed/open-data state without
+ * inventing a second contract:
+ *
+ * - Contract types mirror the server JSON wire names exactly (a parsed `fetch`
+ *   body assigns straight into them).
+ * - {@link parseEmbedTokenFromFragment} enforces fragment-only embed bearer
+ *   tokens and rejects query-string placements.
+ * - Denial helpers model anonymous-safe access state without leaking item
+ *   identity or private titles.
+ * - Open-data helpers project a held read model into DCAT / Schema.org output.
+ *
+ * This entrypoint owns no transport: it consumes server responses that are
+ * already available. Admin/write share operations live on
+ * `@honua/sdk-js/control-plane`.
+ *
+ * @experimental This entrypoint is not yet covered by the SDK's semver contract
+ *   — the surface may change in any minor release prior to `1.0.0`.
+ * @module
+ */
+
+export {
+  HONUA_EMBED_AUDIENCES,
+  HONUA_SHARE_ACCESS_TIERS,
+} from "./types.js";
+export type {
+  HonuaEmbedAudience,
+  HonuaEmbedRedemption,
+  HonuaEmbedToken,
+  HonuaPublicLinkResolution,
+  HonuaPublicLinkToken,
+  HonuaShareAccessTier,
+  HonuaShareDependencyConflict,
+  HonuaShareItemType,
+  HonuaShareProjection,
+} from "./types.js";
+
+export {
+  HONUA_SHARE_DENIAL_MESSAGES,
+  denialFromHttpStatus,
+  denyShareAccess,
+  grantShareAccess,
+  isShareAccessDenied,
+  isShareAccessGranted,
+} from "./denial.js";
+export type {
+  HonuaEmbedAccessState,
+  HonuaPublicLinkAccessState,
+  HonuaShareAccessDenied,
+  HonuaShareAccessGranted,
+  HonuaShareAccessKind,
+  HonuaShareAccessState,
+  HonuaShareDenialReason,
+} from "./denial.js";
+
+export {
+  HONUA_EMBED_TOKEN_FRAGMENT_PARAM,
+  hasQueryStringEmbedToken,
+  parseEmbedTokenFromFragment,
+} from "./embed-token.js";
+export type {
+  HonuaEmbedTokenParseOk,
+  HonuaEmbedTokenParseRejected,
+  HonuaEmbedTokenParseResult,
+  HonuaEmbedTokenRejectionReason,
+  ParseEmbedTokenOptions,
+} from "./embed-token.js";
+
+export {
+  toDcatDataset,
+  toSchemaOrgDataset,
+} from "./open-data.js";
+export type {
+  DcatDataset,
+  DcatDistribution,
+  HonuaOpenDataDistribution,
+  HonuaOpenDataReadProjection,
+  SchemaOrgDataDownload,
+  SchemaOrgDataset,
+} from "./open-data.js";

--- a/src/share/open-data.ts
+++ b/src/share/open-data.ts
@@ -1,0 +1,174 @@
+/**
+ * Browser-safe open-data read projections and DCAT / Schema.org helper shapes.
+ *
+ * Generated apps and embeds frequently render an open-data landing card for a
+ * public-indexed item and need a stable, anonymous-safe shape plus a way to
+ * emit standards-aligned metadata (DCAT distributions, a Schema.org `Dataset`
+ * JSON-LD block) from an already-fetched server response. These helpers do not
+ * fetch or publish — they project a presentation read model the browser already
+ * holds into the shared vocabulary, so Console JS interop and generated apps
+ * agree on field names.
+ *
+ * The DCAT / Schema.org output follows the public DCAT (W3C / DCAT-AP) and
+ * Schema.org `Dataset` vocabularies. When honua-server's open-data publication
+ * API lands its own projection, prefer the server-emitted document; this helper
+ * remains the browser fallback for responses that only carry the read model.
+ *
+ * @module
+ */
+
+import type { HonuaShareItemType } from "./types.js";
+
+/** A downloadable/queryable distribution of an open-data item. */
+export interface HonuaOpenDataDistribution {
+  /** Stable id of the distribution within the item. */
+  readonly id?: string;
+  /** Human title of the distribution (e.g. "GeoJSON download"). */
+  readonly title?: string;
+  /** IANA media type (e.g. `application/geo+json`). */
+  readonly mediaType?: string;
+  /** Short format label (e.g. `GeoJSON`, `CSV`, `OGC API - Features`). */
+  readonly format?: string;
+  /** Direct download URL, when the distribution is a file. */
+  readonly downloadUrl?: string;
+  /** Access URL for service/API distributions (non-file). */
+  readonly accessUrl?: string;
+}
+
+/**
+ * Anonymous-safe open-data read projection for a public-indexed item. Presents
+ * only fields safe to expose on an open-data landing surface.
+ */
+export interface HonuaOpenDataReadProjection {
+  readonly itemId: string;
+  readonly itemType: HonuaShareItemType;
+  readonly title: string;
+  readonly summary?: string;
+  /** Keyword/theme tags. */
+  readonly keywords?: readonly string[];
+  /** License identifier or URL, when published. */
+  readonly license?: string;
+  /** Publishing organization/attribution, when set. */
+  readonly publisher?: string;
+  /** ISO-8601 timestamp the item was last modified, when known. */
+  readonly modified?: string;
+  /** Landing-page URL for the item on the open-data surface. */
+  readonly landingPageUrl?: string;
+  /** Distributions the item is available through. */
+  readonly distributions?: readonly HonuaOpenDataDistribution[];
+}
+
+/** A DCAT distribution object (`dcat:Distribution`). */
+export interface DcatDistribution {
+  readonly "@type": "dcat:Distribution";
+  readonly title?: string;
+  readonly mediaType?: string;
+  readonly format?: string;
+  readonly downloadURL?: string;
+  readonly accessURL?: string;
+}
+
+/** A DCAT dataset object (`dcat:Dataset`) for an open-data item. */
+export interface DcatDataset {
+  readonly "@type": "dcat:Dataset";
+  readonly identifier: string;
+  readonly title: string;
+  readonly description?: string;
+  readonly keyword?: readonly string[];
+  readonly license?: string;
+  readonly publisher?: string;
+  readonly modified?: string;
+  readonly landingPage?: string;
+  readonly distribution?: readonly DcatDistribution[];
+}
+
+/** A Schema.org `DataDownload` node. */
+export interface SchemaOrgDataDownload {
+  readonly "@type": "DataDownload";
+  readonly name?: string;
+  readonly encodingFormat?: string;
+  readonly contentUrl?: string;
+}
+
+/** A Schema.org `Dataset` JSON-LD node for an open-data item. */
+export interface SchemaOrgDataset {
+  readonly "@context": "https://schema.org";
+  readonly "@type": "Dataset";
+  readonly identifier: string;
+  readonly name: string;
+  readonly description?: string;
+  readonly keywords?: readonly string[];
+  readonly license?: string;
+  readonly publisher?: { readonly "@type": "Organization"; readonly name: string };
+  readonly dateModified?: string;
+  readonly url?: string;
+  readonly distribution?: readonly SchemaOrgDataDownload[];
+}
+
+function compact<T extends object>(value: T): T {
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (val === undefined) continue;
+    if (Array.isArray(val) && val.length === 0) continue;
+    out[key] = val;
+  }
+  return out as T;
+}
+
+/**
+ * Projects a browser-held open-data read projection into a `dcat:Dataset`
+ * object. Omits unset/empty fields so the emitted document is minimal.
+ */
+export function toDcatDataset(projection: HonuaOpenDataReadProjection): DcatDataset {
+  const distribution = projection.distributions?.map((d) =>
+    compact<DcatDistribution>({
+      "@type": "dcat:Distribution",
+      title: d.title,
+      mediaType: d.mediaType,
+      format: d.format,
+      downloadURL: d.downloadUrl,
+      accessURL: d.accessUrl,
+    }),
+  );
+  return compact<DcatDataset>({
+    "@type": "dcat:Dataset",
+    identifier: projection.itemId,
+    title: projection.title,
+    description: projection.summary,
+    keyword: projection.keywords,
+    license: projection.license,
+    publisher: projection.publisher,
+    modified: projection.modified,
+    landingPage: projection.landingPageUrl,
+    distribution,
+  });
+}
+
+/**
+ * Projects a browser-held open-data read projection into a Schema.org `Dataset`
+ * JSON-LD node, suitable for injection into a `<script type="application/ld+json">`
+ * block on an open-data landing page. Omits unset/empty fields.
+ */
+export function toSchemaOrgDataset(projection: HonuaOpenDataReadProjection): SchemaOrgDataset {
+  const distribution = projection.distributions?.map((d) =>
+    compact<SchemaOrgDataDownload>({
+      "@type": "DataDownload",
+      name: d.title,
+      encodingFormat: d.mediaType ?? d.format,
+      contentUrl: d.downloadUrl ?? d.accessUrl,
+    }),
+  );
+  return compact<SchemaOrgDataset>({
+    "@context": "https://schema.org",
+    "@type": "Dataset",
+    identifier: projection.itemId,
+    name: projection.title,
+    description: projection.summary,
+    keywords: projection.keywords,
+    license: projection.license,
+    publisher: projection.publisher ? { "@type": "Organization", name: projection.publisher } : undefined,
+    dateModified: projection.modified,
+    url: projection.landingPageUrl,
+    distribution,
+  });
+}

--- a/src/share/types.ts
+++ b/src/share/types.ts
@@ -1,0 +1,181 @@
+/**
+ * Browser-safe Share, embed, public-link, and open-data contract types.
+ *
+ * These mirror the canonical honua-server Console Share contracts
+ * (`ConsoleShareAccessTier`, `ConsoleEmbedAudience`, `ConsoleShareProjection`,
+ * `ConsolePublicLinkResolutionResponse`, `ConsoleEmbedRedeemResponse`, …) and
+ * the `honua-sdk-dotnet` console clients so generated apps, embeds, and Console
+ * JS interop consume one vocabulary instead of inventing a second one. Field
+ * names match the server JSON wire names exactly so a parsed `fetch` body is
+ * assignable to these types without remapping.
+ *
+ * @module
+ */
+
+/**
+ * Effective Share access tier for a content item. The share facet of an item,
+ * distinct from membership visibility: `public-link` exposes opaque-token
+ * access without changing membership; `public-indexed` implies the item is
+ * publicly readable and eligible for catalog indexing / open-data distribution.
+ *
+ * Mirrors `ConsoleShareAccessTier` (`private` | `organization` | `public-link`
+ * | `public-indexed`). The trailing `(string & {})` keeps the union open so a
+ * future server tier round-trips without a type error while preserving
+ * autocomplete on the known members.
+ */
+export type HonuaShareAccessTier = "private" | "organization" | "public-link" | "public-indexed" | (string & {});
+
+/** Known {@link HonuaShareAccessTier} members, for validation/iteration. */
+export const HONUA_SHARE_ACCESS_TIERS = ["private", "organization", "public-link", "public-indexed"] as const;
+
+/**
+ * Scope an embed authorization permits the redeeming surface to render.
+ * Mirrors `ConsoleEmbedAudience` (`map` | `content`).
+ */
+export type HonuaEmbedAudience = "map" | "content" | (string & {});
+
+/** Known {@link HonuaEmbedAudience} members. */
+export const HONUA_EMBED_AUDIENCES = ["map", "content"] as const;
+
+/**
+ * Console content item category. Mirrors `ConsoleContentItemType`.
+ */
+export type HonuaShareItemType =
+  | "service"
+  | "layer"
+  | "saved-map"
+  | "dashboard"
+  | "report"
+  | "generated-app"
+  | "open-data"
+  | (string & {});
+
+/**
+ * A public-link token granting opaque, membership-independent read access.
+ * Mirrors `ConsolePublicLinkToken`.
+ *
+ * The opaque {@link token} value is disclosed only in the mint response and is
+ * `null`/absent on every subsequent read; callers reference a token thereafter
+ * by its stable {@link tokenId}.
+ */
+export interface HonuaPublicLinkToken {
+  /** Stable identifier (safe to surface in lists/audit; carries no capability). */
+  readonly tokenId: string;
+  /** Opaque token value — populated only in the mint response, else `null`. */
+  readonly token?: string | null;
+  /** Content item this token grants access to. */
+  readonly itemId: string;
+  /** ISO-8601 timestamp the token was minted. */
+  readonly createdAt: string;
+  /** ISO-8601 expiry; `null`/absent means it never self-expires. */
+  readonly expiresAt?: string | null;
+  /** Principal that minted the token (audit attribution). */
+  readonly createdById?: string | null;
+  /** True when the token can no longer resolve (revoked or past expiry). */
+  readonly isExpired: boolean;
+}
+
+/**
+ * An embed token authorizing an external surface to render an item for a
+ * bounded audience and TTL. Mirrors `ConsoleEmbedToken`. Embed tokens always
+ * carry a hard {@link expiresAt}.
+ */
+export interface HonuaEmbedToken {
+  /** Stable identifier (audit/listing). */
+  readonly tokenId: string;
+  /** Opaque token value — populated only in the mint response. */
+  readonly token?: string | null;
+  /** Content item this token authorizes embedding for. */
+  readonly itemId: string;
+  /** Audience/scope the embed may render. */
+  readonly audience: HonuaEmbedAudience;
+  /** ISO-8601 timestamp the token was minted. */
+  readonly createdAt: string;
+  /** ISO-8601 hard expiry (always present for embed tokens). */
+  readonly expiresAt: string;
+  /** Principal that minted the token (audit attribution). */
+  readonly createdById?: string | null;
+  /** True when past expiry or embedding has been disabled on the item. */
+  readonly isExpired: boolean;
+}
+
+/**
+ * Server-owned Share access projection — the read model the Share panel renders
+ * without resolving share state client-side. Mirrors `ConsoleShareProjection`.
+ */
+export interface HonuaShareProjection {
+  /** Content item id. */
+  readonly itemId: string;
+  /** Machine-friendly item name. */
+  readonly itemName: string;
+  /** Human-readable title, when set. */
+  readonly itemTitle?: string | null;
+  /** Item category. */
+  readonly itemType: HonuaShareItemType;
+  /** Owner principal id, when set. */
+  readonly ownerId?: string | null;
+  /** Effective Share access tier. */
+  readonly accessTier: HonuaShareAccessTier;
+  /** True when at least one non-expired public-link token exists. */
+  readonly publicLinkEnabled: boolean;
+  /** Active and historical public-link tokens (token value always absent here). */
+  readonly publicLinkTokens?: readonly HonuaPublicLinkToken[];
+  /** True when embedding is enabled for the item. */
+  readonly embedEnabled: boolean;
+  /** Configured embed audience when {@link embedEnabled} is true. */
+  readonly embedAudience?: HonuaEmbedAudience | null;
+  /** Whether the item is currently eligible for open-data distribution. */
+  readonly openDataEligible: boolean;
+  /** Console verbs the requesting principal may perform on the item. */
+  readonly callerPermissions?: readonly string[];
+  /** True when an anonymous caller could read the item through any share mechanism. */
+  readonly anonymousEligible: boolean;
+  /** Logical access endpoints keyed by relation (e.g. `self`). */
+  readonly endpoints?: Readonly<Record<string, string>>;
+  /** ISO-8601 timestamp the share state was last updated, when state exists. */
+  readonly updatedAt?: string | null;
+  /** Principal that last updated the share state, when state exists. */
+  readonly updatedById?: string | null;
+}
+
+/**
+ * A dependency that blocks a public-sharing or embed-enablement request because
+ * it is not shareable by the requested audience. Mirrors
+ * `ConsoleShareDependencyConflict`.
+ *
+ * `itemName` is populated for authenticated callers and omitted on anonymous
+ * surfaces so private titles are never leaked.
+ */
+export interface HonuaShareDependencyConflict {
+  readonly itemId: string;
+  readonly itemType?: HonuaShareItemType | null;
+  readonly itemName?: string | null;
+  readonly blockingReason: string;
+}
+
+/**
+ * Anonymous-safe public-link / public-content resolution response. Mirrors
+ * `ConsolePublicLinkResolutionResponse`. Carries only presentation metadata —
+ * owner, provenance, and caller permissions are never present on this surface.
+ */
+export interface HonuaPublicLinkResolution {
+  readonly itemId: string;
+  readonly itemType: HonuaShareItemType;
+  readonly title?: string | null;
+  readonly summary?: string | null;
+  readonly accessTier: HonuaShareAccessTier;
+  readonly endpoints: Readonly<Record<string, string>>;
+}
+
+/**
+ * Anonymous-safe embed redemption response. Mirrors `ConsoleEmbedRedeemResponse`.
+ */
+export interface HonuaEmbedRedemption {
+  readonly itemId: string;
+  readonly itemType: HonuaShareItemType;
+  readonly title?: string | null;
+  readonly audience: HonuaEmbedAudience;
+  /** ISO-8601 hard expiry of the redeemed token. */
+  readonly expiresAt: string;
+  readonly endpoints: Readonly<Record<string, string>>;
+}

--- a/test/share-contracts.test.ts
+++ b/test/share-contracts.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HONUA_EMBED_AUDIENCES,
+  HONUA_EMBED_TOKEN_FRAGMENT_PARAM,
+  HONUA_SHARE_ACCESS_TIERS,
+  HONUA_SHARE_DENIAL_MESSAGES,
+  denialFromHttpStatus,
+  denyShareAccess,
+  grantShareAccess,
+  hasQueryStringEmbedToken,
+  isShareAccessDenied,
+  isShareAccessGranted,
+  parseEmbedTokenFromFragment,
+  toDcatDataset,
+  toSchemaOrgDataset,
+} from "../src/share/index.js";
+import type {
+  HonuaEmbedRedemption,
+  HonuaOpenDataReadProjection,
+  HonuaPublicLinkResolution,
+  HonuaShareProjection,
+} from "../src/share/index.js";
+
+describe("share contract vocabulary", () => {
+  it("matches the canonical server access-tier and embed-audience names", () => {
+    // These string literals are the honua-server JSON wire values; keep them in
+    // lockstep so a parsed server response assigns straight into the SDK type.
+    expect(HONUA_SHARE_ACCESS_TIERS).toEqual(["private", "organization", "public-link", "public-indexed"]);
+    expect(HONUA_EMBED_AUDIENCES).toEqual(["map", "content"]);
+  });
+
+  it("accepts a server ConsoleShareProjection-shaped object without remapping", () => {
+    const wire = {
+      itemId: "item-1",
+      itemName: "city-parcels",
+      itemTitle: "City Parcels",
+      itemType: "saved-map",
+      ownerId: "user-7",
+      accessTier: "public-link",
+      publicLinkEnabled: true,
+      publicLinkTokens: [
+        {
+          tokenId: "tok-1",
+          token: null,
+          itemId: "item-1",
+          createdAt: "2026-05-01T00:00:00.000Z",
+          expiresAt: null,
+          createdById: "user-7",
+          isExpired: false,
+        },
+      ],
+      embedEnabled: true,
+      embedAudience: "map",
+      openDataEligible: false,
+      callerPermissions: ["share", "embed", "administer"],
+      anonymousEligible: true,
+      endpoints: { self: "/api/v1/console/share/content/item-1" },
+      updatedAt: "2026-05-02T00:00:00.000Z",
+      updatedById: "user-7",
+    };
+    const projection: HonuaShareProjection = wire;
+    expect(projection.accessTier).toBe("public-link");
+    expect(projection.publicLinkTokens?.[0].token).toBeNull();
+    expect(projection.embedAudience).toBe("map");
+  });
+});
+
+describe("fragment-only embed token parsing", () => {
+  it("extracts the token from a URL fragment", () => {
+    const result = parseEmbedTokenFromFragment("https://app.example/embed/item-1#embed_token=abc.def.ghi");
+    expect(result).toEqual({ ok: true, token: "abc.def.ghi", param: HONUA_EMBED_TOKEN_FRAGMENT_PARAM });
+  });
+
+  it("rejects a bearer token placed in the query string", () => {
+    const result = parseEmbedTokenFromFragment("https://app.example/embed/item-1?embed_token=abc.def.ghi");
+    expect(result).toEqual({ ok: false, reason: "query-string-token" });
+  });
+
+  it("rejects a query-string token even when a fragment token is also present", () => {
+    const result = parseEmbedTokenFromFragment("https://app.example/embed?embed_token=leak#embed_token=safe");
+    expect(result).toEqual({ ok: false, reason: "query-string-token" });
+  });
+
+  it("reports a missing token", () => {
+    expect(parseEmbedTokenFromFragment("https://app.example/embed/item-1#theme=dark")).toEqual({
+      ok: false,
+      reason: "missing",
+    });
+  });
+
+  it("reports an empty (blank) fragment token distinctly from missing", () => {
+    expect(parseEmbedTokenFromFragment("https://app.example/embed#embed_token=")).toEqual({
+      ok: false,
+      reason: "empty",
+    });
+    expect(parseEmbedTokenFromFragment("https://app.example/embed#embed_token=%20%20")).toEqual({
+      ok: false,
+      reason: "empty",
+    });
+  });
+
+  it("works with a bare fragment and a bare query", () => {
+    expect(parseEmbedTokenFromFragment("#embed_token=xyz")).toEqual({
+      ok: true,
+      token: "xyz",
+      param: HONUA_EMBED_TOKEN_FRAGMENT_PARAM,
+    });
+    expect(parseEmbedTokenFromFragment("?embed_token=xyz")).toEqual({
+      ok: false,
+      reason: "query-string-token",
+    });
+  });
+
+  it("honors a custom fragment parameter name", () => {
+    expect(parseEmbedTokenFromFragment("https://app.example/#t=zzz", { param: "t" })).toEqual({
+      ok: true,
+      token: "zzz",
+      param: "t",
+    });
+    expect(parseEmbedTokenFromFragment("https://app.example/?t=zzz", { param: "t" })).toEqual({
+      ok: false,
+      reason: "query-string-token",
+    });
+  });
+
+  it("decodes percent-encoded fragment tokens", () => {
+    const result = parseEmbedTokenFromFragment("#embed_token=a%2Bb%2Fc");
+    expect(result).toEqual({ ok: true, token: "a+b/c", param: HONUA_EMBED_TOKEN_FRAGMENT_PARAM });
+  });
+
+  it("hasQueryStringEmbedToken flags leak-prone placements", () => {
+    expect(hasQueryStringEmbedToken("https://app.example/?embed_token=x")).toBe(true);
+    expect(hasQueryStringEmbedToken("https://app.example/#embed_token=x")).toBe(false);
+  });
+});
+
+describe("anonymous-safe denial states", () => {
+  it("denies without leaking item identity and uses a constant message per kind", () => {
+    const denied = denyShareAccess("public-link", "not-found");
+    expect(denied).toEqual({
+      status: "denied",
+      kind: "public-link",
+      reason: "not-found",
+      message: HONUA_SHARE_DENIAL_MESSAGES["public-link"],
+    });
+    // The denial carries no item id/title field at all.
+    expect(Object.keys(denied).sort()).toEqual(["kind", "message", "reason", "status"]);
+  });
+
+  it("uses identical message content across expired/not-found for the same kind (no oracle)", () => {
+    const notFound = denyShareAccess("embed", "not-found");
+    const expired = denyShareAccess("embed", "expired");
+    expect(notFound.message).toBe(expired.message);
+  });
+
+  it("maps anonymous-endpoint HTTP statuses onto coarse denial reasons", () => {
+    expect(denialFromHttpStatus("public-link", 404).reason).toBe("not-found");
+    expect(denialFromHttpStatus("public-content", 200).reason).toBe("not-found");
+    expect(denialFromHttpStatus("embed", 403).reason).toBe("forbidden");
+    expect(denialFromHttpStatus("embed", 410).reason).toBe("expired");
+  });
+
+  it("narrows granted and denied states", () => {
+    const resolution: HonuaPublicLinkResolution = {
+      itemId: "item-1",
+      itemType: "saved-map",
+      title: "City Parcels",
+      summary: "Public parcels layer",
+      accessTier: "public-link",
+      endpoints: { self: "/api/v1/console/share/content/item-1" },
+    };
+    const granted = grantShareAccess("public-link", resolution);
+    expect(isShareAccessGranted(granted)).toBe(true);
+    if (isShareAccessGranted(granted)) {
+      expect(granted.resolution.itemId).toBe("item-1");
+    }
+
+    const denied = denyShareAccess("embed", "expired");
+    expect(isShareAccessDenied(denied)).toBe(true);
+  });
+
+  it("accepts a server ConsoleEmbedRedeemResponse-shaped object", () => {
+    const wire = {
+      itemId: "item-1",
+      itemType: "saved-map",
+      title: "City Parcels",
+      audience: "map",
+      expiresAt: "2026-05-29T12:00:00.000Z",
+      endpoints: { self: "/api/v1/console/share/content/item-1" },
+    };
+    const redemption: HonuaEmbedRedemption = wire;
+    const granted = grantShareAccess("embed", redemption);
+    expect(granted.resolution.audience).toBe("map");
+  });
+});
+
+describe("open-data read projection helpers", () => {
+  const projection: HonuaOpenDataReadProjection = {
+    itemId: "item-1",
+    itemType: "open-data",
+    title: "City Parcels",
+    summary: "Authoritative parcel boundaries.",
+    keywords: ["parcels", "cadastre"],
+    license: "https://creativecommons.org/licenses/by/4.0/",
+    publisher: "City of Example",
+    modified: "2026-05-20T00:00:00.000Z",
+    landingPageUrl: "https://data.example/datasets/item-1",
+    distributions: [
+      {
+        title: "GeoJSON",
+        mediaType: "application/geo+json",
+        format: "GeoJSON",
+        downloadUrl: "https://data.example/datasets/item-1.geojson",
+      },
+      {
+        title: "OGC API - Features",
+        format: "OGC API - Features",
+        accessUrl: "https://data.example/ogc/collections/item-1",
+      },
+    ],
+  };
+
+  it("projects into a dcat:Dataset, omitting empty fields", () => {
+    const dataset = toDcatDataset(projection);
+    expect(dataset["@type"]).toBe("dcat:Dataset");
+    expect(dataset.identifier).toBe("item-1");
+    expect(dataset.title).toBe("City Parcels");
+    expect(dataset.keyword).toEqual(["parcels", "cadastre"]);
+    expect(dataset.landingPage).toBe("https://data.example/datasets/item-1");
+    expect(dataset.distribution).toHaveLength(2);
+    expect(dataset.distribution?.[0]).toEqual({
+      "@type": "dcat:Distribution",
+      title: "GeoJSON",
+      mediaType: "application/geo+json",
+      format: "GeoJSON",
+      downloadURL: "https://data.example/datasets/item-1.geojson",
+    });
+    // The service distribution carries accessURL, not downloadURL.
+    expect(dataset.distribution?.[1]).toEqual({
+      "@type": "dcat:Distribution",
+      title: "OGC API - Features",
+      format: "OGC API - Features",
+      accessURL: "https://data.example/ogc/collections/item-1",
+    });
+  });
+
+  it("projects into a Schema.org Dataset JSON-LD node", () => {
+    const dataset = toSchemaOrgDataset(projection);
+    expect(dataset["@context"]).toBe("https://schema.org");
+    expect(dataset["@type"]).toBe("Dataset");
+    expect(dataset.identifier).toBe("item-1");
+    expect(dataset.name).toBe("City Parcels");
+    expect(dataset.publisher).toEqual({ "@type": "Organization", name: "City of Example" });
+    expect(dataset.distribution?.[0]).toEqual({
+      "@type": "DataDownload",
+      name: "GeoJSON",
+      encodingFormat: "application/geo+json",
+      contentUrl: "https://data.example/datasets/item-1.geojson",
+    });
+    expect(JSON.stringify(dataset)).toContain('"@type":"Dataset"');
+  });
+
+  it("omits publisher and distributions when absent", () => {
+    const minimal: HonuaOpenDataReadProjection = {
+      itemId: "item-2",
+      itemType: "open-data",
+      title: "Minimal",
+    };
+    const dcat = toDcatDataset(minimal);
+    expect(dcat).toEqual({ "@type": "dcat:Dataset", identifier: "item-2", title: "Minimal" });
+    const schema = toSchemaOrgDataset(minimal);
+    expect("publisher" in schema).toBe(false);
+    expect("distribution" in schema).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a new browser-safe `@honua/sdk-js/share` subpath that projects the
canonical honua-server Console Share contracts into TypeScript so generated
apps, embeds, and Console JS interop consume **one** vocabulary instead of
inventing a second one for token/open-data semantics.

The long-term Console runtime is .NET/Blazor, but browser surfaces still need
contracts that match honua-server and `honua-sdk-dotnet`. This subpath owns no
transport — it consumes server responses that are already available. Admin/write
share operations stay on `@honua/sdk-js/control-plane`.

### Contract types (`src/share/types.ts`)

Mirror the server JSON wire names exactly so a parsed `fetch` body assigns
straight into the SDK type with no remapping:

| SDK type | honua-server contract |
|----------|-----------------------|
| `HonuaShareAccessTier` | `ConsoleShareAccessTier` (`private`/`organization`/`public-link`/`public-indexed`) |
| `HonuaEmbedAudience` | `ConsoleEmbedAudience` (`map`/`content`) |
| `HonuaShareItemType` | `ConsoleContentItemType` |
| `HonuaPublicLinkToken` / `HonuaEmbedToken` | `ConsolePublicLinkToken` / `ConsoleEmbedToken` |
| `HonuaShareProjection` | `ConsoleShareProjection` |
| `HonuaPublicLinkResolution` | `ConsolePublicLinkResolutionResponse` |
| `HonuaEmbedRedemption` | `ConsoleEmbedRedeemResponse` |
| `HonuaShareDependencyConflict` | `ConsoleShareDependencyConflict` |

Known string unions stay open with `(string & {})`; `HONUA_SHARE_ACCESS_TIERS` /
`HONUA_EMBED_AUDIENCES` export the known members.

### Fragment-only embed tokens (`src/share/embed-token.ts`)

`parseEmbedTokenFromFragment` extracts an embed bearer token from the URL
**fragment** and **rejects** a query-string placement outright — even when a
fragment token is also present — so a leak-prone token never gets silently
accepted. Rejection reasons: `query-string-token`, `missing`, `empty`,
`malformed`. `hasQueryStringEmbedToken` is a guard for asserting a redirect
stripped the token before it hit a logged surface.

### Anonymous-safe denial states (`src/share/denial.ts`)

`HonuaShareAccessState` is the discriminated browser mirror of the server's
anonymous Share endpoints. A denied state carries only a coarse `reason`
(`not-found`/`expired`/`forbidden`) and a constant, identity-free `message`
sourced from `HONUA_SHARE_DENIAL_MESSAGES` — never from caller item data — so
private titles never leak and the message is not an existence oracle.
`denialFromHttpStatus` maps anonymous-endpoint statuses onto those reasons.

### Open-data read projections (`src/share/open-data.ts`)

`HonuaOpenDataReadProjection` plus `toDcatDataset` / `toSchemaOrgDataset` project
a held read model into W3C DCAT / DCAT-AP and Schema.org `Dataset` JSON-LD for
open-data landing surfaces. When honua-server's open-data publication API ships
its own DCAT/STAC projection, prefer the server document; these remain the
browser fallback for responses that only carry the read model.

## Scope

First, self-contained slice of #233. The issue is a browser **contract
projection**; its `depends_on` server APIs are the source-of-truth for write/mint
flows, and this PR deliberately only projects read/consumption contracts and
helpers (no transport). The Share/embed contracts are projected against the
existing canonical server domain types
(`Honua.Core.Features.Console.Domain.*`); the DCAT/Schema.org helpers follow the
public DCAT and Schema.org vocabularies until the server's open-data publication
projection lands.

## Wiring

- `package.json`: adds the `./share` subpath export.
- `scripts/prepare-split-packages.mjs` + `scripts/verify-split-packages.mjs`:
  copy/declare the subpath in the `@honua/sdk` split package and assert its
  exports (including that the embed-token helper rejects a query-string token).

## Tests

- `test/share-contracts.test.ts` covers: server contract-name compatibility;
  embed-token placement (fragment accept, query-string reject, query-wins-over-
  fragment reject, missing vs empty, custom param, percent-decoding); denial
  states (no identity leak, identical message across reasons, HTTP-status
  mapping, granted/denied narrowing); and open-data DCAT/Schema.org projection
  with empty-field omission.
- Local `tsc --noEmit` passes; Biome `check` passes on the new files. Full
  `npm run check` / unit suite / `verify:split-packages` are exercised by CI (the
  shared local build lock was saturated by other agents at push time).

Refs #233
