### PR TITLE
feat(controls): native basemap switcher custom element (@honua/sdk-js/controls)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,6 +42,7 @@ default-barrel import never pulls them in.
 | `@honua/sdk-js/scene-workspace` | 3D scene workspace + MapLibre/Cesium adapters |
 | `@honua/sdk-js/collaboration` | Saved-map collaboration client |
 | `@honua/sdk-js/control-plane` | Hosted-product / admin client |
+| `@honua/sdk-js/controls` | Native UI control kit (`<honua-basemap-switcher>`) for MapLibre maps — no core/`maplibre-gl` imports |
 | `@honua/sdk-js/generated-app` | Manifest projection + preview runtime for generated apps |
 | `@honua/sdk-js/studio` | Studio package-family projections, validation/preview envelopes, capability manifest, publish/share/embed contracts (MCP/QGIS-safe) |
 | `@honua/sdk-js/agent-tools` | Agent-facing JSON Schema tool definitions (MCP/OpenAI compatible) |

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ tables, and backwards-compatibility policy live in:
     `@honua/sdk-js/filter-registry`, `@honua/sdk-js/style`, `@honua/sdk-js/map`.
   - **Experimental** (subpath-only — not re-exported from the root barrels):
     `/app`, `/app-controller`, `/app-workspace`, `/scene-workspace`, `/collaboration`,
-    `/control-plane`, `/generated-app`, `/studio`, `/agent-tools`, `/realtime`,
+    `/control-plane`, `/controls`, `/generated-app`, `/studio`, `/agent-tools`, `/realtime`,
     `/web-components`, `/operator`, `/operator/*`.
 
 ## More guides

--- a/examples/web-components-basic/README.md
+++ b/examples/web-components-basic/README.md
@@ -1,10 +1,17 @@
 # Honua Web Components Basic
 
-Plain TypeScript sample for `@honua/sdk-js/web-components`.
+Plain TypeScript sample for `@honua/sdk-js/web-components` and the native
+control kit in `@honua/sdk-js/controls`.
 
 The sample registers Honua custom elements, shares one controller across map,
 layer list, legend, table, search, editor, and chart widgets, and demonstrates
 read-only editor capability state without React or another framework.
+
+Basemaps are driven by `<honua-basemap-switcher>` from
+`@honua/sdk-js/controls`: three exclusive bases (Light, Dark, and a composite
+Terrain option) are applied directly to the MapLibre map, wired declaratively
+via `for="ops-map"`, and themed from `styles.css` through the control's
+`::part(group)` / `::part(radio)` / `::part(radio-active)` hooks.
 
 ```bash
 npm run demo:web-components

--- a/examples/web-components-basic/index.html
+++ b/examples/web-components-basic/index.html
@@ -12,7 +12,7 @@
         <honua-map id="ops-map" label="Response map"></honua-map>
         <div class="side-panel">
           <honua-search for="ops-map" source="incidents" placeholder="Find incidents"></honua-search>
-          <honua-basemap-control for="ops-map"></honua-basemap-control>
+          <honua-basemap-switcher for="ops-map" label="Basemaps" value="light"></honua-basemap-switcher>
           <honua-bookmarks
             for="ops-map"
             bookmarks='[{"id":"harbor","label":"Harbor","viewport":{"center":[-157.87,21.31],"zoom":13}},{"id":"kakaako","label":"Kakaako","viewport":{"center":[-157.86,21.29],"zoom":13}}]'

--- a/examples/web-components-basic/mock-server.mjs
+++ b/examples/web-components-basic/mock-server.mjs
@@ -22,6 +22,8 @@ function buildDemoIfNeeded() {
     cwd: projectRoot,
     stdio: "inherit",
     env: process.env,
+    // Node >=20.12 refuses to spawn .cmd shims without a shell (CVE-2024-27980).
+    shell: process.platform === "win32",
   });
   if (result.status !== 0) throw new Error("Failed to build the web components sample.");
 }

--- a/examples/web-components-basic/src/main.ts
+++ b/examples/web-components-basic/src/main.ts
@@ -1,5 +1,12 @@
 import "maplibre-gl/dist/maplibre-gl.css";
 
+// Side-effect import registers <honua-basemap-switcher>.
+import "@honua/sdk-js/controls";
+import type {
+  HonuaBasemapDefinition,
+  HonuaBasemapSwitcherChangeDetail,
+  HonuaBasemapSwitcherElement,
+} from "@honua/sdk-js/controls";
 import {
   type HonuaChartModel,
   type HonuaFeatureRecord,
@@ -97,19 +104,6 @@ const controller = createHonuaWebComponentController({
         },
       },
       layers: [
-        {
-          id: "basemap-background",
-          type: "background",
-          metadata: { title: "Blue basemap", basemap: true },
-          paint: { "background-color": "#e8eef7" },
-        },
-        {
-          id: "basemap-dark",
-          type: "background",
-          metadata: { title: "Dark basemap", basemap: true },
-          layout: { visibility: "none" },
-          paint: { "background-color": "#203040" },
-        },
         {
           id: "incident-halos",
           source: INCIDENT_SOURCE_ID,
@@ -261,11 +255,73 @@ document.addEventListener("honua-filter-change", (event) => {
   writeEventLog();
 });
 
-document.addEventListener("honua-basemap-change", (event) => {
-  const detail = (event as CustomEvent<{ basemapId: string }>).detail;
-  eventLog.push(`basemap:${detail.basemapId}`);
+// Exclusive basemap definitions for <honua-basemap-switcher>. The mock lane
+// stays offline, so the composite "Terrain" base pairs a background with an
+// inline GeoJSON contour layer; against a live Honua deployment the same
+// definition shape carries a pmtiles:// vector base plus a raster-dem
+// hillshade (see @honua/sdk-js/controls docs).
+const demoBasemaps: HonuaBasemapDefinition[] = [
+  {
+    id: "light",
+    label: "Light",
+    kind: "vector",
+    sources: {},
+    layers: [{ id: "base-light", type: "background", paint: { "background-color": "#e8eef7" } }],
+  },
+  {
+    id: "dark",
+    label: "Dark",
+    kind: "vector",
+    sources: {},
+    layers: [{ id: "base-dark", type: "background", paint: { "background-color": "#203040" } }],
+  },
+  {
+    id: "terrain",
+    label: "Terrain",
+    kind: "raster-dem-composite",
+    sources: {
+      "demo-contours": {
+        type: "geojson",
+        data: {
+          type: "FeatureCollection",
+          features: [-157.92, -157.88, -157.84, -157.8].map((lng) => ({
+            type: "Feature",
+            properties: {},
+            geometry: {
+              type: "LineString",
+              coordinates: [
+                [lng, 21.25],
+                [lng + 0.02, 21.35],
+              ],
+            },
+          })),
+        },
+      },
+    },
+    layers: [
+      { id: "base-terrain", type: "background", paint: { "background-color": "#e2ead9" } },
+      {
+        id: "base-terrain-contours",
+        type: "line",
+        source: "demo-contours",
+        paint: { "line-color": "#9db89a", "line-width": 1 },
+      },
+    ],
+  },
+];
+
+const basemapSwitcher = document.querySelector("honua-basemap-switcher") as HonuaBasemapSwitcherElement | null;
+if (!basemapSwitcher) throw new Error("Missing honua-basemap-switcher");
+
+basemapSwitcher.addEventListener("change", (event) => {
+  const detail = (event as CustomEvent<HonuaBasemapSwitcherChangeDetail>).detail;
+  eventLog.push(`basemap:${detail.value}`);
   writeEventLog();
 });
+
+// The element also self-wires from for="ops-map" + the honua-map-ready event;
+// assigning the bases is the only imperative step the host performs.
+basemapSwitcher.bases = demoBasemaps;
 
 document.addEventListener("honua-bookmark-change", (event) => {
   const detail = (event as CustomEvent<{ id: string }>).detail;

--- a/examples/web-components-basic/src/styles.css
+++ b/examples/web-components-basic/src/styles.css
@@ -38,6 +38,28 @@ honua-map {
   min-height: 20px;
 }
 
+/* The basemap switcher ships structural CSS only; theme it via ::part(). */
+honua-basemap-switcher::part(group) {
+  background: #ffffff;
+  border: 1px solid #d0d7e2;
+  border-radius: 8px;
+  gap: 4px;
+  padding: 4px;
+}
+
+honua-basemap-switcher::part(radio) {
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: #172033;
+  padding: 6px 10px;
+}
+
+honua-basemap-switcher::part(radio-active) {
+  background: #2563eb;
+  color: #ffffff;
+}
+
 @media (max-width: 820px) {
   .workspace,
   .bottom-panel {

--- a/examples/web-components-basic/tsconfig.json
+++ b/examples/web-components-basic/tsconfig.json
@@ -12,6 +12,7 @@
     "types": ["vite/client"],
     "paths": {
       "@honua/sdk-js": ["../../src/index.ts"],
+      "@honua/sdk-js/controls": ["../../src/controls/index.ts"],
       "@honua/sdk-js/runtime": ["../../src/runtime/index.ts"],
       "@honua/sdk-js/web-components": ["../../src/web-components/index.ts"]
     }

--- a/examples/web-components-basic/vite.config.ts
+++ b/examples/web-components-basic/vite.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
         replacement: path.resolve(repoRoot, "src/web-components/index.ts"),
       },
       {
+        find: "@honua/sdk-js/controls",
+        replacement: path.resolve(repoRoot, "src/controls/index.ts"),
+      },
+      {
         find: "@honua/sdk-js/runtime",
         replacement: path.resolve(repoRoot, "src/runtime/index.ts"),
       },

--- a/package.json
+++ b/package.json
@@ -66,6 +66,10 @@
       "types": "./dist/src/geocoding/index.d.ts",
       "default": "./dist/src/geocoding/index.js"
     },
+    "./controls": {
+      "types": "./dist/src/controls/index.d.ts",
+      "default": "./dist/src/controls/index.js"
+    },
     "./contract": {
       "types": "./dist/src/contract/index.d.ts",
       "default": "./dist/src/contract/index.js"
@@ -182,7 +186,7 @@
     "verify:split-packages": "npm run build:split-packages --silent && node scripts/verify-split-packages.mjs",
     "pack:split-packages": "npm run build:split-packages --silent && npm pack ./dist/packages/honua-sdk && npm pack ./dist/packages/honua-sdk-esri-compat && npm pack ./dist/packages/honua-migrate",
     "typecheck": "tsc --noEmit",
-    "docs:api": "npx --yes typedoc@^0.26 --tsconfig tsconfig.json --out dist/docs-api --excludeInternal --excludePrivate --readme README.md --name '@honua/sdk-js' src/index.ts src/honua.ts src/contract/index.ts src/expr/index.ts src/webmap/index.ts src/geocoding/index.ts src/runtime/index.ts src/studio/index.ts src/migration-entry.ts src/esri-compat-entry.ts",
+    "docs:api": "npx --yes typedoc@^0.26 --tsconfig tsconfig.json --out dist/docs-api --excludeInternal --excludePrivate --readme README.md --name '@honua/sdk-js' src/index.ts src/honua.ts src/contract/index.ts src/controls/index.ts src/expr/index.ts src/webmap/index.ts src/geocoding/index.ts src/runtime/index.ts src/studio/index.ts src/migration-entry.ts src/esri-compat-entry.ts",
     "demo:quickstart": "vite --config examples/maplibre-quickstart/vite.config.ts",
     "demo:quickstart:build": "vite build --config examples/maplibre-quickstart/vite.config.ts",
     "demo:quickstart:preview": "vite preview --config examples/maplibre-quickstart/vite.config.ts --host 127.0.0.1",
@@ -382,7 +386,11 @@
     "./dist/src/web-components/index.js",
     "./dist/src/web-components/elements.js",
     "./src/web-components/index.ts",
-    "./src/web-components/elements.ts"
+    "./src/web-components/elements.ts",
+    "./dist/src/controls/index.js",
+    "./dist/src/controls/basemap-switcher.js",
+    "./src/controls/index.ts",
+    "./src/controls/basemap-switcher.ts"
   ],
   "engines": {
     "node": ">=20.0.0"

--- a/scripts/prepare-split-packages.mjs
+++ b/scripts/prepare-split-packages.mjs
@@ -42,6 +42,7 @@ function createSdkPackage() {
   fs.mkdirSync(packageRoot, { recursive: true });
 
   copyDirectory(path.join(DIST_SRC_ROOT, "contract"), path.join(packageRoot, "contract"));
+  copyDirectory(path.join(DIST_SRC_ROOT, "controls"), path.join(packageRoot, "controls"));
   copyDirectory(path.join(DIST_SRC_ROOT, "control-plane"), path.join(packageRoot, "control-plane"));
   copyDirectory(path.join(DIST_SRC_ROOT, "collaboration"), path.join(packageRoot, "collaboration"));
   copyDirectory(path.join(DIST_SRC_ROOT, "console"), path.join(packageRoot, "console"));
@@ -85,6 +86,10 @@ function createSdkPackage() {
       "./contract": {
         types: "./contract/index.d.ts",
         default: "./contract/index.js",
+      },
+      "./controls": {
+        types: "./controls/index.d.ts",
+        default: "./controls/index.js",
       },
       "./control-plane": {
         types: "./control-plane/index.d.ts",

--- a/scripts/verify-split-packages.mjs
+++ b/scripts/verify-split-packages.mjs
@@ -127,6 +127,11 @@ import { HonuaMap } from "@honua/sdk/map";
 import { validateHonuaStyle } from "@honua/sdk/style";
 import { loadMapPackage, validateRuntimeStyleSpec } from "@honua/sdk/runtime";
 import { defineHonuaWebComponents } from "@honua/sdk/web-components";
+import {
+  HonuaBasemapStyleBinding,
+  HonuaBasemapSwitcherElement,
+  defineHonuaControls,
+} from "@honua/sdk/controls";
 import { projectBuildSpecToGeneratedAppManifest } from "@honua/sdk/generated-app";
 import { chartWidgetToVegaLiteSpec, isVegaLiteSpec, projectMapPackage } from "@honua/sdk/console";
 import { HONUA_QUERY_PACKAGE_FORMAT_V1, toStudioValidationResponse } from "@honua/sdk/studio";
@@ -306,6 +311,20 @@ if (typeof validateRuntimeStyleSpec !== "function")
   throw new Error("validateRuntimeStyleSpec export missing from @honua/sdk/runtime");
 if (typeof defineHonuaWebComponents !== "function")
   throw new Error("defineHonuaWebComponents export missing from @honua/sdk/web-components");
+if (typeof defineHonuaControls !== "function")
+  throw new Error("defineHonuaControls export missing from @honua/sdk/controls");
+if (typeof HonuaBasemapSwitcherElement !== "function")
+  throw new Error("HonuaBasemapSwitcherElement export missing from @honua/sdk/controls");
+if (typeof HonuaBasemapStyleBinding !== "function")
+  throw new Error("HonuaBasemapStyleBinding export missing from @honua/sdk/controls");
+{
+  const bindingSmoke = new HonuaBasemapStyleBinding();
+  bindingSmoke.setBases([
+    { id: "light", label: "Light", kind: "vector", sources: {}, layers: [{ id: "light-bg", type: "background" }] },
+  ]);
+  if (!bindingSmoke.activate("light") || bindingSmoke.activeId !== "light")
+    throw new Error("@honua/sdk/controls HonuaBasemapStyleBinding failed to activate a base");
+}
 if (typeof projectBuildSpecToGeneratedAppManifest !== "function")
   throw new Error("projectBuildSpecToGeneratedAppManifest export missing from @honua/sdk/generated-app");
 if (typeof chartWidgetToVegaLiteSpec !== "function" || typeof isVegaLiteSpec !== "function")

--- a/src/controls/basemap-style-binding.ts
+++ b/src/controls/basemap-style-binding.ts
@@ -1,0 +1,207 @@
+/**
+ * Headless style binding behind `<honua-basemap-switcher>`.
+ *
+ * `HonuaBasemapStyleBinding` owns the MapLibre style mutations: it lazily
+ * adds each base's sources and layers the first time the base is activated,
+ * keeps base layers grouped beneath the host's overlay layers, and toggles
+ * `visibility` so exactly one base renders at a time. Hosts that do not want
+ * a custom element (React wrappers, imperative apps) can drive it directly.
+ *
+ * @module
+ */
+
+import type { HonuaBasemapDefinition, HonuaBasemapLayerSpecification, HonuaBasemapSwitcherMap } from "./types.js";
+
+/**
+ * Applies exclusive basemap selection to a MapLibre map.
+ *
+ * Strategy: sources and layers belonging to a base are added on first
+ * activation (so inactive bases never fetch tiles) and toggled with
+ * `setLayoutProperty(layerId, "visibility", ...)` afterwards. Layers are
+ * inserted before the first style layer not owned by any registered base, so
+ * bases always sit beneath the host application's overlay layers regardless
+ * of activation order. Bases removed from the definitions list are pruned
+ * from the map (layers and exclusively-owned sources are removed).
+ */
+export class HonuaBasemapStyleBinding {
+  #map: HonuaBasemapSwitcherMap | undefined;
+  #bases: readonly HonuaBasemapDefinition[] = [];
+  #activeId: string | undefined;
+  readonly #addedLayerIds = new Set<string>();
+  readonly #addedSourceIds = new Set<string>();
+
+  /** The bound map, if any. */
+  public get map(): HonuaBasemapSwitcherMap | undefined {
+    return this.#map;
+  }
+
+  /** The registered base definitions. */
+  public get bases(): readonly HonuaBasemapDefinition[] {
+    return this.#bases;
+  }
+
+  /** Id of the currently active base, if one has been applied. */
+  public get activeId(): string | undefined {
+    return this.#activeId;
+  }
+
+  /**
+   * Binds (or unbinds, with `undefined`) the MapLibre map. Unbinding removes
+   * every layer and source this binding added to the previous map. Binding a
+   * map re-applies the current active base when one is set.
+   */
+  public setMap(map: HonuaBasemapSwitcherMap | undefined): void {
+    if (this.#map === map) return;
+    this.#removeAllOwned();
+    this.#map = map;
+    if (map && this.#activeId !== undefined) this.#apply(this.#activeId);
+  }
+
+  /**
+   * Replaces the base definitions. Layers and sources added for bases that no
+   * longer exist are removed from the map; the active base (when still
+   * present) is re-applied so its style objects stay in sync.
+   */
+  public setBases(bases: readonly HonuaBasemapDefinition[]): void {
+    this.#bases = bases;
+    this.#pruneOwned();
+    if (this.#activeId !== undefined && !this.#findBase(this.#activeId)) {
+      this.#activeId = undefined;
+      return;
+    }
+    if (this.#activeId !== undefined) this.#apply(this.#activeId);
+  }
+
+  /**
+   * Activates the base with the given id: ensures its sources/layers exist on
+   * the map, shows them, and hides every other base's layers. Returns `true`
+   * when the id matches a registered base (even if the map is not bound yet —
+   * the selection is re-applied as soon as a map arrives).
+   */
+  public activate(baseId: string): boolean {
+    if (!this.#findBase(baseId)) return false;
+    this.#activeId = baseId;
+    this.#apply(baseId);
+    return true;
+  }
+
+  /** Removes every layer and source this binding added and unbinds the map. */
+  public detach(): void {
+    this.#removeAllOwned();
+    this.#map = undefined;
+  }
+
+  #findBase(baseId: string): HonuaBasemapDefinition | undefined {
+    return this.#bases.find((base) => base.id === baseId);
+  }
+
+  #apply(activeId: string): void {
+    const map = this.#map;
+    const active = this.#findBase(activeId);
+    if (!map || !active) return;
+
+    for (const [sourceId, source] of Object.entries(active.sources)) {
+      if (!this.#sourceExists(map, sourceId)) {
+        map.addSource(sourceId, source);
+        this.#addedSourceIds.add(sourceId);
+      }
+    }
+
+    const activeLayerIds = new Set(active.layers.map((layer) => layer.id));
+    for (const layer of active.layers) {
+      if (this.#layerExists(map, layer.id)) {
+        map.setLayoutProperty(layer.id, "visibility", "visible");
+        continue;
+      }
+      map.addLayer(withVisibility(layer, "visible"), this.#anchorLayerId(map));
+      this.#addedLayerIds.add(layer.id);
+    }
+
+    for (const base of this.#bases) {
+      if (base.id === activeId) continue;
+      for (const layer of base.layers) {
+        if (activeLayerIds.has(layer.id)) continue;
+        if (this.#layerExists(map, layer.id)) map.setLayoutProperty(layer.id, "visibility", "none");
+      }
+    }
+  }
+
+  /**
+   * First style layer not owned by any registered base — base layers are
+   * inserted before it so they render beneath the host's overlay layers.
+   */
+  #anchorLayerId(map: HonuaBasemapSwitcherMap): string | undefined {
+    const owned = new Set<string>(this.#addedLayerIds);
+    for (const base of this.#bases) {
+      for (const layer of base.layers) owned.add(layer.id);
+    }
+    for (const layerId of styleLayerIds(map)) {
+      if (!owned.has(layerId)) return layerId;
+    }
+    return undefined;
+  }
+
+  #pruneOwned(): void {
+    const map = this.#map;
+    const keepLayers = new Set<string>();
+    const keepSources = new Set<string>();
+    for (const base of this.#bases) {
+      for (const layer of base.layers) keepLayers.add(layer.id);
+      for (const sourceId of Object.keys(base.sources)) keepSources.add(sourceId);
+    }
+    for (const layerId of [...this.#addedLayerIds]) {
+      if (keepLayers.has(layerId)) continue;
+      this.#addedLayerIds.delete(layerId);
+      if (map && this.#layerExists(map, layerId)) map.removeLayer?.(layerId);
+    }
+    for (const sourceId of [...this.#addedSourceIds]) {
+      if (keepSources.has(sourceId)) continue;
+      this.#addedSourceIds.delete(sourceId);
+      if (map && this.#sourceExists(map, sourceId)) map.removeSource?.(sourceId);
+    }
+  }
+
+  #removeAllOwned(): void {
+    const map = this.#map;
+    if (map) {
+      for (const layerId of this.#addedLayerIds) {
+        if (this.#layerExists(map, layerId)) map.removeLayer?.(layerId);
+      }
+      for (const sourceId of this.#addedSourceIds) {
+        if (this.#sourceExists(map, sourceId)) map.removeSource?.(sourceId);
+      }
+    }
+    this.#addedLayerIds.clear();
+    this.#addedSourceIds.clear();
+  }
+
+  #layerExists(map: HonuaBasemapSwitcherMap, layerId: string): boolean {
+    return typeof map.getLayer === "function" ? Boolean(map.getLayer(layerId)) : this.#addedLayerIds.has(layerId);
+  }
+
+  #sourceExists(map: HonuaBasemapSwitcherMap, sourceId: string): boolean {
+    return typeof map.getSource === "function" ? Boolean(map.getSource(sourceId)) : this.#addedSourceIds.has(sourceId);
+  }
+}
+
+function withVisibility(
+  layer: HonuaBasemapLayerSpecification,
+  visibility: "visible" | "none",
+): Record<string, unknown> {
+  const layout =
+    typeof layer.layout === "object" && layer.layout !== null ? (layer.layout as Record<string, unknown>) : {};
+  return { ...layer, layout: { ...layout, visibility } };
+}
+
+function styleLayerIds(map: HonuaBasemapSwitcherMap): readonly string[] {
+  const style = typeof map.getStyle === "function" ? map.getStyle() : undefined;
+  const layers =
+    typeof style === "object" && style !== null && "layers" in style
+      ? (style as { layers?: unknown }).layers
+      : undefined;
+  if (!Array.isArray(layers)) return [];
+  return layers.flatMap((layer) => {
+    const id = typeof layer === "object" && layer !== null ? (layer as { id?: unknown }).id : undefined;
+    return typeof id === "string" ? [id] : [];
+  });
+}

--- a/src/controls/basemap-switcher.ts
+++ b/src/controls/basemap-switcher.ts
@@ -1,0 +1,423 @@
+/**
+ * `<honua-basemap-switcher>` — framework-free custom element that switches a
+ * MapLibre map between exclusive basemap definitions (issue #274).
+ *
+ * The element renders an accessible radio group (one radio per base) inside
+ * shadow DOM with structural-only CSS and `::part()` hooks, and delegates all
+ * style mutations to {@link HonuaBasemapStyleBinding}. It never imports
+ * `maplibre-gl` or the SDK core, so the `@honua/sdk-js/controls` entry stays
+ * independent of the core bundle.
+ *
+ * ## Wiring
+ * - `element.map = map` (any MapLibre `Map`) or `element.connect(map)`;
+ * - declaratively via `for="<honua-map id>"` — the element resolves the map
+ *   from a sibling element exposing a `.map` property (e.g. `<honua-map>`)
+ *   and also listens for the `honua-map-ready` event, matching the idiom of
+ *   the `web-components` entry.
+ *
+ * ## Attributes
+ * - `bases` — JSON array of {@link HonuaBasemapDefinition} (property `bases`
+ *   is preferred for non-trivial configs).
+ * - `value` — id of the base to activate; reflected on selection changes.
+ * - `for` — id of the map-providing element, see Wiring.
+ * - `label` — accessible name of the radio group (default "Basemaps").
+ *
+ * ## Events
+ * - `change` — `CustomEvent<HonuaBasemapSwitcherChangeDetail>` (bubbles,
+ *   composed) whenever the active base changes: user interaction,
+ *   programmatic `value` assignment, or the initial/default activation.
+ *
+ * ## CSS parts
+ * - `group` — the radio-group container (button-group layout).
+ * - `radio` — each base button.
+ * - `radio-active` — additionally present on the active base's button.
+ *
+ * ## Accessibility
+ * Radio-group semantics (`role="radiogroup"` / `role="radio"`,
+ * `aria-checked`) with roving tabindex; ArrowLeft/ArrowUp and
+ * ArrowRight/ArrowDown move and select, Home/End jump to the first/last
+ * base, Space/Enter select the focused base.
+ */
+
+import { HonuaBasemapStyleBinding } from "./basemap-style-binding.js";
+import type {
+  HonuaBasemapDefinition,
+  HonuaBasemapKind,
+  HonuaBasemapSwitcherChangeDetail,
+  HonuaBasemapSwitcherMap,
+} from "./types.js";
+
+const globalDom = globalThis as typeof globalThis & {
+  HTMLElement?: typeof HTMLElement;
+  CustomEvent?: typeof CustomEvent;
+  customElements?: CustomElementRegistry;
+};
+
+const HTMLElementBase: typeof HTMLElement = globalDom.HTMLElement ?? (class {} as unknown as typeof HTMLElement);
+
+/**
+ * Custom element implementing the exclusive basemap switcher. Registered as
+ * `honua-basemap-switcher` by {@link defineHonuaControls} (which runs
+ * automatically on import when a `customElements` registry exists).
+ */
+export class HonuaBasemapSwitcherElement extends HTMLElementBase {
+  public static get observedAttributes(): string[] {
+    return ["bases", "value", "for", "label"];
+  }
+
+  readonly #binding = new HonuaBasemapStyleBinding();
+  #requestedValue: string | undefined;
+  #mapReadyListener: ((event: Event) => void) | undefined;
+  #rendered = false;
+
+  /**
+   * The MapLibre map driven by this control. Assigning a map applies the
+   * current selection to it; assigning `undefined` detaches and removes every
+   * layer/source the control added.
+   */
+  public get map(): HonuaBasemapSwitcherMap | undefined {
+    return this.#binding.map;
+  }
+
+  public set map(map: HonuaBasemapSwitcherMap | undefined) {
+    this.#binding.setMap(map);
+    if (map) this.#ensureActive();
+  }
+
+  /** Wires the control to a MapLibre map. Equivalent to setting `.map`. */
+  public connect(map: HonuaBasemapSwitcherMap): void {
+    this.map = map;
+  }
+
+  /** The registered base definitions. */
+  public get bases(): readonly HonuaBasemapDefinition[] {
+    return this.#binding.bases;
+  }
+
+  public set bases(bases: readonly HonuaBasemapDefinition[]) {
+    const previousActive = this.#binding.activeId;
+    this.#binding.setBases(bases);
+    this.#rendered = false;
+    this.render();
+    if (previousActive !== undefined && this.#binding.activeId === undefined) {
+      // The previously active base was removed; fall back to a valid base.
+      this.#ensureActive(previousActive);
+    } else {
+      this.#ensureActive();
+    }
+  }
+
+  /**
+   * Id of the active base. Assigning a registered base id activates it (and
+   * dispatches `change` when the selection actually changes); assignments
+   * are remembered and honored once matching bases arrive.
+   */
+  public get value(): string | undefined {
+    return this.#binding.activeId ?? this.#requestedValue;
+  }
+
+  public set value(value: string | undefined) {
+    if (value === undefined) return;
+    this.select(value);
+  }
+
+  /**
+   * Activates the base with the given id. Returns `true` when the id matched
+   * a registered base. Dispatches `change` when the active base changed.
+   */
+  public select(baseId: string): boolean {
+    const previous = this.#binding.activeId;
+    if (previous === baseId) {
+      this.#requestedValue = undefined;
+      return true;
+    }
+    const base = this.bases.find((candidate) => candidate.id === baseId);
+    if (!base || !this.#binding.activate(baseId)) {
+      this.#requestedValue = baseId;
+      return false;
+    }
+    this.#requestedValue = undefined;
+    this.#reflectValue(baseId);
+    this.#updateSelectionDom();
+    this.#dispatchChange({
+      value: baseId,
+      ...(previous !== undefined ? { previousValue: previous } : {}),
+      kind: base.kind,
+    });
+    return true;
+  }
+
+  public attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null): void {
+    if (name === "bases") {
+      const parsed = parseBases(newValue);
+      if (parsed) this.bases = parsed;
+      return;
+    }
+    if (name === "value") {
+      if (newValue !== null && newValue !== this.#binding.activeId) this.select(newValue);
+      return;
+    }
+    if (name === "for") {
+      this.#resolveMapFromContext();
+      return;
+    }
+    if (name === "label") {
+      this.#rendered = false;
+      this.render();
+    }
+  }
+
+  public connectedCallback(): void {
+    this.#ensureShadowRoot();
+    this.#listenForMapReady();
+    this.#resolveMapFromContext();
+    this.render();
+    this.#ensureActive();
+  }
+
+  public disconnectedCallback(): void {
+    if (this.#mapReadyListener) {
+      this.#rootEventTarget()?.removeEventListener("honua-map-ready", this.#mapReadyListener);
+      this.#mapReadyListener = undefined;
+    }
+  }
+
+  /**
+   * Applies the pending `value` (attribute or property assignment made before
+   * bases were registered), falling back to the first base so the map is
+   * never left without an active base once wiring completes.
+   */
+  #ensureActive(removedActiveId?: string): void {
+    if (this.#binding.activeId !== undefined || this.bases.length === 0) return;
+    const requested =
+      this.#requestedValue ?? (typeof this.getAttribute === "function" ? this.getAttribute("value") : null);
+    if (requested !== null && requested !== undefined && requested !== removedActiveId && this.select(requested))
+      return;
+    const first = this.bases[0];
+    if (first) this.select(first.id);
+  }
+
+  // ── map wiring (matches the web-components `for` + ready-event idiom) ──
+
+  #listenForMapReady(): void {
+    if (this.#mapReadyListener) return;
+    const target = this.#rootEventTarget();
+    if (!target) return;
+    this.#mapReadyListener = (event: Event) => {
+      const detail = (event as CustomEvent<{ map?: unknown }>).detail;
+      if (!detail?.map) return;
+      const forId = this.getAttribute("for");
+      if (forId && (event.target as Element | null)?.id !== forId) return;
+      if (!forId && this.map) return;
+      this.map = detail.map as HonuaBasemapSwitcherMap;
+    };
+    target.addEventListener("honua-map-ready", this.#mapReadyListener as EventListener);
+  }
+
+  #resolveMapFromContext(): void {
+    if (this.map || typeof this.getAttribute !== "function") return;
+    const forId = this.getAttribute("for");
+    if (!forId) return;
+    const root = this.getRootNode?.() as (Document | ShadowRoot) | undefined;
+    const host =
+      root && "getElementById" in root
+        ? root.getElementById(forId)
+        : typeof document !== "undefined"
+          ? document.getElementById(forId)
+          : null;
+    const map = (host as { map?: unknown } | null)?.map;
+    if (map) this.map = map as HonuaBasemapSwitcherMap;
+  }
+
+  #rootEventTarget(): EventTarget | undefined {
+    const root = this.getRootNode?.();
+    if (root && "addEventListener" in root) return root as EventTarget;
+    return typeof document !== "undefined" ? document : undefined;
+  }
+
+  // ── rendering ──────────────────────────────────────────────
+
+  #ensureShadowRoot(): void {
+    if (!this.shadowRoot && typeof this.attachShadow === "function") {
+      this.attachShadow({ mode: "open" });
+    }
+  }
+
+  protected render(): void {
+    const root = this.shadowRoot;
+    if (!root) return;
+    if (this.#rendered) {
+      this.#updateSelectionDom();
+      return;
+    }
+    const label = (typeof this.getAttribute === "function" ? this.getAttribute("label") : null) ?? "Basemaps";
+    root.innerHTML = `
+      <style>${structuralStyles()}</style>
+      <div part="group" class="group" role="radiogroup" aria-label="${escapeAttribute(label)}">
+        ${this.bases
+          .map(
+            (base) => `
+          <button
+            type="button"
+            part="radio"
+            class="radio"
+            role="radio"
+            aria-checked="false"
+            tabindex="-1"
+            data-base-id="${escapeAttribute(base.id)}"
+            data-kind="${escapeAttribute(base.kind)}"
+          >${escapeHtml(base.label)}</button>
+        `,
+          )
+          .join("")}
+      </div>
+    `;
+    this.#rendered = true;
+    this.#bindGroup(root);
+    this.#updateSelectionDom();
+  }
+
+  #bindGroup(root: ShadowRoot): void {
+    root.querySelectorAll<HTMLButtonElement>("button[data-base-id]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const baseId = button.dataset.baseId;
+        if (baseId) this.select(baseId);
+      });
+    });
+    root.querySelector(".group")?.addEventListener("keydown", (event) => {
+      this.#onGroupKeydown(event as KeyboardEvent);
+    });
+  }
+
+  #onGroupKeydown(event: KeyboardEvent): void {
+    const radios = this.#radios();
+    if (radios.length === 0) return;
+    const activeIndex = Math.max(
+      0,
+      radios.findIndex((radio) => radio.dataset.baseId === this.#binding.activeId),
+    );
+    let nextIndex: number;
+    switch (event.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        nextIndex = (activeIndex + 1) % radios.length;
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        nextIndex = (activeIndex - 1 + radios.length) % radios.length;
+        break;
+      case "Home":
+        nextIndex = 0;
+        break;
+      case "End":
+        nextIndex = radios.length - 1;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    const next = radios[nextIndex];
+    const baseId = next?.dataset.baseId;
+    if (!baseId) return;
+    this.select(baseId);
+    next.focus();
+  }
+
+  /** Roving tabindex + checked state, updated in place to preserve focus. */
+  #updateSelectionDom(): void {
+    const radios = this.#radios();
+    if (radios.length === 0) return;
+    const activeId = this.#binding.activeId;
+    const fallbackTabStop = radios.some((radio) => radio.dataset.baseId === activeId) ? undefined : radios[0];
+    for (const radio of radios) {
+      const isActive = radio.dataset.baseId === activeId;
+      radio.setAttribute("aria-checked", String(isActive));
+      radio.setAttribute("part", isActive ? "radio radio-active" : "radio");
+      radio.tabIndex = isActive || radio === fallbackTabStop ? 0 : -1;
+    }
+  }
+
+  #radios(): HTMLButtonElement[] {
+    const root = this.shadowRoot;
+    if (!root || typeof root.querySelectorAll !== "function") return [];
+    return [...root.querySelectorAll<HTMLButtonElement>("button[data-base-id]")];
+  }
+
+  #reflectValue(baseId: string): void {
+    if (typeof this.setAttribute !== "function" || typeof this.getAttribute !== "function") return;
+    if (this.getAttribute("value") !== baseId) this.setAttribute("value", baseId);
+  }
+
+  #dispatchChange(detail: HonuaBasemapSwitcherChangeDetail): void {
+    if (!globalDom.CustomEvent || typeof this.dispatchEvent !== "function") return;
+    this.dispatchEvent(new globalDom.CustomEvent("change", { bubbles: true, composed: true, detail }));
+  }
+}
+
+/**
+ * Registers the controls-entry custom elements (`honua-basemap-switcher`).
+ * Invoked automatically on import when a global `customElements` registry is
+ * present; call explicitly when using a scoped registry.
+ */
+export function defineHonuaControls(registry = globalDom.customElements): void {
+  if (!registry) return;
+  if (!registry.get("honua-basemap-switcher")) {
+    registry.define("honua-basemap-switcher", HonuaBasemapSwitcherElement);
+  }
+}
+
+if (globalDom.customElements) {
+  defineHonuaControls(globalDom.customElements);
+}
+
+function parseBases(value: string | null): readonly HonuaBasemapDefinition[] | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!Array.isArray(parsed)) return undefined;
+    return parsed.flatMap((item): HonuaBasemapDefinition[] => {
+      if (!item || typeof item !== "object") return [];
+      const candidate = item as Partial<HonuaBasemapDefinition>;
+      if (typeof candidate.id !== "string" || typeof candidate.label !== "string") return [];
+      return [
+        {
+          id: candidate.id,
+          label: candidate.label,
+          kind: isBasemapKind(candidate.kind) ? candidate.kind : "vector",
+          sources: candidate.sources && typeof candidate.sources === "object" ? candidate.sources : {},
+          layers: Array.isArray(candidate.layers)
+            ? candidate.layers.filter((layer) => typeof layer?.id === "string")
+            : [],
+        },
+      ];
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+function isBasemapKind(value: unknown): value is HonuaBasemapKind {
+  return value === "vector" || value === "raster" || value === "raster-dem-composite";
+}
+
+/** Structural-only styles; theme via `::part(group)` / `::part(radio)` / `::part(radio-active)`. */
+function structuralStyles(): string {
+  return `
+    :host { display: inline-block; }
+    .group { display: inline-flex; flex-wrap: wrap; }
+    .radio { font: inherit; cursor: pointer; }
+  `;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function escapeAttribute(value: string): string {
+  return escapeHtml(value);
+}

--- a/src/controls/index.ts
+++ b/src/controls/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Native Honua UI control kit (`@honua/sdk-js/controls`) — optional,
+ * framework-free custom elements for apps built on the native lane
+ * (HonuaClient + MapLibre). Tracked by issue #274; the basemap switcher is
+ * the first control, with a layer list and legend to follow.
+ *
+ * This entry is intentionally independent of the SDK core bundle (the same
+ * posture as `@honua/sdk-js/esri-compat`): it imports nothing from
+ * `src/core`/`src/runtime` and has no dependency on `maplibre-gl` — controls
+ * drive any MapLibre `Map` through a duck-typed interface.
+ *
+ * Importing this module registers the shipped custom elements when a browser
+ * `customElements` registry is present. Node imports are safe; call
+ * `defineHonuaControls()` explicitly when using a scoped registry.
+ *
+ * @experimental This entrypoint is not yet covered by the SDK's semver
+ *   contract — the surface may change in any minor release prior to `1.0.0`.
+ * @module
+ */
+
+import "./basemap-switcher.js";
+
+export { HonuaBasemapStyleBinding } from "./basemap-style-binding.js";
+export { HonuaBasemapSwitcherElement, defineHonuaControls } from "./basemap-switcher.js";
+export type {
+  HonuaBasemapDefinition,
+  HonuaBasemapKind,
+  HonuaBasemapLayerSpecification,
+  HonuaBasemapSwitcherChangeDetail,
+  HonuaBasemapSwitcherMap,
+} from "./types.js";

--- a/src/controls/types.ts
+++ b/src/controls/types.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared types for the native Honua control kit (`@honua/sdk-js/controls`).
+ *
+ * Controls in this entry operate directly on a MapLibre `Map` instance via a
+ * duck-typed interface — they never import `maplibre-gl` and never touch the
+ * SDK core, so the entry stays bundle-independent (same packaging posture as
+ * `@honua/sdk-js/esri-compat`).
+ *
+ * @module
+ */
+
+/**
+ * The flavor of a basemap definition. Purely descriptive metadata — the
+ * switcher treats every base the same way (a set of sources + layers that are
+ * shown exclusively). Exposed on the rendered radio as a `data-kind`
+ * attribute so hosts can style per kind.
+ *
+ * - `"vector"` — vector tile base (e.g. MVT or `pmtiles://` vector sources).
+ * - `"raster"` — raster tile base (e.g. XYZ imagery, WMTS, raster PMTiles).
+ * - `"raster-dem-composite"` — composite base that pairs layers from multiple
+ *   sources, typically a vector base plus a `raster-dem` hillshade rendered
+ *   together as one exclusive option (e.g. a "Terrain" base).
+ */
+export type HonuaBasemapKind = "vector" | "raster" | "raster-dem-composite";
+
+/**
+ * A MapLibre layer specification owned by a basemap definition. The switcher
+ * only requires the `id`; everything else is passed straight through to
+ * `map.addLayer`, so any MapLibre layer type (`background`, `raster`, `fill`,
+ * `line`, `symbol`, `hillshade`, ...) is supported.
+ */
+export interface HonuaBasemapLayerSpecification {
+  /** Unique layer id within the map style. */
+  readonly id: string;
+  /** Remaining MapLibre layer specification properties (type, source, paint, layout, ...). */
+  readonly [key: string]: unknown;
+}
+
+/**
+ * One exclusive basemap option: a set of MapLibre sources and layers that are
+ * added/shown together and hidden when another base is activated.
+ *
+ * The switcher is protocol-agnostic — `sources` values are passed verbatim to
+ * `map.addSource`, so `pmtiles://` vector sources, raster tile URL templates,
+ * `raster-dem` terrain sources, and inline GeoJSON all work as long as the
+ * host map can resolve them.
+ *
+ * A composite base (e.g. "Terrain" = vector base + hillshade) is simply a
+ * definition with multiple sources and multiple layers; the layers stay in
+ * the order given. Bases may share source ids and even layer ids (a shared
+ * layer stays visible while any base referencing it is active).
+ */
+export interface HonuaBasemapDefinition {
+  /** Stable identifier emitted in `change` events and used by `value`. */
+  readonly id: string;
+  /** Human-readable label rendered on the radio button. */
+  readonly label: string;
+  /** Descriptive base kind (see {@link HonuaBasemapKind}). */
+  readonly kind: HonuaBasemapKind;
+  /** MapLibre sources keyed by source id, passed verbatim to `map.addSource`. */
+  readonly sources: Readonly<Record<string, unknown>>;
+  /** MapLibre layers added (in order) beneath the host's overlay layers. */
+  readonly layers: readonly HonuaBasemapLayerSpecification[];
+}
+
+/**
+ * Minimal duck-typed subset of `maplibre-gl.Map` required by the basemap
+ * switcher. Mirrors the duck-typing pattern used by `src/runtime/runtime.ts`
+ * (`MaplibreMap`) so the controls entry stays bundle-neutral: any MapLibre-GL
+ * `Map` instance satisfies this interface, and tests can pass a plain stub.
+ */
+export interface HonuaBasemapSwitcherMap {
+  /** Adds a source to the map style. */
+  addSource(id: string, source: unknown): void;
+  /** Removes a source; used when pruning bases that were removed from `bases`. */
+  removeSource?(id: string): void;
+  /** Returns a truthy handle when the source already exists. */
+  getSource?(id: string): unknown;
+  /** Adds a layer, optionally before an existing layer id. */
+  addLayer(layer: unknown, beforeId?: string): void;
+  /** Removes a layer; used when pruning bases that were removed from `bases`. */
+  removeLayer?(id: string): void;
+  /** Returns a truthy handle when the layer already exists. */
+  getLayer?(id: string): unknown;
+  /** Sets a layout property; used to toggle `visibility` exclusively. */
+  setLayoutProperty(layerId: string, name: string, value: unknown): void;
+  /** Used to find the insertion anchor so base layers stay beneath overlays. */
+  getStyle?(): unknown;
+}
+
+/**
+ * Detail payload of the `change` CustomEvent dispatched by
+ * `<honua-basemap-switcher>` whenever the active base changes (user
+ * interaction, programmatic `value` assignment, or initial activation).
+ */
+export interface HonuaBasemapSwitcherChangeDetail {
+  /** Id of the now-active base. */
+  readonly value: string;
+  /** Id of the previously active base; absent on the initial activation. */
+  readonly previousValue?: string;
+  /** Kind of the now-active base. */
+  readonly kind: HonuaBasemapKind;
+}

--- a/test/controls/basemap-switcher.test.ts
+++ b/test/controls/basemap-switcher.test.ts
@@ -1,0 +1,449 @@
+import { describe, expect, test } from "vitest";
+
+import { HonuaBasemapStyleBinding } from "../../src/controls/basemap-style-binding.js";
+import { HonuaBasemapSwitcherElement, defineHonuaControls } from "../../src/controls/basemap-switcher.js";
+import type { HonuaBasemapDefinition, HonuaBasemapSwitcherChangeDetail } from "../../src/controls/types.js";
+
+interface MockCall {
+  method: string;
+  args: unknown[];
+}
+
+interface MockLayer {
+  id: string;
+  layout?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+interface MockMap {
+  _calls: MockCall[];
+  _layers: MockLayer[];
+  _sources: Map<string, unknown>;
+  addSource(id: string, source: unknown): void;
+  removeSource(id: string): void;
+  getSource(id: string): unknown;
+  addLayer(layer: unknown, beforeId?: string): void;
+  removeLayer(id: string): void;
+  getLayer(id: string): unknown;
+  setLayoutProperty(layerId: string, name: string, value: unknown): void;
+  getStyle(): unknown;
+  visibility(layerId: string): string;
+  layerOrder(): string[];
+}
+
+/**
+ * Stateful MapLibre map stub following the duck-typed mock pattern of
+ * test/runtime-style-interactions.test.ts, with enough style bookkeeping to
+ * assert layer order and visibility. Throws on duplicate adds and on layout
+ * updates for missing layers, like the real maplibre-gl Map.
+ */
+function makeMockMap(initialLayers: MockLayer[] = []): MockMap {
+  const calls: MockCall[] = [];
+  const layers: MockLayer[] = initialLayers.map((layer) => ({ ...layer }));
+  const sources = new Map<string, unknown>();
+
+  function record(method: string, args: unknown[]): void {
+    calls.push({ method, args });
+  }
+
+  return {
+    _calls: calls,
+    _layers: layers,
+    _sources: sources,
+    addSource(id, source) {
+      record("addSource", [id, source]);
+      if (sources.has(id)) throw new Error(`Source "${id}" already exists.`);
+      sources.set(id, source);
+    },
+    removeSource(id) {
+      record("removeSource", [id]);
+      sources.delete(id);
+    },
+    getSource(id) {
+      return sources.has(id) ? { id } : undefined;
+    },
+    addLayer(layer, beforeId) {
+      record("addLayer", [layer, beforeId]);
+      const spec = layer as MockLayer;
+      if (layers.some((existing) => existing.id === spec.id)) throw new Error(`Layer "${spec.id}" already exists.`);
+      const index = beforeId === undefined ? -1 : layers.findIndex((existing) => existing.id === beforeId);
+      if (index >= 0) layers.splice(index, 0, { ...spec });
+      else layers.push({ ...spec });
+    },
+    removeLayer(id) {
+      record("removeLayer", [id]);
+      const index = layers.findIndex((existing) => existing.id === id);
+      if (index >= 0) layers.splice(index, 1);
+    },
+    getLayer(id) {
+      return layers.find((existing) => existing.id === id);
+    },
+    setLayoutProperty(layerId, name, value) {
+      record("setLayoutProperty", [layerId, name, value]);
+      const layer = layers.find((existing) => existing.id === layerId);
+      if (!layer) throw new Error(`Layer "${layerId}" does not exist.`);
+      layer.layout = { ...layer.layout, [name]: value };
+    },
+    getStyle() {
+      return { version: 8, sources: Object.fromEntries(sources), layers: layers.map((layer) => ({ ...layer })) };
+    },
+    visibility(layerId) {
+      const layer = layers.find((existing) => existing.id === layerId);
+      if (!layer) return "missing";
+      return (layer.layout?.visibility as string | undefined) ?? "visible";
+    },
+    layerOrder() {
+      return layers.map((layer) => layer.id);
+    },
+  };
+}
+
+/** Real-world shaped bases: pmtiles vector, raster imagery, vector+hillshade composite. */
+function makeBases(): HonuaBasemapDefinition[] {
+  const vectorSource = { type: "vector", url: "pmtiles://https://tiles.example/basemap.pmtiles" };
+  const streetsLayers = [
+    { id: "streets-land", type: "fill", source: "basemap-vec", "source-layer": "land" },
+    { id: "streets-roads", type: "line", source: "basemap-vec", "source-layer": "roads" },
+  ];
+  return [
+    {
+      id: "streets",
+      label: "Streets",
+      kind: "vector",
+      sources: { "basemap-vec": vectorSource },
+      layers: streetsLayers,
+    },
+    {
+      id: "imagery",
+      label: "Imagery",
+      kind: "raster",
+      sources: { imagery: { type: "raster", tiles: ["https://imagery.example/{z}/{x}/{y}.png"], tileSize: 256 } },
+      layers: [{ id: "imagery-tiles", type: "raster", source: "imagery" }],
+    },
+    {
+      id: "terrain",
+      label: "Terrain",
+      kind: "raster-dem-composite",
+      sources: {
+        "basemap-vec": vectorSource,
+        "terrain-dem": { type: "raster-dem", url: "pmtiles://https://tiles.example/terrain.pmtiles" },
+      },
+      layers: [...streetsLayers, { id: "terrain-hillshade", type: "hillshade", source: "terrain-dem" }],
+    },
+  ];
+}
+
+function makeElement(): {
+  element: HonuaBasemapSwitcherElement;
+  attributes: Map<string, string>;
+  events: CustomEvent<HonuaBasemapSwitcherChangeDetail>[];
+} {
+  const element = new HonuaBasemapSwitcherElement();
+  const attributes = new Map<string, string>();
+  const events: CustomEvent<HonuaBasemapSwitcherChangeDetail>[] = [];
+  Object.assign(element, {
+    getAttribute: (name: string) => attributes.get(name) ?? null,
+    setAttribute: (name: string, value: string) => {
+      attributes.set(name, value);
+    },
+    dispatchEvent: (event: Event) => {
+      events.push(event as CustomEvent<HonuaBasemapSwitcherChangeDetail>);
+      return true;
+    },
+  });
+  return { element, attributes, events };
+}
+
+describe("HonuaBasemapStyleBinding", () => {
+  test("activating a base adds only that base's sources and layers", () => {
+    const map = makeMockMap();
+    const binding = new HonuaBasemapStyleBinding();
+    binding.setMap(map);
+    binding.setBases(makeBases());
+
+    expect(binding.activate("streets")).toBe(true);
+
+    expect([...map._sources.keys()]).toEqual(["basemap-vec"]);
+    expect(map.layerOrder()).toEqual(["streets-land", "streets-roads"]);
+    expect(map.visibility("streets-land")).toBe("visible");
+    expect(map.visibility("imagery-tiles")).toBe("missing");
+  });
+
+  test("switching bases is exclusive: the new base shows and the others hide", () => {
+    const map = makeMockMap();
+    const binding = new HonuaBasemapStyleBinding();
+    binding.setMap(map);
+    binding.setBases(makeBases());
+
+    binding.activate("streets");
+    binding.activate("imagery");
+
+    expect(map.visibility("imagery-tiles")).toBe("visible");
+    expect(map.visibility("streets-land")).toBe("none");
+    expect(map.visibility("streets-roads")).toBe("none");
+    // Sources stay registered (cheap once layers are hidden), layers are reused.
+    expect([...map._sources.keys()]).toEqual(["basemap-vec", "imagery"]);
+
+    binding.activate("streets");
+    expect(map.visibility("streets-land")).toBe("visible");
+    expect(map.visibility("imagery-tiles")).toBe("none");
+    expect(
+      map._calls.filter((call) => call.method === "addLayer").map((call) => (call.args[0] as MockLayer).id),
+    ).toEqual(["streets-land", "streets-roads", "imagery-tiles"]);
+  });
+
+  test("composite base shows all of its layers together and shares layers with sibling bases", () => {
+    const map = makeMockMap();
+    const binding = new HonuaBasemapStyleBinding();
+    binding.setMap(map);
+    binding.setBases(makeBases());
+
+    binding.activate("terrain");
+    expect([...map._sources.keys()]).toEqual(["basemap-vec", "terrain-dem"]);
+    expect(map.layerOrder()).toEqual(["streets-land", "streets-roads", "terrain-hillshade"]);
+    expect(map.visibility("terrain-hillshade")).toBe("visible");
+    expect(map.visibility("streets-land")).toBe("visible");
+
+    // Switching to the plain vector base keeps the shared layers visible and
+    // only hides the hillshade half of the composite.
+    binding.activate("streets");
+    expect(map.visibility("streets-land")).toBe("visible");
+    expect(map.visibility("streets-roads")).toBe("visible");
+    expect(map.visibility("terrain-hillshade")).toBe("none");
+
+    binding.activate("terrain");
+    expect(map.visibility("terrain-hillshade")).toBe("visible");
+  });
+
+  test("base layers are inserted beneath layers the switcher does not own", () => {
+    const map = makeMockMap([
+      { id: "incident-halos", type: "circle", source: "incidents" },
+      { id: "incident-points", type: "circle", source: "incidents" },
+    ]);
+    const binding = new HonuaBasemapStyleBinding();
+    binding.setMap(map);
+    binding.setBases(makeBases());
+
+    binding.activate("terrain");
+    expect(map.layerOrder()).toEqual([
+      "streets-land",
+      "streets-roads",
+      "terrain-hillshade",
+      "incident-halos",
+      "incident-points",
+    ]);
+
+    binding.activate("imagery");
+    expect(map.layerOrder()).toEqual([
+      "streets-land",
+      "streets-roads",
+      "terrain-hillshade",
+      "imagery-tiles",
+      "incident-halos",
+      "incident-points",
+    ]);
+  });
+
+  test("activate returns false for unknown base ids and keeps the previous selection", () => {
+    const map = makeMockMap();
+    const binding = new HonuaBasemapStyleBinding();
+    binding.setMap(map);
+    binding.setBases(makeBases());
+
+    binding.activate("streets");
+    expect(binding.activate("nope")).toBe(false);
+    expect(binding.activeId).toBe("streets");
+    expect(map.visibility("streets-land")).toBe("visible");
+  });
+
+  test("selection made before a map is bound is applied when the map arrives", () => {
+    const binding = new HonuaBasemapStyleBinding();
+    binding.setBases(makeBases());
+    expect(binding.activate("imagery")).toBe(true);
+
+    const map = makeMockMap();
+    binding.setMap(map);
+    expect(map.visibility("imagery-tiles")).toBe("visible");
+    expect([...map._sources.keys()]).toEqual(["imagery"]);
+  });
+
+  test("unbinding the map removes every layer and source the binding added", () => {
+    const overlay: MockLayer = { id: "incident-points", type: "circle", source: "incidents" };
+    const map = makeMockMap([overlay]);
+    map._sources.set("incidents", { type: "geojson" });
+    const binding = new HonuaBasemapStyleBinding();
+    binding.setMap(map);
+    binding.setBases(makeBases());
+    binding.activate("terrain");
+
+    binding.setMap(undefined);
+    expect(map.layerOrder()).toEqual(["incident-points"]);
+    expect([...map._sources.keys()]).toEqual(["incidents"]);
+  });
+
+  test("setBases prunes layers and sources of removed bases but keeps shared ones", () => {
+    const map = makeMockMap();
+    const binding = new HonuaBasemapStyleBinding();
+    binding.setMap(map);
+    const bases = makeBases();
+    binding.setBases(bases);
+    binding.activate("terrain");
+    binding.activate("imagery");
+
+    // Drop the composite; its hillshade layer and dem source must be removed,
+    // while the shared vector source/layers (still used by "streets") remain.
+    binding.setBases(bases.filter((base) => base.id !== "terrain"));
+    expect(map.getLayer("terrain-hillshade")).toBeUndefined();
+    expect(map.getSource("terrain-dem")).toBeUndefined();
+    expect(map.getLayer("streets-land")).toBeDefined();
+    expect(map.getSource("basemap-vec")).toBeDefined();
+    expect(binding.activeId).toBe("imagery");
+  });
+
+  test("removing the active base clears the selection", () => {
+    const map = makeMockMap();
+    const binding = new HonuaBasemapStyleBinding();
+    binding.setMap(map);
+    const bases = makeBases();
+    binding.setBases(bases);
+    binding.activate("imagery");
+
+    binding.setBases(bases.filter((base) => base.id !== "imagery"));
+    expect(binding.activeId).toBeUndefined();
+    expect(map.getLayer("imagery-tiles")).toBeUndefined();
+  });
+});
+
+describe("HonuaBasemapSwitcherElement", () => {
+  test("is registered for browser registries via defineHonuaControls", () => {
+    const defined: Record<string, CustomElementConstructor> = {};
+    const registry = {
+      get: (name: string) => defined[name],
+      define: (name: string, ctor: CustomElementConstructor) => {
+        defined[name] = ctor;
+      },
+    } as unknown as CustomElementRegistry;
+    defineHonuaControls(registry);
+    expect(defined["honua-basemap-switcher"]).toBe(HonuaBasemapSwitcherElement);
+    // Idempotent: re-defining must not throw.
+    defineHonuaControls(registry);
+  });
+
+  test("select() switches exclusively and dispatches a change event with the active base id", () => {
+    const { element, events } = makeElement();
+    const map = makeMockMap();
+    element.connect(map);
+    element.bases = makeBases();
+
+    // Wiring auto-activates the first base.
+    expect(element.value).toBe("streets");
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe("change");
+    expect(events[0]?.detail).toEqual({ value: "streets", kind: "vector" });
+
+    expect(element.select("imagery")).toBe(true);
+    expect(map.visibility("imagery-tiles")).toBe("visible");
+    expect(map.visibility("streets-land")).toBe("none");
+    expect(events).toHaveLength(2);
+    expect(events[1]?.detail).toEqual({ value: "imagery", previousValue: "streets", kind: "raster" });
+    expect(events[1]?.bubbles).toBe(true);
+    expect(events[1]?.composed).toBe(true);
+  });
+
+  test("re-selecting the active base does not dispatch change", () => {
+    const { element, events } = makeElement();
+    element.connect(makeMockMap());
+    element.bases = makeBases();
+    const initialEvents = events.length;
+
+    expect(element.select(element.value as string)).toBe(true);
+    element.value = element.value;
+    expect(events).toHaveLength(initialEvents);
+  });
+
+  test("value assignments made before bases arrive are honored once they do", () => {
+    const { element, events } = makeElement();
+    element.value = "terrain";
+    expect(element.value).toBe("terrain");
+    expect(events).toHaveLength(0);
+
+    const map = makeMockMap();
+    element.connect(map);
+    element.bases = makeBases();
+
+    expect(element.value).toBe("terrain");
+    expect(map.visibility("terrain-hillshade")).toBe("visible");
+    expect(events).toHaveLength(1);
+    expect(events[0]?.detail.value).toBe("terrain");
+    expect(events[0]?.detail.kind).toBe("raster-dem-composite");
+  });
+
+  test("the value attribute drives the initial selection", () => {
+    const { element, attributes, events } = makeElement();
+    attributes.set("value", "imagery");
+    const map = makeMockMap();
+    element.connect(map);
+    element.bases = makeBases();
+
+    expect(element.value).toBe("imagery");
+    expect(map.visibility("imagery-tiles")).toBe("visible");
+    expect(events.map((event) => event.detail.value)).toEqual(["imagery"]);
+  });
+
+  test("selection is reflected to the value attribute", () => {
+    const { element, attributes } = makeElement();
+    element.connect(makeMockMap());
+    element.bases = makeBases();
+    element.select("terrain");
+    expect(attributes.get("value")).toBe("terrain");
+  });
+
+  test("bases attribute accepts JSON and ignores malformed input", () => {
+    const { element } = makeElement();
+    const map = makeMockMap();
+    element.connect(map);
+
+    element.attributeChangedCallback("bases", null, "not json");
+    expect(element.bases).toHaveLength(0);
+
+    element.attributeChangedCallback("bases", null, JSON.stringify(makeBases()));
+    expect(element.bases.map((base) => base.id)).toEqual(["streets", "imagery", "terrain"]);
+    expect(element.value).toBe("streets");
+    expect(map.visibility("streets-land")).toBe("visible");
+
+    element.attributeChangedCallback("value", "streets", "terrain");
+    expect(element.value).toBe("terrain");
+    expect(map.visibility("terrain-hillshade")).toBe("visible");
+  });
+
+  test("removing the active base falls back to the first remaining base", () => {
+    const { element, events } = makeElement();
+    const map = makeMockMap();
+    element.connect(map);
+    const bases = makeBases();
+    element.bases = bases;
+    element.select("imagery");
+
+    element.bases = bases.filter((base) => base.id !== "imagery");
+    expect(element.value).toBe("streets");
+    expect(map.getLayer("imagery-tiles")).toBeUndefined();
+    expect(map.visibility("streets-land")).toBe("visible");
+    expect(events.at(-1)?.detail.value).toBe("streets");
+  });
+
+  test("detaching the map removes the switcher's layers and reconnecting restores the selection", () => {
+    const { element } = makeElement();
+    const map = makeMockMap([{ id: "incident-points", type: "circle", source: "incidents" }]);
+    element.connect(map);
+    element.bases = makeBases();
+    element.select("terrain");
+
+    element.map = undefined;
+    expect(map.layerOrder()).toEqual(["incident-points"]);
+
+    const nextMap = makeMockMap();
+    element.connect(nextMap);
+    expect(element.value).toBe("terrain");
+    expect(nextMap.visibility("terrain-hillshade")).toBe("visible");
+  });
+});

--- a/test/playwright/web-components-basic.spec.mjs
+++ b/test/playwright/web-components-basic.spec.mjs
@@ -23,7 +23,11 @@ test("web components compose map, layers, legend, table, search, and editor stat
     await expect(page.locator("honua-editor").getByText("Source metadata marks incidents read-only.")).toBeVisible();
     await expect(page.locator("honua-editor button[data-action='save']")).toBeDisabled();
     await expect(page.locator("honua-chart").getByText("High")).toBeVisible();
-    await expect(page.locator("honua-basemap-control").getByRole("button", { name: "Dark basemap" })).toBeVisible();
+    await expect(page.locator("honua-basemap-switcher").getByRole("radio", { name: "Dark" })).toBeVisible();
+    await expect(page.locator("honua-basemap-switcher").getByRole("radio", { name: "Light" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
     await expect(page.locator("honua-bookmarks").getByRole("button", { name: "Home" })).toBeVisible();
     await expect(page.locator("honua-locate-control").getByRole("button", { name: "Use location" })).toBeVisible();
     await expect(page.locator("honua-measure-control").getByText("Measurement geometry is not available")).toBeVisible();
@@ -88,11 +92,32 @@ test("web components compose map, layers, legend, table, search, and editor stat
     await expect(page.locator("#event-log")).toHaveText("filter:incidents:kakaako");
     await expect(page.locator("honua-feature-table").getByText("Ala Moana shelter route")).toHaveCount(0);
 
-    await page.locator("honua-basemap-control").getByRole("button", { name: "Dark basemap" }).click();
-    await expect(page.locator("#event-log")).toHaveText("basemap:basemap-dark");
+    await page.locator("honua-basemap-switcher").getByRole("radio", { name: "Dark" }).click();
+    await expect(page.locator("#event-log")).toHaveText("basemap:dark");
     await expect
-      .poll(async () => page.evaluate(() => window.__HONUA_WEB_COMPONENTS_DEMO__?.mapLayerVisible("basemap-dark")))
+      .poll(async () => page.evaluate(() => window.__HONUA_WEB_COMPONENTS_DEMO__?.mapLayerVisible("base-dark")))
       .toBe(true);
+    await expect
+      .poll(async () => page.evaluate(() => window.__HONUA_WEB_COMPONENTS_DEMO__?.mapLayerVisible("base-light")))
+      .toBe(false);
+    await expect(page.locator("honua-basemap-switcher").getByRole("radio", { name: "Dark" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+
+    await page.locator("honua-basemap-switcher").getByRole("radio", { name: "Terrain" }).click();
+    await expect(page.locator("#event-log")).toHaveText("basemap:terrain");
+    await expect
+      .poll(async () => page.evaluate(() => window.__HONUA_WEB_COMPONENTS_DEMO__?.mapLayerVisible("base-terrain")))
+      .toBe(true);
+    await expect
+      .poll(async () =>
+        page.evaluate(() => window.__HONUA_WEB_COMPONENTS_DEMO__?.mapLayerVisible("base-terrain-contours")),
+      )
+      .toBe(true);
+    await expect
+      .poll(async () => page.evaluate(() => window.__HONUA_WEB_COMPONENTS_DEMO__?.mapLayerVisible("base-dark")))
+      .toBe(false);
 
     await page.locator("honua-bookmarks").getByRole("button", { name: "Harbor" }).click();
     await expect(page.locator("#event-log")).toHaveText("bookmark:harbor");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -85,6 +85,10 @@ export default defineConfig({
         replacement: path.resolve(import.meta.dirname, "src/contract/index.ts"),
       },
       {
+        find: "@honua/sdk-js/controls",
+        replacement: path.resolve(import.meta.dirname, "src/controls/index.ts"),
+      },
+      {
         find: "@honua/sdk-js/collaboration",
         replacement: path.resolve(import.meta.dirname, "src/collaboration/index.ts"),
       },


### PR DESCRIPTION
Part of #274 (basemap switcher only — layer list and legend follow in separate PRs).

## What

New optional entry **`@honua/sdk-js/controls`** — the native-lane UI control kit — with its first control, **`<honua-basemap-switcher>`**: a framework-free custom element that switches a MapLibre map between exclusive basemap definitions by manipulating the style directly (add sources/layers lazily on first activation, toggle `visibility` exclusively afterwards).

### Bundle independence

Same packaging posture as `esri-compat`: the entry imports nothing from `src/core`/`src/runtime` and has **no `maplibre-gl` import** — the map is duck-typed (`HonuaBasemapSwitcherMap`), so any MapLibre `Map` (or a test stub) works and the core bundle is untouched. Published as `@honua/sdk-js/controls` and `@honua/sdk/controls` (split package).

### Element API

- **Properties:** `map` (MapLibre `Map`), `bases` (`HonuaBasemapDefinition[]`: `{ id, label, kind: "vector" | "raster" | "raster-dem-composite", sources, layers }`), `value` (active base id)
- **Methods:** `connect(map)`, `select(baseId)`
- **Attributes:** `bases` (JSON), `value` (initial + programmatic, reflected), `for` (resolves `.map` from a sibling `<honua-map>` and listens for `honua-map-ready`), `label`
- **Events:** `change` — `CustomEvent<{ value, previousValue?, kind }>` (bubbles, composed)
- **CSS parts:** `group`, `radio`, `radio-active` (structural CSS only; no imposed theme)
- **A11y:** `radiogroup`/`radio` semantics, roving tabindex, Arrow/Home/End keyboard navigation

Composite bases (e.g. "Terrain" = vector base + raster-dem hillshade as ONE exclusive option) are first-class: a base is just a set of sources+layers; bases may share sources and layers (shared layers stay visible while either base is active). Base layers are always inserted beneath layers the switcher does not own, so overlays stay on top regardless of activation order. Protocol-agnostic: `pmtiles://`, raster tile URLs, MVT, inline GeoJSON.

The headless engine (`HonuaBasemapStyleBinding`) is exported for hosts that don't want a custom element.

## Demo wiring

`examples/web-components-basic` now drives basemaps through the SDK control instead of inline demo layers (Light / Dark / composite Terrain, themed via `::part()` in `styles.css`), and the Playwright smoke covers exclusive switching, the composite base, and `aria-checked` state. Also fixes the example mock-server's `npm.cmd` spawn on Windows (Node >= 20.12).

## Validation

- `test/controls/basemap-switcher.test.ts` — 18 unit tests against a stateful MapLibre map stub (exclusive switching, lazy adds, composite/shared layers, insertion order beneath overlays, pruning/detach, change events, value attribute/property semantics, registry idempotence)
- `npm run typecheck`, `npm run build`, `npm run lint` green; `biome check` clean on all changed files
- `npm test`: 2181 passed; the 30 failures on this Windows machine are pre-existing migration-CLI/kepler spawn-path issues (reproduced identically on pristine trunk)
- `demo:examples:typecheck` (all 19 demos) and `demo:web-components:build` green
- Playwright `web-components-basic` smoke: 2/2 passed locally
- Split packages: `build:split-packages` green; `@honua/sdk/controls` smoke-tested from the packed output (the `verify` harness itself cannot spawn npm on Windows — pre-existing; CI covers it)
