### PR TITLE
Console MapPackage/AppPackage projections + contract-ownership docs (#225)

### DIFF
--- a/docs/console-contracts.md
+++ b/docs/console-contracts.md
@@ -1,0 +1,111 @@
+# Console SDK contracts: ownership and parity (`honua-sdk-js#225`)
+
+Status: experimental. The `@honua/sdk-js/console` subpath exposes browser-safe
+contracts so [`honua-console`](https://github.com/honua-io/honua-console) can
+consume the shared metadata / content / package model without copying server
+DTOs or Portal-only types. The decision source is
+`honua-console/docs/adr/0001-unified-honua-console-runtime.md`; the server
+baseline is `honua-server#1162` (Console metadata v2 content + RBAC API).
+
+```ts
+import {
+  // content + metadata v2
+  type HonuaConsoleContentItem,
+  type HonuaConsoleMetadata,
+  type HonuaConsoleSharing,
+  type HonuaConsoleEmbed,
+  type HonuaConsoleProvenance,
+  isKnownConsoleContentKind,
+  // dashboards / reports + Vega-Lite
+  projectDashboardPackage,
+  projectReportPackage,
+  chartWidgetToVegaLiteSpec,
+  normalizeVegaLiteSpec,
+  assertVegaLiteSpec,
+  // map / app package catalog projections
+  projectMapPackage,
+  projectAppPackage,
+  // typed Console errors
+  HonuaConsoleError,
+  toConsoleDiagnostic,
+} from "@honua/sdk-js/console";
+```
+
+There is **no Console-specific copy** of these protocol types: Console imports
+the SDK projection directly, and the SDK reuses the runtime
+(`@honua/sdk-js/runtime`) and generated-app (`@honua/sdk-js/generated-app`) wire
+types rather than redefining them.
+
+## Contract ownership
+
+Every Console contract is exactly one of three kinds. This is the load-bearing
+distinction Console UI must respect: it never mutates a server-owned shape, it
+trusts SDK-projected helpers to validate and narrow, and it owns only the render
+state derived from a projection.
+
+| Contract | Owner | Where |
+| --- | --- | --- |
+| Metadata v2 wire shape | **server-owned** | `honua-server` (`honua_metadata.v2`) |
+| Content item wire shape | **server-owned** | `honua-server` |
+| Sharing / embed / provenance wire shapes | **server-owned** | `honua-server`, RBAC API (`#1162`) |
+| MapPackage (`honua_map_package.v1`) | **server-owned** | `honua-server`; typed in SDK `@honua/sdk-js/runtime` (`HonuaMapPackage`) |
+| Generated AppPackage + manifest artifact | **server-owned** | `honua-server` builder; typed in `@honua/sdk-js/generated-app` |
+| Dashboard / report package wire shape | **server-owned** | `honua-server` |
+| `HonuaConsoleContentItem` / `HonuaConsoleMetadata` / `HonuaConsoleSharing` / `HonuaConsoleEmbed` / `HonuaConsoleProvenance` | **SDK-projected** | `src/console/content.ts` |
+| `HonuaVegaLiteSpec` subset + `assert`/`is`/`normalize` | **SDK-projected** | `src/console/vega-lite.ts` |
+| `projectDashboardPackage` / `projectReportPackage` / `chartWidgetToVegaLiteSpec` | **SDK-projected** | `src/console/dashboard.ts` |
+| `projectMapPackage` / `projectAppPackage` catalog summaries | **SDK-projected** | `src/console/packages.ts` |
+| `HonuaConsoleError` + diagnostics | **SDK-projected** | `src/console/errors.ts` |
+| `*RenderModel`, `*Projection` UI state | **Console-rendered** | `honua-console` (derived from the above) |
+
+- **server-owned** contracts are the canonical wire shapes. The SDK never
+  invents fields; every projection interface keeps an open index signature
+  (`[extra: string]: unknown`) so additive server fields survive a round-trip
+  without a contract bump or a Console-side copy.
+- **SDK-projected** contracts are the browser-safe, validated subset plus the
+  projection helpers. They are the only place that decides "supported vs
+  unsupported" and emit a typed {@link HonuaConsoleError} for the gaps Console
+  needs to render (`unsupported-package-format`, `unsupported-chart-spec`,
+  `missing-binding`, `missing-chart-spec`, `unsupported-content-kind`, …).
+- **Console-rendered** state is owned by `honua-console`. The SDK ships the
+  render *models* (`HonuaConsoleDashboardRenderModel`, the `*Projection`
+  summaries) that Console hydrates; it does not own layout or routing.
+
+## Packages: full runtime vs catalog projection
+
+The package projections in `src/console/packages.ts` are deliberately **slim
+catalog summaries** for content-browser and detail surfaces — they do not
+replace the runtimes:
+
+- To actually render a map, use `loadMapPackage` from `@honua/sdk-js/runtime`.
+- To actually run a generated app, use `loadGeneratedAppRuntime` from
+  `@honua/sdk-js/generated-app`.
+- To list / inspect a package in the Console catalog (identity, status, source
+  and layer counts, widget and chart-kind inventory, sharing, provenance), use
+  `projectMapPackage` / `projectAppPackage`. Both gate on the package `format`
+  and throw a typed `HonuaConsoleError` for an unsupported version or a missing
+  manifest, so Console flags the broken entry instead of rendering a partial
+  view.
+
+## Vega-Lite chart specs
+
+The SDK does not bundle Vega; it owns the **portable, validated chart-spec
+shape** (`HonuaVegaLiteSpec`, a narrow single-view subset) so dashboard / report
+packages can carry chart specs that round-trip cleanly between server, SDK
+projection, and the Console renderer. `normalizeVegaLiteSpec` pins the SDK
+`$schema` and the result re-validates through `assertVegaLiteSpec`.
+
+`chartWidgetToVegaLiteSpec` bridges the generated-app chart-kind vocabulary
+(`categories` / `histogram` / `time-series`) into a Vega-Lite spec, so a chart
+defined for a generated app and a chart defined on a Console dashboard render
+identically.
+
+## MCP / QGIS / Console parity
+
+These contracts describe the **same package artifacts** the MCP server and the
+QGIS plugin consume. The chart-kind vocabulary and the package provenance
+envelope are shared across all surfaces (see
+[`studio-package-parity.md`](./studio-package-parity.md)). A package produced
+through MCP or QGIS validates against the same SDK envelope and opens in Console
+without a surface-specific format — there is one set of package contracts, not
+one per surface.

--- a/scripts/verify-split-packages.mjs
+++ b/scripts/verify-split-packages.mjs
@@ -123,7 +123,7 @@ import { validateHonuaStyle } from "@honua/sdk/style";
 import { loadMapPackage, validateRuntimeStyleSpec } from "@honua/sdk/runtime";
 import { defineHonuaWebComponents } from "@honua/sdk/web-components";
 import { projectBuildSpecToGeneratedAppManifest } from "@honua/sdk/generated-app";
-import { chartWidgetToVegaLiteSpec, isVegaLiteSpec } from "@honua/sdk/console";
+import { chartWidgetToVegaLiteSpec, isVegaLiteSpec, projectMapPackage } from "@honua/sdk/console";
 import { HONUA_QUERY_PACKAGE_FORMAT_V1, toStudioValidationResponse } from "@honua/sdk/studio";
 import { OPERATOR_EXECUTION_OUTPUT_KEY } from "@honua/sdk/operator";
 import { ChatController } from "@honua/sdk/operator/controllers";
@@ -303,6 +303,18 @@ if (typeof chartWidgetToVegaLiteSpec !== "function" || typeof isVegaLiteSpec !==
   throw new Error("console chart spec exports missing from @honua/sdk/console");
 if (!isVegaLiteSpec(chartWidgetToVegaLiteSpec({ chartKind: "categories", groupBy: "status" })))
   throw new Error("@honua/sdk/console chartWidgetToVegaLiteSpec did not produce a valid Vega-Lite spec");
+if (typeof projectMapPackage !== "function")
+  throw new Error("projectMapPackage export missing from @honua/sdk/console");
+{
+  const mapProjection = projectMapPackage({
+    mapPackageId: "verify-mp",
+    format: "honua_map_package.v1",
+    sourceBindings: [],
+    mapSpec: { version: 8, sources: {}, layers: [] },
+  });
+  if (mapProjection.kind !== "map-package" || mapProjection.id !== "verify-mp")
+    throw new Error("@honua/sdk/console projectMapPackage did not produce a MapPackage projection");
+}
 if (HONUA_QUERY_PACKAGE_FORMAT_V1 !== "honua_query_package.v1")
   throw new Error("HONUA_QUERY_PACKAGE_FORMAT_V1 export missing from @honua/sdk/studio");
 if (typeof toStudioValidationResponse !== "function")

--- a/src/console/index.ts
+++ b/src/console/index.ts
@@ -2,17 +2,20 @@
  * `@honua/sdk-js/console` — browser-safe SDK contracts for `honua-console`.
  *
  * This subpath exposes the SDK-projected view of the shared content/metadata
- * model (content items, Metadata v2, sharing, embeds, provenance) and the
- * dashboard/report package projections with Vega-Lite chart spec support, so
- * Console can consume stable contracts without copying server DTOs or Portal
- * types.
+ * model (content items, Metadata v2, sharing, embeds, provenance), the
+ * dashboard/report package projections with Vega-Lite chart spec support, and
+ * normalized MapPackage / AppPackage catalog projections, so Console can consume
+ * stable contracts without copying server DTOs or Portal types.
  *
  * Contract ownership:
  * - **server-owned**: canonical wire shapes in `honua-server` (Metadata v2,
  *   content items, packages, sharing, embeds, provenance). Not defined here.
  * - **SDK-projected**: the browser-safe types and projection helpers in this
- *   module, plus `@honua/sdk-js/runtime` (`MapPackage`), `./control-plane`
- *   (admin resources, sharing), and `./generated-app` (generated-app runtime).
+ *   module (including {@link projectMapPackage} / {@link projectAppPackage}
+ *   catalog summaries), plus `@honua/sdk-js/runtime` (`MapPackage` runtime),
+ *   `./control-plane` (admin resources, sharing), and `./generated-app`
+ *   (generated-app runtime). The projection helpers reuse the runtime and
+ *   generated-app wire types rather than redefining them.
  * - **Console-rendered**: render models (`*RenderModel`) derived from the
  *   projections above.
  *
@@ -83,6 +86,16 @@ export type {
   HonuaConsoleReportRenderModel,
   HonuaConsoleReportSection,
 } from "./dashboard.js";
+
+export { projectAppPackage, projectMapPackage } from "./packages.js";
+export type {
+  HonuaConsoleAppChartKind,
+  HonuaConsoleAppPackageProjection,
+  HonuaConsoleAppWidgetSummary,
+  HonuaConsoleMapPackageProjection,
+  HonuaConsoleMapSourceSummary,
+  HonuaConsolePackageProjectionContext,
+} from "./packages.js";
 
 export { HonuaConsoleError, toConsoleDiagnostic } from "./errors.js";
 export type {

--- a/src/console/packages.ts
+++ b/src/console/packages.ts
@@ -172,7 +172,10 @@ function readStringField(value: unknown, key: string): string | undefined {
 }
 
 function resolveManifest(pkg: HonuaGeneratedAppPackage): HonuaGeneratedAppManifest | undefined {
-  const candidate = pkg.manifestArtifact ?? pkg.manifest_artifact;
+  // Match `projectAppPackageToGeneratedAppManifest` precedence: the canonical
+  // server `manifest_artifact` wins over the camelCase compatibility alias so
+  // the Console catalog summary and the launched runtime read the same manifest.
+  const candidate = pkg.manifest_artifact ?? pkg.manifestArtifact;
   if (!candidate || typeof candidate !== "object") return undefined;
   // The artifact may be the manifest itself or a `{ artifactKind, manifest }` wrapper.
   const wrapper = candidate as { readonly artifactKind?: unknown; readonly manifest?: unknown };

--- a/src/console/packages.ts
+++ b/src/console/packages.ts
@@ -1,0 +1,250 @@
+/**
+ * Browser-safe MapPackage / AppPackage projections for `honua-console`.
+ *
+ * A `MapPackage` (server: `honua_map_package.v1`) and a generated `AppPackage`
+ * are **server-owned** artifacts already typed in `@honua/sdk-js/runtime`
+ * ({@link HonuaMapPackage}) and `@honua/sdk-js/generated-app`
+ * ({@link HonuaGeneratedAppPackage} / {@link HonuaGeneratedAppManifest}). This
+ * module does not redefine those wire shapes; it projects them into the slim,
+ * **SDK-projected** summaries a Console content browser renders without loading
+ * the full runtime: identity, status, source/layer/chart inventory, sharing,
+ * provenance, and a normalized title.
+ *
+ * Console flows that actually render a map or run a generated app continue to
+ * use the runtime (`loadMapPackage`) and generated-app runtime
+ * (`loadGeneratedAppRuntime`) directly — these projections are the lightweight
+ * catalog/detail view, not a replacement for the runtimes.
+ *
+ * Ownership legend (shared across the Console contracts):
+ * - **server-owned**: `HonuaMapPackage`, `HonuaGeneratedAppPackage`, and the
+ *   manifest artifact embedded in an app package.
+ * - **SDK-projected**: the `*Projection` summaries and projection helpers here.
+ * - **Console-rendered**: UI state derived from these projections.
+ *
+ * @module
+ */
+
+import {
+  HONUA_GENERATED_APP_MANIFEST_ARTIFACT_KIND,
+  type HonuaGeneratedAppChartKind,
+  type HonuaGeneratedAppManifest,
+  type HonuaGeneratedAppPackage,
+} from "../generated-app/index.js";
+import { HONUA_MAP_PACKAGE_FORMAT_V1, type HonuaMapPackage } from "../runtime/index.js";
+import type { HonuaConsoleMetadata, HonuaConsoleProvenance, HonuaConsoleSharing } from "./content.js";
+import { HonuaConsoleError } from "./errors.js";
+
+/**
+ * SDK-projected summary of a single source binding on a MapPackage. Console
+ * lists these in a package detail view without binding the runtime.
+ */
+export interface HonuaConsoleMapSourceSummary {
+  readonly sourceId: string;
+  readonly protocol: string;
+  readonly url?: string;
+  readonly attribution?: string;
+}
+
+/** SDK-projected catalog summary of a server MapPackage. */
+export interface HonuaConsoleMapPackageProjection {
+  readonly kind: "map-package";
+  readonly id: string;
+  readonly title?: string;
+  readonly status?: string;
+  readonly createdAt?: string;
+  readonly updatedAt?: string;
+  readonly expiresAt?: string;
+  readonly previewArtifactId?: string;
+  readonly sources: ReadonlyArray<HonuaConsoleMapSourceSummary>;
+  readonly layerCount: number;
+  readonly hasLegend: boolean;
+  readonly initialView?: HonuaMapPackage["initialView"];
+  readonly metadata?: HonuaConsoleMetadata;
+  readonly sharing?: HonuaConsoleSharing;
+  readonly provenance?: HonuaConsoleProvenance;
+}
+
+/** SDK-projected summary of one widget on a generated app. */
+export interface HonuaConsoleAppWidgetSummary {
+  readonly id: string;
+  readonly kind: string;
+  readonly title?: string;
+  readonly chartKind?: HonuaConsoleAppChartKind;
+}
+
+/** Chart-kind vocabulary shared with the generated-app chart widget. */
+export type HonuaConsoleAppChartKind = HonuaGeneratedAppChartKind;
+
+/** SDK-projected catalog summary of a generated AppPackage. */
+export interface HonuaConsoleAppPackageProjection {
+  readonly kind: "app-package";
+  readonly id: string;
+  readonly version?: string;
+  readonly title?: string;
+  readonly description?: string;
+  readonly profile?: string;
+  readonly primarySourceId?: string;
+  readonly mapPackageId?: string;
+  readonly widgets: ReadonlyArray<HonuaConsoleAppWidgetSummary>;
+  readonly chartKinds: ReadonlyArray<HonuaConsoleAppChartKind>;
+  readonly metadata?: HonuaConsoleMetadata;
+  readonly sharing?: HonuaConsoleSharing;
+  readonly provenance?: HonuaConsoleProvenance;
+}
+
+/** Optional Console-side context attached to a projection. */
+export interface HonuaConsolePackageProjectionContext {
+  readonly metadata?: HonuaConsoleMetadata;
+  readonly sharing?: HonuaConsoleSharing;
+  readonly provenance?: HonuaConsoleProvenance;
+}
+
+function optional<K extends string, V>(key: K, value: V | undefined): Partial<Record<K, V>> {
+  return value === undefined ? {} : ({ [key]: value } as Record<K, V>);
+}
+
+/**
+ * Projects a server {@link HonuaMapPackage} into a slim Console catalog
+ * summary. The package `format` is the version gate; an unexpected format
+ * raises a typed `unsupported-package-format` error so Console can flag the
+ * package instead of rendering a partial view.
+ *
+ * The full runtime (`loadMapPackage`) remains the way to actually render the
+ * map; this projection only powers the catalog/detail surfaces.
+ */
+export function projectMapPackage(
+  pkg: HonuaMapPackage,
+  context: HonuaConsolePackageProjectionContext = {},
+): HonuaConsoleMapPackageProjection {
+  if (!pkg || typeof pkg !== "object") {
+    throw new HonuaConsoleError("projection-failed", "MapPackage must be an object", {
+      stage: "projection",
+      detail: { path: "package", received: pkg },
+    });
+  }
+  if (pkg.format !== HONUA_MAP_PACKAGE_FORMAT_V1) {
+    throw new HonuaConsoleError("unsupported-package-format", `Unsupported MapPackage format "${String(pkg.format)}"`, {
+      stage: "projection",
+      detail: {
+        packageId: pkg.mapPackageId,
+        path: "format",
+        received: pkg.format,
+        expected: HONUA_MAP_PACKAGE_FORMAT_V1,
+      },
+    });
+  }
+
+  const sources: HonuaConsoleMapSourceSummary[] = (pkg.sourceBindings ?? []).map((binding) => ({
+    sourceId: binding.sourceId,
+    protocol: binding.protocol,
+    ...optional("url", binding.locator?.url),
+    ...optional("attribution", binding.attribution),
+  }));
+
+  const layers = Array.isArray(pkg.mapSpec?.layers) ? pkg.mapSpec.layers : [];
+  const title = readStringField(pkg.metadata, "title") ?? context.metadata?.title;
+
+  return {
+    kind: "map-package",
+    id: pkg.mapPackageId,
+    ...optional("title", title),
+    ...optional("status", pkg.status),
+    ...optional("createdAt", pkg.createdAt),
+    ...optional("updatedAt", pkg.updatedAt),
+    ...optional("expiresAt", pkg.expiresAt),
+    ...optional("previewArtifactId", pkg.previewArtifactId),
+    sources,
+    layerCount: layers.length,
+    hasLegend: Array.isArray(pkg.legend) && pkg.legend.length > 0,
+    ...optional("initialView", pkg.initialView),
+    ...optional("metadata", context.metadata),
+    ...optional("sharing", context.sharing),
+    ...optional("provenance", context.provenance),
+  };
+}
+
+function readStringField(value: unknown, key: string): string | undefined {
+  if (value && typeof value === "object") {
+    const field = (value as Record<string, unknown>)[key];
+    if (typeof field === "string") return field;
+  }
+  return undefined;
+}
+
+function resolveManifest(pkg: HonuaGeneratedAppPackage): HonuaGeneratedAppManifest | undefined {
+  const candidate = pkg.manifestArtifact ?? pkg.manifest_artifact;
+  if (!candidate || typeof candidate !== "object") return undefined;
+  // The artifact may be the manifest itself or a `{ artifactKind, manifest }` wrapper.
+  const wrapper = candidate as { readonly artifactKind?: unknown; readonly manifest?: unknown };
+  if (wrapper.artifactKind === HONUA_GENERATED_APP_MANIFEST_ARTIFACT_KIND && wrapper.manifest) {
+    return wrapper.manifest as HonuaGeneratedAppManifest;
+  }
+  if ("layout" in candidate) {
+    return candidate as HonuaGeneratedAppManifest;
+  }
+  return undefined;
+}
+
+/**
+ * Projects a generated {@link HonuaGeneratedAppPackage} into a slim Console
+ * catalog summary derived from its embedded manifest artifact. A package with
+ * no resolvable manifest raises a typed `missing-binding` error so Console can
+ * flag the broken package rather than show an empty app entry.
+ *
+ * The generated-app runtime (`loadGeneratedAppRuntime`) is still the way to
+ * actually run the app; this projection only powers the catalog/detail surfaces
+ * and reuses the shared `categories` / `histogram` / `time-series` chart-kind
+ * vocabulary so Console and the runtime agree on chart inventory.
+ */
+export function projectAppPackage(
+  pkg: HonuaGeneratedAppPackage,
+  context: HonuaConsolePackageProjectionContext = {},
+): HonuaConsoleAppPackageProjection {
+  if (!pkg || typeof pkg !== "object") {
+    throw new HonuaConsoleError("projection-failed", "AppPackage must be an object", {
+      stage: "projection",
+      detail: { path: "package", received: pkg },
+    });
+  }
+  const manifest = resolveManifest(pkg);
+  if (!manifest) {
+    throw new HonuaConsoleError("missing-binding", `AppPackage "${pkg.id}" has no resolvable manifest artifact`, {
+      stage: "projection",
+      detail: { packageId: pkg.id, path: "manifestArtifact" },
+    });
+  }
+
+  const widgets: HonuaConsoleAppWidgetSummary[] = (manifest.layout?.widgets ?? []).map((widget) => ({
+    id: widget.id,
+    kind: widget.kind,
+    ...optional("title", widget.title),
+    ...optional(
+      "chartKind",
+      widget.kind === "chart" ? (widget as { chartKind?: HonuaConsoleAppChartKind }).chartKind : undefined,
+    ),
+  }));
+
+  const chartKinds = Array.from(
+    new Set(
+      widgets.map((widget) => widget.chartKind).filter((kind): kind is HonuaConsoleAppChartKind => kind !== undefined),
+    ),
+  );
+
+  const title = manifest.title ?? context.metadata?.title;
+
+  return {
+    kind: "app-package",
+    id: pkg.id,
+    ...optional("version", pkg.version ?? manifest.version),
+    ...optional("title", title),
+    ...optional("description", manifest.description),
+    ...optional("profile", manifest.profile),
+    ...optional("primarySourceId", manifest.data?.sourceId),
+    ...optional("mapPackageId", manifest.mapPackageId ?? manifest.mapPackage?.mapPackageId),
+    widgets,
+    chartKinds,
+    ...optional("metadata", context.metadata),
+    ...optional("sharing", context.sharing),
+    ...optional("provenance", context.provenance),
+  };
+}

--- a/test/console-contracts.test.ts
+++ b/test/console-contracts.test.ts
@@ -323,6 +323,24 @@ describe("AppPackage projection", () => {
     expect(projection.widgets).toHaveLength(3);
   });
 
+  it("prefers the canonical manifest_artifact over the camelCase alias", () => {
+    const staleManifest: HonuaGeneratedAppManifest = {
+      ...manifest,
+      title: "Stale alias title",
+      layout: { kind: "operations-dashboard", widgets: [{ id: "w-stale", kind: "map" }] },
+    };
+    const pkg: HonuaGeneratedAppPackage = {
+      id: "app-mixed",
+      version: "1.0.0",
+      // Canonical snake_case field must win, matching the generated-app runtime.
+      manifest_artifact: manifest,
+      manifestArtifact: staleManifest,
+    };
+    const projection = projectAppPackage(pkg);
+    expect(projection.title).toBe("Incident ops");
+    expect(projection.widgets).toHaveLength(3);
+  });
+
   it("raises a typed missing-binding error when no manifest resolves", () => {
     const pkg = { id: "app-3", version: "0.0.1" } as unknown as HonuaGeneratedAppPackage;
     try {

--- a/test/console-contracts.test.ts
+++ b/test/console-contracts.test.ts
@@ -13,10 +13,21 @@ import {
   isKnownConsoleContentKind,
   isVegaLiteSpec,
   normalizeVegaLiteSpec,
+  projectAppPackage,
   projectDashboardPackage,
+  projectMapPackage,
   projectReportPackage,
   toConsoleDiagnostic,
 } from "../src/console/index.js";
+import {
+  HONUA_GENERATED_APP_MANIFEST_ARTIFACT_KIND,
+  HONUA_GENERATED_APP_MANIFEST_ARTIFACT_VERSION,
+  HONUA_GENERATED_APP_MANIFEST_FORMAT_V1,
+  HONUA_GENERATED_APP_PROFILE_OPERATIONS_DASHBOARD_V1,
+  type HonuaGeneratedAppManifest,
+  type HonuaGeneratedAppPackage,
+} from "../src/generated-app/index.js";
+import { HONUA_MAP_PACKAGE_FORMAT_V1, type HonuaMapPackage } from "../src/runtime/index.js";
 
 const validSpec: HonuaVegaLiteSpec = {
   mark: "bar",
@@ -194,5 +205,134 @@ describe("report package projection", () => {
     expect(model.sections[0]?.charts[0]?.chartSpec.$schema).toBe(HONUA_CONSOLE_VEGA_LITE_SCHEMA);
     expect(model.sections[0]?.body).toBe("Overview text");
     expect(model.sections[1]?.charts).toHaveLength(0);
+  });
+});
+
+describe("MapPackage projection", () => {
+  const mapPackage: HonuaMapPackage = {
+    mapPackageId: "mp-1",
+    format: HONUA_MAP_PACKAGE_FORMAT_V1,
+    status: "Ready",
+    createdAt: "2026-05-01T00:00:00Z",
+    previewArtifactId: "preview-9",
+    metadata: { title: "City incidents" },
+    sourceBindings: [
+      {
+        sourceId: "incidents",
+        protocol: "geoservices_feature_service",
+        locator: { url: "https://example.test/incidents" },
+        attribution: "City GIS",
+      },
+    ],
+    mapSpec: {
+      version: 8,
+      sources: {},
+      layers: [
+        { id: "incidents-fill", type: "fill", source: "incidents" },
+        { id: "incidents-line", type: "line", source: "incidents" },
+      ],
+    } as unknown as HonuaMapPackage["mapSpec"],
+    legend: [{ label: "Open", color: "#f00" }],
+    initialView: { center: [-122, 37], zoom: 10 },
+  };
+
+  it("projects identity, sources, layers, and metadata into a catalog summary", () => {
+    const projection = projectMapPackage(mapPackage, {
+      sharing: { visibility: "workspace" },
+      provenance: { createdBy: "operator" },
+    });
+    expect(projection.kind).toBe("map-package");
+    expect(projection.id).toBe("mp-1");
+    expect(projection.title).toBe("City incidents");
+    expect(projection.status).toBe("Ready");
+    expect(projection.sources).toHaveLength(1);
+    expect(projection.sources[0]?.sourceId).toBe("incidents");
+    expect(projection.sources[0]?.url).toBe("https://example.test/incidents");
+    expect(projection.layerCount).toBe(2);
+    expect(projection.hasLegend).toBe(true);
+    expect(projection.previewArtifactId).toBe("preview-9");
+    expect(projection.initialView?.zoom).toBe(10);
+    expect(projection.sharing?.visibility).toBe("workspace");
+    expect(projection.provenance?.createdBy).toBe("operator");
+  });
+
+  it("rejects an unsupported MapPackage format with a typed error", () => {
+    const bad = { ...mapPackage, format: "honua_map_package.v2" } as unknown as HonuaMapPackage;
+    try {
+      projectMapPackage(bad);
+      throw new Error("expected throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(HonuaConsoleError);
+      const diag = toConsoleDiagnostic(error);
+      expect(diag.code).toBe("unsupported-package-format");
+      expect(diag.detail?.packageId).toBe("mp-1");
+    }
+  });
+});
+
+describe("AppPackage projection", () => {
+  const manifest: HonuaGeneratedAppManifest = {
+    format: HONUA_GENERATED_APP_MANIFEST_FORMAT_V1,
+    profile: HONUA_GENERATED_APP_PROFILE_OPERATIONS_DASHBOARD_V1,
+    appId: "app-1",
+    title: "Incident ops",
+    description: "Operations dashboard",
+    version: "1.2.0",
+    data: { sourceId: "incidents" },
+    mapPackageId: "mp-1",
+    layout: {
+      kind: "operations-dashboard",
+      widgets: [
+        { id: "w-map", kind: "map" },
+        { id: "w-chart", kind: "chart", chartKind: "categories", groupBy: "status", title: "By status" },
+        { id: "w-hist", kind: "chart", chartKind: "histogram", field: "magnitude" },
+      ],
+    },
+  };
+
+  it("projects a manifest-artifact-wrapped package into a catalog summary", () => {
+    const pkg: HonuaGeneratedAppPackage = {
+      id: "app-1",
+      version: "1.2.0",
+      manifestArtifact: {
+        artifactKind: HONUA_GENERATED_APP_MANIFEST_ARTIFACT_KIND,
+        artifactVersion: HONUA_GENERATED_APP_MANIFEST_ARTIFACT_VERSION,
+        manifest,
+      },
+    };
+    const projection = projectAppPackage(pkg);
+    expect(projection.kind).toBe("app-package");
+    expect(projection.id).toBe("app-1");
+    expect(projection.version).toBe("1.2.0");
+    expect(projection.title).toBe("Incident ops");
+    expect(projection.profile).toBe(HONUA_GENERATED_APP_PROFILE_OPERATIONS_DASHBOARD_V1);
+    expect(projection.primarySourceId).toBe("incidents");
+    expect(projection.mapPackageId).toBe("mp-1");
+    expect(projection.widgets).toHaveLength(3);
+    expect(projection.chartKinds).toEqual(["categories", "histogram"]);
+  });
+
+  it("accepts a bare manifest as the artifact", () => {
+    const pkg: HonuaGeneratedAppPackage = {
+      id: "app-2",
+      version: "0.1.0",
+      manifest_artifact: manifest,
+    };
+    const projection = projectAppPackage(pkg);
+    expect(projection.id).toBe("app-2");
+    expect(projection.widgets).toHaveLength(3);
+  });
+
+  it("raises a typed missing-binding error when no manifest resolves", () => {
+    const pkg = { id: "app-3", version: "0.0.1" } as unknown as HonuaGeneratedAppPackage;
+    try {
+      projectAppPackage(pkg);
+      throw new Error("expected throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(HonuaConsoleError);
+      const diag = toConsoleDiagnostic(error);
+      expect(diag.code).toBe("missing-binding");
+      expect(diag.detail?.packageId).toBe("app-3");
+    }
   });
 });


### PR DESCRIPTION
## What this does

Completes the deferred acceptance criteria of #225 on top of the already-merged
first slice (PR #242: console content / metadata-v2 / dashboard / report /
Vega-Lite contracts). It adds the normalized MapPackage / AppPackage projections
and the public contract-ownership docs the issue calls for.

New module `src/console/packages.ts`:
- **`projectMapPackage`** — normalizes a server-owned `HonuaMapPackage`
  (`honua_map_package.v1`, typed in `@honua/sdk-js/runtime`) into a slim,
  browser-safe `HonuaConsoleMapPackageProjection` for the Console content
  browser / detail surfaces: identity, status, source summaries, layer count,
  legend flag, initial view, plus optional metadata/sharing/provenance context.
  Gates on `format` and raises a typed `unsupported-package-format`
  `HonuaConsoleError`.
- **`projectAppPackage`** — normalizes a generated `HonuaGeneratedAppPackage`
  (typed in `@honua/sdk-js/generated-app`) into
  `HonuaConsoleAppPackageProjection`: identity, version, profile, primary
  source, map-package link, widget inventory, and the de-duplicated chart-kind
  set. Resolves either a `{ artifactKind, manifest }` wrapper or a bare
  manifest, and raises a typed `missing-binding` error when no manifest
  resolves.

Both helpers deliberately reuse the runtime and generated-app wire types rather
than redefining them, and they are catalog projections — the full `loadMapPackage`
/ `loadGeneratedAppRuntime` runtimes remain the way to actually render/run.

Wiring:
- Projections + types exported from the stable `./console` subpath.
- `verify:split-packages` now asserts `projectMapPackage` is exported and
  produces a `map-package` projection from `@honua/sdk/console`.

Docs:
- `docs/console-contracts.md` enumerates each contract as **server-owned**,
  **SDK-projected**, or **Console-rendered**, documents the full-runtime vs
  catalog-projection split, the Vega-Lite spec ownership, and MCP/QGIS/Console
  package parity.

## Testing

- `npm run typecheck` — passes.
- `npm run check` (Biome) — clean on changed `src` / `test` / `scripts` files.
- `npx vitest run test/console-contracts.test.ts test/generated-app-runtime.test.ts`
  — 35 tests pass. New tests cover MapPackage projection (identity / sources /
  layers / legend / sharing-provenance context and the unsupported-format error)
  and AppPackage projection (wrapped artifact, bare manifest, and the
  missing-manifest error). Existing generated-app runtime behavior is unchanged.

Fixes #225