### PR TITLE
feat: honua://styles resources + get_style/apply_style_preset MCP tools (#14)

### DIFF
--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -8,10 +8,13 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 
 import * as layerSchemaResource from "./resources/layer-schema.js";
 import * as servicesResource from "./resources/services.js";
+import * as stylesResource from "./resources/styles.js";
+import * as applyStylePreset from "./tools/apply-style-preset.js";
 import * as countFeatures from "./tools/count-features.js";
 import * as describeLayer from "./tools/describe-layer.js";
 import * as explainCapabilityGap from "./tools/explain-capability-gap.js";
 import * as getExtent from "./tools/get-extent.js";
+import * as getStyle from "./tools/get-style.js";
 import * as listServices from "./tools/list-services.js";
 import * as queryFeatures from "./tools/query-features.js";
 import * as statistics from "./tools/statistics.js";
@@ -205,6 +208,20 @@ export function createServer(client: HonuaClient) {
     async (args) => explainCapabilityGap.execute(client, explainCapabilityGap.schema.parse(args)),
   );
 
+  server.tool(
+    "honua_get_style",
+    "Resolve a style from the server's OGC API – Styles surface. Pass styleId for the canonical StyleRef (style_id, title, encodings incl. inlined MapLibre); omit it to list available styles.",
+    getStyle.schema.shape,
+    async (args) => getStyle.execute(client, getStyle.schema.parse(args)),
+  );
+
+  server.tool(
+    "honua_apply_style_preset",
+    "Resolve a style preset and its MapLibre stylesheet for client-side application. Read-only: returns the stylesheet to apply locally; it does not mutate server state.",
+    applyStylePreset.schema.shape,
+    async (args) => applyStylePreset.execute(client, applyStylePreset.schema.parse(args)),
+  );
+
   // ── Resources ──────────────────────────────────────────────────
 
   server.resource("services-catalog", servicesResource.uri, async (uri) => servicesResource.read(client));
@@ -214,6 +231,12 @@ export function createServer(client: HonuaClient) {
     new ResourceTemplate(layerSchemaResource.uriTemplate, { list: undefined }),
     async (uri, params) =>
       layerSchemaResource.read(client, params.encodedServiceId as string, params.layerId as string),
+  );
+
+  server.resource("styles-catalog", stylesResource.uri, async (uri) => stylesResource.readCatalog(client));
+
+  server.resource("style", new ResourceTemplate(stylesResource.uriTemplate, { list: undefined }), async (uri, params) =>
+    stylesResource.read(client, params.styleId as string),
   );
 
   return server;

--- a/mcp/src/resources/styles.ts
+++ b/mcp/src/resources/styles.ts
@@ -1,0 +1,50 @@
+import type { HonuaClient } from "@honua/sdk-js";
+import { listStyles, resolveStyleRef } from "../styles.js";
+
+/** URI for the styles catalog resource (`honua://styles`). */
+export const uri = "honua://styles";
+
+/** URI template for a single style resource (`honua://styles/{styleId}`). */
+export const uriTemplate = "honua://styles/{styleId}";
+
+/**
+ * Read the styles catalog: the list of styles available on the server, each
+ * with its stable styleId, title, and canonical URI (`honua://styles/{id}`).
+ */
+export async function readCatalog(client: HonuaClient) {
+  const list = await listStyles(client);
+  const styles = list.styles.map((entry) => ({
+    styleId: entry.id,
+    title: entry.title ?? entry.id,
+    uri: `honua://styles/${encodeURIComponent(entry.id)}`,
+  }));
+
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: "application/json" as const,
+        text: JSON.stringify({ styles, default: list.default ?? null }, null, 2),
+      },
+    ],
+  };
+}
+
+/**
+ * Read a single style as a `StyleRef` projection (style_id / title /
+ * description / style_version / encodings / legend_url), resolved against the
+ * server's `/ogc/styles/{styleId}` surface.
+ */
+export async function read(client: HonuaClient, styleId: string) {
+  const styleRef = await resolveStyleRef(client, styleId);
+
+  return {
+    contents: [
+      {
+        uri: `honua://styles/${encodeURIComponent(styleId)}`,
+        mimeType: "application/json" as const,
+        text: JSON.stringify(styleRef, null, 2),
+      },
+    ],
+  };
+}

--- a/mcp/src/styles.ts
+++ b/mcp/src/styles.ts
@@ -1,0 +1,199 @@
+import type { HonuaClient } from "@honua/sdk-js";
+
+/**
+ * Thin read-only client over the server's OGC API – Styles surface
+ * (honua-server, ADR-0048):
+ *
+ *   GET /ogc/styles                     -> styles list   ({ styles: [{ id, title, links }], default? })
+ *   GET /ogc/styles/{styleId}/metadata  -> style metadata ({ id, title, description, keywords, license, version, links })
+ *   GET /ogc/styles/{styleId}           -> stylesheet body (MapLibre/Mapbox JSON by default; SLD via Accept)
+ *
+ * These helpers project the server responses into the geospatial-grpc
+ * `StyleRef` / `StyleEncoding` shape (style_id / title / encodings) so the MCP
+ * resource + `get_style` tool surface a single canonical style object.
+ *
+ * The MCP package only consumes the public {@link HonuaClient.pipelineFetch}
+ * request pipeline (auth / retry / timeout / interceptors) rather than a
+ * private route, matching the other `/ogc/*` consumers in the SDK.
+ *
+ * @module
+ */
+
+/** Default path prefix for the server's OGC API – Styles surface. */
+export const OGC_STYLES_PATH = "/ogc/styles";
+
+/** MapLibre / Mapbox style media type (server default stylesheet encoding). */
+export const MAPLIBRE_STYLE_MEDIA_TYPE = "application/vnd.mapbox.style+json";
+
+/** SLD 1.0 stylesheet media type. */
+export const SLD_10_MEDIA_TYPE = "application/vnd.ogc.sld+xml;version=1.0";
+
+/** SLD 1.1 stylesheet media type. */
+export const SLD_11_MEDIA_TYPE = "application/vnd.ogc.sld+xml;version=1.1";
+
+/**
+ * Stylesheet encodings the MCP surface understands, keyed by the canonical
+ * geospatial-grpc `StyleEncoding.encoding` identifier. The server
+ * content-negotiates these via the `Accept` header.
+ */
+export const STYLE_ENCODINGS = {
+  "mapbox-style": MAPLIBRE_STYLE_MEDIA_TYPE,
+  "sld-1.0.0": SLD_10_MEDIA_TYPE,
+  "sld-1.1.0": SLD_11_MEDIA_TYPE,
+} as const;
+
+/** A geospatial-grpc `StyleEncoding`-aligned encoding identifier. */
+export type StyleEncodingId = keyof typeof STYLE_ENCODINGS;
+
+/** Hypermedia link entry on an OGC styles document. */
+export interface OgcStyleLink {
+  href: string;
+  rel?: string;
+  type?: string;
+  title?: string;
+}
+
+/** One entry in the `GET /ogc/styles` styles list. */
+export interface OgcStyleListEntry {
+  id: string;
+  title?: string;
+  links?: OgcStyleLink[];
+}
+
+/** Response body of `GET /ogc/styles`. */
+export interface OgcStyleList {
+  styles: OgcStyleListEntry[];
+  default?: string;
+  links?: OgcStyleLink[];
+}
+
+/** Response body of `GET /ogc/styles/{styleId}/metadata`. */
+export interface OgcStyleMetadata {
+  id: string;
+  title?: string;
+  description?: string;
+  keywords?: string[];
+  license?: string;
+  version?: string;
+  links?: OgcStyleLink[];
+}
+
+/**
+ * A single encoded representation of a style, aligned with the geospatial-grpc
+ * `StyleEncoding` message. The MCP surface carries the inline body for the
+ * MapLibre encoding (the default the server serves) and exposes the alternate
+ * SLD encodings by reference (`storageRef` = the stylesheet URL).
+ */
+export interface StyleEncoding {
+  encoding: StyleEncodingId | string;
+  contentType?: string;
+  inlineBody?: unknown;
+  storageRef?: string;
+}
+
+/**
+ * Canonical style projection aligned with the geospatial-grpc `StyleRef`
+ * message (`style_id` / `title` / `description` / `style_version` /
+ * `encodings` / `legend_url`).
+ */
+export interface StyleRef {
+  styleId: string;
+  title: string;
+  description: string | null;
+  styleVersion: number | null;
+  legendUrl: string | null;
+  encodings: StyleEncoding[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function getJson<T>(client: HonuaClient, path: string, accept: string): Promise<T> {
+  const response = await client.pipelineFetch("GET", path, { headers: { Accept: accept } });
+  return (await response.json()) as T;
+}
+
+function stylePath(styleId: string): string {
+  return `${OGC_STYLES_PATH}/${encodeURIComponent(styleId)}`;
+}
+
+/** List available styles via `GET /ogc/styles`. */
+export async function listStyles(client: HonuaClient): Promise<OgcStyleList> {
+  const body = await getJson<unknown>(client, OGC_STYLES_PATH, "application/json");
+  if (!isRecord(body) || !Array.isArray(body.styles)) {
+    return { styles: [] };
+  }
+  const styles: OgcStyleListEntry[] = [];
+  for (const entry of body.styles) {
+    if (isRecord(entry) && typeof entry.id === "string") {
+      styles.push({
+        id: entry.id,
+        ...(typeof entry.title === "string" ? { title: entry.title } : {}),
+        ...(Array.isArray(entry.links) ? { links: entry.links as OgcStyleLink[] } : {}),
+      });
+    }
+  }
+  return {
+    styles,
+    ...(typeof body.default === "string" ? { default: body.default } : {}),
+    ...(Array.isArray(body.links) ? { links: body.links as OgcStyleLink[] } : {}),
+  };
+}
+
+/** Fetch style metadata via `GET /ogc/styles/{styleId}/metadata`. */
+export async function getStyleMetadata(client: HonuaClient, styleId: string): Promise<OgcStyleMetadata> {
+  const body = await getJson<OgcStyleMetadata>(client, `${stylePath(styleId)}/metadata`, "application/json");
+  return body;
+}
+
+/**
+ * Fetch the MapLibre/Mapbox stylesheet body via `GET /ogc/styles/{styleId}`
+ * (content-negotiated to {@link MAPLIBRE_STYLE_MEDIA_TYPE}).
+ */
+export async function getMapLibreStylesheet(client: HonuaClient, styleId: string): Promise<unknown> {
+  return getJson<unknown>(client, stylePath(styleId), `${MAPLIBRE_STYLE_MEDIA_TYPE}, application/json;q=0.9`);
+}
+
+/** Coerce a free-form metadata `version` (string) into the numeric style_version, when possible. */
+function parseStyleVersion(version: string | undefined): number | null {
+  if (version === undefined) return null;
+  const parsed = Number.parseInt(version, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Resolve a single style into a `StyleRef` projection: fetch metadata and the
+ * canonical MapLibre stylesheet, and advertise the alternate SLD encodings by
+ * reference. The stylesheet base URL (`{baseUrl}/ogc/styles/{styleId}`) backs
+ * the `storageRef` for the by-reference encodings.
+ */
+export async function resolveStyleRef(client: HonuaClient, styleId: string): Promise<StyleRef> {
+  const [metadata, maplibre] = await Promise.all([
+    getStyleMetadata(client, styleId).catch(() => null),
+    getMapLibreStylesheet(client, styleId),
+  ]);
+
+  const stylesheetUrl = `${client.serverBaseUrl}${stylePath(styleId)}`;
+
+  const encodings: StyleEncoding[] = [
+    {
+      encoding: "mapbox-style",
+      contentType: MAPLIBRE_STYLE_MEDIA_TYPE,
+      inlineBody: maplibre,
+    },
+    { encoding: "sld-1.0.0", contentType: SLD_10_MEDIA_TYPE, storageRef: stylesheetUrl },
+    { encoding: "sld-1.1.0", contentType: SLD_11_MEDIA_TYPE, storageRef: stylesheetUrl },
+  ];
+
+  const legendUrl = metadata?.links?.find((l) => l.rel === "preview")?.href ?? null;
+
+  return {
+    styleId,
+    title: metadata?.title ?? styleId,
+    description: metadata?.description ?? null,
+    styleVersion: parseStyleVersion(metadata?.version),
+    legendUrl,
+    encodings,
+  };
+}

--- a/mcp/src/tools/apply-style-preset.ts
+++ b/mcp/src/tools/apply-style-preset.ts
@@ -1,0 +1,34 @@
+import type { HonuaClient } from "@honua/sdk-js";
+import { z } from "zod";
+import { jsonText } from "../helpers.js";
+import { getMapLibreStylesheet, resolveStyleRef } from "../styles.js";
+
+export const schema = z.object({
+  styleId: z.string().describe("Stable style identifier of the preset to resolve."),
+});
+
+export type Input = z.infer<typeof schema>;
+
+/**
+ * Resolve a style preset for client-side application. Returns the canonical
+ * `StyleRef` plus the MapLibre/Mapbox stylesheet body so an agent or downstream
+ * runtime can apply the preset to a map.
+ *
+ * This is a read-only inspection projection: it resolves and returns the
+ * preset's stylesheet but never mutates server state. Persisting a preset onto
+ * a map or published service stays with the typed gRPC execution layer per the
+ * MCP boundary (geospatial-mcp taxonomy / ADR-0028).
+ */
+export async function execute(client: HonuaClient, input: Input) {
+  const [styleRef, stylesheet] = await Promise.all([
+    resolveStyleRef(client, input.styleId),
+    getMapLibreStylesheet(client, input.styleId),
+  ]);
+
+  return jsonText({
+    style: styleRef,
+    stylesheet,
+    application: "client-side",
+    note: "Apply this MapLibre stylesheet client-side. MCP does not mutate server state; persisting a preset to a map or service uses the gRPC execution layer.",
+  });
+}

--- a/mcp/src/tools/get-style.ts
+++ b/mcp/src/tools/get-style.ts
@@ -1,0 +1,34 @@
+import type { HonuaClient } from "@honua/sdk-js";
+import { z } from "zod";
+import { jsonText } from "../helpers.js";
+import { listStyles, resolveStyleRef } from "../styles.js";
+
+export const schema = z.object({
+  styleId: z.string().optional().describe("Stable style identifier. Omit to list the styles available on the server."),
+});
+
+export type Input = z.infer<typeof schema>;
+
+/**
+ * Resolve a style from the server's OGC API – Styles surface. With a `styleId`,
+ * returns the canonical `StyleRef` projection (style_id / title / description /
+ * style_version / encodings / legend_url), with the MapLibre stylesheet inlined.
+ * Without a `styleId`, returns the styles catalog so an agent can discover what
+ * is available.
+ */
+export async function execute(client: HonuaClient, input: Input) {
+  if (!input.styleId) {
+    const list = await listStyles(client);
+    return jsonText({
+      styles: list.styles.map((entry) => ({
+        styleId: entry.id,
+        title: entry.title ?? entry.id,
+        uri: `honua://styles/${encodeURIComponent(entry.id)}`,
+      })),
+      default: list.default ?? null,
+    });
+  }
+
+  const styleRef = await resolveStyleRef(client, input.styleId);
+  return jsonText(styleRef);
+}

--- a/mcp/test/index.test.ts
+++ b/mcp/test/index.test.ts
@@ -5,10 +5,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { SERVER_VERSION, createClientFromEnv, createServer, resolveRuntimeOptions } from "../src/index.js";
 import * as layerSchemaResource from "../src/resources/layer-schema.js";
 import * as servicesResource from "../src/resources/services.js";
+import * as stylesResource from "../src/resources/styles.js";
+import * as applyStylePreset from "../src/tools/apply-style-preset.js";
 import * as countFeatures from "../src/tools/count-features.js";
 import * as describeLayer from "../src/tools/describe-layer.js";
 import * as explainCapabilityGap from "../src/tools/explain-capability-gap.js";
 import * as getExtent from "../src/tools/get-extent.js";
+import * as getStyle from "../src/tools/get-style.js";
 import * as listServices from "../src/tools/list-services.js";
 import * as queryFeatures from "../src/tools/query-features.js";
 import * as statistics from "../src/tools/statistics.js";
@@ -49,8 +52,14 @@ describe("MCP server setup", () => {
     const explainSpy = vi
       .spyOn(explainCapabilityGap, "execute")
       .mockResolvedValue({ content: [{ type: "text", text: "{}" }] });
+    const getStyleSpy = vi.spyOn(getStyle, "execute").mockResolvedValue({ content: [{ type: "text", text: "{}" }] });
+    const applyStyleSpy = vi
+      .spyOn(applyStylePreset, "execute")
+      .mockResolvedValue({ content: [{ type: "text", text: "{}" }] });
     const servicesReadSpy = vi.spyOn(servicesResource, "read").mockResolvedValue({ contents: [] });
     const layerReadSpy = vi.spyOn(layerSchemaResource, "read").mockResolvedValue({ contents: [] });
+    const stylesCatalogSpy = vi.spyOn(stylesResource, "readCatalog").mockResolvedValue({ contents: [] });
+    const styleReadSpy = vi.spyOn(stylesResource, "read").mockResolvedValue({ contents: [] });
 
     const client = asClient(createMockClient());
     createServer(client);
@@ -63,8 +72,15 @@ describe("MCP server setup", () => {
       "honua_get_extent",
       "honua_statistics",
       "honua_explain_capability_gap",
+      "honua_get_style",
+      "honua_apply_style_preset",
     ]);
-    expect(resourceSpy.mock.calls.map((call) => call[0])).toEqual(["services-catalog", "layer-schema"]);
+    expect(resourceSpy.mock.calls.map((call) => call[0])).toEqual([
+      "services-catalog",
+      "layer-schema",
+      "styles-catalog",
+      "style",
+    ]);
 
     const toolInputs: Record<string, Record<string, unknown>> = {
       honua_list_services: {},
@@ -74,6 +90,8 @@ describe("MCP server setup", () => {
       honua_get_extent: { serviceId: "Parks", layerId: 0 },
       honua_statistics: { serviceId: "Parks", layerId: 0, statisticType: "count", onField: "OBJECTID" },
       honua_explain_capability_gap: { protocol: "wmts", capability: "query" },
+      honua_get_style: { styleId: "topographic" },
+      honua_apply_style_preset: { styleId: "topographic" },
     };
 
     for (const [name, args] of Object.entries(toolInputs)) {
@@ -94,6 +112,8 @@ describe("MCP server setup", () => {
       onField: "OBJECTID",
     });
     expect(explainSpy).toHaveBeenCalledWith(client, { protocol: "wmts", capability: "query" });
+    expect(getStyleSpy).toHaveBeenCalledWith(client, { styleId: "topographic" });
+    expect(applyStyleSpy).toHaveBeenCalledWith(client, { styleId: "topographic" });
 
     const servicesRegistration = resourceSpy.mock.calls.find((call) => call[0] === "services-catalog");
     const servicesHandler = servicesRegistration?.[2] as (uri: URL) => Promise<unknown>;
@@ -103,8 +123,18 @@ describe("MCP server setup", () => {
     const layerHandler = layerRegistration?.[2] as (uri: URL, params: Record<string, unknown>) => Promise<unknown>;
     await layerHandler(new URL("honua://services/Parks/layers/0"), { encodedServiceId: "Parks", layerId: "0" });
 
+    const stylesCatalogRegistration = resourceSpy.mock.calls.find((call) => call[0] === "styles-catalog");
+    const stylesCatalogHandler = stylesCatalogRegistration?.[2] as (uri: URL) => Promise<unknown>;
+    await stylesCatalogHandler(new URL("honua://styles"));
+
+    const styleRegistration = resourceSpy.mock.calls.find((call) => call[0] === "style");
+    const styleHandler = styleRegistration?.[2] as (uri: URL, params: Record<string, unknown>) => Promise<unknown>;
+    await styleHandler(new URL("honua://styles/topographic"), { styleId: "topographic" });
+
     expect(servicesReadSpy).toHaveBeenCalledWith(client);
     expect(layerReadSpy).toHaveBeenCalledWith(client, "Parks", "0");
+    expect(stylesCatalogSpy).toHaveBeenCalledWith(client);
+    expect(styleReadSpy).toHaveBeenCalledWith(client, "topographic");
   });
 });
 

--- a/mcp/test/resources/styles.test.ts
+++ b/mcp/test/resources/styles.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { read, readCatalog, uri, uriTemplate } from "../../src/resources/styles.js";
+import { asClient, createMockClient } from "../test-helpers.js";
+
+describe("styles resource", () => {
+  it("has the correct catalog URI and template", () => {
+    expect(uri).toBe("honua://styles");
+    expect(uriTemplate).toBe("honua://styles/{styleId}");
+  });
+
+  it("lists styles with canonical URIs in the catalog", async () => {
+    const mock = createMockClient();
+    const result = await readCatalog(asClient(mock));
+
+    expect(result.contents).toHaveLength(1);
+    expect(result.contents[0].uri).toBe("honua://styles");
+    expect(result.contents[0].mimeType).toBe("application/json");
+
+    const parsed = JSON.parse(result.contents[0].text);
+    expect(parsed.default).toBe("topographic");
+    expect(parsed.styles).toHaveLength(2);
+    expect(parsed.styles[0]).toEqual({
+      styleId: "topographic",
+      title: "Topographic",
+      uri: "honua://styles/topographic",
+    });
+  });
+
+  it("projects a single style into a StyleRef with inlined MapLibre encoding", async () => {
+    const mock = createMockClient();
+    const result = await read(asClient(mock), "topographic");
+
+    expect(result.contents[0].uri).toBe("honua://styles/topographic");
+    const styleRef = JSON.parse(result.contents[0].text);
+
+    expect(styleRef.styleId).toBe("topographic");
+    expect(styleRef.title).toBe("Topographic");
+    expect(styleRef.description).toBe("Default topographic basemap style");
+    expect(styleRef.styleVersion).toBe(3);
+    expect(styleRef.legendUrl).toBe("https://example.test/ogc/styles/topographic/preview");
+
+    const mapbox = styleRef.encodings.find((e: { encoding: string }) => e.encoding === "mapbox-style");
+    expect(mapbox.contentType).toBe("application/vnd.mapbox.style+json");
+    expect(mapbox.inlineBody).toEqual({
+      version: 8,
+      name: "Topographic",
+      layers: [{ id: "background", type: "background" }],
+    });
+
+    const sld10 = styleRef.encodings.find((e: { encoding: string }) => e.encoding === "sld-1.0.0");
+    expect(sld10.storageRef).toBe("https://example.test/ogc/styles/topographic");
+  });
+
+  it("URL-encodes style IDs in the resource URI", async () => {
+    const mock = createMockClient({
+      pipelineFetch: vi.fn(async (_m: string, path: string) => {
+        if (path === "/ogc/styles/my%20style/metadata") {
+          return new Response(JSON.stringify({ id: "my style", title: "My Style" }), { status: 200 });
+        }
+        return new Response(JSON.stringify({ version: 8, layers: [] }), { status: 200 });
+      }),
+    });
+    const result = await read(asClient(mock), "my style");
+    expect(result.contents[0].uri).toBe("honua://styles/my%20style");
+  });
+
+  it("falls back to styleId when metadata is unavailable", async () => {
+    const mock = createMockClient({
+      pipelineFetch: vi.fn(async (_m: string, path: string) => {
+        if (path.endsWith("/metadata")) {
+          throw new Error("metadata unavailable");
+        }
+        return new Response(JSON.stringify({ version: 8, layers: [] }), { status: 200 });
+      }),
+    });
+    const result = await read(asClient(mock), "orphan");
+    const styleRef = JSON.parse(result.contents[0].text);
+    expect(styleRef.title).toBe("orphan");
+    expect(styleRef.description).toBeNull();
+    expect(styleRef.styleVersion).toBeNull();
+  });
+});

--- a/mcp/test/test-helpers.ts
+++ b/mcp/test/test-helpers.ts
@@ -14,6 +14,43 @@ export interface MockHonuaClient {
   queryFeatures: ReturnType<
     typeof vi.fn<(...args: unknown[]) => Promise<HonuaQueryResponse | Record<string, unknown>>>
   >;
+  pipelineFetch: ReturnType<typeof vi.fn<(method: string, path: string, init?: RequestInit) => Promise<Response>>>;
+  serverBaseUrl: string;
+}
+
+/**
+ * Default `pipelineFetch` for the OGC API – Styles surface used by the styles
+ * resource/tools. Routes by path to canned styles list, metadata, and MapLibre
+ * stylesheet bodies.
+ */
+function defaultStylesPipelineFetch(): MockHonuaClient["pipelineFetch"] {
+  return vi.fn<(method: string, path: string, init?: RequestInit) => Promise<Response>>(async (_method, path) => {
+    const json = (body: unknown) =>
+      new Response(JSON.stringify(body), { status: 200, headers: { "Content-Type": "application/json" } });
+
+    if (path === "/ogc/styles") {
+      return json({
+        styles: [
+          { id: "topographic", title: "Topographic", links: [] },
+          { id: "imagery", title: "Imagery", links: [] },
+        ],
+        default: "topographic",
+      });
+    }
+    if (path === "/ogc/styles/topographic/metadata") {
+      return json({
+        id: "topographic",
+        title: "Topographic",
+        description: "Default topographic basemap style",
+        version: "3",
+        links: [{ rel: "preview", type: "image/png", href: "https://example.test/ogc/styles/topographic/preview" }],
+      });
+    }
+    if (path === "/ogc/styles/topographic") {
+      return json({ version: 8, name: "Topographic", layers: [{ id: "background", type: "background" }] });
+    }
+    return new Response(JSON.stringify({ error: "not found" }), { status: 404 });
+  });
 }
 
 export function createMockClient(overrides: Partial<MockHonuaClient> = {}): MockHonuaClient {
@@ -65,6 +102,8 @@ export function createMockClient(overrides: Partial<MockHonuaClient> = {}): Mock
         ],
         exceededTransferLimit: false,
       }),
+    pipelineFetch: overrides.pipelineFetch ?? defaultStylesPipelineFetch(),
+    serverBaseUrl: overrides.serverBaseUrl ?? "https://example.test",
   };
 }
 

--- a/mcp/test/tools/apply-style-preset.test.ts
+++ b/mcp/test/tools/apply-style-preset.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { execute, schema } from "../../src/tools/apply-style-preset.js";
+import { asClient, createMockClient } from "../test-helpers.js";
+
+describe("honua_apply_style_preset", () => {
+  it("returns the resolved StyleRef and MapLibre stylesheet for client-side application", async () => {
+    const mock = createMockClient();
+    const result = await execute(asClient(mock), schema.parse({ styleId: "topographic" }));
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.style.styleId).toBe("topographic");
+    expect(parsed.application).toBe("client-side");
+    expect(parsed.stylesheet).toEqual({
+      version: 8,
+      name: "Topographic",
+      layers: [{ id: "background", type: "background" }],
+    });
+    expect(parsed.note).toMatch(/does not mutate server state/i);
+  });
+
+  it("requires a styleId", () => {
+    expect(() => schema.parse({})).toThrow();
+  });
+
+  it("only issues GET requests (read-only)", async () => {
+    const mock = createMockClient();
+    await execute(asClient(mock), schema.parse({ styleId: "topographic" }));
+
+    for (const call of mock.pipelineFetch.mock.calls) {
+      expect(call[0]).toBe("GET");
+    }
+  });
+});

--- a/mcp/test/tools/get-style.test.ts
+++ b/mcp/test/tools/get-style.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { execute, schema } from "../../src/tools/get-style.js";
+import { asClient, createMockClient } from "../test-helpers.js";
+
+describe("honua_get_style", () => {
+  it("returns the styles catalog when no styleId is given", async () => {
+    const mock = createMockClient();
+    const result = await execute(asClient(mock), schema.parse({}));
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.default).toBe("topographic");
+    expect(parsed.styles).toHaveLength(2);
+    expect(parsed.styles[0]).toEqual({
+      styleId: "topographic",
+      title: "Topographic",
+      uri: "honua://styles/topographic",
+    });
+  });
+
+  it("returns a StyleRef for a specific styleId", async () => {
+    const mock = createMockClient();
+    const result = await execute(asClient(mock), schema.parse({ styleId: "topographic" }));
+    const styleRef = JSON.parse(result.content[0].text);
+
+    expect(styleRef.styleId).toBe("topographic");
+    expect(styleRef.title).toBe("Topographic");
+    expect(styleRef.styleVersion).toBe(3);
+    expect(styleRef.encodings).toHaveLength(3);
+    expect(styleRef.encodings.map((e: { encoding: string }) => e.encoding)).toEqual([
+      "mapbox-style",
+      "sld-1.0.0",
+      "sld-1.1.0",
+    ]);
+  });
+
+  it("requests the OGC styles endpoints", async () => {
+    const mock = createMockClient();
+    await execute(asClient(mock), schema.parse({ styleId: "topographic" }));
+
+    const paths = mock.pipelineFetch.mock.calls.map((call) => call[1]);
+    expect(paths).toContain("/ogc/styles/topographic");
+    expect(paths).toContain("/ogc/styles/topographic/metadata");
+  });
+});


### PR DESCRIPTION
Implements `honua://styles/{styleId}` MCP resources and the `get_style` / `apply_style_preset` tools in the `@honua/mcp-server` package, resolving real styles through the server's **OGC API - Styles** surface (honua-server, ADR-0048).

Closes honua-io/geospatial-mcp#14. Part of umbrella honua-io/honua-server#1387.

## What changed
- `mcp/src/styles.ts` — read-only client over `/ogc/styles`, `/ogc/styles/{styleId}`, and `/ogc/styles/{styleId}/metadata`, using the public `HonuaClient.pipelineFetch` request pipeline (auth/retry/timeout/interceptors), matching the other `/ogc/*` consumers. Projects responses into a `StyleRef` shape aligned with the merged `geospatial.v1.StyleRef` message (`styleId` / `title` / `description` / `styleVersion` / `encodings` / `legendUrl`). The MapLibre/Mapbox encoding is inlined; SLD 1.0/1.1 are advertised by reference.
- Resources: `honua://styles` (catalog) and `honua://styles/{styleId}` (single `StyleRef`).
- Tools: `honua_get_style` (returns a `StyleRef`, or lists available styles when `styleId` is omitted) and `honua_apply_style_preset` (resolves a preset `StyleRef` + MapLibre stylesheet for client-side application). Both are read-only and never mutate server state, per the MCP boundary (ADR-0028).
- Tests: new resource + tool specs and updated registration assertions; `pipelineFetch` / `serverBaseUrl` added to the MCP mock client.

The spec side of #14 (making the `honua://styles` resource + style-tool contract concrete) is a companion PR in `honua-io/geospatial-mcp`.

## Test results
- `npm run typecheck` — pass
- `npm run check` (Biome) — pass
- `npm test` — 85 passed (14 added)
- `npm run build` — pass