### PR TITLE
fix(browser): bind default fetch, construct EventSource with new, degrade odata $metadata failures

### DIFF
--- a/src/contract/source.ts
+++ b/src/contract/source.ts
@@ -2730,9 +2730,13 @@ async function buildOdataParams<T>(
     if (rewritten !== "") filterParts.push(rewritten);
   }
   if (request.spatialFilter) {
-    const meta = await entity.metadata();
-    const typeName = meta.entitySets[entity.entitySetName];
-    const spatialFields = (typeName ? meta.fields[typeName] : []) ?? [];
+    // `$metadata` is advisory here — it only refines the geometry column
+    // and SRID context. When it is missing or failing, fall back to the
+    // descriptor-derived `geomColumn` and column defaults instead of
+    // rejecting the query (same degradation as `resolveOdataGeometryColumn`).
+    const meta = await entity.metadata().catch(() => undefined);
+    const typeName = meta ? meta.entitySets[entity.entitySetName] : undefined;
+    const spatialFields = (typeName && meta ? meta.fields[typeName] : undefined) ?? [];
     // The WKT SRID stamps the **input** literal's coordinate system, not
     // the desired output SR (`Query.outSr` controls the response geometry
     // SR via column-side projection on the server). Derive the input SRID
@@ -2970,7 +2974,13 @@ class OdataCapabilityNegotiator {
     // narrower sets short-circuit through `ensureCapability` before this
     // is reached.
     if (!this.declared.includes(capability)) return;
-    const meta = await this.materialize();
+    // A missing or failing `$metadata` endpoint is allowed at runtime —
+    // degrade to the descriptor's declared capability set instead of
+    // rejecting the canonical call, mirroring `fieldsFor` / `keyFields` /
+    // `batchAdvertised`. Errors from the data request itself still
+    // surface from `query`.
+    const meta = await this.materialize().catch(() => undefined);
+    if (!meta) return;
     const advertised: HonuaOdataAdvertisedCapabilities = meta.capabilities[this.entity.entitySetName] ?? {};
     const flag = advertisedFlag(advertised, capability);
     if (flag === false) {

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -377,7 +377,12 @@ export class HonuaClient {
    */
   public constructor(options: HonuaClientOptions) {
     this.baseUrl = normalizeBaseUrl(options.baseUrl);
-    this.fetchFn = options.fetchFn ?? fetch;
+    // Bind to `globalThis` at assignment: the default browser `fetch` is an
+    // unbound `window.fetch`, and invoking it as `this.fetchFn(...)` rebinds
+    // its receiver to the client instance, which browsers reject with
+    // "TypeError: Illegal invocation". Binding is a no-op for Node's undici
+    // fetch and for caller-supplied wrappers (arrow/bound functions ignore it).
+    this.fetchFn = (options.fetchFn ?? fetch).bind(globalThis);
 
     const headers: Record<string, string> = {};
     if (options.apiKey) {

--- a/src/geocoding/index.ts
+++ b/src/geocoding/index.ts
@@ -153,7 +153,11 @@ export class HonuaGeocodingClient {
   public constructor(options: GeocodingClientOptions) {
     this.baseUrl = normalizeBaseUrl(options.baseUrl);
     this.locatorName = options.locatorName ?? "World";
-    this.fetchFn = options.fetchFn ?? fetch;
+    // Bind to `globalThis` at assignment: invoking an unbound `window.fetch`
+    // as `this.fetchFn(...)` throws "TypeError: Illegal invocation" in
+    // browsers. Binding is a no-op for Node's undici fetch and for
+    // caller-supplied wrappers.
+    this.fetchFn = (options.fetchFn ?? fetch).bind(globalThis);
     this.timeoutMs = options.timeoutMs;
 
     const headers: Record<string, string> = {};

--- a/src/migration/content.ts
+++ b/src/migration/content.ts
@@ -190,7 +190,7 @@ export interface ContentReconcileReport {
 }
 
 export async function runContentScan(options: ContentScanOptions): Promise<ContentScanReport> {
-  const fetchFn = options.fetchFn ?? fetch;
+  const fetchFn = options.fetchFn ?? fetch.bind(globalThis);
   const sharingRestBase = resolvePortalSharingRestBase(options.portalUrl);
   const pageSize = options.pageSize ?? DEFAULT_PORTAL_PAGE_SIZE;
 
@@ -223,7 +223,7 @@ export async function runContentScan(options: ContentScanOptions): Promise<Conte
 }
 
 export async function runContentExport(options: ContentExportOptions): Promise<ContentExportReport> {
-  const fetchFn = options.fetchFn ?? fetch;
+  const fetchFn = options.fetchFn ?? fetch.bind(globalThis);
   const includeWebMaps = options.includeWebMaps !== false;
   const includeHostedLayers = options.includeHostedLayers !== false;
   const includeFeatures = options.includeFeatures !== false;
@@ -352,7 +352,7 @@ export async function runContentExport(options: ContentExportOptions): Promise<C
 }
 
 export async function runContentImport(options: ContentImportOptions): Promise<ContentImportReport> {
-  const fetchFn = options.fetchFn ?? fetch;
+  const fetchFn = options.fetchFn ?? fetch.bind(globalThis);
   const sourceDir = path.resolve(options.sourceDir);
   const outputDir = path.resolve(options.outputDir ?? path.join(sourceDir, "content-import"));
   fs.mkdirSync(outputDir, { recursive: true });

--- a/src/migration/demo.ts
+++ b/src/migration/demo.ts
@@ -156,7 +156,7 @@ export async function runMigrationDemo(options: MigrationDemoOptions): Promise<M
 export async function runGeoservicesImportJob(
   options: GeoservicesImportStageOptions,
 ): Promise<GeoservicesImportJobReport> {
-  const fetchFn = options.fetchFn ?? fetch;
+  const fetchFn = options.fetchFn ?? fetch.bind(globalThis);
   const pollIntervalMs =
     typeof options.pollIntervalMs === "number" && Number.isFinite(options.pollIntervalMs)
       ? Math.max(100, Math.trunc(options.pollIntervalMs))

--- a/src/migration/reconcile.ts
+++ b/src/migration/reconcile.ts
@@ -44,7 +44,7 @@ interface QueryFeaturesResponse {
 const DEFAULT_SAMPLE_SIZE = 100;
 
 export async function runLayerReconciliation(options: LayerReconciliationOptions): Promise<LayerReconciliationReport> {
-  const fetchFn = options.fetchFn ?? fetch;
+  const fetchFn = options.fetchFn ?? fetch.bind(globalThis);
   const sampleSize =
     typeof options.sampleSize === "number" && Number.isFinite(options.sampleSize)
       ? Math.max(1, Math.trunc(options.sampleSize))

--- a/src/realtime/sse.ts
+++ b/src/realtime/sse.ts
@@ -139,13 +139,19 @@ function createEventSource<TFeature>(
   url: string,
   options: RealtimeServerSentEventsTransportOptions<TFeature>,
 ): RealtimeServerSentEventSource {
-  const factory =
-    options.eventSourceFactory ??
-    ((globalThis as unknown as { EventSource?: RealtimeServerSentEventSourceFactory }).EventSource as
-      | RealtimeServerSentEventSourceFactory
-      | undefined);
-  if (!factory) throw new Error("EventSource is not available; provide eventSourceFactory for this runtime.");
-  return factory(url, { withCredentials: options.withCredentials });
+  if (options.eventSourceFactory) {
+    return options.eventSourceFactory(url, { withCredentials: options.withCredentials });
+  }
+  // The global `EventSource` is a constructor: calling it as a plain
+  // function (`EventSource(url, init)`) throws a TypeError in browsers,
+  // so the default path must construct with `new`.
+  const EventSourceCtor = (
+    globalThis as unknown as {
+      EventSource?: new (url: string, init?: EventSourceInit) => RealtimeServerSentEventSource;
+    }
+  ).EventSource;
+  if (!EventSourceCtor) throw new Error("EventSource is not available; provide eventSourceFactory for this runtime.");
+  return new EventSourceCtor(url, { withCredentials: options.withCredentials });
 }
 
 function resolveEventSourceUrl(input: string, url: URL): string {

--- a/src/runtime/map-package-realtime.ts
+++ b/src/runtime/map-package-realtime.ts
@@ -413,13 +413,19 @@ function createEventSource(
   url: string,
   options: MapPackageServerSentEventsTransportOptions,
 ): MapPackageRealtimeEventSource {
-  const factory =
-    options.eventSourceFactory ??
-    ((globalThis as unknown as { EventSource?: MapPackageRealtimeEventSourceFactory }).EventSource as
-      | MapPackageRealtimeEventSourceFactory
-      | undefined);
-  if (!factory) throw new Error("EventSource is not available; provide eventSourceFactory for this runtime.");
-  return factory(url, { withCredentials: options.withCredentials });
+  if (options.eventSourceFactory) {
+    return options.eventSourceFactory(url, { withCredentials: options.withCredentials });
+  }
+  // The global `EventSource` is a constructor: calling it as a plain
+  // function (`EventSource(url, init)`) throws a TypeError in browsers,
+  // so the default path must construct with `new`.
+  const EventSourceCtor = (
+    globalThis as unknown as {
+      EventSource?: new (url: string, init?: EventSourceInit) => MapPackageRealtimeEventSource;
+    }
+  ).EventSource;
+  if (!EventSourceCtor) throw new Error("EventSource is not available; provide eventSourceFactory for this runtime.");
+  return new EventSourceCtor(url, { withCredentials: options.withCredentials });
 }
 
 function applyMapPackageRealtimeAuth(url: URL, auth: MapPackageRealtimeAuth | undefined): void {

--- a/src/scene-workspace/cesium-adapter.ts
+++ b/src/scene-workspace/cesium-adapter.ts
@@ -455,7 +455,7 @@ export function resolveHonua3DStyleUri(uri: string, tilesetUrl: string): string 
  */
 export async function fetchHonua3DStyleSpec(
   styleUrl: string,
-  fetchImpl: typeof fetch = fetch,
+  fetchImpl: typeof fetch = fetch.bind(globalThis),
 ): Promise<Honua3DStyleSpec> {
   const response = await fetchImpl(styleUrl);
   if (!response.ok) {
@@ -476,7 +476,7 @@ export async function fetchHonua3DStyleSpec(
 export async function loadHonua3DStyle(
   extras: unknown,
   tilesetUrl: string,
-  fetchImpl: typeof fetch = fetch,
+  fetchImpl: typeof fetch = fetch.bind(globalThis),
 ): Promise<Honua3DStyleSpec | undefined> {
   const descriptor = readHonua3DStyleDescriptor(extras);
   if (!descriptor) return undefined;
@@ -542,7 +542,7 @@ export async function applyTilesetServerStyle(
   tileset: CesiumTilesetLike,
   tilesetUrl: string,
   cesium?: CesiumModule,
-  fetchImpl: typeof fetch = fetch,
+  fetchImpl: typeof fetch = fetch.bind(globalThis),
 ): Promise<Honua3DStyleSpec | undefined> {
   const spec = await loadHonua3DStyle(tileset.extras, tilesetUrl, fetchImpl);
   if (!spec) return undefined;
@@ -592,7 +592,7 @@ export async function addCesium3DTileset(
     tileset.modelMatrix = placementToModelMatrix(mod, modelLayerToCesiumPlacement(primitive));
   }
   if (options.applyServerStyle !== false) {
-    await applyTilesetServerStyle(tileset, primitive.uri, mod, options.fetchImpl ?? fetch);
+    await applyTilesetServerStyle(tileset, primitive.uri, mod, options.fetchImpl ?? fetch.bind(globalThis));
   }
   scene.primitives.add(tileset);
   return makeLayerHandle(scene, primitive.id, tileset, "model-layer", primitive.format);

--- a/test/contract/odata-conformance.test.ts
+++ b/test/contract/odata-conformance.test.ts
@@ -1518,3 +1518,49 @@ describe("odata / HonuaOdataEntitySet.apply signature (README fix)", () => {
     expect(result.rows).toHaveLength(2);
   });
 });
+
+describe("odata / $metadata degradation", () => {
+  function makeMetadataFailingSource(extra?: Partial<SourceDescriptor>) {
+    const client = makeMockClient({
+      routes: [
+        ["/odata/$metadata", () => new Response("metadata unavailable", { status: 500 })],
+        ["/odata/Parcels", () => jsonResponse(odataParcelsResponse())],
+      ],
+    });
+    return odataSource<ParcelAttrs>(
+      {
+        id: "parcels-odata",
+        protocol: "odata",
+        locator: { url: "https://mock/odata", entitySet: "Parcels" },
+        capabilities: PROTOCOL_DEFAULT_CAPABILITIES.odata,
+        ...extra,
+      },
+      client,
+      "strict",
+    );
+  }
+
+  it("query() succeeds when $metadata is missing or failing — the capability check degrades like fieldsFor (#270)", async () => {
+    // `ensureAdvertised` must not reject the canonical surface when the
+    // `$metadata` fetch fails; it degrades to the declared capability
+    // set the same way `fieldsFor` tolerates a missing schema.
+    const source = makeMetadataFailingSource();
+    const result = await source.query({ where: "STATE eq 'CA'" });
+    expect(result.features).toHaveLength(PARCEL_FEATURES.length);
+    // Schema degraded silently — no fields block, but no rejection.
+    expect(result.fields ?? []).toEqual([]);
+  });
+
+  it("spatial-filter queries succeed without $metadata — SRID/geometry context degrades to defaults", async () => {
+    // The geometry column comes from the descriptor schema; `$metadata`
+    // only refines the SRID context here, so its failure must not
+    // reject the query.
+    const source = makeMetadataFailingSource({
+      schema: { fields: [{ name: "Geometry", type: "esriFieldTypeGeometry" }] },
+    });
+    const result = await source.query({
+      spatialFilter: envelope(-120, 30, -110, 40, { wkid: 4326 }),
+    });
+    expect(result.features).toHaveLength(PARCEL_FEATURES.length);
+  });
+});

--- a/test/core-client.test.ts
+++ b/test/core-client.test.ts
@@ -1578,3 +1578,33 @@ function buildMinimalPbf(): Uint8Array {
   const fcpb = [...sf(1, "1.0"), ...ld(2, queryResult)];
   return new Uint8Array(fcpb);
 }
+
+describe("HonuaClient default fetch binding", () => {
+  // Browsers reject `window.fetch` invoked with any receiver other than
+  // the global object — calling the stored default through
+  // `this.fetchFn(...)` rebinds the receiver to the client instance and
+  // throws "TypeError: Illegal invocation" (#269). Emulate the browser
+  // receiver contract in Node with a strict double so the regression
+  // fails when the default fetch is stored unbound.
+  it("invokes the default global fetch with a globalThis-safe receiver, not the client instance", async () => {
+    const realFetch = globalThis.fetch;
+    const strictFetch = function (this: unknown, ..._args: Parameters<typeof fetch>): Promise<Response> {
+      if (this !== undefined && this !== globalThis) {
+        throw new TypeError("Illegal invocation");
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ services: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    };
+    globalThis.fetch = strictFetch as typeof fetch;
+    try {
+      const client = new HonuaClient({ baseUrl: "https://example.test" });
+      await expect(client.listServices()).resolves.toMatchObject({ services: [] });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});

--- a/test/geocoding.test.ts
+++ b/test/geocoding.test.ts
@@ -567,4 +567,34 @@ describe("HonuaGeocodingClient", () => {
       expect(capturedUrl).not.toContain("///");
     });
   });
+
+  describe("default fetch binding", () => {
+    // Browsers reject `window.fetch` invoked with any receiver other than
+    // the global object — calling the stored default through
+    // `this.fetchFn(...)` rebinds the receiver to the client instance and
+    // throws "TypeError: Illegal invocation" (#272, same family as #269).
+    // Emulate the browser receiver contract in Node with a strict double
+    // so the regression fails when the default fetch is stored unbound.
+    it("invokes the default global fetch with a globalThis-safe receiver, not the client instance", async () => {
+      const realFetch = globalThis.fetch;
+      const strictFetch = function (this: unknown, ..._args: Parameters<typeof fetch>): Promise<Response> {
+        if (this !== undefined && this !== globalThis) {
+          throw new TypeError("Illegal invocation");
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify({ candidates: [] }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      };
+      globalThis.fetch = strictFetch as typeof fetch;
+      try {
+        const client = new HonuaGeocodingClient({ baseUrl: BASE_URL });
+        await expect(client.forwardGeocode("380 New York St, Redlands")).resolves.toEqual([]);
+      } finally {
+        globalThis.fetch = realFetch;
+      }
+    });
+  });
 });

--- a/test/realtime.test.ts
+++ b/test/realtime.test.ts
@@ -477,3 +477,50 @@ describe("realtime feature state", () => {
     ctx.dispose();
   });
 });
+
+describe("realtime SSE default EventSource factory", () => {
+  // The global `EventSource` is a constructor: invoking it as a plain
+  // call (`EventSource(url, init)`) throws a TypeError in browsers
+  // (#271). A class double reproduces that — class constructors also
+  // throw when invoked without `new` — so this test fails unless the
+  // default factory constructs the source.
+  it("constructs the global EventSource with `new` when no eventSourceFactory is provided", () => {
+    const constructed: GlobalEventSourceDouble[] = [];
+    class GlobalEventSourceDouble implements RealtimeServerSentEventSource {
+      public onopen: ((event: Event) => void) | null = null;
+      public onmessage: ((event: MessageEvent<string>) => void) | null = null;
+      public onerror: ((event: Event) => void) | null = null;
+      public readyState = 0;
+      public closed = false;
+      public constructor(
+        public readonly url: string,
+        public readonly init?: EventSourceInit,
+      ) {
+        constructed.push(this);
+      }
+      public close(): void {
+        this.closed = true;
+        this.readyState = 2;
+      }
+    }
+    vi.stubGlobal("EventSource", GlobalEventSourceDouble);
+    try {
+      const transport = createRealtimeServerSentEventsTransport<{ status: string }>({
+        url: "https://honua.example/api/v1/realtime/events",
+        withCredentials: true,
+      });
+      const handle = transport.subscribe(
+        { sourceId: "incidents" },
+        { next: () => {}, error: () => {}, complete: () => {} },
+      );
+      expect(constructed).toHaveLength(1);
+      expect(constructed[0]).toBeInstanceOf(GlobalEventSourceDouble);
+      expect(constructed[0].url).toContain("sourceId=incidents");
+      expect(constructed[0].init).toEqual({ withCredentials: true });
+      handle.close();
+      expect(constructed[0].closed).toBe(true);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/test/runtime/map-package-watch.test.ts
+++ b/test/runtime/map-package-watch.test.ts
@@ -11,6 +11,7 @@ import {
   type MapPackageRealtimeSubscribeRequest,
   type MapPackageRealtimeTransport,
   type MapPackageWatchEvent,
+  createMapPackageServerSentEventsTransport,
   mapPackageFingerprint,
   watchMapPackage,
 } from "../../src/runtime/index.js";
@@ -410,3 +411,58 @@ function jsonResponse(body: unknown): Response {
 async function flushPromises(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
+
+describe("map-package SSE default EventSource factory", () => {
+  // The global `EventSource` is a constructor: invoking it as a plain
+  // call (`EventSource(url, init)`) throws a TypeError in browsers —
+  // the same family as the realtime SSE transport bug (#271). A class
+  // double reproduces that — class constructors also throw when invoked
+  // without `new` — so this test fails unless the default factory
+  // constructs the source.
+  test("constructs the global EventSource with `new` when no eventSourceFactory is provided", () => {
+    const constructed: GlobalEventSourceDouble[] = [];
+    class GlobalEventSourceDouble implements MapPackageRealtimeEventSource {
+      public onopen: ((event: Event) => void) | null = null;
+      public onmessage: ((event: MessageEvent<string>) => void) | null = null;
+      public onerror: ((event: Event) => void) | null = null;
+      public readyState = 0;
+      public closed = false;
+      public constructor(
+        public readonly url: string,
+        public readonly init?: EventSourceInit,
+      ) {
+        constructed.push(this);
+      }
+      public close(): void {
+        this.closed = true;
+        this.readyState = 2;
+      }
+    }
+    vi.stubGlobal("EventSource", GlobalEventSourceDouble);
+    try {
+      const transport = createMapPackageServerSentEventsTransport({
+        url: "/api/v1/map-packages/pkg-001/watch",
+        withCredentials: true,
+      });
+      const controller = new AbortController();
+      const handle = transport.subscribe(
+        {
+          locator: "pkg-001",
+          packageId: "pkg-001",
+          path: "/api/v1/map-packages/pkg-001",
+          client: { serverBaseUrl: "https://honua.example" } as unknown as HonuaClient,
+          signal: controller.signal,
+        },
+        { connected: () => {}, message: () => {}, disconnected: () => {}, error: () => {} },
+      );
+      expect(constructed).toHaveLength(1);
+      expect(constructed[0]).toBeInstanceOf(GlobalEventSourceDouble);
+      expect(constructed[0].url).toContain("packageId=pkg-001");
+      expect(constructed[0].init).toEqual({ withCredentials: true });
+      handle.close();
+      expect(constructed[0].closed).toBe(true);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes four browser-runtime bugs that only surface outside Node:

- **#269 / #272 — unbound default `fetch`**: `HonuaClient` and `HonuaGeocodingClient` stored the default as `options.fetchFn ?? fetch`, so invoking it via `this.fetchFn(...)` rebound the receiver to the client instance — browsers reject that with `TypeError: Illegal invocation`. The default is now bound to `globalThis` at assignment (a no-op for Node's undici fetch and for caller-supplied wrappers). The same unbound-default pattern was swept repo-wide and fixed in `src/migration/content.ts`, `src/migration/demo.ts`, `src/migration/reconcile.ts`, and `src/scene-workspace/cesium-adapter.ts`.
- **#271 — `EventSource` called without `new`**: the default `eventSourceFactory` in both `src/realtime/sse.ts` and `src/runtime/map-package-realtime.ts` invoked the global `EventSource` as a plain function, which throws in browsers since it is a constructor. The default path now constructs with `new`; caller-supplied factories are untouched.
- **#270 — odata `ensureAdvertised` rejects on missing `$metadata`**: the capability negotiator awaited `$metadata` uncaught, so a missing/failing metadata endpoint failed `query()` even though `fieldsFor`/`keyFields`/`batchAdvertised` all tolerate its absence. `ensureAdvertised` and the spatial-filter SRID resolution in `buildOdataParams` now catch the failure and degrade to descriptor-declared capabilities/columns.

## Regression tests

- `test/core-client.test.ts`, `test/geocoding.test.ts`: strict fetch doubles that throw `Illegal invocation` unless invoked with a `globalThis`-safe receiver.
- `test/realtime.test.ts`, `test/runtime/map-package-watch.test.ts`: class-based `EventSource` doubles (class constructors throw when called without `new`), asserting construction, URL/init propagation, and close.
- `test/contract/odata-conformance.test.ts`: `$metadata` returning 500 — `query()` and spatial-filter queries succeed with degraded schema instead of rejecting.

## Verification

- Targeted suites: 5 files, 184 tests passing
- `npm run typecheck` clean, `npm run lint` clean (614 files), `npm run build` clean
- Rebased onto trunk after #275/#277 (clean fast-forward, no conflicts)

Fixes #269
Fixes #270
Fixes #271
Fixes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)
