### PR TITLE
Verify Operate observability subpath in entrypoint and split-package gates

### DIFF
--- a/scripts/verify-split-packages.mjs
+++ b/scripts/verify-split-packages.mjs
@@ -77,6 +77,11 @@ import {
   toDcatDataset,
 } from "@honua/sdk/share";
 import {
+  HONUA_OPERATE_BASE_PATH,
+  HonuaOperateClient,
+  createHonuaOperate,
+} from "@honua/sdk/operate";
+import {
   CAPABILITIES,
   PROTOCOLS,
   createDataset,
@@ -239,6 +244,10 @@ if (typeof parseEmbedTokenFromFragment !== "function" || typeof toDcatDataset !=
   throw new Error("share contract exports missing from @honua/sdk/share");
 if (parseEmbedTokenFromFragment("https://app.example/embed?embed_token=leaked").ok)
   throw new Error("share embed-token helper accepted a query-string bearer token");
+if (HONUA_OPERATE_BASE_PATH !== "/api/v1/operate")
+  throw new Error("HONUA_OPERATE_BASE_PATH export missing from @honua/sdk/operate");
+if (typeof createHonuaOperate !== "function" || typeof HonuaOperateClient !== "function")
+  throw new Error("operate observability exports missing from @honua/sdk/operate");
 if (!Array.isArray(HONUA_AGENT_TOOL_NAMES) || !HONUA_AGENT_TOOL_NAMES.includes("explainCapabilityGap"))
   throw new Error("agent tool exports missing from @honua/sdk/agent-tools");
 if (explainHonuaCapabilityGap({ protocol: "wmts", capability: "query" }).supported)

--- a/test/entrypoints.test.ts
+++ b/test/entrypoints.test.ts
@@ -219,6 +219,19 @@ import {
   summarizeJsParityMatrix,
 } from "../src/migration-entry.js";
 import {
+  HONUA_OPERATE_BASE_PATH,
+  HonuaAlertRulesClient,
+  HonuaAlertsClient,
+  HonuaEventsClient,
+  HonuaGeofencesClient,
+  HonuaInvestigationsClient,
+  HonuaJobsClient,
+  HonuaLogsClient,
+  HonuaOperateClient,
+  HonuaTelemetryClient,
+  createHonuaOperate,
+} from "../src/operate/index.js";
+import {
   createRealtimeFeatureStore,
   emptyRealtimeFeatureState,
   reduceRealtimeFeatureState,
@@ -495,6 +508,20 @@ describe("entrypoint modules", () => {
     expect(createHonuaReplicaSync).toBeTypeOf("function");
     expect(createFixtureReplicaSyncTransport).toBeTypeOf("function");
     expect(isUnsupportedReplicaSyncError).toBeTypeOf("function");
+  });
+
+  it("exposes the operate observability entrypoint", () => {
+    expect(HONUA_OPERATE_BASE_PATH).toBe("/api/v1/operate");
+    expect(createHonuaOperate).toBeTypeOf("function");
+    expect(HonuaOperateClient).toBeTypeOf("function");
+    expect(HonuaTelemetryClient).toBeTypeOf("function");
+    expect(HonuaEventsClient).toBeTypeOf("function");
+    expect(HonuaLogsClient).toBeTypeOf("function");
+    expect(HonuaAlertsClient).toBeTypeOf("function");
+    expect(HonuaAlertRulesClient).toBeTypeOf("function");
+    expect(HonuaGeofencesClient).toBeTypeOf("function");
+    expect(HonuaInvestigationsClient).toBeTypeOf("function");
+    expect(HonuaJobsClient).toBeTypeOf("function");
   });
 
   it("exposes the runtime style and interaction helper entrypoint", () => {


### PR DESCRIPTION
## What

The `@honua/sdk-js/operate` observability contracts for issue #229 already landed on trunk (PR #243): TypeScript types for observability target, server telemetry status, operational events (distinguished from audit), log records, metric snapshots, alerts, realtime alert rules, geofence zones, delivery channel bindings, investigations, and the job viewer (run summary/detail, stage, log, artifact); the `HonuaOperateClient` with telemetry / events / logs / alerts / alert-rules / geofences / investigations / jobs sub-clients; 14 fixtures (healthy/degraded/disabled telemetry, critical/suppressed alerts, geofence rule, delivery failure, running/failed/retried/artifact-producing jobs, investigation timeline, unsupported-capability responses); capability flags that degrade missing providers to typed `HonuaOperateUnsupported` results; and the `./operate` subpath export wired into `package.json` and the split-package build.

That PR used `Refs #229` instead of `Fixes #229`, so the issue stayed open, and the `./operate` subpath — unlike its sibling experimental subpaths — was not smoke-imported in the entrypoint test or asserted in the split-package verifier. This PR closes those gaps and the issue.

- `test/entrypoints.test.ts`: import and assert every operate client export (`HonuaOperateClient` plus the eight sub-clients, the `createHonuaOperate` factory, and `HONUA_OPERATE_BASE_PATH`).
- `scripts/verify-split-packages.mjs`: import from `@honua/sdk/operate` and fail the split-package smoke if the base path or client/factory exports are missing from the published package.

## Testing

- `npm run typecheck` — green
- `npm run check` (Biome) — green
- `npx vitest run test/entrypoints.test.ts test/operate.test.ts` — 29 passed (15 entrypoints + 14 operate)
- `npm run verify:split-packages` — green (`splitPackageSmoke=ok`, `./operate` subpath asserted in the published `@honua/sdk`)

Fixes #229