### PR TITLE
feat: resolve styleRefs via /ogc/styles (#251)

### DIFF
--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -157,6 +157,22 @@ export { applyStyleRefs, applyTheme, composeStyle } from "./style-compose.js";
 export type { StyleComposeOptions, StyleRefResolver, ThemeResolver } from "./style-compose.js";
 
 export {
+  DEFAULT_OGC_STYLES_PATH_PREFIX,
+  MAPLIBRE_STYLE_MEDIA_TYPE,
+  OgcStylesClient,
+  createOgcStyleRefResolver,
+  styleDocumentToRefBody,
+} from "./ogc-styles.js";
+export type {
+  OgcStyleLink,
+  OgcStyleList,
+  OgcStyleListEntry,
+  OgcStyleRefResolverOptions,
+  OgcStylesClientOptions,
+  OgcStylesRequestOptions,
+} from "./ogc-styles.js";
+
+export {
   prepareRuntimeStyleSpecValidation,
   validateRuntimeFilterStyleSpec,
   validateRuntimeLayerStyleSpec,

--- a/src/runtime/load-package.ts
+++ b/src/runtime/load-package.ts
@@ -14,6 +14,7 @@ import { HonuaMap } from "../map/honua-map.js";
 import type { HonuaLayerSpecification, HonuaStyleSpecification } from "../style/specification.js";
 import { HonuaMapPackageError } from "./errors.js";
 import { HONUA_MAP_PACKAGE_FORMAT_V1, type HonuaMapPackage } from "./map-package.js";
+import { createOgcStyleRefResolver } from "./ogc-styles.js";
 import type { PopupFactory, PopupRenderer } from "./popups.js";
 import {
   HonuaMapRuntime,
@@ -55,8 +56,22 @@ export type SourceErrorPolicy = "tolerant" | "fail-fast";
 export interface LoadMapPackageOptions {
   /** Active `HonuaClient`; used for protocol adapter binding. */
   client: HonuaClient;
-  /** Out-of-band style-ref body resolver. Only called when the ref has no inline body. */
+  /**
+   * Out-of-band style-ref body resolver. Only called when the ref has no
+   * inline body. When omitted, the runtime defaults to resolving
+   * `styleRefs.styleId` against the server's OGC API – Styles surface
+   * (`GET /ogc/styles/{styleId}`, content-negotiated MapLibre) via
+   * {@link createOgcStyleRefResolver}, so the JS identifier matches the
+   * server's canonical styleId. Pass a callback to override that path
+   * (back-compat), or set {@link disableDefaultStyleRefResolver} to skip it.
+   */
   resolveStyleRef?: StyleRefResolver;
+  /**
+   * Disable the default `/ogc/styles` StyleRef resolver. When true and no
+   * {@link resolveStyleRef} callback is supplied, style refs without an
+   * inline body are left unresolved (composition then errors on them).
+   */
+  disableDefaultStyleRefResolver?: boolean;
   /** Out-of-band theme resolver. Only called when `pkg.theme` is absent and `pkg.themeId` is set. */
   resolveTheme?: ThemeResolver;
   /**
@@ -139,6 +154,12 @@ export async function loadMapPackage(
 
   const sourceErrorPolicy: SourceErrorPolicy = options.sourceErrorPolicy ?? "tolerant";
   const styleSpecValidationMode: RuntimeStyleSpecValidationMode = options.styleSpecValidationMode ?? "strict";
+  // Default StyleRef resolution to the server's OGC API – Styles surface so
+  // `styleRefs.styleId` aligns with the server's canonical styleId. A
+  // caller-supplied callback overrides this for back-compat.
+  const styleRefResolver: StyleRefResolver | undefined =
+    options.resolveStyleRef ??
+    (options.disableDefaultStyleRefResolver ? undefined : createOgcStyleRefResolver({ client: options.client }));
   throwRuntimeDiagnostics(
     await prepareRuntimeStyleSpecValidation(styleSpecValidationMode),
     "Cannot initialize MapLibre style-spec validation.",
@@ -227,7 +248,7 @@ export async function loadMapPackage(
     }
 
     const composed = await composeStyle(target, preComposed, {
-      resolveStyleRef: options.resolveStyleRef,
+      resolveStyleRef: styleRefResolver,
       resolveTheme: options.resolveTheme,
     });
     return { composed, dataset, honuaMap, failedSources };

--- a/src/runtime/map-package-fetch.ts
+++ b/src/runtime/map-package-fetch.ts
@@ -9,6 +9,7 @@ import {
   validateMapPackage,
 } from "./map-package-validation.js";
 import type { HonuaMapPackage, HonuaMapPackageStyleRef, HonuaStyleRefBody } from "./map-package.js";
+import { createOgcStyleRefResolver } from "./ogc-styles.js";
 import type { HonuaMapRuntime, MaplibreMap } from "./runtime.js";
 import type { StyleRefResolver } from "./style-compose.js";
 
@@ -37,8 +38,16 @@ export interface FetchMapPackageOptions {
   readonly resolvePath?: MapPackagePathResolver;
   /** In-memory response cache. Omit for a per-client default; pass `false` to bypass SDK validators. */
   readonly cache?: MapPackageFetchCache | false;
-  /** Resolve out-of-band style refs and inline successful bodies into the returned package. */
+  /**
+   * Resolve out-of-band style refs and inline successful bodies into the
+   * returned package. When omitted, defaults to resolving `styleRefs.styleId`
+   * against the server's OGC API – Styles surface (`GET /ogc/styles/{styleId}`)
+   * via {@link createOgcStyleRefResolver}. Pass a callback to override that
+   * path (back-compat), or set {@link disableDefaultStyleRefResolver} to skip it.
+   */
   readonly resolveStyleRef?: StyleRefResolver;
+  /** Disable the default `/ogc/styles` StyleRef resolver when no callback is supplied. */
+  readonly disableDefaultStyleRefResolver?: boolean;
   /** Treat unresolved style refs as validation errors instead of warnings. */
   readonly requireStyleRefResolution?: boolean;
   /** Emit a stale-package warning when the package timestamp is older than this many ms. */
@@ -129,8 +138,11 @@ export async function fetchMapPackage(
 
   const body = await parseJsonBody(response, path);
   const rawPackage = unwrapMapPackageEnvelope(body);
+  const styleRefResolver =
+    options.resolveStyleRef ??
+    (options.disableDefaultStyleRefResolver ? undefined : createOgcStyleRefResolver({ client: options.client }));
   const resolved = await resolveMapPackageStyleRefs(rawPackage, {
-    resolveStyleRef: options.resolveStyleRef,
+    ...(styleRefResolver ? { resolveStyleRef: styleRefResolver } : {}),
     requireStyleRefResolution: options.requireStyleRefResolution === true,
   });
   const mapPackage = resolved.mapPackage;
@@ -185,6 +197,7 @@ export async function loadMapPackageFromId(
     resolvePath: options.resolvePath,
     cache: options.cache,
     resolveStyleRef: options.resolveStyleRef,
+    disableDefaultStyleRefResolver: options.disableDefaultStyleRefResolver,
     requireStyleRefResolution: options.requireStyleRefResolution ?? true,
     maxAgeMs: options.maxAgeMs,
     now: options.now,

--- a/src/runtime/ogc-styles.ts
+++ b/src/runtime/ogc-styles.ts
@@ -1,0 +1,253 @@
+/**
+ * OGC API – Styles client + StyleRef resolver.
+ *
+ * Consumes the server's OGC API – Styles surface (honua-server, ADR-0048) so
+ * that `styleRefs.styleId` aligns with the server's canonical styleId instead
+ * of relying on an ad-hoc, caller-supplied callback:
+ *
+ *   GET /ogc/styles                       -> { styles: [{ id, title, links }], default? }
+ *   GET /ogc/styles/{styleId}             -> MapLibre style document
+ *     (Accept: application/vnd.mapbox.style+json — content negotiated)
+ *   GET /ogc/styles/{styleId}/metadata    -> style metadata document
+ *
+ * The {@link createOgcStyleRefResolver} factory adapts the full MapLibre style
+ * document returned by `/ogc/styles/{styleId}` into the per-layer
+ * {@link HonuaStyleRefBody} override map consumed by `applyStyleRefs`. This is
+ * wired as the default StyleRef resolution path in the runtime loader, while a
+ * caller-supplied callback remains supported as a back-compat override.
+ *
+ * @module
+ */
+
+import type { HonuaClient } from "../core/client.js";
+import type { HonuaLayerSpecification, HonuaStyleSpecification } from "../style/specification.js";
+import { HonuaMapPackageError } from "./errors.js";
+import type { HonuaStyleRefBody, HonuaStyleRefLayerOverride } from "./map-package.js";
+import type { StyleRefResolver } from "./style-compose.js";
+
+/** Default path prefix for the server's OGC API – Styles surface. */
+export const DEFAULT_OGC_STYLES_PATH_PREFIX = "/ogc/styles";
+
+/**
+ * MapLibre style media type used to content-negotiate the encoded style
+ * document from `/ogc/styles/{styleId}`. Matches the server default.
+ */
+export const MAPLIBRE_STYLE_MEDIA_TYPE = "application/vnd.mapbox.style+json";
+
+/** A link entry on a styles list / style metadata document. */
+export interface OgcStyleLink {
+  readonly rel: string;
+  readonly type?: string;
+  readonly href: string;
+  readonly title?: string;
+}
+
+/** One entry in the `/ogc/styles` style list. */
+export interface OgcStyleListEntry {
+  readonly id: string;
+  readonly title?: string;
+  readonly links?: readonly OgcStyleLink[];
+}
+
+/** Response body of `GET /ogc/styles`. */
+export interface OgcStyleList {
+  readonly styles: readonly OgcStyleListEntry[];
+  /** Server-designated default styleId, when present. */
+  readonly default?: string;
+}
+
+/** Options shared by the OGC styles client calls. */
+export interface OgcStylesRequestOptions {
+  readonly signal?: AbortSignal;
+  readonly headers?: HeadersInit;
+}
+
+/** Options for constructing an OGC styles client. */
+export interface OgcStylesClientOptions {
+  readonly client: HonuaClient;
+  /**
+   * Override the OGC styles path prefix. Defaults to
+   * {@link DEFAULT_OGC_STYLES_PATH_PREFIX} (`/ogc/styles`).
+   */
+  readonly pathPrefix?: string;
+}
+
+/**
+ * Thin client over the server's OGC API – Styles surface. Uses the shared
+ * {@link HonuaClient} request pipeline (auth / retry / interceptors), matching
+ * the other `/ogc/*` consumers in the SDK.
+ */
+export class OgcStylesClient {
+  private readonly client: HonuaClient;
+  private readonly pathPrefix: string;
+
+  constructor(options: OgcStylesClientOptions) {
+    this.client = options.client;
+    this.pathPrefix = normalizePrefix(options.pathPrefix ?? DEFAULT_OGC_STYLES_PATH_PREFIX);
+  }
+
+  /** List available styles via `GET /ogc/styles`. */
+  public async listStyles(options: OgcStylesRequestOptions = {}): Promise<OgcStyleList> {
+    const body = await this.getJson(this.pathPrefix, "application/json", options);
+    return normalizeStyleList(body);
+  }
+
+  /**
+   * Fetch the MapLibre style document for `styleId` via
+   * `GET /ogc/styles/{styleId}` (content-negotiated to
+   * {@link MAPLIBRE_STYLE_MEDIA_TYPE}).
+   */
+  public async getStyle(styleId: string, options: OgcStylesRequestOptions = {}): Promise<HonuaStyleSpecification> {
+    const path = this.stylePath(styleId);
+    const body = await this.getJson(path, `${MAPLIBRE_STYLE_MEDIA_TYPE}, application/json;q=0.9`, options);
+    if (!isRecord(body) || !Array.isArray((body as { layers?: unknown }).layers)) {
+      throw new HonuaMapPackageError(`OGC style "${styleId}" did not return a MapLibre style document`, {
+        stage: "style-compose",
+        detail: { styleId, path },
+      });
+    }
+    return body as unknown as HonuaStyleSpecification;
+  }
+
+  /** Fetch the style metadata document via `GET /ogc/styles/{styleId}/metadata`. */
+  public async getStyleMetadata(
+    styleId: string,
+    options: OgcStylesRequestOptions = {},
+  ): Promise<Record<string, unknown>> {
+    const path = `${this.stylePath(styleId)}/metadata`;
+    const body = await this.getJson(path, "application/json", options);
+    if (!isRecord(body)) {
+      throw new HonuaMapPackageError(`OGC style metadata for "${styleId}" was not an object`, {
+        stage: "style-compose",
+        detail: { styleId, path },
+      });
+    }
+    return body;
+  }
+
+  /** Resolve the request path for a single style. */
+  public stylePath(styleId: string): string {
+    return `${this.pathPrefix}/${encodeURIComponent(styleId)}`;
+  }
+
+  private async getJson(path: string, accept: string, options: OgcStylesRequestOptions): Promise<unknown> {
+    const headers = new Headers(options.headers);
+    if (!headers.has("Accept")) headers.set("Accept", accept);
+    const response = await this.client.pipelineFetch("GET", path, { headers }, options.signal);
+    try {
+      return await response.json();
+    } catch (cause) {
+      throw new HonuaMapPackageError(`OGC styles response from "${path}" was not valid JSON`, {
+        stage: "style-compose",
+        detail: { path },
+        cause,
+      });
+    }
+  }
+}
+
+/** Options for {@link createOgcStyleRefResolver}. */
+export interface OgcStyleRefResolverOptions extends OgcStylesClientOptions, OgcStylesRequestOptions {}
+
+/**
+ * Build a {@link StyleRefResolver} backed by the server's `/ogc/styles`
+ * surface. The resolver fetches `GET /ogc/styles/{styleId}` (content-negotiated
+ * MapLibre) and projects the returned style document's layers into the
+ * per-layer {@link HonuaStyleRefBody} override map that `applyStyleRefs`
+ * consumes. Layer overrides are keyed by MapLibre layer id; only
+ * paint/layout/zoom/filter/metadata are carried over (structural fields such
+ * as `source` are intentionally dropped — a StyleRef refines existing layers).
+ *
+ * The `presetId` argument is currently advisory and not encoded into the
+ * request path; the server resolves presets server-side by styleId.
+ */
+export function createOgcStyleRefResolver(options: OgcStyleRefResolverOptions): StyleRefResolver {
+  const ogc = new OgcStylesClient({
+    client: options.client,
+    ...(options.pathPrefix ? { pathPrefix: options.pathPrefix } : {}),
+  });
+  const requestOptions: OgcStylesRequestOptions = {
+    ...(options.signal ? { signal: options.signal } : {}),
+    ...(options.headers ? { headers: options.headers } : {}),
+  };
+  return async (styleId: string): Promise<HonuaStyleRefBody> => {
+    const style = await ogc.getStyle(styleId, requestOptions);
+    return styleDocumentToRefBody(style);
+  };
+}
+
+/**
+ * Project a MapLibre style document into a {@link HonuaStyleRefBody} — a map of
+ * per-layer paint/layout overrides keyed by layer id. Layers without any
+ * override-relevant fields are omitted.
+ */
+export function styleDocumentToRefBody(style: HonuaStyleSpecification): HonuaStyleRefBody {
+  const body: HonuaStyleRefBody = {};
+  for (const layer of style.layers ?? []) {
+    if (!layer || typeof layer.id !== "string") continue;
+    const override = layerToOverride(layer);
+    if (override) body[layer.id] = override;
+  }
+  return body;
+}
+
+function layerToOverride(layer: HonuaLayerSpecification): HonuaStyleRefLayerOverride | undefined {
+  const override: HonuaStyleRefLayerOverride = {};
+  let hasField = false;
+  if (layer.paint !== undefined) {
+    override.paint = layer.paint;
+    hasField = true;
+  }
+  if (layer.layout !== undefined) {
+    override.layout = layer.layout;
+    hasField = true;
+  }
+  if (layer.minzoom !== undefined) {
+    override.minzoom = layer.minzoom;
+    hasField = true;
+  }
+  if (layer.maxzoom !== undefined) {
+    override.maxzoom = layer.maxzoom;
+    hasField = true;
+  }
+  if (layer.filter !== undefined) {
+    override.filter = layer.filter;
+    hasField = true;
+  }
+  if (layer.metadata !== undefined) {
+    override.metadata = layer.metadata;
+    hasField = true;
+  }
+  return hasField ? override : undefined;
+}
+
+function normalizeStyleList(body: unknown): OgcStyleList {
+  if (!isRecord(body) || !Array.isArray(body.styles)) {
+    throw new HonuaMapPackageError("OGC styles list did not contain a styles array", {
+      stage: "style-compose",
+      detail: { body },
+    });
+  }
+  const styles: OgcStyleListEntry[] = [];
+  for (const entry of body.styles) {
+    if (!isRecord(entry) || typeof entry.id !== "string") continue;
+    styles.push({
+      id: entry.id,
+      ...(typeof entry.title === "string" ? { title: entry.title } : {}),
+      ...(Array.isArray(entry.links) ? { links: entry.links as readonly OgcStyleLink[] } : {}),
+    });
+  }
+  return {
+    styles,
+    ...(typeof body.default === "string" ? { default: body.default } : {}),
+  };
+}
+
+function normalizePrefix(prefix: string): string {
+  const trimmed = prefix.replace(/\/+$/, "");
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/test/runtime/map-package-fetch.test.ts
+++ b/test/runtime/map-package-fetch.test.ts
@@ -94,6 +94,46 @@ describe("fetchMapPackage", () => {
     });
   });
 
+  test("defaults to resolving style refs via /ogc/styles when no callback is supplied", async () => {
+    const requests: string[] = [];
+    const client = makeClient(async (url) => {
+      requests.push(String(url));
+      if (String(url).endsWith("/ogc/styles/style-fill")) {
+        return jsonResponse({
+          version: 8,
+          sources: {},
+          layers: [{ id: "parcels-fill", type: "fill", source: "parcels", paint: { "fill-color": "#00ff00" } }],
+        });
+      }
+      return jsonResponse(makePackage({ styleRefs: [{ styleId: "style-fill", body: undefined }] }));
+    });
+
+    const resolved = await fetchMapPackage("pkg-001", { client });
+
+    expect(requests.some((url) => url.endsWith("/ogc/styles/style-fill"))).toBe(true);
+    expect(resolved.diagnostics).toEqual([]);
+    expect(resolved.mapPackage.styleRefs?.[0].body).toEqual({
+      "parcels-fill": { paint: { "fill-color": "#00ff00" } },
+    });
+  });
+
+  test("disableDefaultStyleRefResolver skips the /ogc/styles default", async () => {
+    const requests: string[] = [];
+    const client = makeClient(async (url) => {
+      requests.push(String(url));
+      return jsonResponse(makePackage({ styleRefs: [{ styleId: "style-fill", body: undefined }] }));
+    });
+
+    const resolved = await fetchMapPackage("pkg-001", {
+      client,
+      allowInvalid: true,
+      disableDefaultStyleRefResolver: true,
+    });
+
+    expect(requests.some((url) => url.includes("/ogc/styles/"))).toBe(false);
+    expect(resolved.diagnostics).toEqual([expect.objectContaining({ code: "style-ref-unresolved" })]);
+  });
+
   test("reports style-ref resolver failures as diagnostics", async () => {
     const client = makeClient(async () =>
       jsonResponse(

--- a/test/runtime/ogc-styles.test.ts
+++ b/test/runtime/ogc-styles.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "vitest";
+
+import { HonuaClient } from "../../src/core/client.js";
+import {
+  MAPLIBRE_STYLE_MEDIA_TYPE,
+  OgcStylesClient,
+  createOgcStyleRefResolver,
+  styleDocumentToRefBody,
+} from "../../src/runtime/index.js";
+import type { HonuaStyleSpecification } from "../../src/style/specification.js";
+
+interface RecordedRequest {
+  readonly url: string;
+  readonly accept: string | null;
+}
+
+describe("OgcStylesClient", () => {
+  test("listStyles fetches /ogc/styles and normalizes entries + default", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = makeClient(requests, async (url) => {
+      expect(url).toBe("https://mock.honua.test/ogc/styles");
+      return jsonResponse({
+        styles: [
+          {
+            id: "topo",
+            title: "Topographic",
+            links: [{ rel: "stylesheet", type: MAPLIBRE_STYLE_MEDIA_TYPE, href: "/ogc/styles/topo" }],
+          },
+          { id: "imagery" },
+          { notAStyle: true },
+        ],
+        default: "topo",
+      });
+    });
+
+    const list = await new OgcStylesClient({ client }).listStyles();
+
+    expect(list.default).toBe("topo");
+    expect(list.styles.map((s) => s.id)).toEqual(["topo", "imagery"]);
+    expect(list.styles[0].title).toBe("Topographic");
+    expect(list.styles[0].links?.[0].rel).toBe("stylesheet");
+  });
+
+  test("getStyle content-negotiates the MapLibre media type", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = makeClient(requests, async () => jsonResponse(sampleStyleDoc()));
+
+    const style = await new OgcStylesClient({ client }).getStyle("topo");
+
+    expect(requests[0].url).toBe("https://mock.honua.test/ogc/styles/topo");
+    expect(requests[0].accept).toContain(MAPLIBRE_STYLE_MEDIA_TYPE);
+    expect(style.layers.map((l) => l.id)).toEqual(["parcels-fill", "parcels-outline"]);
+  });
+
+  test("getStyle encodes the styleId and respects a custom path prefix", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = makeClient(requests, async () => jsonResponse(sampleStyleDoc()));
+
+    await new OgcStylesClient({ client, pathPrefix: "/custom/styles/" }).getStyle("city blocks");
+
+    expect(requests[0].url).toBe("https://mock.honua.test/custom/styles/city%20blocks");
+  });
+
+  test("getStyle throws a typed error when the body is not a MapLibre style", async () => {
+    const client = makeClient([], async () => jsonResponse({ id: "topo", not: "a style" }));
+
+    await expect(new OgcStylesClient({ client }).getStyle("topo")).rejects.toMatchObject({
+      name: "HonuaMapPackageError",
+      stage: "style-compose",
+    });
+  });
+
+  test("getStyleMetadata fetches the /metadata sub-resource", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = makeClient(requests, async () => jsonResponse({ id: "topo", layers: [] }));
+
+    const metadata = await new OgcStylesClient({ client }).getStyleMetadata("topo");
+
+    expect(requests[0].url).toBe("https://mock.honua.test/ogc/styles/topo/metadata");
+    expect(metadata.id).toBe("topo");
+  });
+});
+
+describe("styleDocumentToRefBody", () => {
+  test("projects layers into a per-layer override body and drops structural fields", () => {
+    const body = styleDocumentToRefBody(sampleStyleDoc());
+
+    expect(Object.keys(body)).toEqual(["parcels-fill", "parcels-outline"]);
+    expect(body["parcels-fill"]).toEqual({ paint: { "fill-color": "#ff0000" } });
+    // `source` / `type` are not carried into the override.
+    expect(body["parcels-fill"]).not.toHaveProperty("source");
+    expect(body["parcels-outline"]).toEqual({
+      paint: { "line-color": "#000000" },
+      minzoom: 4,
+    });
+  });
+
+  test("omits layers that carry no override-relevant fields", () => {
+    const body = styleDocumentToRefBody({
+      version: 8,
+      sources: {},
+      layers: [{ id: "bare", type: "background", source: "parcels" }],
+    });
+    expect(body).toEqual({});
+  });
+});
+
+describe("createOgcStyleRefResolver", () => {
+  test("resolves a styleId via /ogc/styles/{styleId} into an override body", async () => {
+    const requests: RecordedRequest[] = [];
+    const client = makeClient(requests, async () => jsonResponse(sampleStyleDoc()));
+
+    const resolve = createOgcStyleRefResolver({ client });
+    const body = await resolve("topo");
+
+    expect(requests[0].url).toBe("https://mock.honua.test/ogc/styles/topo");
+    expect(requests[0].accept).toContain(MAPLIBRE_STYLE_MEDIA_TYPE);
+    expect(body["parcels-fill"]).toEqual({ paint: { "fill-color": "#ff0000" } });
+  });
+});
+
+function sampleStyleDoc(): HonuaStyleSpecification {
+  return {
+    version: 8,
+    sources: { parcels: { type: "geojson", data: { type: "FeatureCollection", features: [] } } },
+    layers: [
+      { id: "parcels-fill", type: "fill", source: "parcels", paint: { "fill-color": "#ff0000" } },
+      { id: "parcels-outline", type: "line", source: "parcels", paint: { "line-color": "#000000" }, minzoom: 4 },
+    ],
+  };
+}
+
+function makeClient(
+  requests: RecordedRequest[],
+  fetchFn: (url: string, init?: RequestInit) => Promise<Response>,
+): HonuaClient {
+  return new HonuaClient({
+    baseUrl: "https://mock.honua.test",
+    fetchFn: async (url, init) => {
+      requests.push({ url: String(url), accept: new Headers(init?.headers).get("accept") });
+      return fetchFn(String(url), init);
+    },
+  });
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}


### PR DESCRIPTION
## Summary

Aligns `styleRefs.styleId` with the server's canonical `styleId` by resolving styles against the OGC API – Styles surface instead of relying solely on an ad-hoc caller callback.

- New `src/runtime/ogc-styles.ts`:
  - `OgcStylesClient` — thin client over `GET /ogc/styles`, `GET /ogc/styles/{styleId}` (content-negotiated MapLibre via `application/vnd.mapbox.style+json`), and `GET /ogc/styles/{styleId}/metadata`, using the shared `HonuaClient.pipelineFetch` pipeline (auth/retry/interceptors), matching the other `/ogc/*` consumers.
  - `createOgcStyleRefResolver(...)` — a `StyleRefResolver` that fetches a style by `styleId` and projects its layers into the per-layer `HonuaStyleRefBody` override map consumed by `applyStyleRefs` (paint/layout/zoom/filter/metadata; structural fields like `source` are dropped since a StyleRef refines existing layers).
  - `styleDocumentToRefBody(...)` — the projection helper.
- Wired `createOgcStyleRefResolver` as the **default** StyleRef resolution path in `loadMapPackage` and `fetchMapPackage`/`loadMapPackageFromId`. The caller-supplied `resolveStyleRef` callback still **overrides** the default (back-compat); new `disableDefaultStyleRefResolver` flag opts out.
- MapLibre runtime integration and the Esri renderer/symbol converters are untouched. Composition/theme behavior unchanged.
- Exported the new surface from `src/runtime/index.ts`.

## Tests

- New `test/runtime/ogc-styles.test.ts` (8 tests): list/get/metadata calls, content negotiation, styleId encoding + custom prefix, typed error on non-style bodies, document→ref-body projection, and resolver end-to-end. Fetch is mocked via `HonuaClient({ fetchFn })`.
- Extended `test/runtime/map-package-fetch.test.ts`: default `/ogc/styles` resolution and the `disableDefaultStyleRefResolver` opt-out.
- `npm run typecheck` and `npm run check` (Biome) pass. Full `npm test`: 2145 passed; the one failure (`migration-cli-content-webmap.test.ts`) is a pre-existing, environment-dependent 30s timeout in `ensureBuiltCliArtifacts` (CLI build under the shared build-lock) and is unrelated to these runtime/style changes — it fails identically on the baseline.

## Links

- Closes #251
- Umbrella: honua-io/honua-server#1387
- Per ADR-0048 (honua-server: `docs/contributor/adr/0048-ogc-api-styles-and-cross-repo-style-coherence.md`)