### PR TITLE
fix(security): resolve high-severity CodeQL findings

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1555,9 +1555,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -25,6 +25,9 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^3.24.0"
   },
+  "overrides": {
+    "hono": "^4.12.21"
+  },
   "peerDependencies": {
     "@honua/sdk-js": "^0.0.12-alpha.0"
   },

--- a/scripts/prepare-split-packages.mjs
+++ b/scripts/prepare-split-packages.mjs
@@ -337,6 +337,10 @@ function copyMigrationCoreTypeSupport(packageRoot) {
   copyFile(path.join(DIST_SRC_ROOT, "core", "types.d.ts"), path.join(coreRoot, "types.d.ts"));
   copyFile(path.join(DIST_SRC_ROOT, "core", "cache-state.js"), path.join(coreRoot, "cache-state.js"));
   copyFile(path.join(DIST_SRC_ROOT, "core", "cache-state.d.ts"), path.join(coreRoot, "cache-state.d.ts"));
+  // path-utils provides the linear slash/trim helpers used by migration/reconcile + content
+  // (self-contained, no further core deps).
+  copyFile(path.join(DIST_SRC_ROOT, "core", "path-utils.js"), path.join(coreRoot, "path-utils.js"));
+  copyFile(path.join(DIST_SRC_ROOT, "core", "path-utils.d.ts"), path.join(coreRoot, "path-utils.d.ts"));
 }
 
 function writePackageJson(packageRoot, overrides) {

--- a/src/contract/source.ts
+++ b/src/contract/source.ts
@@ -31,6 +31,7 @@ import { HonuaOgcCollectionMap, HonuaOgcMaps } from "../core/ogc-maps.js";
 import type { HonuaOgcProcesses } from "../core/ogc-processes.js";
 import { HonuaOgcRecordCollection } from "../core/ogc-records.js";
 import { HonuaOgcTiles, HonuaOgcTileset } from "../core/ogc-tiles.js";
+import { trimTrailingSlashes } from "../core/path-utils.js";
 import { HonuaStacSearch } from "../core/stac.js";
 import {
   HonuaFeatureLayer,
@@ -2605,11 +2606,11 @@ function requireOdataLocator(descriptor: SourceDescriptor): { entitySet: string;
 function extractOdataBasePath(url: string): string {
   try {
     const parsed = new URL(url);
-    const pathname = parsed.pathname.replace(/\/+$/, "");
+    const pathname = trimTrailingSlashes(parsed.pathname);
     return pathname === "" ? "/odata" : pathname;
   } catch {
     // Relative URL: take it as the basePath verbatim.
-    return url.startsWith("/") ? url.replace(/\/+$/, "") || "/odata" : `/${url.replace(/\/+$/, "")}`;
+    return url.startsWith("/") ? trimTrailingSlashes(url) || "/odata" : `/${trimTrailingSlashes(url)}`;
   }
 }
 

--- a/src/contract/tiles.ts
+++ b/src/contract/tiles.ts
@@ -9,6 +9,7 @@
  * @module
  */
 
+import { trimLeadingSlashes, trimSurroundingSlashes, trimTrailingSlashes } from "../core/path-utils.js";
 import type { HonuaTypedFeature } from "../core/types.js";
 import {
   analyticsSourceId,
@@ -743,7 +744,7 @@ function queryTileServerRequestParamsFromOptions<T = Record<string, unknown>>(
 }
 
 function normalizeRoutePrefix(prefix: string): string {
-  return prefix.replace(/^\/+|\/+$/g, "");
+  return trimSurroundingSlashes(prefix);
 }
 
 function encodePathSegment(value: string | number): string {
@@ -752,7 +753,7 @@ function encodePathSegment(value: string | number): string {
 
 function joinRouteUrl(baseUrl: string, path: string): string {
   const [basePath, query = ""] = baseUrl.split("?", 2);
-  const joined = `${basePath.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+  const joined = `${trimTrailingSlashes(basePath)}/${trimLeadingSlashes(path)}`;
   return query ? `${joined}?${query}` : joined;
 }
 

--- a/src/control-plane/client.ts
+++ b/src/control-plane/client.ts
@@ -1,6 +1,7 @@
 import { honuaCacheValidatorFromHeaders } from "../core/cache-state.js";
 import type { HonuaClient } from "../core/client.js";
 import { HonuaHttpError } from "../core/errors.js";
+import { trimTrailingSlashes } from "../core/path-utils.js";
 import type { QueryMethod } from "../core/types.js";
 import type { HonuaMapPackage } from "../runtime/index.js";
 import {
@@ -416,7 +417,7 @@ function unsupportedFromStatus<T>(
 
 function normalizeBasePath(path: string): string {
   const normalized = path.startsWith("/") ? path : `/${path}`;
-  return normalized.replace(/\/+$/, "");
+  return trimTrailingSlashes(normalized);
 }
 
 function withListQuery(path: string, options: HonuaControlPlaneListOptions): string {

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -18,6 +18,7 @@ import { HonuaOgcMaps } from "./ogc-maps.js";
 import { HonuaOgcProcesses } from "./ogc-processes.js";
 import { HonuaOgcRecords } from "./ogc-records.js";
 import { HonuaOgcTiles } from "./ogc-tiles.js";
+import { stripQuery, trimTrailingSlashes } from "./path-utils.js";
 import { decodePbfQueryResponse, isPbfResponse } from "./pbf-decoder.js";
 import {
   type HonuaProcessRunner,
@@ -143,7 +144,7 @@ import { type WmtsCapabilities, parseWmtsCapabilities } from "./wmts-capabilitie
 import { HonuaWmts } from "./wmts.js";
 
 function normalizeBaseUrl(baseUrl: string): string {
-  return baseUrl.replace(/\/+$/, "");
+  return trimTrailingSlashes(baseUrl);
 }
 
 function normalizePath(path: string): string {
@@ -2525,7 +2526,7 @@ export class HonuaClient {
         } catch {
           // PBF decode failed — fall back to JSON request
           params.set("f", "json");
-          const jsonPath = `${path.replace(/\?.*$/, "")}?${params.toString()}`;
+          const jsonPath = `${stripQuery(path)}?${params.toString()}`;
           return this.requestJson("GET", jsonPath, undefined, callerSignal ?? request.init.signal ?? undefined);
         }
       }
@@ -3121,7 +3122,7 @@ function normalizePathValue(path: string): string {
   }
 
   const prefixed = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
-  return prefixed.replace(/\/+$/, "");
+  return trimTrailingSlashes(prefixed);
 }
 
 function getReleaseChannelRank(releaseChannel: string): number | undefined {

--- a/src/core/odata.ts
+++ b/src/core/odata.ts
@@ -28,6 +28,7 @@ import {
   withoutHonuaCacheState,
 } from "./cache-state.js";
 import type { HonuaClient } from "./client.js";
+import { trimTrailingSlashes } from "./path-utils.js";
 import type { HonuaFieldInfo } from "./types.js";
 
 // ── Locator + options ─────────────────────────────────────────
@@ -630,7 +631,7 @@ interface OdataValueEnvelope<T> {
 
 function normalizeBasePath(path: string | undefined): string {
   if (path === undefined || path === "") return "/odata";
-  return path.startsWith("/") ? path.replace(/\/+$/, "") || "/" : `/${path.replace(/\/+$/, "")}`;
+  return path.startsWith("/") ? trimTrailingSlashes(path) || "/" : `/${trimTrailingSlashes(path)}`;
 }
 
 /**

--- a/src/core/path-utils.ts
+++ b/src/core/path-utils.ts
@@ -1,0 +1,79 @@
+/**
+ * Linear-time string trimming helpers used for URL and path normalization.
+ *
+ * These intentionally avoid regular expressions such as `\/+$` or `^\/+`.
+ * Anchored quantifier regexes over repeated characters can exhibit
+ * super-linear (polynomial) matching on adversarial input, so the helpers
+ * below scan from the relevant end with simple index arithmetic, which is
+ * always O(n) regardless of input shape.
+ */
+
+/** Remove every trailing `/` character from `value`. */
+export function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47 /* '/' */) {
+    end -= 1;
+  }
+  return end === value.length ? value : value.slice(0, end);
+}
+
+/** Remove every leading `/` character from `value`. */
+export function trimLeadingSlashes(value: string): string {
+  let start = 0;
+  while (start < value.length && value.charCodeAt(start) === 47 /* '/' */) {
+    start += 1;
+  }
+  return start === 0 ? value : value.slice(start);
+}
+
+/** Remove every leading and trailing `/` character from `value`. */
+export function trimSurroundingSlashes(value: string): string {
+  return trimTrailingSlashes(trimLeadingSlashes(value));
+}
+
+/**
+ * Remove leading and trailing runs of `char` from `value`.
+ *
+ * `char` must be a single-character string; only its first code unit is
+ * considered. Used for slug/identifier normalization (e.g. stripping `-`
+ * or `_` padding) without anchored `^x+|x+$` regexes.
+ */
+export function trimChar(value: string, char: string): string {
+  const code = char.charCodeAt(0);
+  let start = 0;
+  let end = value.length;
+  while (start < end && value.charCodeAt(start) === code) {
+    start += 1;
+  }
+  while (end > start && value.charCodeAt(end - 1) === code) {
+    end -= 1;
+  }
+  return start === 0 && end === value.length ? value : value.slice(start, end);
+}
+
+/**
+ * Return `value` with any `?query` and `#fragment` suffix removed.
+ *
+ * Equivalent to `value.replace(/[?#].*$/, "")` but uses `indexOf` slicing
+ * so it stays linear and cannot backtrack.
+ */
+export function stripQueryAndFragment(value: string): string {
+  let cut = -1;
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code === 63 /* '?' */ || code === 35 /* '#' */) {
+      cut = i;
+      break;
+    }
+  }
+  return cut < 0 ? value : value.slice(0, cut);
+}
+
+/**
+ * Return `value` with any `?query` suffix removed (the fragment, if present,
+ * is preserved). Equivalent to `value.replace(/\?.*$/, "")`.
+ */
+export function stripQuery(value: string): string {
+  const index = value.indexOf("?");
+  return index < 0 ? value : value.slice(0, index);
+}

--- a/src/core/wms-capabilities.ts
+++ b/src/core/wms-capabilities.ts
@@ -14,6 +14,8 @@
  * @module
  */
 
+import { decodeXmlText as decodeXmlEntities } from "./xml-text.js";
+
 /**
  * Top-level WMS Capabilities surface.
  */
@@ -614,15 +616,7 @@ function parseFloatText(value: string | undefined): number {
 
 function decodeXmlText(text: string): string {
   if (text.indexOf("&") < 0 && text.indexOf("<![CDATA[") < 0) return text;
-  return text
-    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, "$1")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&amp;/g, "&")
-    .replace(/&apos;/g, "'")
-    .replace(/&quot;/g, '"')
-    .replace(/&#(\d+);/g, (_match, dec: string) => String.fromCodePoint(Number(dec)))
-    .replace(/&#x([0-9a-fA-F]+);/g, (_match, hex: string) => String.fromCodePoint(Number.parseInt(hex, 16)));
+  return decodeXmlEntities(text);
 }
 
 /**

--- a/src/core/wmts-capabilities.ts
+++ b/src/core/wmts-capabilities.ts
@@ -8,6 +8,8 @@
  * @module
  */
 
+import { decodeXmlText as decodeXmlEntities } from "./xml-text.js";
+
 /**
  * Top-level WMTS Capabilities surface.
  */
@@ -444,15 +446,7 @@ function readTextElement(xml: string, tag: string): string | undefined {
 
 function decodeXmlText(text: string): string {
   if (text.indexOf("&") < 0 && text.indexOf("<![CDATA[") < 0) return text;
-  return text
-    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, "$1")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&amp;/g, "&")
-    .replace(/&apos;/g, "'")
-    .replace(/&quot;/g, '"')
-    .replace(/&#(\d+);/g, (_match, dec: string) => String.fromCodePoint(Number(dec)))
-    .replace(/&#x([0-9a-fA-F]+);/g, (_match, hex: string) => String.fromCodePoint(Number.parseInt(hex, 16)));
+  return decodeXmlEntities(text);
 }
 
 /** Find a layer by identifier in a parsed `WmtsCapabilities`. */

--- a/src/core/xml-text.ts
+++ b/src/core/xml-text.ts
@@ -1,0 +1,95 @@
+/**
+ * Single-pass XML text decoding used by the WMS/WMTS capabilities parsers.
+ *
+ * Decoding XML entities with a chain of independent `String.prototype.replace`
+ * calls is unsafe: an earlier substitution (for example `&amp;` -> `&`) can
+ * synthesize characters that a later substitution then re-interprets, causing
+ * double-unescaping (CodeQL `js/double-escaping`). Walking the input exactly
+ * once and emitting each decoded character directly avoids that class of bug —
+ * a `&` produced by decoding `&amp;` is final and never re-scanned.
+ */
+
+const NAMED_ENTITIES: Record<string, string> = {
+  lt: "<",
+  gt: ">",
+  amp: "&",
+  apos: "'",
+  quot: '"',
+};
+
+const CDATA_OPEN = "<![CDATA[";
+const CDATA_CLOSE = "]]>";
+
+/**
+ * Decode XML character data in a single forward pass.
+ *
+ * Handles `<![CDATA[…]]>` sections (emitted verbatim), the five predefined
+ * named entities (`&lt;`, `&gt;`, `&amp;`, `&apos;`, `&quot;`), and numeric
+ * character references (`&#1234;` / `&#x1F4A9;`). Any `&` that does not begin
+ * a recognized reference is emitted literally.
+ */
+export function decodeXmlText(text: string): string {
+  let result = "";
+  let i = 0;
+  const length = text.length;
+
+  while (i < length) {
+    const char = text[i];
+
+    if (char === "<" && text.startsWith(CDATA_OPEN, i)) {
+      const end = text.indexOf(CDATA_CLOSE, i + CDATA_OPEN.length);
+      if (end < 0) {
+        // Unterminated CDATA: emit the remainder verbatim.
+        result += text.slice(i + CDATA_OPEN.length);
+        break;
+      }
+      result += text.slice(i + CDATA_OPEN.length, end);
+      i = end + CDATA_CLOSE.length;
+      continue;
+    }
+
+    if (char === "&") {
+      const semicolon = text.indexOf(";", i + 1);
+      if (semicolon > i) {
+        const entity = text.slice(i + 1, semicolon);
+        const decoded = decodeEntity(entity);
+        if (decoded !== undefined) {
+          result += decoded;
+          i = semicolon + 1;
+          continue;
+        }
+      }
+    }
+
+    result += char;
+    i += 1;
+  }
+
+  return result;
+}
+
+function decodeEntity(entity: string): string | undefined {
+  const named = NAMED_ENTITIES[entity];
+  if (named !== undefined) {
+    return named;
+  }
+
+  if (entity.length >= 2 && entity.charCodeAt(0) === 35 /* '#' */) {
+    const isHex = entity.charCodeAt(1) === 120 /* 'x' */ || entity.charCodeAt(1) === 88 /* 'X' */;
+    const digits = isHex ? entity.slice(2) : entity.slice(1);
+    if (digits === "") {
+      return undefined;
+    }
+    const codePoint = isHex ? Number.parseInt(digits, 16) : Number.parseInt(digits, 10);
+    if (Number.isNaN(codePoint) || codePoint < 0 || codePoint > 0x10ffff) {
+      return undefined;
+    }
+    try {
+      return String.fromCodePoint(codePoint);
+    } catch {
+      return undefined;
+    }
+  }
+
+  return undefined;
+}

--- a/src/geocoding/index.ts
+++ b/src/geocoding/index.ts
@@ -30,6 +30,7 @@
  */
 
 import { HonuaAbortError, HonuaHttpError, HonuaNetworkError, HonuaTimeoutError } from "../core/errors.js";
+import { trimTrailingSlashes } from "../core/path-utils.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -123,7 +124,7 @@ interface ServerError {
 // ---------------------------------------------------------------------------
 
 function normalizeBaseUrl(url: string): string {
-  return url.replace(/\/+$/, "");
+  return trimTrailingSlashes(url);
 }
 
 function stringifyAttributes(attrs: Record<string, unknown>): Record<string, string | null> {

--- a/src/map/maplibre-target.ts
+++ b/src/map/maplibre-target.ts
@@ -1,3 +1,4 @@
+import { stripQueryAndFragment, trimTrailingSlashes } from "../core/path-utils.js";
 import type {
   HonuaFeatureServiceSourceSpecification,
   HonuaLayerSpecification,
@@ -136,7 +137,7 @@ export function createHonuaMapServiceLayer(options: HonuaMapServiceLayerOptions)
  */
 export function createHonuaTileServiceLayer(options: HonuaTileServiceLayerOptions): HonuaMapLibreLayerDefinition {
   const sourceId = normalizeLayerId(options.id, options.title, options.url, "tile-service");
-  const baseUrl = options.url.replace(/\/+$/, "");
+  const baseUrl = trimTrailingSlashes(options.url);
   const source: HonuaMapLibreRasterSourceSpecification = {
     type: "raster",
     tiles: [`${baseUrl}/tile/{z}/{y}/{x}`],
@@ -232,7 +233,7 @@ function normalizeLayerId(id: string | undefined, title: string | undefined, url
 }
 
 function lastUrlSegment(url: string): string | undefined {
-  const trimmed = url.replace(/[?#].*$/, "").replace(/\/+$/, "");
+  const trimmed = trimTrailingSlashes(stripQueryAndFragment(url));
   const segment = trimmed.slice(trimmed.lastIndexOf("/") + 1);
   return segment || undefined;
 }

--- a/src/migration/content.ts
+++ b/src/migration/content.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { trimChar, trimTrailingSlashes } from "../core/path-utils.js";
 import { parseWebMap } from "../webmap/parse.js";
 import type { WebMapJson } from "../webmap/types.js";
 import { type GeoservicesImportJobReport, runGeoservicesImportJob } from "./demo.js";
@@ -1171,7 +1172,7 @@ function quotePortalQueryValue(value: string): string {
 }
 
 function normalizeBaseUrl(baseUrl: string): string {
-  return baseUrl.replace(/\/+$/, "");
+  return trimTrailingSlashes(baseUrl);
 }
 
 function redactSensitiveUrl(url: string): string {
@@ -1209,11 +1210,7 @@ function buildUrl(base: string, params: Record<string, string>): string {
 }
 
 function makeUniqueTableName(baseName: string, used: Set<string>): string {
-  const normalizedBase =
-    baseName
-      .replace(/_+/g, "_")
-      .replace(/^_+|_+$/g, "")
-      .slice(0, 48) || "layer";
+  const normalizedBase = trimChar(baseName.replace(/_+/g, "_"), "_").slice(0, 48) || "layer";
   let candidate = normalizedBase;
   let suffix = 1;
   while (used.has(candidate)) {

--- a/src/migration/demo.ts
+++ b/src/migration/demo.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { trimTrailingSlashes } from "../core/path-utils.js";
 import { type CodemodTarget, runEsriCompatCodemod } from "./codemod.js";
 import {
   type LayerReconciliationOptions,
@@ -268,7 +269,7 @@ export function parseGeoservicesServiceUrl(serviceUrl: string): ParsedGeoservice
     return undefined;
   }
 
-  const pathname = parsed.pathname.replace(/\/+$/, "");
+  const pathname = trimTrailingSlashes(parsed.pathname);
   const marker = "/rest/services/";
   const lowerPath = pathname.toLowerCase();
   const markerIndex = lowerPath.indexOf(marker);
@@ -384,7 +385,7 @@ function buildJsonHeaders(adminApiKey?: string): Record<string, string> {
 }
 
 function normalizeBaseUrl(baseUrl: string): string {
-  return baseUrl.replace(/\/+$/, "");
+  return trimTrailingSlashes(baseUrl);
 }
 
 function redactSensitiveUrl(url: string): string {

--- a/src/migration/reconcile.ts
+++ b/src/migration/reconcile.ts
@@ -1,3 +1,5 @@
+import { trimTrailingSlashes } from "../core/path-utils.js";
+
 export interface LayerReconciliationOptions {
   sourceBaseUrl: string;
   sourceServiceId: string;
@@ -199,7 +201,7 @@ function buildQueryUrl(baseUrl: string, serviceId: string, layerId: number, para
 }
 
 function normalizeBaseUrl(baseUrl: string): string {
-  return baseUrl.replace(/\/+$/, "");
+  return trimTrailingSlashes(baseUrl);
 }
 
 function computeGeometryValidityRatio(features: readonly unknown[]): number {

--- a/src/operate/client.ts
+++ b/src/operate/client.ts
@@ -1,6 +1,7 @@
 import { honuaCacheValidatorFromHeaders } from "../core/cache-state.js";
 import type { HonuaClient } from "../core/client.js";
 import { HonuaHttpError } from "../core/errors.js";
+import { trimTrailingSlashes } from "../core/path-utils.js";
 import type { QueryMethod } from "../core/types.js";
 import {
   HONUA_OPERATE_BASE_PATH,
@@ -443,7 +444,7 @@ export class HonuaJobsClient {
 
 function normalizeBasePath(basePath: string): string {
   const normalized = basePath.startsWith("/") ? basePath : `/${basePath}`;
-  return normalized.replace(/\/+$/, "");
+  return trimTrailingSlashes(normalized);
 }
 
 function supported<T>(value: T): HonuaOperateResult<T> {

--- a/src/runtime/legend.ts
+++ b/src/runtime/legend.ts
@@ -7,6 +7,7 @@
  * @module
  */
 
+import { trimChar } from "../core/path-utils.js";
 import type { HonuaStyleSpecification } from "../style/specification.js";
 import type { HonuaMapPackageLegendEntry } from "./map-package.js";
 
@@ -40,11 +41,13 @@ export function buildLegend(
 }
 
 function legendEntryId(entry: HonuaMapPackageLegendEntry, index: number): string {
-  const slug = entry.label
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+  const slug = trimChar(
+    entry.label
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-"),
+    "-",
+  );
   return slug ? `${slug}-${index}` : `legend-${index}`;
 }
 

--- a/src/runtime/ogc-styles.ts
+++ b/src/runtime/ogc-styles.ts
@@ -20,6 +20,7 @@
  */
 
 import type { HonuaClient } from "../core/client.js";
+import { trimTrailingSlashes } from "../core/path-utils.js";
 import type { HonuaLayerSpecification, HonuaStyleSpecification } from "../style/specification.js";
 import { HonuaMapPackageError } from "./errors.js";
 import type { HonuaStyleRefBody, HonuaStyleRefLayerOverride } from "./map-package.js";
@@ -244,7 +245,7 @@ function normalizeStyleList(body: unknown): OgcStyleList {
 }
 
 function normalizePrefix(prefix: string): string {
-  const trimmed = prefix.replace(/\/+$/, "");
+  const trimmed = trimTrailingSlashes(prefix);
   return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
 }
 

--- a/src/runtime/query-tiles.ts
+++ b/src/runtime/query-tiles.ts
@@ -37,6 +37,7 @@ import {
   stableJson,
 } from "../contract/tiles.js";
 import type { Capability, Protocol } from "../contract/types.js";
+import { trimLeadingSlashes, trimTrailingSlashes } from "../core/path-utils.js";
 
 export interface MapLibreQueryTileSourceSpec {
   type: "vector";
@@ -378,8 +379,9 @@ export function buildQueryTileUrlTemplate<T = Record<string, unknown>>(
       sourceId: normalized.sourceId,
       routePrefix: "",
       format: normalized.format ?? "mvt",
-    }).replace(/^\/+/, "");
-  const url = joinUrl(baseUrl, path);
+    });
+  const normalizedPath = trimLeadingSlashes(path);
+  const url = joinUrl(baseUrl, normalizedPath);
   const params = {
     ...queryTileServerRequestParamsFromDescriptor(normalized, {
       params: options.includeCacheKey
@@ -972,7 +974,7 @@ function queryTileServerResponseError(
 
 function joinUrl(baseUrl: string, path: string): string {
   const [basePath, query = ""] = baseUrl.split("?", 2);
-  const joined = `${basePath.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+  const joined = `${trimTrailingSlashes(basePath)}/${trimLeadingSlashes(path)}`;
   return query ? `${joined}?${query}` : joined;
 }
 

--- a/src/scene-workspace/scene-discovery.ts
+++ b/src/scene-workspace/scene-discovery.ts
@@ -25,6 +25,7 @@
  * @module
  */
 
+import { trimTrailingSlashes } from "../core/path-utils.js";
 import type { QueryMethod } from "../core/types.js";
 import type { SceneCameraPrimitive, SceneElevationSourcePrimitive, SceneModelLayerPrimitive } from "./primitives.js";
 import type { SceneBookmark, SceneCameraState, SceneLayerState } from "./types.js";
@@ -250,7 +251,7 @@ export async function getScene(
 export function resolveSceneTilesetUrl(scene: HonuaScene, baseUrl?: string): string | undefined {
   if (scene.tilesetUrl && scene.tilesetUrl.trim() !== "") return scene.tilesetUrl;
   if (!baseUrl) return undefined;
-  const trimmed = baseUrl.replace(/\/+$/, "");
+  const trimmed = trimTrailingSlashes(baseUrl);
   return `${trimmed}/scenes/${encodeURIComponent(scene.sceneId)}/tileset.json`;
 }
 

--- a/src/style/specification.ts
+++ b/src/style/specification.ts
@@ -219,13 +219,23 @@ export function parseOgcFeaturesUrl(url: string): ParsedOgcFeaturesUrl {
   const absoluteUrl = parseAbsoluteHttpUrl(url);
   const path = absoluteUrl ? absoluteUrl.pathname : stripQueryAndHash(url);
   const normalizedPath = trimTrailingSlashes(path);
-  const collectionsMatch = normalizedPath.match(/^(.*?)(?:\/collections\/([^/?#]+))(?:\/.*)?$/i);
-  if (collectionsMatch) {
-    const basePath = normalizeCollectionBasePath(collectionsMatch[1] ?? "", normalizedPath);
-    return {
-      baseUrl: joinUrlParts(absoluteUrl?.origin, basePath),
-      collectionId: collectionsMatch[2],
-    };
+  // Locate the first `/collections/` segment (case-insensitive) and split the
+  // path into basePath + collectionId. Linear `indexOf` scanning replaces the
+  // prior `/^(.*?)\/collections\/([^/?#]+)(?:\/.*)?$/i` regex, whose lazy
+  // leading `.*?` plus trailing alternation could backtrack super-linearly.
+  const collectionsToken = "/collections/";
+  const markerIndex = normalizedPath.toLowerCase().indexOf(collectionsToken);
+  if (markerIndex >= 0) {
+    const afterMarker = normalizedPath.slice(markerIndex + collectionsToken.length);
+    const nextSlash = afterMarker.indexOf("/");
+    const collectionId = nextSlash >= 0 ? afterMarker.slice(0, nextSlash) : afterMarker;
+    if (collectionId !== "") {
+      const basePath = normalizeCollectionBasePath(normalizedPath.slice(0, markerIndex), normalizedPath);
+      return {
+        baseUrl: joinUrlParts(absoluteUrl?.origin, basePath),
+        collectionId,
+      };
+    }
   }
 
   return {
@@ -258,7 +268,13 @@ function trimTrailingSlashes(path: string): string {
     return "/";
   }
 
-  return path.replace(/\/+$/, "");
+  // Linear-time trailing-slash trim. Avoids the `/\/+$/` regex, whose
+  // anchored quantifier can backtrack super-linearly on long slash runs.
+  let end = path.length;
+  while (end > 0 && path.charCodeAt(end - 1) === 47 /* '/' */) {
+    end -= 1;
+  }
+  return end === path.length ? path : path.slice(0, end);
 }
 
 function normalizeCollectionBasePath(basePath: string, fullPath: string): string {

--- a/src/web-components/controller.ts
+++ b/src/web-components/controller.ts
@@ -1,4 +1,5 @@
 import type { FeatureId, Query } from "../contract/index.js";
+import { trimChar } from "../core/path-utils.js";
 import type { HonuaTypedFeature } from "../core/types.js";
 import type { HonuaLayerSpecification } from "../style/index.js";
 import type {
@@ -680,10 +681,12 @@ function layerColor(layer: HonuaLayerSpecification): string | undefined {
 }
 
 function legendId(label: string, index: number): string {
-  const slug = label
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+  const slug = trimChar(
+    label
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-"),
+    "-",
+  );
   return slug ? `${slug}-${index}` : `legend-${index}`;
 }


### PR DESCRIPTION
## Summary

Triages the open CodeQL + Dependabot security findings concentrated in this repo and fixes the genuinely impactful ones in shipped source with minimal, behavior-preserving changes.

## Triage breakdown

**CodeQL alerts (80 open):**

| Category | Count | Action |
|---|---|---|
| `js/polynomial-redos` — URL/path/slug trim regexes in shipped source | 31 | **Fixed** (linear helpers) |
| `js/double-escaping` — WMS/WMTS XML entity decode | 2 | **Fixed** (single-pass decoder) |
| `js/polynomial-redos` — odata `$metadata` XML attr regexes, migration scan tooling, single-`[^}]+` template regexes | 6 | **Left** (low-impact / dev-tool / trusted input; safe to dismiss in UI) |
| `js/incomplete-url-substring-sanitization` — `test/migration-demo.test.ts` | 1 | **Left** (test-only false positive: asserts a request was *not* sent to an attacker host) |
| GitHub Actions hardening (`PinnedDependenciesID`, `TokenPermissionsID`, `actions/missing-workflow-permissions`, scorecard `*ID`) | 38 | **Out of scope** (workflow/supply-chain policy, not SDK source) |

**Dependabot alerts (5 open):**
- `vitest` (critical) — already addressed by existing Dependabot PR #258; not duplicated here.
- `hono` x4 (medium) — transitive via `@modelcontextprotocol/sdk` in `mcp/`; **fixed** by pinning `hono` to `^4.12.21` (lockfile → 4.12.25).

## What changed

**ReDoS — new `src/core/path-utils.ts`** with linear-time helpers (`trimTrailingSlashes`, `trimLeadingSlashes`, `trimSurroundingSlashes`, `trimChar`, `stripQueryAndFragment`, `stripQuery`). Replaced the anchored `\/+$` / `^\/+` / `^\/+|\/+$` / `^-+|-+$` / `^_+|_+$` / `[?#].*$` / `\?.*$` regex idioms across the URL/path/slug normalization sites in `contract`, `core`, `control-plane`, `geocoding`, `map`, `migration`, `operate`, `runtime`, `scene-workspace`, and `web-components`. Helper outputs were verified character-for-character against the original regexes.

`parseOgcFeaturesUrl` (`src/style/specification.ts`) now splits on `/collections/` with a linear `indexOf` scan instead of a lazy-quantifier regex — verified equivalent (first-match wins, case-insensitive, empty-collection fallthrough, query/fragment handling).

**Double-escaping — new `src/core/xml-text.ts`** single-pass XML text decoder, used by the WMS and WMTS capabilities parsers. A `&` produced while decoding (e.g. `&amp;` → `&`) is final and never re-scanned, so `&amp;lt;` now correctly decodes to the literal `&lt;` instead of being double-unescaped to `<`.

**Dependencies** — `mcp/package.json` `overrides.hono = ^4.12.21`; `mcp/package-lock.json` bumped hono 4.12.18 → 4.12.25 (integrity verified against the npm registry).

## Verification
- `npm run lint` (biome) — pass
- `npm run build` (tsc) — pass
- `npm test` (vitest) — 2166/2167 pass; the one failure is an environmental 30s timeout in `migration-cli-content-webmap` under full-suite parallelism, which passes deterministically in isolation (~21s) and exercises the changed `content.ts` URL-rewrite path.

## Remaining for human review/dismissal
- 6 `js/polynomial-redos` alerts on trusted/dev-tool regexes (odata `$metadata` attr parsing, migration scan tooling, single-`[^}]+` template substitution) — recommend dismiss as low/won't-fix.
- 1 `js/incomplete-url-substring-sanitization` in test code — dismiss as false positive.
- 38 GitHub Actions / scorecard hardening findings — separate supply-chain PR.
- vitest critical: merge Dependabot PR #258.