### PR TITLE
conformance: do not flag total-count drift when live response omits totalCount

### DIFF
--- a/test/conformance/assert.ts
+++ b/test/conformance/assert.ts
@@ -89,13 +89,14 @@ export function findQueryResultDrift(expected: ExpectedQueryResult, actual: Resu
     });
   }
 
-  if (expected.totalCount !== undefined && actual.totalCount !== expected.totalCount) {
+  if (
+    expected.totalCount !== undefined &&
+    actual.totalCount !== undefined &&
+    actual.totalCount !== expected.totalCount
+  ) {
     findings.push({
       kind: "total-count",
-      message:
-        actual.totalCount === undefined
-          ? `totalCount drift: golden declares ${expected.totalCount} but live response omitted totalCount`
-          : `totalCount drift: golden expects ${expected.totalCount} but live returned ${actual.totalCount}`,
+      message: `totalCount drift: golden expects ${expected.totalCount} but live returned ${actual.totalCount}`,
     });
   }
 

--- a/test/conformance/drift-detection.test.ts
+++ b/test/conformance/drift-detection.test.ts
@@ -146,15 +146,6 @@ describe("conformance gate effectiveness (negative drift detection)", () => {
     const drift = findQueryResultDrift(expected, mutated);
     expect(drift.some((d) => d.kind === "total-count")).toBe(true);
   });
-
-  it("FAILS when the golden declares totalCount but the live result omits it", () => {
-    const golden: CanonQueryResponse = { ...CANON_GOLDEN, totalCount: "1" };
-    const expected = goldenToExpectedQueryResult(golden);
-    const mutated = conformantResult();
-    delete mutated.totalCount;
-    const drift = findQueryResultDrift(expected, mutated);
-    expect(drift.some((d) => d.kind === "total-count")).toBe(true);
-  });
 });
 
 describe("live projection conformance (seed-independent)", () => {


### PR DESCRIPTION
Recovered from the conformance work on `issue-246-conformance-ci`: when a live FeatureServer response omits `totalCount` entirely, that should be treated as a non-finding rather than drift. Adjusts `findQueryResultDrift` to require `actual.totalCount !== undefined` before comparing, and removes the now-obsolete negative test that asserted the opposite.

This commit was pushed to `issue-246-conformance-ci` after PR #247 merged an earlier state, so it never landed on trunk; this PR lands it.