### PR TITLE
feat(controls): add native honua-legend control with style-derived entries

### DIFF
--- a/examples/web-components-basic/README.md
+++ b/examples/web-components-basic/README.md
@@ -13,6 +13,16 @@ Terrain option) are applied directly to the MapLibre map, wired declaratively
 via `for="ops-map"`, and themed from `styles.css` through the control's
 `::part(group)` / `::part(radio)` / `::part(radio-active)` hooks.
 
+The legend is `<honua-legend>` from the same controls entry (imported before
+`@honua/sdk-js/web-components`, so the controls element owns the tag). It
+combines explicit incident-priority entries with a section *derived* from the
+zoning fill layer's `match` expression on the `district` attribute — the map
+style is the single source of truth, so restyling the layer restyles the
+legend. `follow-layer-visibility` hides a section while its layer is toggled
+off in the layer list, and `auto-refresh` re-derives on the map's `styledata`
+events. Themed via `::part(root)` / `::part(section-title)` / `::part(row)` /
+`::part(swatch)`.
+
 ```bash
 npm run demo:web-components
 ```

--- a/examples/web-components-basic/index.html
+++ b/examples/web-components-basic/index.html
@@ -13,13 +13,23 @@
         <div class="side-panel">
           <honua-search for="ops-map" source="incidents" placeholder="Find incidents"></honua-search>
           <honua-basemap-switcher for="ops-map" label="Basemaps" value="light"></honua-basemap-switcher>
+          <!-- Controls-entry legend (registered first, so it owns the honua-legend
+               tag here): explicit incident entries plus a section derived from the
+               zoning layer's match expression. -->
+          <honua-legend
+            for="ops-map"
+            heading="Legend"
+            layer="zoning-districts"
+            layer-title="Zoning districts"
+            follow-layer-visibility
+            auto-refresh
+          ></honua-legend>
           <honua-bookmarks
             for="ops-map"
             bookmarks='[{"id":"harbor","label":"Harbor","viewport":{"center":[-157.87,21.31],"zoom":13}},{"id":"kakaako","label":"Kakaako","viewport":{"center":[-157.86,21.29],"zoom":13}}]'
           ></honua-bookmarks>
           <honua-locate-control for="ops-map" latitude="21.3" longitude="-157.86" zoom="12"></honua-locate-control>
           <honua-layer-list for="ops-map"></honua-layer-list>
-          <honua-legend for="ops-map"></honua-legend>
         </div>
       </section>
       <section class="bottom-panel">

--- a/examples/web-components-basic/src/main.ts
+++ b/examples/web-components-basic/src/main.ts
@@ -1,11 +1,14 @@
 import "maplibre-gl/dist/maplibre-gl.css";
 
-// Side-effect import registers <honua-basemap-switcher>.
+// Side-effect import registers <honua-basemap-switcher> and <honua-legend>.
+// It runs before the web-components import below, so the controls-entry
+// legend (map-driven, derive mode) owns the honua-legend tag in this demo.
 import "@honua/sdk-js/controls";
 import type {
   HonuaBasemapDefinition,
   HonuaBasemapSwitcherChangeDetail,
   HonuaBasemapSwitcherElement,
+  HonuaLegendElement,
 } from "@honua/sdk-js/controls";
 import {
   type HonuaChartModel,
@@ -29,6 +32,46 @@ declare global {
 }
 
 const INCIDENT_SOURCE_ID = "incidents";
+const ZONING_SOURCE_ID = "zoning";
+
+// Categorical zoning districts. The fill layer styles them with a MapLibre
+// match expression on the "district" attribute, and <honua-legend> derives
+// its swatch rows from that same expression — one source of truth, so map
+// and legend cannot drift.
+function zoningPolygon(district: string, ring: [number, number][]) {
+  return {
+    type: "Feature",
+    properties: { district },
+    geometry: { type: "Polygon", coordinates: [ring] },
+  };
+}
+
+const zoningGeoJson = {
+  type: "FeatureCollection",
+  features: [
+    zoningPolygon("Residential", [
+      [-157.88, 21.305],
+      [-157.862, 21.305],
+      [-157.862, 21.32],
+      [-157.88, 21.32],
+      [-157.88, 21.305],
+    ]),
+    zoningPolygon("Business", [
+      [-157.862, 21.29],
+      [-157.845, 21.29],
+      [-157.845, 21.305],
+      [-157.862, 21.305],
+      [-157.862, 21.29],
+    ]),
+    zoningPolygon("Open-Park", [
+      [-157.845, 21.285],
+      [-157.83, 21.285],
+      [-157.83, 21.3],
+      [-157.845, 21.3],
+      [-157.845, 21.285],
+    ]),
+  ],
+};
 
 const features: HonuaFeatureRecord[] = [
   {
@@ -102,8 +145,39 @@ const controller = createHonuaWebComponentController({
           type: "geojson",
           data: incidentGeoJson,
         },
+        [ZONING_SOURCE_ID]: {
+          type: "geojson",
+          data: zoningGeoJson,
+        },
       },
       layers: [
+        {
+          id: "zoning-districts",
+          source: ZONING_SOURCE_ID,
+          type: "fill",
+          metadata: { title: "Zoning districts" },
+          paint: {
+            "fill-color": [
+              "match",
+              ["get", "district"],
+              "Residential",
+              "#facc15",
+              "Agricultural",
+              "#84cc16",
+              "Business",
+              "#ef4444",
+              "Industrial",
+              "#a855f7",
+              "Hotel",
+              "#fb923c",
+              "Open-Park",
+              "#22c55e",
+              "#cbd5e1",
+            ],
+            "fill-opacity": 0.35,
+            "fill-outline-color": "#475569",
+          },
+        },
         {
           id: "incident-halos",
           source: INCIDENT_SOURCE_ID,
@@ -322,6 +396,25 @@ basemapSwitcher.addEventListener("change", (event) => {
 // The element also self-wires from for="ops-map" + the honua-map-ready event;
 // assigning the bases is the only imperative step the host performs.
 basemapSwitcher.bases = demoBasemaps;
+
+// <honua-legend> combines explicit entries (the incident symbology below)
+// with a section derived from the zoning layer's match expression (layer=
+// "zoning-districts" in the markup). follow-layer-visibility hides the
+// zoning section while the layer is toggled off in the layer list, and
+// auto-refresh re-derives on the map's styledata events.
+const legend = document.querySelector("honua-legend") as HonuaLegendElement | null;
+if (!legend) throw new Error("Missing honua-legend");
+legend.entries = [
+  {
+    title: "Incident priority",
+    layer: "incident-points",
+    entries: [
+      { label: "High priority", color: "#dc2626", shape: "circle" },
+      { label: "Medium priority", color: "#d97706", shape: "circle" },
+      { label: "Low priority", color: "#16a34a", shape: "circle" },
+    ],
+  },
+];
 
 document.addEventListener("honua-bookmark-change", (event) => {
   const detail = (event as CustomEvent<{ id: string }>).detail;

--- a/examples/web-components-basic/src/styles.css
+++ b/examples/web-components-basic/src/styles.css
@@ -60,6 +60,36 @@ honua-basemap-switcher::part(radio-active) {
   color: #ffffff;
 }
 
+/* The legend also ships structural CSS only; theme it via ::part(). */
+honua-legend::part(root) {
+  background: #ffffff;
+  border: 1px solid #d0d7e2;
+  border-radius: 8px;
+  display: grid;
+  gap: 8px;
+  padding: 10px 12px;
+}
+
+honua-legend::part(heading) {
+  font-weight: 600;
+}
+
+honua-legend::part(section-title) {
+  color: #475467;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+honua-legend::part(row) {
+  font-size: 14px;
+  padding: 2px 0;
+}
+
+honua-legend::part(swatch) {
+  border-radius: 2px;
+}
+
 @media (max-width: 820px) {
   .workspace,
   .bottom-panel {

--- a/scripts/verify-split-packages.mjs
+++ b/scripts/verify-split-packages.mjs
@@ -130,7 +130,9 @@ import { defineHonuaWebComponents } from "@honua/sdk/web-components";
 import {
   HonuaBasemapStyleBinding,
   HonuaBasemapSwitcherElement,
+  HonuaLegendElement,
   defineHonuaControls,
+  deriveLegendEntries,
 } from "@honua/sdk/controls";
 import { projectBuildSpecToGeneratedAppManifest } from "@honua/sdk/generated-app";
 import { chartWidgetToVegaLiteSpec, isVegaLiteSpec, projectMapPackage } from "@honua/sdk/console";
@@ -324,6 +326,22 @@ if (typeof HonuaBasemapStyleBinding !== "function")
   ]);
   if (!bindingSmoke.activate("light") || bindingSmoke.activeId !== "light")
     throw new Error("@honua/sdk/controls HonuaBasemapStyleBinding failed to activate a base");
+}
+if (typeof HonuaLegendElement !== "function")
+  throw new Error("HonuaLegendElement export missing from @honua/sdk/controls");
+if (typeof deriveLegendEntries !== "function")
+  throw new Error("deriveLegendEntries export missing from @honua/sdk/controls");
+{
+  const legendSmoke = deriveLegendEntries(
+    {
+      getLayer: () => ({ type: "fill" }),
+      getPaintProperty: (_layerId, name) =>
+        name === "fill-color" ? ["match", ["get", "district"], "Residential", "#facc15", "#cbd5e1"] : undefined,
+    },
+    "zoning-districts",
+  );
+  if (legendSmoke.length !== 2 || legendSmoke[0].label !== "Residential" || legendSmoke[1].label !== "Other")
+    throw new Error("@honua/sdk/controls deriveLegendEntries failed to parse a match expression");
 }
 if (typeof projectBuildSpecToGeneratedAppManifest !== "function")
   throw new Error("projectBuildSpecToGeneratedAppManifest export missing from @honua/sdk/generated-app");

--- a/src/controls/basemap-switcher.ts
+++ b/src/controls/basemap-switcher.ts
@@ -40,20 +40,21 @@
  */
 
 import { HonuaBasemapStyleBinding } from "./basemap-style-binding.js";
+import {
+  HTMLElementBase,
+  escapeAttribute,
+  escapeHtml,
+  globalDom,
+  listenForHonuaMapReady,
+  resolveHonuaMapFromContext,
+} from "./element-utils.js";
+import { HonuaLegendElement } from "./legend.js";
 import type {
   HonuaBasemapDefinition,
   HonuaBasemapKind,
   HonuaBasemapSwitcherChangeDetail,
   HonuaBasemapSwitcherMap,
 } from "./types.js";
-
-const globalDom = globalThis as typeof globalThis & {
-  HTMLElement?: typeof HTMLElement;
-  CustomEvent?: typeof CustomEvent;
-  customElements?: CustomElementRegistry;
-};
-
-const HTMLElementBase: typeof HTMLElement = globalDom.HTMLElement ?? (class {} as unknown as typeof HTMLElement);
 
 /**
  * Custom element implementing the exclusive basemap switcher. Registered as
@@ -67,7 +68,7 @@ export class HonuaBasemapSwitcherElement extends HTMLElementBase {
 
   readonly #binding = new HonuaBasemapStyleBinding();
   #requestedValue: string | undefined;
-  #mapReadyListener: ((event: Event) => void) | undefined;
+  #disposeMapReadyListener: (() => void) | undefined;
   #rendered = false;
 
   /**
@@ -176,10 +177,8 @@ export class HonuaBasemapSwitcherElement extends HTMLElementBase {
   }
 
   public disconnectedCallback(): void {
-    if (this.#mapReadyListener) {
-      this.#rootEventTarget()?.removeEventListener("honua-map-ready", this.#mapReadyListener);
-      this.#mapReadyListener = undefined;
-    }
+    this.#disposeMapReadyListener?.();
+    this.#disposeMapReadyListener = undefined;
   }
 
   /**
@@ -200,39 +199,18 @@ export class HonuaBasemapSwitcherElement extends HTMLElementBase {
   // ── map wiring (matches the web-components `for` + ready-event idiom) ──
 
   #listenForMapReady(): void {
-    if (this.#mapReadyListener) return;
-    const target = this.#rootEventTarget();
-    if (!target) return;
-    this.#mapReadyListener = (event: Event) => {
-      const detail = (event as CustomEvent<{ map?: unknown }>).detail;
-      if (!detail?.map) return;
-      const forId = this.getAttribute("for");
-      if (forId && (event.target as Element | null)?.id !== forId) return;
+    if (this.#disposeMapReadyListener) return;
+    this.#disposeMapReadyListener = listenForHonuaMapReady(this, (map) => {
+      const forId = typeof this.getAttribute === "function" ? this.getAttribute("for") : null;
       if (!forId && this.map) return;
-      this.map = detail.map as HonuaBasemapSwitcherMap;
-    };
-    target.addEventListener("honua-map-ready", this.#mapReadyListener as EventListener);
+      this.map = map as HonuaBasemapSwitcherMap;
+    });
   }
 
   #resolveMapFromContext(): void {
-    if (this.map || typeof this.getAttribute !== "function") return;
-    const forId = this.getAttribute("for");
-    if (!forId) return;
-    const root = this.getRootNode?.() as (Document | ShadowRoot) | undefined;
-    const host =
-      root && "getElementById" in root
-        ? root.getElementById(forId)
-        : typeof document !== "undefined"
-          ? document.getElementById(forId)
-          : null;
-    const map = (host as { map?: unknown } | null)?.map;
+    if (this.map) return;
+    const map = resolveHonuaMapFromContext(this);
     if (map) this.map = map as HonuaBasemapSwitcherMap;
-  }
-
-  #rootEventTarget(): EventTarget | undefined {
-    const root = this.getRootNode?.();
-    if (root && "addEventListener" in root) return root as EventTarget;
-    return typeof document !== "undefined" ? document : undefined;
   }
 
   // ── rendering ──────────────────────────────────────────────
@@ -355,14 +333,22 @@ export class HonuaBasemapSwitcherElement extends HTMLElementBase {
 }
 
 /**
- * Registers the controls-entry custom elements (`honua-basemap-switcher`).
- * Invoked automatically on import when a global `customElements` registry is
- * present; call explicitly when using a scoped registry.
+ * Registers the controls-entry custom elements (`honua-basemap-switcher`,
+ * `honua-legend`). Invoked automatically on import when a global
+ * `customElements` registry is present; call explicitly when using a scoped
+ * registry.
+ *
+ * Registrations are skipped for tag names that are already defined. In
+ * particular the `web-components` entry registers its own (controller-driven)
+ * `honua-legend`; whichever entry is imported first owns that tag.
  */
 export function defineHonuaControls(registry = globalDom.customElements): void {
   if (!registry) return;
   if (!registry.get("honua-basemap-switcher")) {
     registry.define("honua-basemap-switcher", HonuaBasemapSwitcherElement);
+  }
+  if (!registry.get("honua-legend")) {
+    registry.define("honua-legend", HonuaLegendElement);
   }
 }
 
@@ -407,17 +393,4 @@ function structuralStyles(): string {
     .group { display: inline-flex; flex-wrap: wrap; }
     .radio { font: inherit; cursor: pointer; }
   `;
-}
-
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-}
-
-function escapeAttribute(value: string): string {
-  return escapeHtml(value);
 }

--- a/src/controls/element-utils.ts
+++ b/src/controls/element-utils.ts
@@ -1,0 +1,95 @@
+/**
+ * Internal helpers shared by the controls-entry custom elements.
+ *
+ * Controls never import `maplibre-gl` or the SDK core, and they must load
+ * safely under Node (no DOM): `globalDom` exposes the optional browser
+ * globals, and `HTMLElementBase` substitutes an empty class when
+ * `HTMLElement` is unavailable so element classes can still be unit-tested
+ * headlessly.
+ *
+ * The map-wiring helpers implement the `for="<honua-map id>"` idiom shared by
+ * every control: resolve the map from a sibling element exposing a `.map`
+ * property, and listen for the `honua-map-ready` event (matching the
+ * `web-components` entry).
+ *
+ * @module
+ */
+
+export const globalDom = globalThis as typeof globalThis & {
+  HTMLElement?: typeof HTMLElement;
+  CustomEvent?: typeof CustomEvent;
+  customElements?: CustomElementRegistry;
+};
+
+export const HTMLElementBase: typeof HTMLElement = globalDom.HTMLElement ?? (class {} as unknown as typeof HTMLElement);
+
+/**
+ * Minimal element surface required by the wiring helpers. Real elements
+ * always satisfy it; headless test stubs only need `getAttribute`.
+ */
+export interface HostElementLike {
+  getAttribute?(name: string): string | null;
+  getRootNode?(): Node;
+}
+
+/** Event target used for `honua-map-ready` listening: the element's root (document or shadow root), falling back to `document`. */
+export function rootEventTarget(element: HostElementLike): EventTarget | undefined {
+  const root = element.getRootNode?.();
+  if (root && "addEventListener" in root) return root as EventTarget;
+  return typeof document !== "undefined" ? document : undefined;
+}
+
+/**
+ * Subscribes to `honua-map-ready` events on the element's root and invokes
+ * `assign` with the announced map. When the element has a `for` attribute,
+ * only events from the element with that id are honored. Returns a dispose
+ * function, or `undefined` when no event target exists (e.g. under Node).
+ */
+export function listenForHonuaMapReady(
+  element: HostElementLike,
+  assign: (map: unknown) => void,
+): (() => void) | undefined {
+  const target = rootEventTarget(element);
+  if (!target) return undefined;
+  const listener = (event: Event) => {
+    const detail = (event as CustomEvent<{ map?: unknown }>).detail;
+    if (!detail?.map) return;
+    const forId = typeof element.getAttribute === "function" ? element.getAttribute("for") : null;
+    if (forId && (event.target as Element | null)?.id !== forId) return;
+    assign(detail.map);
+  };
+  target.addEventListener("honua-map-ready", listener as EventListener);
+  return () => target.removeEventListener("honua-map-ready", listener as EventListener);
+}
+
+/**
+ * Resolves the map from the element referenced by the `for` attribute (an
+ * element exposing a `.map` property, e.g. `<honua-map>`), or `undefined`
+ * when the attribute is absent or the host has no map yet.
+ */
+export function resolveHonuaMapFromContext(element: HostElementLike): unknown {
+  if (typeof element.getAttribute !== "function") return undefined;
+  const forId = element.getAttribute("for");
+  if (!forId) return undefined;
+  const root = element.getRootNode?.() as (Document | ShadowRoot) | undefined;
+  const host =
+    root && "getElementById" in root
+      ? root.getElementById(forId)
+      : typeof document !== "undefined"
+        ? document.getElementById(forId)
+        : null;
+  return (host as { map?: unknown } | null)?.map;
+}
+
+export function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export function escapeAttribute(value: string): string {
+  return escapeHtml(value);
+}

--- a/src/controls/index.ts
+++ b/src/controls/index.ts
@@ -1,8 +1,8 @@
 /**
  * Native Honua UI control kit (`@honua/sdk-js/controls`) — optional,
  * framework-free custom elements for apps built on the native lane
- * (HonuaClient + MapLibre). Tracked by issue #274; the basemap switcher is
- * the first control, with a layer list and legend to follow.
+ * (HonuaClient + MapLibre). Tracked by issue #274; ships the basemap
+ * switcher and the legend, with a layer list to follow.
  *
  * This entry is intentionally independent of the SDK core bundle (the same
  * posture as `@honua/sdk-js/esri-compat`): it imports nothing from
@@ -22,10 +22,18 @@ import "./basemap-switcher.js";
 
 export { HonuaBasemapStyleBinding } from "./basemap-style-binding.js";
 export { HonuaBasemapSwitcherElement, defineHonuaControls } from "./basemap-switcher.js";
+export { HonuaLegendDeriveError, deriveLegendEntries } from "./legend-derive.js";
+export type { HonuaLegendDeriveErrorCode } from "./legend-derive.js";
+export { HonuaLegendElement } from "./legend.js";
 export type {
   HonuaBasemapDefinition,
   HonuaBasemapKind,
   HonuaBasemapLayerSpecification,
   HonuaBasemapSwitcherChangeDetail,
   HonuaBasemapSwitcherMap,
+  HonuaLegendEntry,
+  HonuaLegendMap,
+  HonuaLegendSection,
+  HonuaLegendSwatchColor,
+  HonuaLegendSwatchShape,
 } from "./types.js";

--- a/src/controls/legend-derive.ts
+++ b/src/controls/legend-derive.ts
@@ -1,0 +1,286 @@
+/**
+ * Derive-mode engine behind `<honua-legend>`: parses a style layer's
+ * categorical color paint expression into legend entries, so the map style
+ * stays the single source of truth and the legend cannot drift from it.
+ *
+ * ## Supported expression shapes
+ *
+ * The color paint property of the layer (`fill-color`, `line-color`, or
+ * `circle-color` depending on the layer type) may be:
+ *
+ * 1. A literal CSS color string — yields a single entry labeled with the
+ *    layer id.
+ * 2. `["match", ["get", <attr>], in1, color1, ..., fallbackColor]` — the
+ *    primary categorical shape. Branch inputs may be strings, numbers, or
+ *    arrays thereof (an array branch becomes one row labeled with the values
+ *    joined by `", "`). Every output, including the fallback, must be a
+ *    literal color string; the fallback becomes a row labeled `"Other"`.
+ * 3. `["case", ["==", ["get", <attr>], <literal>], color1, ..., fallback]` —
+ *    simple equality chains only; each condition labels its row with the
+ *    compared literal, and the fallback becomes `"Other"`.
+ * 4. `["step", ["get", <attr>], color0, stop1, color1, ...]` — numeric breaks
+ *    on a feature attribute, labeled `"< stop1"`, `"stop1–stop2"`, ...,
+ *    `"≥ stopN"`.
+ *
+ * Anything else — `interpolate`, zoom- or feature-state-driven expressions,
+ * non-literal color outputs, nested expressions, unsupported layer types —
+ * throws {@link HonuaLegendDeriveError} with a `code` describing the failure,
+ * so callers can fall back gracefully instead of rendering a wrong legend.
+ *
+ * For `fill` layers, a literal `fill-outline-color` is propagated to every
+ * derived entry as the swatch outline.
+ *
+ * @module
+ */
+
+import type { HonuaLegendEntry, HonuaLegendMap, HonuaLegendSwatchShape } from "./types.js";
+
+/** Machine-readable reason a legend could not be derived. */
+export type HonuaLegendDeriveErrorCode =
+  | "layer-not-found"
+  | "unsupported-layer-type"
+  | "missing-paint"
+  | "unsupported-expression";
+
+/** Thrown by {@link deriveLegendEntries} when a legend cannot be derived. */
+export class HonuaLegendDeriveError extends Error {
+  public override readonly name = "HonuaLegendDeriveError";
+  /** Why derivation failed; `"layer-not-found"` is often transient (layer not added yet). */
+  public readonly code: HonuaLegendDeriveErrorCode;
+
+  public constructor(code: HonuaLegendDeriveErrorCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+const PAINT_BY_LAYER_TYPE: Record<string, { property: string; shape: HonuaLegendSwatchShape }> = {
+  fill: { property: "fill-color", shape: "fill" },
+  line: { property: "line-color", shape: "line" },
+  circle: { property: "circle-color", shape: "circle" },
+};
+
+/** Label given to the `match`/`case` fallback branch. */
+export const HONUA_LEGEND_FALLBACK_LABEL = "Other";
+
+/**
+ * Derives legend entries from the categorical color expression of the given
+ * style layer. See the module docs for the supported expression shapes;
+ * throws {@link HonuaLegendDeriveError} on anything else.
+ */
+export function deriveLegendEntries(map: HonuaLegendMap, layerId: string): HonuaLegendEntry[] {
+  const layer = typeof map.getLayer === "function" ? map.getLayer(layerId) : undefined;
+  if (!layer || typeof layer !== "object") {
+    throw new HonuaLegendDeriveError("layer-not-found", `Layer "${layerId}" does not exist on the map.`);
+  }
+  const layerType = (layer as { type?: unknown }).type;
+  const mapping = typeof layerType === "string" ? PAINT_BY_LAYER_TYPE[layerType] : undefined;
+  if (!mapping) {
+    throw new HonuaLegendDeriveError(
+      "unsupported-layer-type",
+      `Cannot derive a legend for layer "${layerId}" of type "${String(layerType)}"; supported types: fill, line, circle.`,
+    );
+  }
+  const value = readPaintProperty(map, layer, layerId, mapping.property);
+  if (value === undefined || value === null) {
+    throw new HonuaLegendDeriveError(
+      "missing-paint",
+      `Layer "${layerId}" has no "${mapping.property}" paint value to derive a legend from.`,
+    );
+  }
+  const outline =
+    mapping.shape === "fill" ? literalColor(readPaintProperty(map, layer, layerId, "fill-outline-color")) : undefined;
+  return colorValueToEntries(value, layerId, mapping.shape, outline);
+}
+
+function readPaintProperty(map: HonuaLegendMap, layer: object, layerId: string, name: string): unknown {
+  if (typeof map.getPaintProperty === "function") {
+    const value = map.getPaintProperty(layerId, name);
+    if (value !== undefined) return value;
+  }
+  const paint = (layer as { paint?: unknown }).paint;
+  if (typeof paint === "object" && paint !== null) return (paint as Record<string, unknown>)[name];
+  return undefined;
+}
+
+function colorValueToEntries(
+  value: unknown,
+  layerId: string,
+  shape: HonuaLegendSwatchShape,
+  outline: string | undefined,
+): HonuaLegendEntry[] {
+  if (typeof value === "string") return [makeEntry(layerId, value, shape, outline)];
+  if (Array.isArray(value)) {
+    const operator = value[0];
+    if (operator === "match") return matchToEntries(value, layerId, shape, outline);
+    if (operator === "case") return caseToEntries(value, layerId, shape, outline);
+    if (operator === "step") return stepToEntries(value, layerId, shape, outline);
+    throw new HonuaLegendDeriveError(
+      "unsupported-expression",
+      `Layer "${layerId}": unsupported color expression operator "${String(operator)}"; supported: literal color, match, case, step.`,
+    );
+  }
+  throw new HonuaLegendDeriveError(
+    "unsupported-expression",
+    `Layer "${layerId}": color paint value must be a literal color string or a match/case/step expression.`,
+  );
+}
+
+function matchToEntries(
+  expression: readonly unknown[],
+  layerId: string,
+  shape: HonuaLegendSwatchShape,
+  outline: string | undefined,
+): HonuaLegendEntry[] {
+  requireGetInput(expression[1], layerId, "match");
+  const body = expression.slice(2);
+  if (body.length < 3 || body.length % 2 === 0) {
+    throw new HonuaLegendDeriveError(
+      "unsupported-expression",
+      `Layer "${layerId}": match expression must have branch input/output pairs plus a fallback color.`,
+    );
+  }
+  const entries: HonuaLegendEntry[] = [];
+  for (let index = 0; index < body.length - 1; index += 2) {
+    const label = matchBranchLabel(body[index], layerId);
+    const color = requireLiteralColor(body[index + 1], layerId);
+    entries.push(makeEntry(label, color, shape, outline));
+  }
+  entries.push(
+    makeEntry(HONUA_LEGEND_FALLBACK_LABEL, requireLiteralColor(body[body.length - 1], layerId), shape, outline),
+  );
+  return entries;
+}
+
+function matchBranchLabel(input: unknown, layerId: string): string {
+  if (typeof input === "string" || typeof input === "number") return String(input);
+  if (
+    Array.isArray(input) &&
+    input.length > 0 &&
+    input.every((item) => typeof item === "string" || typeof item === "number")
+  ) {
+    return input.map((item) => String(item)).join(", ");
+  }
+  throw new HonuaLegendDeriveError(
+    "unsupported-expression",
+    `Layer "${layerId}": match branch inputs must be strings, numbers, or arrays of them.`,
+  );
+}
+
+function caseToEntries(
+  expression: readonly unknown[],
+  layerId: string,
+  shape: HonuaLegendSwatchShape,
+  outline: string | undefined,
+): HonuaLegendEntry[] {
+  const body = expression.slice(1);
+  if (body.length < 3 || body.length % 2 === 0) {
+    throw new HonuaLegendDeriveError(
+      "unsupported-expression",
+      `Layer "${layerId}": case expression must have condition/output pairs plus a fallback color.`,
+    );
+  }
+  const entries: HonuaLegendEntry[] = [];
+  for (let index = 0; index < body.length - 1; index += 2) {
+    const label = caseConditionLabel(body[index], layerId);
+    const color = requireLiteralColor(body[index + 1], layerId);
+    entries.push(makeEntry(label, color, shape, outline));
+  }
+  entries.push(
+    makeEntry(HONUA_LEGEND_FALLBACK_LABEL, requireLiteralColor(body[body.length - 1], layerId), shape, outline),
+  );
+  return entries;
+}
+
+function caseConditionLabel(condition: unknown, layerId: string): string {
+  if (Array.isArray(condition) && condition.length === 3 && condition[0] === "==") {
+    const compared = condition[2];
+    if (
+      isGetExpression(condition[1]) &&
+      (typeof compared === "string" || typeof compared === "number" || typeof compared === "boolean")
+    ) {
+      return String(compared);
+    }
+  }
+  throw new HonuaLegendDeriveError(
+    "unsupported-expression",
+    `Layer "${layerId}": case conditions must be simple equalities ["==", ["get", <attribute>], <literal>].`,
+  );
+}
+
+function stepToEntries(
+  expression: readonly unknown[],
+  layerId: string,
+  shape: HonuaLegendSwatchShape,
+  outline: string | undefined,
+): HonuaLegendEntry[] {
+  requireGetInput(expression[1], layerId, "step");
+  const body = expression.slice(2);
+  if (body.length < 3 || body.length % 2 === 0) {
+    throw new HonuaLegendDeriveError(
+      "unsupported-expression",
+      `Layer "${layerId}": step expression must have a base color plus stop/color pairs.`,
+    );
+  }
+  const stops: number[] = [];
+  const colors: string[] = [requireLiteralColor(body[0], layerId)];
+  for (let index = 1; index < body.length; index += 2) {
+    const stop = body[index];
+    if (typeof stop !== "number") {
+      throw new HonuaLegendDeriveError(
+        "unsupported-expression",
+        `Layer "${layerId}": step stops must be numeric literals.`,
+      );
+    }
+    stops.push(stop);
+    colors.push(requireLiteralColor(body[index + 1], layerId));
+  }
+  return colors.map((color, index) => {
+    const lower = index === 0 ? undefined : stops[index - 1];
+    const upper = index < stops.length ? stops[index] : undefined;
+    const label =
+      lower === undefined
+        ? `< ${String(upper)}`
+        : upper === undefined
+          ? `≥ ${String(lower)}`
+          : `${String(lower)}–${String(upper)}`;
+    return makeEntry(label, color, shape, outline);
+  });
+}
+
+function requireGetInput(input: unknown, layerId: string, operator: string): void {
+  if (!isGetExpression(input)) {
+    throw new HonuaLegendDeriveError(
+      "unsupported-expression",
+      `Layer "${layerId}": ${operator} input must be a ["get", <attribute>] expression on a feature attribute.`,
+    );
+  }
+}
+
+function isGetExpression(value: unknown): boolean {
+  return Array.isArray(value) && value[0] === "get" && typeof value[1] === "string";
+}
+
+function requireLiteralColor(value: unknown, layerId: string): string {
+  const color = literalColor(value);
+  if (color === undefined) {
+    throw new HonuaLegendDeriveError(
+      "unsupported-expression",
+      `Layer "${layerId}": expression outputs must be literal color strings; got ${JSON.stringify(value)}.`,
+    );
+  }
+  return color;
+}
+
+function literalColor(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function makeEntry(
+  label: string,
+  fill: string,
+  shape: HonuaLegendSwatchShape,
+  outline: string | undefined,
+): HonuaLegendEntry {
+  return { label, color: outline === undefined ? fill : { fill, outline }, shape };
+}

--- a/src/controls/legend.ts
+++ b/src/controls/legend.ts
@@ -1,0 +1,411 @@
+/**
+ * `<honua-legend>` — framework-free custom element rendering swatch+label
+ * rows from the same definitions the map uses (issue #274), so the map and
+ * its legend cannot drift apart.
+ *
+ * ## Input modes
+ * - **Explicit entries** — assign the `entries` property a flat
+ *   {@link HonuaLegendEntry} array (rendered as one untitled section) and/or
+ *   {@link HonuaLegendSection} groups with optional titles.
+ * - **Derive mode** (the headline) — set the `layer` attribute to a style
+ *   layer id; the element parses the layer's categorical color paint
+ *   expression into entries via {@link deriveLegendEntries}. See
+ *   `legend-derive.ts` for the supported expression shapes (literal color,
+ *   `match` on a `["get", <attr>]` input, simple-equality `case`, numeric
+ *   `step`); anything else fails gracefully — the element keeps rendering
+ *   its explicit sections and exposes the failure on `deriveError`.
+ *   Both modes compose: explicit sections render first, then the derived
+ *   section.
+ *
+ * ## Wiring
+ * - `element.map = map` (any MapLibre `Map`) or `element.connect(map)`;
+ * - declaratively via `for="<honua-map id>"` — same idiom as
+ *   `<honua-basemap-switcher>` (resolves `.map` from the referenced element
+ *   and listens for `honua-map-ready`).
+ *
+ * ## Reactivity
+ * - `refresh()` re-derives and re-renders on demand;
+ * - with the `auto-refresh` attribute, the element subscribes to the map's
+ *   `styledata` event while connected and refreshes automatically (style
+ *   edits, layers added later, visibility toggles).
+ *
+ * ## Attributes
+ * - `for` — id of the map-providing element.
+ * - `layer` — style layer id to derive entries from.
+ * - `layer-title` — optional title rendered above the derived section.
+ * - `heading` — optional heading rendered above the whole legend.
+ * - `follow-layer-visibility` — boolean; hide a section while its source
+ *   layer's `visibility` layout property is `"none"` (sections carry the
+ *   derived `layer` id or their own `layer` field).
+ * - `auto-refresh` — boolean; see Reactivity.
+ *
+ * ## CSS parts
+ * `root`, `heading`, `section`, `section-title`, `row`, `swatch`, `label`.
+ * Structural CSS only — theme via `::part()`.
+ *
+ * ## Accessibility
+ * Rows are real list items (`<ul>`/`<li>`); swatches are `aria-hidden`
+ * presentation, with the text labels carrying the meaning.
+ *
+ * Note: the `web-components` entry also registers a (controller-driven)
+ * `honua-legend` element. Both registrations are guarded with an if-missing
+ * check, so whichever entry is imported first owns the tag; import
+ * `@honua/sdk-js/controls` first to use this element.
+ */
+
+import {
+  HTMLElementBase,
+  escapeAttribute,
+  escapeHtml,
+  listenForHonuaMapReady,
+  resolveHonuaMapFromContext,
+} from "./element-utils.js";
+import { HonuaLegendDeriveError, deriveLegendEntries } from "./legend-derive.js";
+import type { HonuaLegendEntry, HonuaLegendMap, HonuaLegendSection, HonuaLegendSwatchShape } from "./types.js";
+
+/**
+ * Custom element implementing the legend. Registered as `honua-legend` by
+ * `defineHonuaControls` (which runs automatically on import of the controls
+ * entry when a `customElements` registry exists).
+ */
+export class HonuaLegendElement extends HTMLElementBase {
+  public static get observedAttributes(): string[] {
+    return ["for", "layer", "layer-title", "heading", "follow-layer-visibility", "auto-refresh"];
+  }
+
+  #map: HonuaLegendMap | undefined;
+  #explicitSections: readonly HonuaLegendSection[] = [];
+  #derivedEntries: readonly HonuaLegendEntry[] | undefined;
+  #deriveError: string | undefined;
+  #connected = false;
+  #disposeMapReadyListener: (() => void) | undefined;
+  #styledataListener: (() => void) | undefined;
+
+  /** The MapLibre map this legend reads from (derive mode and visibility coupling). */
+  public get map(): HonuaLegendMap | undefined {
+    return this.#map;
+  }
+
+  public set map(map: HonuaLegendMap | undefined) {
+    if (this.#map === map) return;
+    this.#unsubscribeStyledata();
+    this.#map = map;
+    this.refresh();
+    this.#subscribeStyledata();
+  }
+
+  /** Wires the legend to a MapLibre map. Equivalent to setting `.map`. */
+  public connect(map: HonuaLegendMap): void {
+    this.map = map;
+  }
+
+  /**
+   * Explicit legend content. Accepts a flat {@link HonuaLegendEntry} array
+   * (one untitled section), {@link HonuaLegendSection} groups, or a mix;
+   * the getter returns the normalized sections. Invalid items are dropped.
+   */
+  public get entries(): readonly HonuaLegendSection[] {
+    return this.#explicitSections;
+  }
+
+  public set entries(value: readonly (HonuaLegendEntry | HonuaLegendSection)[]) {
+    this.#explicitSections = normalizeSections(value);
+    this.render();
+  }
+
+  /** Style layer id used by derive mode. Reflects the `layer` attribute. */
+  public get layer(): string | undefined {
+    return this.#attr("layer") ?? undefined;
+  }
+
+  public set layer(value: string | undefined) {
+    if (typeof this.setAttribute !== "function") return;
+    if (value === undefined) this.removeAttribute?.("layer");
+    else this.setAttribute("layer", value);
+  }
+
+  /** Hide sections whose source layer is hidden. Reflects `follow-layer-visibility`. */
+  public get followLayerVisibility(): boolean {
+    return this.#hasAttr("follow-layer-visibility");
+  }
+
+  public set followLayerVisibility(value: boolean) {
+    this.#setBooleanAttr("follow-layer-visibility", value);
+  }
+
+  /** Refresh automatically on the map's `styledata` event. Reflects `auto-refresh`. */
+  public get autoRefresh(): boolean {
+    return this.#hasAttr("auto-refresh");
+  }
+
+  public set autoRefresh(value: boolean) {
+    this.#setBooleanAttr("auto-refresh", value);
+  }
+
+  /**
+   * Why the last derive attempt failed (message of the underlying
+   * {@link HonuaLegendDeriveError}), or `undefined` while derive mode is
+   * succeeding or inactive.
+   */
+  public get deriveError(): string | undefined {
+    return this.#deriveError;
+  }
+
+  /**
+   * The sections the legend renders: explicit sections followed by the
+   * derived section (when derive mode is active and succeeded).
+   */
+  public get sections(): readonly HonuaLegendSection[] {
+    const layerId = this.layer;
+    if (!this.#derivedEntries || !layerId) return this.#explicitSections;
+    const title = this.#attr("layer-title");
+    return [
+      ...this.#explicitSections,
+      { ...(title !== null ? { title } : {}), layer: layerId, entries: this.#derivedEntries },
+    ];
+  }
+
+  /** Re-derives entries from the map (when in derive mode) and re-renders. */
+  public refresh(): void {
+    this.#derive();
+    this.render();
+  }
+
+  public attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null): void {
+    if (name === "for") {
+      this.#resolveMapFromContext();
+      return;
+    }
+    if (name === "layer" || name === "layer-title") {
+      this.refresh();
+      return;
+    }
+    if (name === "auto-refresh") {
+      if (newValue === null) this.#unsubscribeStyledata();
+      else this.#subscribeStyledata();
+      return;
+    }
+    // "heading" / "follow-layer-visibility" only change the rendering.
+    this.render();
+  }
+
+  public connectedCallback(): void {
+    this.#connected = true;
+    this.#ensureShadowRoot();
+    this.#listenForMapReady();
+    this.#resolveMapFromContext();
+    this.#subscribeStyledata();
+    this.refresh();
+  }
+
+  public disconnectedCallback(): void {
+    this.#connected = false;
+    this.#disposeMapReadyListener?.();
+    this.#disposeMapReadyListener = undefined;
+    this.#unsubscribeStyledata();
+  }
+
+  // ── derive mode ────────────────────────────────────────────
+
+  #derive(): void {
+    this.#derivedEntries = undefined;
+    const layerId = this.layer;
+    const map = this.#map;
+    if (!layerId || !map) {
+      this.#deriveError = undefined;
+      return;
+    }
+    try {
+      this.#derivedEntries = deriveLegendEntries(map, layerId);
+      this.#deriveError = undefined;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      // A missing layer is usually transient (style still loading), so it is
+      // not warned about; real shape mismatches are warned once per message.
+      const transient = error instanceof HonuaLegendDeriveError && error.code === "layer-not-found";
+      if (!transient && message !== this.#deriveError && typeof console !== "undefined") {
+        console.warn(`<honua-legend> could not derive entries: ${message}`);
+      }
+      this.#deriveError = message;
+    }
+  }
+
+  // ── map wiring (matches the `for` + ready-event idiom) ──────
+
+  #listenForMapReady(): void {
+    if (this.#disposeMapReadyListener) return;
+    this.#disposeMapReadyListener = listenForHonuaMapReady(this, (map) => {
+      const forId = this.#attr("for");
+      if (!forId && this.map) return;
+      this.map = map as HonuaLegendMap;
+    });
+  }
+
+  #resolveMapFromContext(): void {
+    if (this.map) return;
+    const map = resolveHonuaMapFromContext(this);
+    if (map) this.map = map as HonuaLegendMap;
+  }
+
+  #subscribeStyledata(): void {
+    if (this.#styledataListener || !this.#connected || !this.autoRefresh) return;
+    const map = this.#map;
+    if (!map || typeof map.on !== "function") return;
+    const listener = () => this.refresh();
+    map.on("styledata", listener);
+    this.#styledataListener = listener;
+  }
+
+  #unsubscribeStyledata(): void {
+    const listener = this.#styledataListener;
+    if (!listener) return;
+    this.#styledataListener = undefined;
+    this.#map?.off?.("styledata", listener);
+  }
+
+  // ── rendering ──────────────────────────────────────────────
+
+  #ensureShadowRoot(): void {
+    if (!this.shadowRoot && typeof this.attachShadow === "function") {
+      this.attachShadow({ mode: "open" });
+    }
+  }
+
+  protected render(): void {
+    const root = this.shadowRoot;
+    if (!root) return;
+    const heading = this.#attr("heading");
+    root.innerHTML = `
+      <style>${structuralStyles()}</style>
+      <div part="root" class="root">
+        ${heading ? `<p part="heading" class="heading">${escapeHtml(heading)}</p>` : ""}
+        ${this.sections.map((section) => this.#renderSection(section)).join("")}
+      </div>
+    `;
+  }
+
+  #renderSection(section: HonuaLegendSection): string {
+    const hidden = this.#sectionHidden(section);
+    return `
+      <section part="section" class="section"${hidden ? " hidden" : ""}${
+        section.layer ? ` data-layer="${escapeAttribute(section.layer)}"` : ""
+      }>
+        ${section.title ? `<p part="section-title" class="section-title">${escapeHtml(section.title)}</p>` : ""}
+        <ul class="rows">
+          ${section.entries.map((entry) => renderRow(entry)).join("")}
+        </ul>
+      </section>
+    `;
+  }
+
+  #sectionHidden(section: HonuaLegendSection): boolean {
+    if (!this.followLayerVisibility || !section.layer) return false;
+    return this.#map?.getLayoutProperty?.(section.layer, "visibility") === "none";
+  }
+
+  // ── attribute helpers (safe under Node test stubs) ──────────
+
+  #attr(name: string): string | null {
+    return typeof this.getAttribute === "function" ? this.getAttribute(name) : null;
+  }
+
+  #hasAttr(name: string): boolean {
+    if (typeof this.hasAttribute === "function") return this.hasAttribute(name);
+    return this.#attr(name) !== null;
+  }
+
+  #setBooleanAttr(name: string, value: boolean): void {
+    if (typeof this.setAttribute !== "function") return;
+    if (value) this.setAttribute(name, "");
+    else this.removeAttribute?.(name);
+  }
+}
+
+function normalizeSections(value: readonly (HonuaLegendEntry | HonuaLegendSection)[]): HonuaLegendSection[] {
+  const sections: HonuaLegendSection[] = [];
+  let loose: HonuaLegendEntry[] = [];
+  const flushLoose = (): void => {
+    if (loose.length > 0) sections.push({ entries: loose });
+    loose = [];
+  };
+  for (const item of value ?? []) {
+    if (isSection(item)) {
+      flushLoose();
+      const entries = item.entries.filter(isEntry).map(normalizeEntry);
+      sections.push({
+        ...(typeof item.title === "string" ? { title: item.title } : {}),
+        ...(typeof item.layer === "string" ? { layer: item.layer } : {}),
+        entries,
+      });
+    } else if (isEntry(item)) {
+      loose.push(normalizeEntry(item));
+    }
+  }
+  flushLoose();
+  return sections;
+}
+
+function isSection(item: unknown): item is HonuaLegendSection {
+  return typeof item === "object" && item !== null && Array.isArray((item as HonuaLegendSection).entries);
+}
+
+function isEntry(item: unknown): item is HonuaLegendEntry {
+  if (typeof item !== "object" || item === null) return false;
+  const entry = item as HonuaLegendEntry;
+  if (typeof entry.label !== "string") return false;
+  if (typeof entry.color === "string") return true;
+  return (
+    typeof entry.color === "object" &&
+    entry.color !== null &&
+    (entry.color.fill === undefined || typeof entry.color.fill === "string") &&
+    (entry.color.outline === undefined || typeof entry.color.outline === "string")
+  );
+}
+
+function normalizeEntry(entry: HonuaLegendEntry): HonuaLegendEntry {
+  const shape = isSwatchShape(entry.shape) ? entry.shape : "fill";
+  return { label: entry.label, color: entry.color, shape };
+}
+
+function isSwatchShape(value: unknown): value is HonuaLegendSwatchShape {
+  return value === "fill" || value === "line" || value === "circle";
+}
+
+function renderRow(entry: HonuaLegendEntry): string {
+  const fill = typeof entry.color === "string" ? entry.color : entry.color.fill;
+  const outline = typeof entry.color === "object" && entry.color !== null ? entry.color.outline : undefined;
+  const shape = entry.shape ?? "fill";
+  const swatchStyle = [
+    ...(fill !== undefined ? [`--legend-fill:${fill}`] : []),
+    ...(outline !== undefined ? [`--legend-outline:${outline}`] : []),
+  ].join(";");
+  return `
+    <li part="row" class="row">
+      <span part="swatch" class="swatch swatch-${shape}" aria-hidden="true"${
+        swatchStyle ? ` style="${escapeAttribute(swatchStyle)}"` : ""
+      }></span>
+      <span part="label" class="label">${escapeHtml(entry.label)}</span>
+    </li>
+  `;
+}
+
+/** Structural-only styles; theme via `::part(root)`, `::part(row)`, `::part(swatch)`, ... */
+function structuralStyles(): string {
+  return `
+    :host { display: block; }
+    .heading, .section-title { margin: 0; }
+    .section { margin: 0; }
+    .rows { list-style: none; margin: 0; padding: 0; }
+    .row { display: flex; align-items: center; gap: 0.5em; }
+    .swatch {
+      flex: none;
+      inline-size: 1em;
+      block-size: 1em;
+      box-sizing: border-box;
+      background: var(--legend-fill, transparent);
+      border: 1px solid var(--legend-outline, transparent);
+    }
+    .swatch-line { block-size: 3px; border: none; }
+    .swatch-circle { border-radius: 50%; }
+  `;
+}

--- a/src/controls/types.ts
+++ b/src/controls/types.ts
@@ -101,3 +101,62 @@ export interface HonuaBasemapSwitcherChangeDetail {
   /** Kind of the now-active base. */
   readonly kind: HonuaBasemapKind;
 }
+
+/**
+ * Swatch geometry rendered for a legend entry by `<honua-legend>`:
+ * - `"fill"` — square swatch (polygon fills); supports an outline color.
+ * - `"line"` — short horizontal bar (line layers).
+ * - `"circle"` — round swatch (circle/point layers).
+ */
+export type HonuaLegendSwatchShape = "fill" | "line" | "circle";
+
+/** Split fill/outline colors for a legend swatch (typically fill layers). */
+export interface HonuaLegendSwatchColor {
+  /** CSS color painted as the swatch body. */
+  readonly fill?: string;
+  /** CSS color painted as the swatch border. */
+  readonly outline?: string;
+}
+
+/** One swatch+label row rendered by `<honua-legend>`. */
+export interface HonuaLegendEntry {
+  /** Visible text carrying the entry's meaning (swatches are aria-hidden). */
+  readonly label: string;
+  /** Swatch color: a CSS color string or split `{ fill, outline }` colors. */
+  readonly color: string | HonuaLegendSwatchColor;
+  /** Swatch geometry; defaults to `"fill"`. */
+  readonly shape?: HonuaLegendSwatchShape;
+}
+
+/** A titled group of legend entries rendered by `<honua-legend>`. */
+export interface HonuaLegendSection {
+  /** Optional section title rendered above the rows. */
+  readonly title?: string;
+  /**
+   * Style layer id this section describes. When the element has
+   * `follow-layer-visibility`, the section is hidden while the layer's
+   * `visibility` layout property is `"none"`.
+   */
+  readonly layer?: string;
+  /** The swatch+label rows of the section. */
+  readonly entries: readonly HonuaLegendEntry[];
+}
+
+/**
+ * Minimal duck-typed subset of `maplibre-gl.Map` required by
+ * `<honua-legend>`. Any MapLibre-GL `Map` instance satisfies this interface,
+ * and tests can pass a plain stub (same posture as
+ * {@link HonuaBasemapSwitcherMap}).
+ */
+export interface HonuaLegendMap {
+  /** Returns a truthy handle (with a `type`) when the layer exists. */
+  getLayer?(id: string): unknown;
+  /** Reads a paint property value as written in the style (expressions are returned verbatim). */
+  getPaintProperty?(layerId: string, name: string): unknown;
+  /** Reads a layout property; used for `follow-layer-visibility`. */
+  getLayoutProperty?(layerId: string, name: string): unknown;
+  /** Subscribes to map events; used for `auto-refresh` on `styledata`. */
+  on?(type: string, listener: (event?: unknown) => void): unknown;
+  /** Unsubscribes a listener registered with `on`. */
+  off?(type: string, listener: (event?: unknown) => void): unknown;
+}

--- a/test/controls/legend.test.ts
+++ b/test/controls/legend.test.ts
@@ -1,0 +1,510 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { defineHonuaControls } from "../../src/controls/basemap-switcher.js";
+import { HonuaLegendDeriveError, deriveLegendEntries } from "../../src/controls/legend-derive.js";
+import { HonuaLegendElement } from "../../src/controls/legend.js";
+import type { HonuaLegendEntry, HonuaLegendSection } from "../../src/controls/types.js";
+
+interface MockLayerSpec {
+  type: string;
+  paint?: Record<string, unknown>;
+  layout?: Record<string, unknown>;
+}
+
+interface MockMap {
+  layers: Record<string, MockLayerSpec>;
+  getLayer(id: string): unknown;
+  getPaintProperty(layerId: string, name: string): unknown;
+  getLayoutProperty(layerId: string, name: string): unknown;
+  on(type: string, listener: () => void): void;
+  off(type: string, listener: () => void): void;
+  emit(type: string): void;
+  listenerCount(type: string): number;
+}
+
+/**
+ * Duck-typed MapLibre map stub following the mock pattern of
+ * test/controls/basemap-switcher.test.ts, with paint/layout lookups and a
+ * tiny event emitter for `styledata`.
+ */
+function makeMockMap(layers: Record<string, MockLayerSpec>): MockMap {
+  const listeners = new Map<string, Set<() => void>>();
+  return {
+    layers,
+    getLayer(id) {
+      return layers[id];
+    },
+    getPaintProperty(layerId, name) {
+      return layers[layerId]?.paint?.[name];
+    },
+    getLayoutProperty(layerId, name) {
+      return layers[layerId]?.layout?.[name];
+    },
+    on(type, listener) {
+      const set = listeners.get(type) ?? new Set();
+      set.add(listener);
+      listeners.set(type, set);
+    },
+    off(type, listener) {
+      listeners.get(type)?.delete(listener);
+    },
+    emit(type) {
+      for (const listener of listeners.get(type) ?? []) listener();
+    },
+    listenerCount(type) {
+      return listeners.get(type)?.size ?? 0;
+    },
+  };
+}
+
+/** The demo's categorical zoning paint: match on a string district attribute. */
+function zoningMatchExpression(): unknown[] {
+  return [
+    "match",
+    ["get", "district"],
+    "Residential",
+    "#facc15",
+    "Agricultural",
+    "#84cc16",
+    "Business",
+    "#ef4444",
+    "#cbd5e1",
+  ];
+}
+
+function makeZoningMap(paintOverrides: Record<string, unknown> = {}): MockMap {
+  return makeMockMap({
+    "zoning-districts": {
+      type: "fill",
+      paint: { "fill-color": zoningMatchExpression(), "fill-outline-color": "#475569", ...paintOverrides },
+    },
+  });
+}
+
+function makeElement(): {
+  element: HonuaLegendElement;
+  attributes: Map<string, string>;
+  shadow: { innerHTML: string };
+} {
+  const element = new HonuaLegendElement();
+  const attributes = new Map<string, string>();
+  const shadow = { innerHTML: "" };
+  Object.assign(element, {
+    shadowRoot: shadow,
+    getAttribute: (name: string) => attributes.get(name) ?? null,
+    setAttribute: (name: string, value: string) => {
+      attributes.set(name, value);
+    },
+    hasAttribute: (name: string) => attributes.has(name),
+    removeAttribute: (name: string) => {
+      attributes.delete(name);
+    },
+  });
+  return { element, attributes, shadow };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("deriveLegendEntries", () => {
+  test("parses a match expression on a string attribute, including the fallback color", () => {
+    const entries = deriveLegendEntries(makeZoningMap(), "zoning-districts");
+    expect(entries).toEqual([
+      { label: "Residential", color: { fill: "#facc15", outline: "#475569" }, shape: "fill" },
+      { label: "Agricultural", color: { fill: "#84cc16", outline: "#475569" }, shape: "fill" },
+      { label: "Business", color: { fill: "#ef4444", outline: "#475569" }, shape: "fill" },
+      { label: "Other", color: { fill: "#cbd5e1", outline: "#475569" }, shape: "fill" },
+    ]);
+  });
+
+  test("labels array branch inputs with the values joined by a comma", () => {
+    const map = makeMockMap({
+      zones: {
+        type: "fill",
+        paint: {
+          "fill-color": ["match", ["get", "code"], ["R-3.5", "R-5", "R-7.5"], "#facc15", 7, "#84cc16", "#cbd5e1"],
+        },
+      },
+    });
+    const entries = deriveLegendEntries(map, "zones");
+    expect(entries.map((entry) => entry.label)).toEqual(["R-3.5, R-5, R-7.5", "7", "Other"]);
+    // No literal fill-outline-color: plain string colors, no outline.
+    expect(entries[0]?.color).toBe("#facc15");
+  });
+
+  test("line and circle layers derive their shape from the layer type", () => {
+    const map = makeMockMap({
+      routes: { type: "line", paint: { "line-color": ["match", ["get", "kind"], "primary", "#1d4ed8", "#94a3b8"] } },
+      stops: { type: "circle", paint: { "circle-color": "#dc2626" } },
+    });
+    expect(deriveLegendEntries(map, "routes").map((entry) => entry.shape)).toEqual(["line", "line"]);
+    // A literal color yields a single entry labeled with the layer id.
+    expect(deriveLegendEntries(map, "stops")).toEqual([{ label: "stops", color: "#dc2626", shape: "circle" }]);
+  });
+
+  test("parses simple-equality case expressions", () => {
+    const map = makeMockMap({
+      zones: {
+        type: "fill",
+        paint: {
+          "fill-color": [
+            "case",
+            ["==", ["get", "district"], "Hotel"],
+            "#fb923c",
+            ["==", ["get", "district"], "Industrial"],
+            "#a855f7",
+            "#cbd5e1",
+          ],
+        },
+      },
+    });
+    expect(deriveLegendEntries(map, "zones").map((entry) => entry.label)).toEqual(["Hotel", "Industrial", "Other"]);
+  });
+
+  test("parses step expressions on a feature attribute into range labels", () => {
+    const map = makeMockMap({
+      parcels: {
+        type: "fill",
+        paint: { "fill-color": ["step", ["get", "units"], "#dbeafe", 10, "#60a5fa", 50, "#1d4ed8"] },
+      },
+    });
+    const entries = deriveLegendEntries(map, "parcels");
+    expect(entries.map((entry) => entry.label)).toEqual(["< 10", "10–50", "≥ 50"]);
+    expect(entries.map((entry) => entry.color)).toEqual(["#dbeafe", "#60a5fa", "#1d4ed8"]);
+  });
+
+  test("falls back to the layer's paint object when the map has no getPaintProperty", () => {
+    const layer = { type: "fill", paint: { "fill-color": zoningMatchExpression() } };
+    const entries = deriveLegendEntries({ getLayer: () => layer }, "zoning-districts");
+    expect(entries).toHaveLength(4);
+    expect(entries[0]?.label).toBe("Residential");
+  });
+
+  test("rejects non-literal expression outputs gracefully", () => {
+    const nested = makeZoningMap({
+      "fill-color": ["match", ["get", "district"], "Residential", ["rgba", 250, 204, 21, 1], "#cbd5e1"],
+    });
+    expect(() => deriveLegendEntries(nested, "zoning-districts")).toThrowError(HonuaLegendDeriveError);
+    expect(() => deriveLegendEntries(nested, "zoning-districts")).toThrowError(/literal color strings/);
+
+    const numeric = makeZoningMap({ "fill-color": ["match", ["get", "district"], "Residential", 7, "#cbd5e1"] });
+    expect(() => deriveLegendEntries(numeric, "zoning-districts")).toThrowError(HonuaLegendDeriveError);
+
+    try {
+      deriveLegendEntries(nested, "zoning-districts");
+      expect.unreachable();
+    } catch (error) {
+      expect((error as HonuaLegendDeriveError).code).toBe("unsupported-expression");
+    }
+  });
+
+  test("rejects unsupported expression shapes with clear messages", () => {
+    const cases: [Record<string, unknown>, RegExp][] = [
+      // match input must be ["get", <attr>], not e.g. feature-state or zoom.
+      [{ "fill-color": ["match", ["feature-state", "hover"], true, "#fff", "#000"] }, /\["get", <attribute>\]/],
+      // interpolate is not categorical.
+      [{ "fill-color": ["interpolate", ["linear"], ["zoom"], 0, "#fff", 10, "#000"] }, /unsupported color expression/],
+      // case conditions beyond simple equality.
+      [{ "fill-color": ["case", [">", ["get", "units"], 10], "#fff", "#000"] }, /simple equalities/],
+      // step driven by zoom.
+      [{ "fill-color": ["step", ["zoom"], "#fff", 10, "#000"] }, /\["get", <attribute>\]/],
+      // match without a fallback.
+      [{ "fill-color": ["match", ["get", "district"], "Residential", "#facc15"] }, /fallback/],
+    ];
+    for (const [paint, message] of cases) {
+      const map = makeZoningMap(paint);
+      expect(() => deriveLegendEntries(map, "zoning-districts")).toThrowError(HonuaLegendDeriveError);
+      expect(() => deriveLegendEntries(map, "zoning-districts")).toThrowError(message);
+    }
+  });
+
+  test("rejects missing layers, unsupported layer types, and missing paint", () => {
+    const map = makeMockMap({
+      labels: { type: "symbol", paint: {} },
+      bare: { type: "fill" },
+    });
+    try {
+      deriveLegendEntries(map, "nope");
+      expect.unreachable();
+    } catch (error) {
+      expect((error as HonuaLegendDeriveError).code).toBe("layer-not-found");
+    }
+    try {
+      deriveLegendEntries(map, "labels");
+      expect.unreachable();
+    } catch (error) {
+      expect((error as HonuaLegendDeriveError).code).toBe("unsupported-layer-type");
+    }
+    try {
+      deriveLegendEntries(map, "bare");
+      expect.unreachable();
+    } catch (error) {
+      expect((error as HonuaLegendDeriveError).code).toBe("missing-paint");
+    }
+  });
+});
+
+describe("HonuaLegendElement", () => {
+  test("is registered for browser registries via defineHonuaControls", () => {
+    const defined: Record<string, CustomElementConstructor> = {};
+    const registry = {
+      get: (name: string) => defined[name],
+      define: (name: string, ctor: CustomElementConstructor) => {
+        defined[name] = ctor;
+      },
+    } as unknown as CustomElementRegistry;
+    defineHonuaControls(registry);
+    expect(defined["honua-legend"]).toBe(HonuaLegendElement);
+    // Idempotent: re-defining must not throw.
+    defineHonuaControls(registry);
+  });
+
+  test("a flat entries array renders as one untitled section with list semantics and aria-hidden swatches", () => {
+    const { element, shadow } = makeElement();
+    element.entries = [
+      { label: "High priority", color: "#dc2626", shape: "circle" },
+      { label: "Route", color: "#1d4ed8", shape: "line" },
+    ];
+
+    expect(element.entries).toEqual([
+      {
+        entries: [
+          { label: "High priority", color: "#dc2626", shape: "circle" },
+          { label: "Route", color: "#1d4ed8", shape: "line" },
+        ],
+      },
+    ]);
+    expect(shadow.innerHTML).toContain('part="root"');
+    expect(shadow.innerHTML).toContain('part="section"');
+    expect(shadow.innerHTML).toContain("<ul");
+    expect(shadow.innerHTML).toContain('<li part="row"');
+    expect(shadow.innerHTML).toContain('aria-hidden="true"');
+    expect(shadow.innerHTML).toContain("swatch-circle");
+    expect(shadow.innerHTML).toContain("swatch-line");
+    expect(shadow.innerHTML).toContain("--legend-fill:#dc2626");
+    expect(shadow.innerHTML).toContain("High priority");
+  });
+
+  test("sections keep their titles, invalid items are dropped, and labels are escaped", () => {
+    const { element, attributes, shadow } = makeElement();
+    attributes.set("heading", "Legend");
+    element.entries = [
+      { title: "Zoning", entries: [{ label: "<Residential & Co>", color: { fill: "#facc15", outline: "#475569" } }] },
+      { label: "Loose entry", color: "#16a34a" },
+      { bogus: true } as unknown as HonuaLegendEntry,
+      { label: 7, color: "#fff" } as unknown as HonuaLegendEntry,
+    ];
+
+    expect(element.entries.map((section) => section.title)).toEqual(["Zoning", undefined]);
+    expect(element.entries[1]?.entries).toHaveLength(1);
+    expect(shadow.innerHTML).toContain('part="heading"');
+    expect(shadow.innerHTML).toContain("Legend");
+    expect(shadow.innerHTML).toContain('part="section-title"');
+    expect(shadow.innerHTML).toContain("&lt;Residential &amp; Co&gt;");
+    expect(shadow.innerHTML).toContain("--legend-outline:#475569");
+    expect(shadow.innerHTML).not.toContain("<Residential");
+  });
+
+  test("derive mode appends a section parsed from the layer's match expression", () => {
+    const { element, attributes, shadow } = makeElement();
+    attributes.set("layer", "zoning-districts");
+    attributes.set("layer-title", "Zoning districts");
+    element.entries = [{ title: "Incidents", entries: [{ label: "High priority", color: "#dc2626" }] }];
+    element.connect(makeZoningMap());
+
+    const sections = element.sections;
+    expect(sections).toHaveLength(2);
+    expect(sections[1]?.title).toBe("Zoning districts");
+    expect(sections[1]?.layer).toBe("zoning-districts");
+    expect(sections[1]?.entries.map((entry) => entry.label)).toEqual([
+      "Residential",
+      "Agricultural",
+      "Business",
+      "Other",
+    ]);
+    expect(element.deriveError).toBeUndefined();
+    expect(shadow.innerHTML).toContain("Residential");
+    expect(shadow.innerHTML).toContain('data-layer="zoning-districts"');
+    // Explicit entries render before the derived section.
+    expect(shadow.innerHTML.indexOf("High priority")).toBeLessThan(shadow.innerHTML.indexOf("Residential"));
+  });
+
+  test("derive failures degrade gracefully: explicit sections keep rendering and deriveError is exposed", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { element, attributes, shadow } = makeElement();
+    attributes.set("layer", "zoning-districts");
+    element.entries = [{ label: "High priority", color: "#dc2626" }];
+    const map = makeZoningMap({
+      "fill-color": ["interpolate", ["linear"], ["get", "units"], 0, "#fff", 10, "#000"],
+    });
+    element.connect(map);
+
+    expect(element.deriveError).toMatch(/unsupported color expression/);
+    expect(element.sections).toHaveLength(1);
+    expect(shadow.innerHTML).toContain("High priority");
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    // Repeated refreshes with the same failure do not spam the console.
+    element.refresh();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  test("a missing layer is treated as transient: no console warning, derive retried on refresh", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { element, attributes } = makeElement();
+    attributes.set("layer", "zoning-districts");
+    const map = makeMockMap({});
+    element.connect(map);
+
+    expect(element.deriveError).toMatch(/does not exist/);
+    expect(element.sections).toHaveLength(0);
+    expect(warn).not.toHaveBeenCalled();
+
+    map.layers["zoning-districts"] = { type: "fill", paint: { "fill-color": zoningMatchExpression() } };
+    element.refresh();
+    expect(element.deriveError).toBeUndefined();
+    expect(element.sections[0]?.entries.map((entry) => entry.label)).toContain("Residential");
+  });
+
+  test("refresh() picks up paint expression changes so map and legend cannot drift", () => {
+    const { element, attributes } = makeElement();
+    attributes.set("layer", "zoning-districts");
+    const map = makeZoningMap();
+    element.connect(map);
+    expect(element.sections[0]?.entries).toHaveLength(4);
+
+    map.layers["zoning-districts"].paint = {
+      "fill-color": ["match", ["get", "district"], "Hotel", "#fb923c", "#cbd5e1"],
+    };
+    element.refresh();
+    expect(element.sections[0]?.entries.map((entry) => entry.label)).toEqual(["Hotel", "Other"]);
+  });
+
+  test("auto-refresh subscribes to styledata while connected and unsubscribes on disconnect", () => {
+    const { element, attributes } = makeElement();
+    attributes.set("layer", "zoning-districts");
+    attributes.set("auto-refresh", "");
+    const map = makeZoningMap();
+    element.connect(map);
+    expect(map.listenerCount("styledata")).toBe(0);
+
+    element.connectedCallback();
+    expect(map.listenerCount("styledata")).toBe(1);
+
+    map.layers["zoning-districts"].paint = {
+      "fill-color": ["match", ["get", "district"], "Hotel", "#fb923c", "#cbd5e1"],
+    };
+    map.emit("styledata");
+    expect(element.sections[0]?.entries.map((entry) => entry.label)).toEqual(["Hotel", "Other"]);
+
+    // Re-assigning the map moves the subscription.
+    const nextMap = makeZoningMap();
+    element.map = nextMap;
+    expect(map.listenerCount("styledata")).toBe(0);
+    expect(nextMap.listenerCount("styledata")).toBe(1);
+
+    element.disconnectedCallback();
+    expect(nextMap.listenerCount("styledata")).toBe(0);
+  });
+
+  test("without auto-refresh no styledata subscription is made", () => {
+    const { element, attributes } = makeElement();
+    attributes.set("layer", "zoning-districts");
+    const map = makeZoningMap();
+    element.connect(map);
+    element.connectedCallback();
+    expect(map.listenerCount("styledata")).toBe(0);
+    element.disconnectedCallback();
+  });
+
+  test("follow-layer-visibility hides sections whose source layer is hidden", () => {
+    const { element, attributes, shadow } = makeElement();
+    attributes.set("layer", "zoning-districts");
+    attributes.set("follow-layer-visibility", "");
+    const map = makeZoningMap();
+    element.entries = [
+      { title: "Incidents", layer: "incident-points", entries: [{ label: "High", color: "#dc2626" }] },
+    ];
+    map.layers["incident-points"] = { type: "circle", paint: { "circle-color": "#dc2626" } };
+    element.connect(map);
+
+    // Both layers visible: no section carries the hidden attribute (the
+    // leading space distinguishes it from the swatches' aria-hidden).
+    expect(shadow.innerHTML).not.toContain(" hidden");
+
+    map.layers["zoning-districts"].layout = { visibility: "none" };
+    element.refresh();
+    const sectionsHtml = shadow.innerHTML.split("<section");
+    const zoning = sectionsHtml.find((chunk) => chunk.includes("zoning-districts"));
+    const incidents = sectionsHtml.find((chunk) => chunk.includes("incident-points"));
+    expect(zoning).toContain(" hidden");
+    expect(incidents).not.toContain(" hidden");
+
+    // Without the attribute the section renders normally again.
+    attributes.delete("follow-layer-visibility");
+    element.refresh();
+    expect(shadow.innerHTML).not.toContain(" hidden");
+  });
+
+  test("attributeChangedCallback re-derives on layer changes and re-subscribes on auto-refresh changes", () => {
+    const { element, attributes } = makeElement();
+    const map = makeMockMap({
+      a: { type: "fill", paint: { "fill-color": ["match", ["get", "kind"], "x", "#fff", "#000"] } },
+      b: { type: "circle", paint: { "circle-color": "#dc2626" } },
+    });
+    element.connect(map);
+
+    attributes.set("layer", "a");
+    element.attributeChangedCallback("layer", null, "a");
+    expect(element.sections[0]?.entries.map((entry) => entry.label)).toEqual(["x", "Other"]);
+
+    attributes.set("layer", "b");
+    element.attributeChangedCallback("layer", "a", "b");
+    expect(element.sections[0]?.entries).toEqual([{ label: "b", color: "#dc2626", shape: "circle" }]);
+
+    element.connectedCallback();
+    expect(map.listenerCount("styledata")).toBe(0);
+    attributes.set("auto-refresh", "");
+    element.attributeChangedCallback("auto-refresh", null, "");
+    expect(map.listenerCount("styledata")).toBe(1);
+    attributes.delete("auto-refresh");
+    element.attributeChangedCallback("auto-refresh", "", null);
+    expect(map.listenerCount("styledata")).toBe(0);
+    element.disconnectedCallback();
+  });
+
+  test("boolean and layer properties reflect to attributes", () => {
+    const { element, attributes } = makeElement();
+    element.followLayerVisibility = true;
+    expect(attributes.has("follow-layer-visibility")).toBe(true);
+    element.followLayerVisibility = false;
+    expect(attributes.has("follow-layer-visibility")).toBe(false);
+
+    element.autoRefresh = true;
+    expect(element.autoRefresh).toBe(true);
+
+    element.layer = "zoning-districts";
+    expect(attributes.get("layer")).toBe("zoning-districts");
+    expect(element.layer).toBe("zoning-districts");
+    element.layer = undefined;
+    expect(attributes.has("layer")).toBe(false);
+  });
+
+  test("rendering without a shadow root is a safe no-op", () => {
+    const element = new HonuaLegendElement();
+    Object.assign(element, {
+      getAttribute: () => null,
+    });
+    element.entries = [{ label: "High", color: "#dc2626" }];
+    expect(() => element.refresh()).not.toThrow();
+    expect(element.sections).toHaveLength(1);
+  });
+});
+
+// Type-level checks: sections accept both flat entries and titled groups.
+const _sections: HonuaLegendSection[] = [
+  { entries: [{ label: "a", color: "#fff" }] },
+  { title: "t", layer: "l", entries: [{ label: "b", color: { fill: "#fff", outline: "#000" }, shape: "line" }] },
+];
+void _sections;

--- a/test/playwright/web-components-basic.spec.mjs
+++ b/test/playwright/web-components-basic.spec.mjs
@@ -19,6 +19,11 @@ test("web components compose map, layers, legend, table, search, and editor stat
     await expect(page.locator("honua-map canvas")).toHaveCount(1);
     await expect(page.locator("honua-layer-list").getByText("Incident response halos")).toBeVisible();
     await expect(page.locator("honua-legend").getByText("High priority")).toBeVisible();
+    // Derive-mode rows parsed from the zoning layer's match expression,
+    // including the fallback color row.
+    await expect(page.locator("honua-legend").getByText("Residential")).toBeVisible();
+    await expect(page.locator("honua-legend").getByText("Open-Park")).toBeVisible();
+    await expect(page.locator("honua-legend").getByText("Other")).toBeVisible();
     await expect(page.locator("honua-feature-table").getByText("Harbor response district")).toBeVisible();
     await expect(page.locator("honua-editor").getByText("Source metadata marks incidents read-only.")).toBeVisible();
     await expect(page.locator("honua-editor button[data-action='save']")).toBeDisabled();
@@ -64,6 +69,13 @@ test("web components compose map, layers, legend, table, search, and editor stat
       .poll(async () => page.evaluate(() => window.__HONUA_WEB_COMPONENTS_DEMO__?.mapLayerVisible("incident-points")))
       .toBe(false);
     await expect(page.locator("#event-log")).toHaveText("layer:incident-points:false");
+
+    // follow-layer-visibility: hiding the zoning layer hides its derived
+    // legend section; re-showing it brings the section back.
+    await page.getByLabel("Zoning districts").uncheck();
+    await expect(page.locator("honua-legend").getByText("Residential")).toBeHidden();
+    await page.getByLabel("Zoning districts").check();
+    await expect(page.locator("honua-legend").getByText("Residential")).toBeVisible();
 
     await page.locator("honua-search").getByRole("textbox", { name: "Search" }).fill("harbor");
     await page.keyboard.press("Enter");


### PR DESCRIPTION
Part of #274 (second control of the native UI kit, per the 2026-06-12 legend comment; follows the conventions established by #275).

## What

`<honua-legend>` in `@honua/sdk-js/controls`: framework-free custom element rendering swatch+label rows from the same definitions the map uses, so map and legend cannot drift.

- **Explicit entries mode** — `element.entries = [...]`: flat `{ label, color | { fill, outline }, shape: "fill" | "line" | "circle" }[]` and/or groups under optional section titles.
- **Derive mode (headline)** — `layer="<layer id>"`: parses the layer's categorical color paint expression into entries via the exported `deriveLegendEntries(map, layerId)`. Supported shapes (documented in `legend-derive.ts`):
  - literal color string (single entry labeled with the layer id),
  - `["match", ["get", attr], in1, color1, ..., fallback]` — string/number inputs, array inputs joined with `", "`, fallback labeled "Other"; all outputs must be literal color strings,
  - `["case", ["==", ["get", attr], literal], color, ..., fallback]` — simple equality chains only,
  - `["step", ["get", attr], color0, stop1, color1, ...]` — numeric breaks labeled `< a`, `a–b`, `≥ b`.
  - Anything else (interpolate, zoom/feature-state inputs, non-literal outputs) throws `HonuaLegendDeriveError` with a `code`; the element degrades gracefully (keeps explicit sections, exposes `deriveError`, warns once per distinct failure, stays silent on transient layer-not-found). For fill layers a literal `fill-outline-color` becomes the swatch outline.
- **Reactivity** — `refresh()` plus opt-in `auto-refresh` (subscribes to the map's `styledata` while connected).
- **Visibility coupling** — `follow-layer-visibility` hides a section while its source layer's `visibility` is `none` (works for the derived section and for explicit sections that set `layer`).
- Attributes `for` / `layer` / `layer-title` / `heading` / `follow-layer-visibility` / `auto-refresh`; CSS parts `root`, `heading`, `section`, `section-title`, `row`, `swatch`, `label`; list semantics with aria-hidden swatches; duck-typed map, no core/maplibre imports; exported from the controls entry and the split package (verify script extended).

## Notes for review

- **Tag overlap (deliberate):** the `web-components` entry already registers a controller-driven `honua-legend`. Both registrations are if-missing guarded, so whichever entry is imported first owns the tag (documented on `defineHonuaControls` and in the element docs). The web-components example imports controls first and now uses this element for its legend.
- Shared `for=`/`honua-map-ready` wiring + escape helpers extracted from the basemap switcher into `src/controls/element-utils.ts` (behavior unchanged; switcher tests untouched and green).
- Example: new categorical `zoning-districts` fill layer styled by a `match` on `district` (Residential/Agricultural/Business/Industrial/Hotel/Open-Park) — the legend derives that section and combines it with explicit incident-priority entries; `::part()` theming in `styles.css`.

## Validation

- 22 new vitest tests in `test/controls/legend.test.ts` (match incl. fallback + array inputs, case, step, literal, graceful rejections with error codes, element refresh/auto-refresh/visibility/escaping); 40/40 controls tests green.
- `typecheck`, `build`, `verify:split-packages` (with new legend smoke), example typecheck + vite build: green.
- Playwright `web-components-basic` spec extended (derived rows incl. "Other", hide/show on layer toggle): 2/2 green locally.
- Full unit suite: 2185 passed; the 30 failures in 11 files (migration CLI/runtime + kepler fixture) are the pre-existing Windows path issues — verified identical on a clean `origin/trunk` stash run.