### PR TITLE
feat(sdk-js): first-class 3D SceneView — Cesium runtime, 3D Tiles/terrain/glTF rendering, and analysis widgets

### DIFF
--- a/src/scene-workspace/index.ts
+++ b/src/scene-workspace/index.ts
@@ -101,6 +101,31 @@ export type {
   ViewshedResult,
   ViewshedSample,
 } from "./analysis-widgets.js";
+export {
+  getScene,
+  listScenes,
+  normalizeScene,
+  resolveSceneTilesetUrl,
+  sceneCameraPrimitive,
+  sceneLayerStates,
+  sceneTerrainPrimitive,
+  sceneTilesetPrimitive,
+  sceneToRuntimePrimitives,
+  sceneViewpointBookmarks,
+} from "./scene-discovery.js";
+export type {
+  HonuaScene,
+  SceneDiscoveryRequestExecutor,
+  SceneExtent3D,
+  SceneViewpoint,
+} from "./scene-discovery.js";
+export { SceneView } from "./scene-view.js";
+export type {
+  SceneViewEvent,
+  SceneViewEventListener,
+  SceneViewOptions,
+  SceneViewRequestExecutor,
+} from "./scene-view.js";
 export { SCENE_WORKSPACE_SLICES } from "./types.js";
 export type {
   MapLibreExtrusionLayerSpecification,

--- a/src/scene-workspace/scene-discovery.ts
+++ b/src/scene-workspace/scene-discovery.ts
@@ -1,0 +1,358 @@
+/**
+ * HTTP scene discovery for the 3D scene workspace.
+ *
+ * Honua publishes 3D scenes over the `geospatial.v1` `SceneService`
+ * (`ListScenes` / `GetScene`) and mirrors that catalog over plain HTTP scene
+ * discovery (`GET /api/scenes`, `GET /api/scenes/{id}`) alongside the static
+ * 3D-Tiles entry point (`GET /scenes/{id}/tileset.json`). This module gives the
+ * SDK a typed read model over that discovery surface and maps a discovered
+ * {@link HonuaScene} onto the renderer-neutral {@link SceneRuntimePrimitive}s the
+ * Cesium adapter renders.
+ *
+ * Discovery calls go through a caller-supplied {@link SceneDiscoveryRequestExecutor}
+ * — typically `(...args) => client.pipelineRequestJson(...args)` against a
+ * `HonuaClient` — so they reuse the SDK's shared auth / retry / timeout /
+ * interceptor pipeline rather than issuing ad-hoc `fetch` calls. Modelling the
+ * transport as a function keeps this module free of a hard `core/client` import
+ * (and equally usable from a Node backend, a worker, or a unit test with a mock).
+ *
+ * The mapping helpers ({@link sceneToRuntimePrimitives},
+ * {@link sceneCameraPrimitive}, {@link sceneViewpointBookmarks}) are pure (no
+ * Cesium, no transport) and unit-testable on their own.
+ *
+ * @experimental Part of the experimental `scene-workspace` surface; not yet
+ *   covered by the SDK's semver contract prior to `1.0.0`.
+ * @module
+ */
+
+import type { QueryMethod } from "../core/types.js";
+import type { SceneCameraPrimitive, SceneElevationSourcePrimitive, SceneModelLayerPrimitive } from "./primitives.js";
+import type { SceneBookmark, SceneCameraState, SceneLayerState } from "./types.js";
+
+/**
+ * The minimal request executor scene discovery needs. This is exactly the shape
+ * of `HonuaClient.pipelineRequestJson`, so a consumer wires the SDK's shared
+ * HTTP pipeline (auth, retries, timeouts, interceptors) in with:
+ *
+ * ```ts
+ * const executor: SceneDiscoveryRequestExecutor =
+ *   (method, path, init, signal) => client.pipelineRequestJson(method, path, init, signal);
+ * ```
+ */
+export type SceneDiscoveryRequestExecutor = <T = unknown>(
+  method: QueryMethod,
+  path: string,
+  init?: { headers?: Record<string, string>; body?: string | null },
+  signal?: AbortSignal,
+) => Promise<T>;
+
+/** A 3D bounding volume mirroring the server's `Extent3D` (horizontal envelope + height range). */
+export interface SceneExtent3D {
+  readonly xmin: number;
+  readonly ymin: number;
+  readonly xmax: number;
+  readonly ymax: number;
+  readonly minHeight?: number;
+  readonly maxHeight?: number;
+  readonly spatialReference?: number;
+}
+
+/** A named camera position (bookmark / initial view) mirroring the server's `Viewpoint`. */
+export interface SceneViewpoint {
+  readonly id: string;
+  readonly title: string;
+  readonly camera: SceneCameraState;
+}
+
+/**
+ * A discovered Honua 3D scene, normalized from the server's `SceneMetadata`
+ * (`geospatial.v1.SceneService`). Field names follow the SDK's camelCase
+ * convention; both `tilesetUrl` (camelCase) and `tileset_url` (proto JSON) are
+ * accepted on the wire and normalized here.
+ */
+export interface HonuaScene {
+  readonly sceneId: string;
+  readonly title?: string;
+  readonly description?: string;
+  /** URL of the root 3D-Tiles tileset (`tileset.json`). */
+  readonly tilesetUrl?: string;
+  /** URL of the terrain provider backing the scene, when present. */
+  readonly terrainUrl?: string;
+  /** Full 3D extent of the scene (horizontal envelope + min/max height). */
+  readonly extent?: SceneExtent3D;
+  /** Suggested initial camera for the first view. */
+  readonly initialCamera?: SceneCameraState;
+  /** Named viewpoints / bookmarks. */
+  readonly viewpoints: readonly SceneViewpoint[];
+  /** Scene-wide 3D-Tiles styling expression, when published with the scene. */
+  readonly styleExpression?: string;
+  /** Edition required to access the scene (e.g. `community`, `pro`); empty when unrestricted. */
+  readonly edition?: string;
+  /** Capability flags advertised for the scene (e.g. `terrain`, `point-cloud`, `styling`). */
+  readonly capabilities: readonly string[];
+}
+
+const SCENES_BASE_PATH = "/api/scenes";
+
+/** Raw camera shape accepted from the server (proto3 JSON). */
+interface RawCamera {
+  longitude?: number;
+  latitude?: number;
+  height?: number;
+  heading?: number;
+  pitch?: number;
+  roll?: number;
+}
+
+/** Raw scene shape accepted from the server. Tolerates both camelCase and proto snake_case. */
+interface RawScene {
+  sceneId?: string;
+  scene_id?: string;
+  title?: string;
+  description?: string;
+  tilesetUrl?: string;
+  tileset_url?: string;
+  terrainUrl?: string;
+  terrain_url?: string;
+  extent?: {
+    extent?: { xmin?: number; ymin?: number; xmax?: number; ymax?: number; spatialReference?: number };
+    xmin?: number;
+    ymin?: number;
+    xmax?: number;
+    ymax?: number;
+    minHeight?: number;
+    min_height?: number;
+    maxHeight?: number;
+    max_height?: number;
+    spatialReference?: number;
+  };
+  initialCamera?: RawCamera;
+  initial_camera?: RawCamera;
+  viewpoints?: Array<{ id?: string; title?: string; camera?: RawCamera }>;
+  style?: { expression?: string };
+  styleExpression?: string;
+  edition?: string;
+  capabilities?: string[];
+}
+
+interface RawListScenesResponse {
+  scenes?: RawScene[];
+}
+
+interface RawGetSceneResponse {
+  scene?: RawScene;
+}
+
+function normalizeCamera(raw: RawCamera | undefined): SceneCameraState | undefined {
+  if (!raw || raw.longitude === undefined || raw.latitude === undefined) return undefined;
+  return {
+    longitude: raw.longitude,
+    latitude: raw.latitude,
+    height: raw.height ?? 0,
+    ...(raw.heading !== undefined ? { heading: raw.heading } : {}),
+    ...(raw.pitch !== undefined ? { pitch: raw.pitch } : {}),
+    ...(raw.roll !== undefined ? { roll: raw.roll } : {}),
+  };
+}
+
+function normalizeExtent(raw: RawScene["extent"]): SceneExtent3D | undefined {
+  if (!raw) return undefined;
+  const envelope = raw.extent ?? raw;
+  if (
+    envelope.xmin === undefined ||
+    envelope.ymin === undefined ||
+    envelope.xmax === undefined ||
+    envelope.ymax === undefined
+  ) {
+    return undefined;
+  }
+  const minHeight = raw.minHeight ?? raw.min_height;
+  const maxHeight = raw.maxHeight ?? raw.max_height;
+  return {
+    xmin: envelope.xmin,
+    ymin: envelope.ymin,
+    xmax: envelope.xmax,
+    ymax: envelope.ymax,
+    ...(minHeight !== undefined ? { minHeight } : {}),
+    ...(maxHeight !== undefined ? { maxHeight } : {}),
+    ...(envelope.spatialReference !== undefined ? { spatialReference: envelope.spatialReference } : {}),
+  };
+}
+
+/**
+ * Normalize a raw scene payload (camelCase or proto3-JSON snake_case) into a
+ * {@link HonuaScene}. Exported so the normalization is unit-testable against
+ * either wire shape without a transport.
+ */
+export function normalizeScene(raw: RawScene): HonuaScene {
+  const sceneId = raw.sceneId ?? raw.scene_id ?? "";
+  const tilesetUrl = raw.tilesetUrl ?? raw.tileset_url;
+  const terrainUrl = raw.terrainUrl ?? raw.terrain_url;
+  const initialCamera = normalizeCamera(raw.initialCamera ?? raw.initial_camera);
+  const viewpoints: SceneViewpoint[] = (raw.viewpoints ?? [])
+    .map((viewpoint) => {
+      const camera = normalizeCamera(viewpoint.camera);
+      if (!camera || !viewpoint.id) return undefined;
+      return { id: viewpoint.id, title: viewpoint.title ?? viewpoint.id, camera };
+    })
+    .filter((viewpoint): viewpoint is SceneViewpoint => viewpoint !== undefined);
+  const styleExpression = raw.styleExpression ?? raw.style?.expression;
+  return {
+    sceneId,
+    ...(raw.title !== undefined ? { title: raw.title } : {}),
+    ...(raw.description !== undefined ? { description: raw.description } : {}),
+    ...(tilesetUrl !== undefined ? { tilesetUrl } : {}),
+    ...(terrainUrl !== undefined ? { terrainUrl } : {}),
+    ...(normalizeExtent(raw.extent) ? { extent: normalizeExtent(raw.extent) } : {}),
+    ...(initialCamera ? { initialCamera } : {}),
+    viewpoints,
+    ...(styleExpression !== undefined ? { styleExpression } : {}),
+    ...(raw.edition !== undefined ? { edition: raw.edition } : {}),
+    capabilities: raw.capabilities ?? [],
+  };
+}
+
+/**
+ * List the catalog of available 3D scenes from `GET /api/scenes`
+ * (`SceneService.ListScenes`). Returns the normalized {@link HonuaScene}s.
+ */
+export async function listScenes(execute: SceneDiscoveryRequestExecutor, signal?: AbortSignal): Promise<HonuaScene[]> {
+  const raw = await execute<RawListScenesResponse>("GET", SCENES_BASE_PATH, undefined, signal);
+  return (raw.scenes ?? []).map(normalizeScene);
+}
+
+/**
+ * Fetch a single scene's metadata from `GET /api/scenes/{sceneId}`
+ * (`SceneService.GetScene`). The response is tolerated as either the bare scene
+ * object or a `{ scene }` envelope.
+ */
+export async function getScene(
+  execute: SceneDiscoveryRequestExecutor,
+  sceneId: string,
+  signal?: AbortSignal,
+): Promise<HonuaScene> {
+  if (!sceneId) throw new Error("getScene requires a non-empty sceneId.");
+  const raw = await execute<RawGetSceneResponse & RawScene>(
+    "GET",
+    `${SCENES_BASE_PATH}/${encodeURIComponent(sceneId)}`,
+    undefined,
+    signal,
+  );
+  return normalizeScene(raw.scene ?? raw);
+}
+
+/**
+ * Resolve the static 3D-Tiles entry-point URL for a scene
+ * (`/scenes/{sceneId}/tileset.json`). Prefers the scene's advertised
+ * `tilesetUrl`; falls back to the conventional discovery path under `baseUrl`
+ * when the scene omits one. Returns `undefined` when neither is available.
+ */
+export function resolveSceneTilesetUrl(scene: HonuaScene, baseUrl?: string): string | undefined {
+  if (scene.tilesetUrl && scene.tilesetUrl.trim() !== "") return scene.tilesetUrl;
+  if (!baseUrl) return undefined;
+  const trimmed = baseUrl.replace(/\/+$/, "");
+  return `${trimmed}/scenes/${encodeURIComponent(scene.sceneId)}/tileset.json`;
+}
+
+/**
+ * Build the camera primitive for a scene's suggested initial view, or
+ * `undefined` when the scene advertises no initial camera. Pure.
+ */
+export function sceneCameraPrimitive(scene: HonuaScene): SceneCameraPrimitive | undefined {
+  if (!scene.initialCamera) return undefined;
+  return {
+    kind: "camera",
+    id: `${scene.sceneId}:camera`,
+    camera: scene.initialCamera,
+    mode: "global",
+  };
+}
+
+/**
+ * Build the 3D-Tiles model-layer primitive for a scene's root tileset, or
+ * `undefined` when the scene has no resolvable tileset URL. Pure.
+ */
+export function sceneTilesetPrimitive(scene: HonuaScene, baseUrl?: string): SceneModelLayerPrimitive | undefined {
+  const uri = resolveSceneTilesetUrl(scene, baseUrl);
+  if (!uri) return undefined;
+  return {
+    kind: "model-layer",
+    id: `${scene.sceneId}:tileset`,
+    uri,
+    format: "3d-tiles",
+    ...(scene.title !== undefined ? { title: scene.title } : {}),
+  };
+}
+
+/**
+ * Build the terrain elevation-source primitive for a scene's terrain provider,
+ * or `undefined` when the scene advertises no terrain. Pure. The provider is
+ * treated as a quantized-mesh endpoint (Cesium's `CesiumTerrainProvider`).
+ */
+export function sceneTerrainPrimitive(scene: HonuaScene): SceneElevationSourcePrimitive | undefined {
+  if (!scene.terrainUrl || scene.terrainUrl.trim() === "") return undefined;
+  return {
+    kind: "elevation-source",
+    id: `${scene.sceneId}:terrain`,
+    sourceId: `${scene.sceneId}:terrain`,
+    protocol: "quantized-mesh",
+    url: scene.terrainUrl,
+  };
+}
+
+/**
+ * Map a discovered scene onto the renderer-neutral primitives the Cesium
+ * adapter renders: an initial-camera primitive, the terrain elevation source
+ * (when present), and the 3D-Tiles tileset (when resolvable). Pure; the result
+ * feeds straight into `applyCesiumScenePrimitives` / a `SceneView`.
+ */
+export function sceneToRuntimePrimitives(
+  scene: HonuaScene,
+  baseUrl?: string,
+): Array<SceneCameraPrimitive | SceneElevationSourcePrimitive | SceneModelLayerPrimitive> {
+  const primitives: Array<SceneCameraPrimitive | SceneElevationSourcePrimitive | SceneModelLayerPrimitive> = [];
+  const camera = sceneCameraPrimitive(scene);
+  if (camera) primitives.push(camera);
+  const terrain = sceneTerrainPrimitive(scene);
+  if (terrain) primitives.push(terrain);
+  const tileset = sceneTilesetPrimitive(scene, baseUrl);
+  if (tileset) primitives.push(tileset);
+  return primitives;
+}
+
+/**
+ * Build the workspace layer states for a discovered scene (one per rendered
+ * primitive), so a {@link module:scene-workspace/workspace.SceneWorkspace} can
+ * seed its layer list from the scene. Pure.
+ */
+export function sceneLayerStates(scene: HonuaScene, baseUrl?: string): SceneLayerState[] {
+  const layers: SceneLayerState[] = [];
+  if (sceneTilesetPrimitive(scene, baseUrl)) {
+    layers.push({
+      id: `${scene.sceneId}:tileset`,
+      title: scene.title ?? scene.sceneId,
+      visible: true,
+      kind: "tiles",
+    });
+  }
+  if (sceneTerrainPrimitive(scene)) {
+    layers.push({
+      id: `${scene.sceneId}:terrain`,
+      title: "Terrain",
+      visible: true,
+      kind: "scene",
+    });
+  }
+  return layers;
+}
+
+/**
+ * Convert a scene's named viewpoints into workspace {@link SceneBookmark}s. Pure.
+ */
+export function sceneViewpointBookmarks(scene: HonuaScene): SceneBookmark[] {
+  return scene.viewpoints.map((viewpoint) => ({
+    id: viewpoint.id,
+    label: viewpoint.title,
+    camera: viewpoint.camera,
+  }));
+}

--- a/src/scene-workspace/scene-view.ts
+++ b/src/scene-workspace/scene-view.ts
@@ -1,0 +1,392 @@
+/**
+ * `SceneView` — first-class 3D scene container backed by a Cesium runtime.
+ *
+ * `SceneView` is the 3D counterpart of {@link module:map.HonuaMap}: a cohesive,
+ * typed handle that loads a Honua scene and drives a live Cesium globe through
+ * the renderer-neutral {@link module:scene-workspace/cesium-adapter} (#1196). It
+ * renders the scene's 3D Tiles + terrain + glTF models (#1197) and exposes the
+ * 3D analysis + measurement widgets — line-of-sight, viewshed, measure, and
+ * elevation profile (#1205) — wired to the SDK's request pipeline.
+ *
+ * Like the rest of the scene workspace, this module never imports CesiumJS
+ * statically — the live `Viewer`/`Scene` is supplied by the caller as a
+ * {@link CesiumSceneRuntimeTarget}, and the adapter pulls the runtime in lazily
+ * only when it drives the globe. A `SceneView` constructed without a `target`
+ * still loads + diagnoses scenes (useful headless / in tests) but renders
+ * nothing.
+ *
+ * @example
+ * ```ts
+ * import { SceneView } from "@honua/sdk-js/scene-workspace";
+ *
+ * const view = new SceneView({ client, target: { camera: viewer.camera, scene: viewer.scene } });
+ * await view.loadScene("downtown");
+ * view.on((event) => { if (event.type === "scene-loaded") console.log(event.scene.title); });
+ *
+ * const los = await view.lineOfSight({
+ *   datasetId: "dem",
+ *   observer: { longitude: -157.8, latitude: 21.3, height: 30 },
+ *   target: { longitude: -157.81, latitude: 21.31 },
+ *   entities: viewer.entities,
+ * });
+ * ```
+ *
+ * @experimental Part of the experimental `scene-workspace` surface; not yet
+ *   covered by the SDK's semver contract prior to `1.0.0`.
+ * @module
+ */
+
+import type { HonuaClient } from "../core/client.js";
+import type { QueryMethod } from "../core/types.js";
+import {
+  type CesiumEntityCollectionLike,
+  type ElevationProfileRequest,
+  type ElevationProfileResult,
+  type LineOfSightRequest,
+  type LineOfSightResult,
+  type SceneAnalysisCesiumModule,
+  type SceneAnalysisOverlay,
+  type SceneAnalysisPosition,
+  type SceneAnalysisRequestExecutor,
+  type SceneMeasurement,
+  type ViewshedRequest,
+  type ViewshedResult,
+  measureScenePositions,
+  renderElevationProfilePolyline,
+  renderLineOfSight,
+  renderMeasurement,
+  renderViewshed,
+  requestElevationProfile,
+  requestLineOfSight,
+  requestViewshed,
+} from "./analysis-widgets.js";
+import {
+  type CesiumLayerHandle,
+  type CesiumSceneRuntimeTarget,
+  applyCesiumScenePrimitives,
+  cesiumCameraToSceneState,
+} from "./cesium-adapter.js";
+import type { ScenePrimitiveDiagnostic } from "./primitives.js";
+import {
+  type HonuaScene,
+  type SceneDiscoveryRequestExecutor,
+  getScene,
+  listScenes,
+  sceneLayerStates,
+  sceneToRuntimePrimitives,
+  sceneViewpointBookmarks,
+} from "./scene-discovery.js";
+import type { SceneBookmark, SceneCameraState, SceneLayerState } from "./types.js";
+
+/**
+ * The request transport a {@link SceneView} uses for scene discovery and
+ * analysis endpoints. Exactly `HonuaClient.pipelineRequestJson`, so it reuses
+ * the SDK's shared auth / retry / timeout / interceptor pipeline.
+ */
+export type SceneViewRequestExecutor = <T = unknown>(
+  method: QueryMethod,
+  path: string,
+  init?: { headers?: Record<string, string>; body?: string | null },
+  signal?: AbortSignal,
+) => Promise<T>;
+
+/** Options for constructing a {@link SceneView}. */
+export interface SceneViewOptions {
+  /**
+   * The Honua client whose request pipeline backs scene discovery and the
+   * analysis endpoints. Either `client` or an explicit `execute` is required.
+   */
+  readonly client?: HonuaClient;
+  /**
+   * Explicit request executor (overrides `client.pipelineRequestJson`). Lets a
+   * caller wire a custom transport, or a test inject a mock without a client.
+   */
+  readonly execute?: SceneViewRequestExecutor;
+  /**
+   * The live Cesium target (a `camera`, plus an optional `scene` for layer
+   * rendering). Omit to load + diagnose scenes headlessly without rendering.
+   */
+  readonly target?: CesiumSceneRuntimeTarget;
+  /**
+   * Base URL used to resolve a scene's static `tileset.json` entry point when
+   * the scene omits an explicit `tilesetUrl`. Defaults to `client.serverBaseUrl`.
+   */
+  readonly baseUrl?: string;
+}
+
+/** Events emitted by a {@link SceneView}. */
+export type SceneViewEvent =
+  | { readonly type: "scene-loaded"; readonly scene: HonuaScene }
+  | { readonly type: "layers-changed"; readonly layers: readonly SceneLayerState[] }
+  | { readonly type: "layer-visibility"; readonly layerId: string; readonly visible: boolean }
+  | { readonly type: "camera-change"; readonly camera: SceneCameraState }
+  | { readonly type: "diagnostics"; readonly diagnostics: readonly ScenePrimitiveDiagnostic[] };
+
+/** A listener registered via {@link SceneView.on}. */
+export type SceneViewEventListener = (event: SceneViewEvent) => void;
+
+/** The detached request shape shared by the analysis widget convenience methods. */
+type AnalysisOverlayTarget = {
+  /** Entity collection (typically `viewer.entities`) the result is drawn into. */
+  readonly entities?: CesiumEntityCollectionLike;
+  /** Optional Cesium-module override (test seam). */
+  readonly cesium?: SceneAnalysisCesiumModule;
+};
+
+/**
+ * First-class 3D scene container. Loads a Honua scene, renders it through the
+ * Cesium adapter, and exposes the analysis/measurement widgets.
+ */
+export class SceneView {
+  readonly #execute: SceneViewRequestExecutor;
+  readonly #target: CesiumSceneRuntimeTarget | undefined;
+  readonly #baseUrl: string | undefined;
+  readonly #listeners = new Set<SceneViewEventListener>();
+  readonly #layerHandles = new Map<string, CesiumLayerHandle>();
+
+  #scene: HonuaScene | undefined;
+  #layers: SceneLayerState[] = [];
+  #bookmarks: SceneBookmark[] = [];
+  #diagnostics: readonly ScenePrimitiveDiagnostic[] = [];
+
+  constructor(options: SceneViewOptions) {
+    const execute = options.execute ?? bindClientExecutor(options.client);
+    if (!execute) {
+      throw new Error("SceneView requires either a `client` or an explicit `execute` transport.");
+    }
+    this.#execute = execute;
+    this.#target = options.target;
+    this.#baseUrl = options.baseUrl ?? options.client?.serverBaseUrl;
+  }
+
+  // ── Discovery ───────────────────────────────────────────────
+
+  /** List the catalog of available 3D scenes (`GET /api/scenes`). */
+  listScenes(signal?: AbortSignal): Promise<HonuaScene[]> {
+    return listScenes(this.#discoveryExecutor(), signal);
+  }
+
+  /** Fetch a single scene's metadata without loading it (`GET /api/scenes/{id}`). */
+  getScene(sceneId: string, signal?: AbortSignal): Promise<HonuaScene> {
+    return getScene(this.#discoveryExecutor(), sceneId, signal);
+  }
+
+  // ── Loading / rendering ─────────────────────────────────────
+
+  /**
+   * Load a scene by id (or a pre-fetched {@link HonuaScene}) and render it onto
+   * the live target: the initial camera, terrain provider, and 3D-Tiles
+   * tileset. Replaces any previously loaded scene's layers. Returns the loaded
+   * scene. When no target is attached the scene is loaded + diagnosed but not
+   * rendered.
+   */
+  async loadScene(scene: string | HonuaScene, signal?: AbortSignal): Promise<HonuaScene> {
+    const resolved = typeof scene === "string" ? await this.getScene(scene, signal) : scene;
+    this.#teardownLayers();
+    this.#scene = resolved;
+    this.#bookmarks = sceneViewpointBookmarks(resolved);
+    this.#layers = sceneLayerStates(resolved, this.#baseUrl);
+
+    if (this.#target) {
+      const primitives = sceneToRuntimePrimitives(resolved, this.#baseUrl);
+      const result = await applyCesiumScenePrimitives(this.#target, primitives);
+      this.#diagnostics = result.diagnostics;
+      for (const [id, handle] of result.layers) this.#layerHandles.set(id, handle);
+      this.#emit({ type: "diagnostics", diagnostics: this.#diagnostics });
+    }
+
+    this.#emit({ type: "scene-loaded", scene: resolved });
+    this.#emit({ type: "layers-changed", layers: this.#layers });
+    return resolved;
+  }
+
+  /** The currently loaded scene, or `undefined` before the first `loadScene`. */
+  get scene(): HonuaScene | undefined {
+    return this.#scene;
+  }
+
+  /** Snapshot of the loaded scene's layers (one per rendered primitive). */
+  get layers(): readonly SceneLayerState[] {
+    return this.#layers;
+  }
+
+  /** The loaded scene's named viewpoints as workspace bookmarks. */
+  get bookmarks(): readonly SceneBookmark[] {
+    return this.#bookmarks;
+  }
+
+  /** Diagnostics from the most recent render (capability gaps, fallbacks). */
+  get diagnostics(): readonly ScenePrimitiveDiagnostic[] {
+    return this.#diagnostics;
+  }
+
+  /** Whether a live Cesium target is attached (and therefore rendering). */
+  get hasTarget(): boolean {
+    return this.#target !== undefined;
+  }
+
+  /**
+   * Toggle a rendered layer's visibility on the live globe and in the layer
+   * snapshot. No-ops (still updates the snapshot) when the layer is not rendered
+   * (e.g. no target attached). Returns `true` when the layer is known.
+   */
+  setLayerVisible(layerId: string, visible: boolean): boolean {
+    const layer = this.#layers.find((entry) => entry.id === layerId);
+    if (!layer) return false;
+    this.#layerHandles.get(layerId)?.setVisible(visible);
+    this.#layers = this.#layers.map((entry) => (entry.id === layerId ? { ...entry, visible } : entry));
+    this.#emit({ type: "layer-visibility", layerId, visible });
+    this.#emit({ type: "layers-changed", layers: this.#layers });
+    return true;
+  }
+
+  // ── Camera ──────────────────────────────────────────────────
+
+  /**
+   * Read the live camera back as a renderer-neutral {@link SceneCameraState},
+   * or `undefined` when no target is attached. Also emits a `camera-change`
+   * event so subscribers can persist the current view.
+   */
+  readCamera(): SceneCameraState | undefined {
+    if (!this.#target) return undefined;
+    const camera = cesiumCameraToSceneState(this.#target.camera);
+    this.#emit({ type: "camera-change", camera });
+    return camera;
+  }
+
+  /**
+   * Fly/jump to a named viewpoint (bookmark) on the loaded scene. Returns the
+   * applied camera state, or `undefined` when the viewpoint is unknown. The
+   * actual `Camera.setView` is performed through the adapter so no static Cesium
+   * import is needed here.
+   */
+  async applyBookmark(bookmarkId: string): Promise<SceneCameraState | undefined> {
+    const bookmark = this.#bookmarks.find((entry) => entry.id === bookmarkId);
+    if (!bookmark) return undefined;
+    return this.setCamera(bookmark.camera);
+  }
+
+  /**
+   * Set the live camera to an explicit {@link SceneCameraState}. Returns the
+   * applied state (or `undefined` when no target is attached). Routed through
+   * the adapter's camera primitive so the lazy Cesium import stays centralized.
+   */
+  async setCamera(camera: SceneCameraState): Promise<SceneCameraState | undefined> {
+    if (!this.#target) return undefined;
+    await applyCesiumScenePrimitives(this.#target, [
+      { kind: "camera", id: "scene-view:set-camera", camera, mode: "global" },
+    ]);
+    this.#emit({ type: "camera-change", camera });
+    return camera;
+  }
+
+  // ── Analysis + measurement widgets (#1205) ──────────────────
+
+  /**
+   * Run a line-of-sight analysis between an observer and a target. When an
+   * `entities` collection is supplied the sightline + obstruction marker are
+   * drawn into the scene and the overlay handle is returned alongside the
+   * result.
+   */
+  async lineOfSight(
+    request: LineOfSightRequest & AnalysisOverlayTarget,
+  ): Promise<{ result: LineOfSightResult; overlay?: SceneAnalysisOverlay }> {
+    const result = await requestLineOfSight(this.#analysisExecutor(), request);
+    if (!request.entities) return { result };
+    const overlay = await renderLineOfSight(request.entities, request, result, request.cesium);
+    return { result, overlay };
+  }
+
+  /**
+   * Run a viewshed analysis from an observer position. When an `entities`
+   * collection is supplied the radial visibility samples are drawn into the
+   * scene and the overlay handle is returned alongside the result.
+   */
+  async viewshed(
+    request: ViewshedRequest & AnalysisOverlayTarget,
+  ): Promise<{ result: ViewshedResult; overlay?: SceneAnalysisOverlay }> {
+    const result = await requestViewshed(this.#analysisExecutor(), request);
+    if (!request.entities) return { result };
+    const overlay = await renderViewshed(request.entities, result, request.cesium);
+    return { result, overlay };
+  }
+
+  /**
+   * Request an elevation profile along a polyline. When an `entities`
+   * collection is supplied the draped profile line is drawn into the scene and
+   * the overlay handle is returned alongside the result.
+   */
+  async elevationProfile(
+    request: ElevationProfileRequest & AnalysisOverlayTarget,
+  ): Promise<{ result: ElevationProfileResult; overlay?: SceneAnalysisOverlay }> {
+    const result = await requestElevationProfile(this.#analysisExecutor(), request);
+    if (!request.entities) return { result };
+    const overlay = await renderElevationProfilePolyline(request.entities, request.polyline, request.cesium);
+    return { result, overlay };
+  }
+
+  /**
+   * Compute a fully client-side 3D distance or area measurement from an ordered
+   * list of positions (typically picked off the scene). When an `entities`
+   * collection is supplied the measured polyline/polygon + label are drawn into
+   * the scene and the overlay handle is returned alongside the measurement.
+   */
+  async measure(
+    positions: readonly SceneAnalysisPosition[],
+    options: { readonly mode?: "distance" | "area" } & AnalysisOverlayTarget = {},
+  ): Promise<{ measurement: SceneMeasurement; overlay?: SceneAnalysisOverlay }> {
+    const measurement = measureScenePositions(positions, options.mode ?? "distance");
+    if (!options.entities) return { measurement };
+    const overlay = await renderMeasurement(options.entities, measurement, options.cesium);
+    return { measurement, overlay };
+  }
+
+  // ── Events / lifecycle ──────────────────────────────────────
+
+  /** Subscribe to view events. Returns a handle with `remove()` to unsubscribe. */
+  on(listener: SceneViewEventListener): { remove(): void } {
+    this.#listeners.add(listener);
+    return {
+      remove: () => {
+        this.#listeners.delete(listener);
+      },
+    };
+  }
+
+  /**
+   * Tear down all rendered layers and clear listeners. The supplied Cesium
+   * target is owned by the caller and is NOT destroyed.
+   */
+  dispose(): void {
+    this.#teardownLayers();
+    this.#listeners.clear();
+    this.#scene = undefined;
+    this.#layers = [];
+    this.#bookmarks = [];
+    this.#diagnostics = [];
+  }
+
+  // ── Internals ───────────────────────────────────────────────
+
+  #discoveryExecutor(): SceneDiscoveryRequestExecutor {
+    return this.#execute;
+  }
+
+  #analysisExecutor(): SceneAnalysisRequestExecutor {
+    return this.#execute;
+  }
+
+  #teardownLayers(): void {
+    for (const handle of this.#layerHandles.values()) handle.remove();
+    this.#layerHandles.clear();
+  }
+
+  #emit(event: SceneViewEvent): void {
+    for (const listener of this.#listeners) listener(event);
+  }
+}
+
+function bindClientExecutor(client: HonuaClient | undefined): SceneViewRequestExecutor | undefined {
+  if (!client) return undefined;
+  return (method, path, init, signal) => client.pipelineRequestJson(method, path, init, signal);
+}

--- a/test/scene-discovery.test.ts
+++ b/test/scene-discovery.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { QueryMethod } from "../src/core/types.js";
+import {
+  type HonuaScene,
+  type SceneDiscoveryRequestExecutor,
+  getScene,
+  listScenes,
+  normalizeScene,
+  resolveSceneTilesetUrl,
+  sceneCameraPrimitive,
+  sceneLayerStates,
+  sceneTerrainPrimitive,
+  sceneTilesetPrimitive,
+  sceneToRuntimePrimitives,
+  sceneViewpointBookmarks,
+} from "../src/scene-workspace/index.js";
+
+const CAMELCASE_SCENE = {
+  sceneId: "downtown",
+  title: "Downtown",
+  description: "City core",
+  tilesetUrl: "https://cdn.example/scenes/downtown/tileset.json",
+  terrainUrl: "https://cdn.example/terrain",
+  extent: { extent: { xmin: -158, ymin: 21, xmax: -157, ymax: 22 }, minHeight: 0, maxHeight: 400 },
+  initialCamera: { longitude: -157.8, latitude: 21.3, height: 1200, heading: 30, pitch: -45 },
+  viewpoints: [{ id: "harbor", title: "Harbor", camera: { longitude: -157.85, latitude: 21.31, height: 300 } }],
+  style: { expression: "color('red')" },
+  edition: "pro",
+  capabilities: ["terrain", "styling"],
+};
+
+const SNAKECASE_SCENE = {
+  scene_id: "valley",
+  title: "Valley",
+  tileset_url: "https://cdn.example/scenes/valley/tileset.json",
+  terrain_url: "https://cdn.example/valley-terrain",
+  initial_camera: { longitude: 10, latitude: 46, height: 5000 },
+};
+
+describe("scene discovery normalization", () => {
+  it("normalizes a camelCase scene payload", () => {
+    const scene = normalizeScene(CAMELCASE_SCENE);
+    expect(scene.sceneId).toBe("downtown");
+    expect(scene.tilesetUrl).toBe(CAMELCASE_SCENE.tilesetUrl);
+    expect(scene.terrainUrl).toBe(CAMELCASE_SCENE.terrainUrl);
+    expect(scene.initialCamera).toEqual({ longitude: -157.8, latitude: 21.3, height: 1200, heading: 30, pitch: -45 });
+    expect(scene.extent).toEqual({ xmin: -158, ymin: 21, xmax: -157, ymax: 22, minHeight: 0, maxHeight: 400 });
+    expect(scene.styleExpression).toBe("color('red')");
+    expect(scene.edition).toBe("pro");
+    expect(scene.capabilities).toEqual(["terrain", "styling"]);
+    expect(scene.viewpoints).toEqual([
+      { id: "harbor", title: "Harbor", camera: { longitude: -157.85, latitude: 21.31, height: 300 } },
+    ]);
+  });
+
+  it("normalizes a proto-snake_case scene payload", () => {
+    const scene = normalizeScene(SNAKECASE_SCENE);
+    expect(scene.sceneId).toBe("valley");
+    expect(scene.tilesetUrl).toBe(SNAKECASE_SCENE.tileset_url);
+    expect(scene.terrainUrl).toBe(SNAKECASE_SCENE.terrain_url);
+    expect(scene.initialCamera).toEqual({ longitude: 10, latitude: 46, height: 5000 });
+    expect(scene.capabilities).toEqual([]);
+    expect(scene.viewpoints).toEqual([]);
+  });
+
+  it("drops viewpoints without an id or camera", () => {
+    const scene = normalizeScene({
+      sceneId: "s",
+      viewpoints: [
+        { id: "ok", camera: { longitude: 1, latitude: 2 } },
+        { title: "no-id", camera: { longitude: 1, latitude: 2 } },
+        { id: "no-camera" },
+      ],
+    });
+    expect(scene.viewpoints.map((v) => v.id)).toEqual(["ok"]);
+  });
+});
+
+describe("scene → primitive mapping", () => {
+  const scene = normalizeScene(CAMELCASE_SCENE);
+
+  it("resolves the explicit tileset url and falls back to the discovery path", () => {
+    expect(resolveSceneTilesetUrl(scene)).toBe(CAMELCASE_SCENE.tilesetUrl);
+    const bare: HonuaScene = { sceneId: "bare", viewpoints: [], capabilities: [] };
+    expect(resolveSceneTilesetUrl(bare, "https://h.example/")).toBe("https://h.example/scenes/bare/tileset.json");
+    expect(resolveSceneTilesetUrl(bare)).toBeUndefined();
+  });
+
+  it("builds camera / tileset / terrain primitives", () => {
+    expect(sceneCameraPrimitive(scene)).toMatchObject({ kind: "camera", id: "downtown:camera", mode: "global" });
+    expect(sceneTilesetPrimitive(scene)).toMatchObject({
+      kind: "model-layer",
+      id: "downtown:tileset",
+      format: "3d-tiles",
+      uri: CAMELCASE_SCENE.tilesetUrl,
+    });
+    expect(sceneTerrainPrimitive(scene)).toMatchObject({
+      kind: "elevation-source",
+      id: "downtown:terrain",
+      protocol: "quantized-mesh",
+      url: CAMELCASE_SCENE.terrainUrl,
+    });
+  });
+
+  it("maps a full scene to ordered runtime primitives (camera, terrain, tileset)", () => {
+    const primitives = sceneToRuntimePrimitives(scene);
+    expect(primitives.map((p) => p.kind)).toEqual(["camera", "elevation-source", "model-layer"]);
+  });
+
+  it("omits primitives the scene does not advertise", () => {
+    const minimal = normalizeScene({ sceneId: "m" });
+    expect(sceneToRuntimePrimitives(minimal)).toEqual([]);
+    expect(sceneToRuntimePrimitives(minimal, "https://h.example")).toMatchObject([{ kind: "model-layer" }]);
+  });
+
+  it("builds layer states and viewpoint bookmarks", () => {
+    expect(sceneLayerStates(scene).map((l) => l.id)).toEqual(["downtown:tileset", "downtown:terrain"]);
+    expect(sceneViewpointBookmarks(scene)).toEqual([
+      { id: "harbor", label: "Harbor", camera: { longitude: -157.85, latitude: 21.31, height: 300 } },
+    ]);
+  });
+});
+
+describe("scene discovery transport", () => {
+  it("lists scenes via GET /api/scenes", async () => {
+    const execute = vi.fn(async () => ({
+      scenes: [CAMELCASE_SCENE, SNAKECASE_SCENE],
+    })) as unknown as SceneDiscoveryRequestExecutor;
+    const scenes = await listScenes(execute);
+    expect(scenes.map((s) => s.sceneId)).toEqual(["downtown", "valley"]);
+    expect(execute).toHaveBeenCalledWith("GET", "/api/scenes", undefined, undefined);
+  });
+
+  it("fetches a single scene via GET /api/scenes/{id} and unwraps the envelope", async () => {
+    const calls: Array<[QueryMethod, string]> = [];
+    const execute: SceneDiscoveryRequestExecutor = async (method, path) => {
+      calls.push([method, path]);
+      return { scene: CAMELCASE_SCENE } as never;
+    };
+    const scene = await getScene(execute, "downtown");
+    expect(scene.sceneId).toBe("downtown");
+    expect(calls).toEqual([["GET", "/api/scenes/downtown"]]);
+  });
+
+  it("rejects an empty sceneId", async () => {
+    const execute = vi.fn() as unknown as SceneDiscoveryRequestExecutor;
+    await expect(getScene(execute, "")).rejects.toThrow(/non-empty sceneId/);
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/test/scene-view.test.ts
+++ b/test/scene-view.test.ts
@@ -1,0 +1,298 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The SceneView drives the Cesium adapter + analysis renderers, both of which
+// pull CesiumJS in lazily (`await import("cesium")`). Cesium needs a WebGL
+// context unavailable headless, so we mock only the surface they touch — the
+// same minimal slice the adapter / widget tests mock. The 2D bundle never loads
+// these modules; this exercises the full SceneView wiring without a live globe.
+const tilesetFromUrl = vi.fn(async (url: string) => ({ kind: "tileset", url, show: true, modelMatrix: undefined }));
+const terrainFromUrl = vi.fn(async (url: string) => ({ kind: "terrain-provider", url }));
+
+vi.mock("cesium", () => ({
+  Cartesian3: {
+    fromDegrees: (longitude: number, latitude: number, height?: number) => ({ longitude, latitude, height }),
+    fromDegreesArrayHeights: (coordinates: number[]) => ({ kind: "cart-array-h", coordinates }),
+  },
+  Color: {
+    fromCssColorString: (color: string) => ({ kind: "css-color", color }),
+    LIME: { name: "LIME" },
+    RED: { name: "RED" },
+    YELLOW: { name: "YELLOW" },
+  },
+  Cesium3DTileset: { fromUrl: (url: string) => tilesetFromUrl(url) },
+  CesiumTerrainProvider: { fromUrl: (url: string) => terrainFromUrl(url) },
+  Cesium3DTileStyle: class {},
+}));
+
+import type { QueryMethod } from "../src/core/types.js";
+import {
+  type CesiumEntityCollectionLike,
+  type CesiumSceneRuntimeTarget,
+  SceneView,
+  type SceneViewEvent,
+  type SceneViewRequestExecutor,
+} from "../src/scene-workspace/index.js";
+
+const DEG2RAD = Math.PI / 180;
+
+const SCENE = {
+  sceneId: "downtown",
+  title: "Downtown",
+  tilesetUrl: "https://cdn.example/scenes/downtown/tileset.json",
+  terrainUrl: "https://cdn.example/terrain",
+  initialCamera: { longitude: -157.8, latitude: 21.3, height: 1200 },
+  viewpoints: [{ id: "harbor", title: "Harbor", camera: { longitude: -157.85, latitude: 21.31, height: 300 } }],
+  capabilities: ["terrain"],
+};
+
+/** A pure-JS Cesium camera stand-in mirroring the getter contract the adapter reads. */
+function createMockCamera() {
+  const position = { longitude: 0, latitude: 0, height: 0 };
+  const orientation = { heading: 0, pitch: -Math.PI / 2, roll: 0 };
+  return {
+    get positionCartographic() {
+      return position;
+    },
+    get heading() {
+      return orientation.heading;
+    },
+    get pitch() {
+      return orientation.pitch;
+    },
+    get roll() {
+      return orientation.roll;
+    },
+    setView: vi.fn((options: { destination?: { longitude: number; latitude: number; height: number } }) => {
+      if (options.destination) {
+        position.longitude = options.destination.longitude * DEG2RAD;
+        position.latitude = options.destination.latitude * DEG2RAD;
+        position.height = options.destination.height;
+      }
+    }),
+  };
+}
+
+/** A scene primitive collection that records adds/removes so layer teardown is observable. */
+function createMockScene() {
+  const primitives: unknown[] = [];
+  return {
+    primitives: {
+      add: (primitive: unknown) => {
+        primitives.push(primitive);
+        return primitive;
+      },
+      remove: (primitive: unknown) => {
+        const index = primitives.indexOf(primitive);
+        if (index >= 0) primitives.splice(index, 1);
+        return index >= 0;
+      },
+      contains: (primitive: unknown) => primitives.includes(primitive),
+    },
+    terrainProvider: undefined as unknown,
+    verticalExaggeration: 1,
+    _primitives: primitives,
+  };
+}
+
+function createMockEntities(): CesiumEntityCollectionLike & { added: unknown[] } {
+  const added: unknown[] = [];
+  return {
+    added,
+    add: (entity: unknown) => {
+      added.push(entity);
+      return entity;
+    },
+    remove: (entity: unknown) => {
+      const index = added.indexOf(entity);
+      if (index >= 0) added.splice(index, 1);
+      return index >= 0;
+    },
+  };
+}
+
+beforeEach(() => {
+  tilesetFromUrl.mockClear();
+  terrainFromUrl.mockClear();
+});
+
+describe("SceneView construction", () => {
+  it("requires a client or an execute transport", () => {
+    expect(() => new SceneView({})).toThrow(/client.*or.*execute/i);
+  });
+});
+
+describe("SceneView scene loading + rendering", () => {
+  function makeExecutor() {
+    return vi.fn(async (_method: QueryMethod, path: string) => {
+      if (path.startsWith("/api/scenes/")) return { scene: SCENE };
+      if (path === "/api/scenes") return { scenes: [SCENE] };
+      return {};
+    }) as unknown as SceneViewRequestExecutor;
+  }
+
+  it("loads a scene by id and renders the tileset + terrain onto the target", async () => {
+    const camera = createMockCamera();
+    const scene = createMockScene();
+    const target: CesiumSceneRuntimeTarget = { camera, scene };
+    const view = new SceneView({ execute: makeExecutor(), target });
+
+    const events: SceneViewEvent[] = [];
+    view.on((event) => events.push(event));
+
+    const loaded = await view.loadScene("downtown");
+    expect(loaded.sceneId).toBe("downtown");
+    expect(view.scene?.sceneId).toBe("downtown");
+
+    // tileset + terrain materialized
+    expect(tilesetFromUrl).toHaveBeenCalledWith(SCENE.tilesetUrl);
+    expect(terrainFromUrl).toHaveBeenCalledWith(SCENE.terrainUrl);
+    expect(scene.terrainProvider).toMatchObject({ kind: "terrain-provider" });
+
+    // initial camera applied
+    expect(camera.setView).toHaveBeenCalled();
+
+    // layers + bookmarks surfaced
+    expect(view.layers.map((l) => l.id)).toEqual(["downtown:tileset", "downtown:terrain"]);
+    expect(view.bookmarks.map((b) => b.id)).toEqual(["harbor"]);
+
+    // events emitted
+    expect(events.map((e) => e.type)).toEqual(
+      expect.arrayContaining(["scene-loaded", "layers-changed", "diagnostics"]),
+    );
+  });
+
+  it("loads + diagnoses headlessly without a target (no rendering)", async () => {
+    const view = new SceneView({ execute: makeExecutor() });
+    const loaded = await view.loadScene("downtown");
+    expect(loaded.sceneId).toBe("downtown");
+    expect(view.hasTarget).toBe(false);
+    expect(tilesetFromUrl).not.toHaveBeenCalled();
+    expect(view.layers.length).toBe(2);
+  });
+
+  it("tears down prior layers when a new scene is loaded", async () => {
+    const scene = createMockScene();
+    const view = new SceneView({ execute: makeExecutor(), target: { camera: createMockCamera(), scene } });
+    await view.loadScene("downtown");
+    expect(scene._primitives.length).toBe(1); // one tileset
+    await view.loadScene(SCENE); // reload via object
+    expect(scene._primitives.length).toBe(1); // prior tileset removed, new one added
+  });
+
+  it("toggles layer visibility through the live handle", async () => {
+    const scene = createMockScene();
+    const view = new SceneView({ execute: makeExecutor(), target: { camera: createMockCamera(), scene } });
+    await view.loadScene("downtown");
+    const tileset = scene._primitives[0] as { show: boolean };
+    expect(view.setLayerVisible("downtown:tileset", false)).toBe(true);
+    expect(tileset.show).toBe(false);
+    expect(view.layers.find((l) => l.id === "downtown:tileset")?.visible).toBe(false);
+    expect(view.setLayerVisible("missing", false)).toBe(false);
+  });
+
+  it("applies viewpoint bookmarks and reads the camera back", async () => {
+    const camera = createMockCamera();
+    const view = new SceneView({ execute: makeExecutor(), target: { camera, scene: createMockScene() } });
+    await view.loadScene("downtown");
+    const applied = await view.applyBookmark("harbor");
+    expect(applied).toMatchObject({ longitude: -157.85, latitude: 21.31 });
+    expect(await view.applyBookmark("nope")).toBeUndefined();
+    const read = view.readCamera();
+    expect(read?.longitude).toBeCloseTo(-157.85, 4);
+  });
+});
+
+describe("SceneView analysis + measurement widgets", () => {
+  it("runs line-of-sight and draws an overlay when entities are supplied", async () => {
+    const execute = vi.fn(async () => ({ visible: true, distanceMeters: 1000 })) as unknown as SceneViewRequestExecutor;
+    const view = new SceneView({ execute });
+    const entities = createMockEntities();
+    const { result, overlay } = await view.lineOfSight({
+      datasetId: "dem",
+      observer: { longitude: -157.8, latitude: 21.3, height: 30 },
+      target: { longitude: -157.81, latitude: 21.31 },
+      entities,
+    });
+    expect(result.visible).toBe(true);
+    expect(entities.added.length).toBeGreaterThan(0);
+    expect(overlay?.kind).toBe("line-of-sight");
+    overlay?.remove();
+    expect(entities.added.length).toBe(0);
+  });
+
+  it("runs viewshed and returns only the result when no entities are supplied", async () => {
+    const execute = vi.fn(async () => ({
+      samples: [{ lon: 1, lat: 2, azimuthDegrees: 0, distanceMeters: 10, visible: true }],
+      visibleSampleCount: 1,
+      sampleCount: 1,
+    })) as unknown as SceneViewRequestExecutor;
+    const view = new SceneView({ execute });
+    const { result, overlay } = await view.viewshed({
+      datasetId: "dem",
+      observer: { longitude: 1, latitude: 2 },
+      radiusMeters: 500,
+    });
+    expect(result.visibleSampleCount).toBe(1);
+    expect(overlay).toBeUndefined();
+  });
+
+  it("requests an elevation profile and drapes it into the scene", async () => {
+    const execute = vi.fn(async () => ({
+      samples: [
+        { distanceMeters: 0, elevation: 10 },
+        { distanceMeters: 50, elevation: 12 },
+      ],
+      lineLengthMeters: 50,
+    })) as unknown as SceneViewRequestExecutor;
+    const view = new SceneView({ execute });
+    const entities = createMockEntities();
+    const { result, overlay } = await view.elevationProfile({
+      datasetId: "dem",
+      polyline: [
+        { longitude: 1, latitude: 2 },
+        { longitude: 1.1, latitude: 2.1 },
+      ],
+      entities,
+    });
+    expect(result.samples.length).toBe(2);
+    expect(overlay?.kind).toBe("elevation-profile");
+    expect(entities.added.length).toBe(1);
+  });
+
+  it("computes a client-side area measurement and renders it", async () => {
+    const view = new SceneView({ execute: vi.fn() as unknown as SceneViewRequestExecutor });
+    const entities = createMockEntities();
+    const { measurement, overlay } = await view.measure(
+      [
+        { longitude: 0, latitude: 0 },
+        { longitude: 0, latitude: 0.001 },
+        { longitude: 0.001, latitude: 0.001 },
+      ],
+      { mode: "area", entities },
+    );
+    expect(measurement.mode).toBe("area");
+    expect(measurement.areaSquareMeters).toBeGreaterThan(0);
+    expect(overlay?.kind).toBe("measurement");
+  });
+});
+
+describe("SceneView lifecycle", () => {
+  it("removes listeners and rendered layers on dispose", async () => {
+    const scene = createMockScene();
+    const execute = vi.fn(async (_m: QueryMethod, path: string) =>
+      path === "/api/scenes" ? { scenes: [SCENE] } : { scene: SCENE },
+    ) as unknown as SceneViewRequestExecutor;
+    const view = new SceneView({ execute, target: { camera: createMockCamera(), scene } });
+    let count = 0;
+    view.on(() => count++);
+    await view.loadScene("downtown");
+    expect(scene._primitives.length).toBe(1);
+    const before = count;
+    view.dispose();
+    expect(scene._primitives.length).toBe(0);
+    expect(view.scene).toBeUndefined();
+    // listeners cleared: a post-dispose no-op load path would not fire, but we
+    // simply assert the listener set is detached by checking it does not grow.
+    expect(count).toBe(before);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a cohesive, first-class **`SceneView`** to `@honua/sdk-js/scene-workspace` — the 3D counterpart of `HonuaMap`. It ties the already-landed Cesium runtime adapter, 3D content rendering, and analysis primitives together into a single typed container, and adds the missing **HTTP scene discovery** that loads a Honua scene end-to-end.

Groups three 3D issues into one PR:

- **#1196 — first-class 3D SceneView via a Cesium runtime adapter.** `SceneView` is constructed with a `HonuaClient` (or an explicit request executor) and an optional live Cesium target (`{ camera, scene }`). It loads a scene, syncs the camera, exposes viewpoint bookmarks, layer visibility, render diagnostics, events (`scene-loaded`/`layers-changed`/`layer-visibility`/`camera-change`/`diagnostics`), and disposal. With no target attached it still loads + diagnoses a scene headlessly (renders nothing) — useful for Node/tests. CesiumJS is never imported statically; the runtime is pulled in lazily by the underlying adapter only when a live globe is driven.
- **#1197 — render 3D Tiles, terrain, and glTF models in SceneView.** `loadScene` materializes the scene's 3D-Tiles tileset, terrain provider, and initial camera onto the live globe through the Cesium adapter, keeping live layer handles for visibility/teardown. (The adapter's tileset/glTF/terrain/pick + attribute-driven 3D-Tiles styling rendering was already on `trunk`; this wires it into the cohesive view.)
- **#1205 — 3D analysis + measurement widgets.** `SceneView` exposes `lineOfSight`, `viewshed`, `elevationProfile`, and `measure` (client-side distance/area). Each runs against the SDK's request pipeline (reusing auth/retry/timeout/interceptors) and optionally draws a Cesium overlay into a supplied entity collection, returning both the typed result and an overlay handle.

## Changes

- `src/scene-workspace/scene-view.ts` — new `SceneView` class (discovery + rendering + camera + layers + widgets + events/lifecycle).
- `src/scene-workspace/scene-discovery.ts` — typed `listScenes` / `getScene` over `GET /api/scenes` and `GET /api/scenes/{id}` (`geospatial.v1.SceneService`), plus pure helpers that normalize `SceneMetadata` (camelCase **and** proto3-JSON snake_case tolerant) and map a `HonuaScene` onto renderer-neutral scene primitives, layer states, and bookmarks. Resolves the static `/scenes/{id}/tileset.json` entry point when a scene omits an explicit `tilesetUrl`.
- `src/scene-workspace/index.ts` — export the new `SceneView` + discovery surface.
- `test/scene-discovery.test.ts`, `test/scene-view.test.ts` — unit coverage for discovery normalization/transport and the full SceneView lifecycle + widgets, using the repo's existing `vi.mock("cesium")` pattern (no WebGL).

## Deferred / notes

- The lower-level Cesium adapter (#1196 base), 3D content rendering + pick (#1197), and analysis/measurement primitives (#1205 base) already landed on `trunk` in prior PRs; this PR delivers the **first-class `SceneView` API + scene discovery** that unifies them and was the remaining gap. No widget was skipped — all four (LOS, viewshed, profile, measure) are wired and tested.
- Cesium remains a `peerDependency` (`^1.139`) and is dynamically imported, so the 2D bundle is unaffected — enforced by the existing static-import guard test, which scans every `scene-workspace` source.
- I3S model layers and extrusions stay declared-capable but not materialized (no server primitives emit them yet), consistent with the existing adapter.

> Note: the referenced issue numbers (#1196/#1197/#1205) did not resolve in this repo's GitHub tracker at PR time (likely cross-repo/Specifica IDs), so they are cited for traceability rather than auto-closed.

## Testing

- `npm run typecheck` — pass
- `npm run lint` — pass (597 files)
- `npm run build` — pass
- `npm run verify:split-packages` — pass
- `npm test` — pass (2167 tests / 202 files), including 22 new scene tests and the Cesium static-import guard.