### PR TITLE
feat(sdk): MapLibre/browser consumption cluster (#264–#268)

### DIFF
--- a/docs/migration-honua-maplibre.md
+++ b/docs/migration-honua-maplibre.md
@@ -61,6 +61,43 @@ is defined in `src/migration/codemod.ts` as
 
 The helper signatures live in `src/map/maplibre-target.ts`.
 
+### Rendering feature-service layers (custom source → `geojson`)
+
+`createHonuaTileServiceLayer` and `createHonuaMapServiceLayer` emit
+MapLibre-native `raster` sources that render as soon as you add them to
+a map. `createHonuaFeatureServiceLayer` is different: its `source` uses
+the custom `honua-feature-service` type, which MapLibre's renderer does
+not understand. Adding that source to a `maplibre-gl` `Map` directly is
+a silent no-op — no error, no features.
+
+To render feature-service layers, run them through the MapLibre runtime
+adapter exported from `@honua/sdk-js/map`. It fetches features via the
+SDK query path and produces a standard `geojson` source MapLibre renders
+natively:
+
+```ts
+import maplibregl from "maplibre-gl";
+import { HonuaClient } from "@honua/sdk-js";
+import {
+  createHonuaFeatureServiceLayer,
+  loadHonuaFeatureServiceGeoJson,
+} from "@honua/sdk-js/map";
+
+const client = new HonuaClient({ baseUrl: "https://gis.example.com" });
+const layer = createHonuaFeatureServiceLayer({ url, outFields: ["*"] });
+
+// Replace the custom honua-feature-service source with a fetched geojson source.
+const source = await loadHonuaFeatureServiceGeoJson(client, layer.source.url);
+map.addSource(layer.sourceId, source);
+map.addLayer(layer.layer);
+```
+
+For a whole `HonuaMap`, `registerHonuaFeatureServiceSources(map, honuaMap,
+client)` walks every `honua-feature-service` source and live-patches it
+on the MapLibre map (adding a new `geojson` source or calling `setData`
+on an existing one). Both helpers live in
+`src/map/feature-service-adapter.ts`.
+
 Every other constructor kind in `REWRITE_SPECS` — geometries,
 symbols, renderers, `WebMap`, `SceneView`, `GraphicsLayer`,
 `GroupLayer`, `VectorTileLayer`, `GeoJSONLayer`, `WMSLayer`,

--- a/examples/maplibre-quickstart/src/esri-geojson.ts
+++ b/examples/maplibre-quickstart/src/esri-geojson.ts
@@ -1,3 +1,4 @@
+import { esriGeometryToGeoJSON } from "@honua/sdk-js";
 import type { HonuaFeature } from "@honua/sdk-js/honua";
 
 export type QuickstartRenderableGeometryType = "point" | "line" | "polygon";
@@ -96,170 +97,6 @@ function isFinitePosition(value: unknown): value is QuickstartPosition {
   );
 }
 
-function collectFinitePositions(value: unknown): QuickstartPosition[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.filter(isFinitePosition);
-}
-
-function collectPositionSets(value: unknown): QuickstartPosition[][] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.map((entry) => collectFinitePositions(entry)).filter((entry) => entry.length > 0);
-}
-
-function computeRingSignedArea(ring: readonly QuickstartPosition[]): number {
-  if (ring.length < 3) {
-    return 0;
-  }
-
-  let area = 0;
-  for (let index = 0; index < ring.length; index += 1) {
-    const current = ring[index];
-    const next = ring[(index + 1) % ring.length];
-    if (!current || !next) {
-      continue;
-    }
-    area += current[0] * next[1] - next[0] * current[1];
-  }
-
-  return area / 2;
-}
-
-function isExteriorRing(ring: readonly QuickstartPosition[]): boolean {
-  return computeRingSignedArea(ring) < 0;
-}
-
-function isPointOnSegment(
-  point: QuickstartPosition,
-  segmentStart: QuickstartPosition,
-  segmentEnd: QuickstartPosition,
-): boolean {
-  const epsilon = 1e-9;
-  const crossProduct =
-    (point[0] - segmentStart[0]) * (segmentEnd[1] - segmentStart[1]) -
-    (point[1] - segmentStart[1]) * (segmentEnd[0] - segmentStart[0]);
-
-  if (Math.abs(crossProduct) > epsilon) {
-    return false;
-  }
-
-  const dotProduct =
-    (point[0] - segmentStart[0]) * (segmentEnd[0] - segmentStart[0]) +
-    (point[1] - segmentStart[1]) * (segmentEnd[1] - segmentStart[1]);
-  if (dotProduct < -epsilon) {
-    return false;
-  }
-
-  const segmentLengthSquared =
-    (segmentEnd[0] - segmentStart[0]) * (segmentEnd[0] - segmentStart[0]) +
-    (segmentEnd[1] - segmentStart[1]) * (segmentEnd[1] - segmentStart[1]);
-
-  return dotProduct - segmentLengthSquared <= epsilon;
-}
-
-function isPointInsideRing(point: QuickstartPosition, ring: readonly QuickstartPosition[]): boolean {
-  if (ring.length < 3) {
-    return false;
-  }
-
-  let isInside = false;
-  for (let index = 0, previousIndex = ring.length - 1; index < ring.length; previousIndex = index, index += 1) {
-    const current = ring[index];
-    const previous = ring[previousIndex];
-    if (!current || !previous) {
-      continue;
-    }
-
-    if (isPointOnSegment(point, previous, current)) {
-      return true;
-    }
-
-    const intersects =
-      current[1] > point[1] !== previous[1] > point[1] &&
-      point[0] < ((previous[0] - current[0]) * (point[1] - current[1])) / (previous[1] - current[1]) + current[0];
-    if (intersects) {
-      isInside = !isInside;
-    }
-  }
-
-  return isInside;
-}
-
-function findContainingPolygonIndex(
-  polygons: readonly QuickstartPosition[][][],
-  outerAreas: readonly number[],
-  ring: readonly QuickstartPosition[],
-): number {
-  const samplePoint = ring[0];
-  if (!samplePoint) {
-    return -1;
-  }
-
-  let containingPolygonIndex = -1;
-  let smallestContainingArea = Number.POSITIVE_INFINITY;
-
-  for (let index = 0; index < polygons.length; index += 1) {
-    const polygon = polygons[index];
-    const outerRing = polygon?.[0];
-    const outerArea = outerAreas[index];
-    if (!outerRing || outerArea === undefined || !isPointInsideRing(samplePoint, outerRing)) {
-      continue;
-    }
-
-    if (outerArea < smallestContainingArea) {
-      smallestContainingArea = outerArea;
-      containingPolygonIndex = index;
-    }
-  }
-
-  return containingPolygonIndex;
-}
-
-function convertPolygonRings(
-  rings: readonly QuickstartPosition[][],
-): QuickstartGeoJsonPolygon | QuickstartGeoJsonMultiPolygon {
-  const polygons: QuickstartPosition[][][] = [];
-  const outerAreas: number[] = [];
-  const interiorRings: QuickstartPosition[][] = [];
-
-  for (const ring of rings) {
-    if (isExteriorRing(ring)) {
-      polygons.push([ring]);
-      outerAreas.push(Math.abs(computeRingSignedArea(ring)));
-      continue;
-    }
-
-    interiorRings.push(ring);
-  }
-
-  for (const ring of interiorRings) {
-    const containingPolygonIndex = findContainingPolygonIndex(polygons, outerAreas, ring);
-
-    if (containingPolygonIndex < 0) {
-      polygons.push([ring]);
-      outerAreas.push(Math.abs(computeRingSignedArea(ring)));
-      continue;
-    }
-
-    polygons[containingPolygonIndex]?.push(ring);
-  }
-
-  return polygons.length === 1
-    ? {
-        type: "Polygon",
-        coordinates: polygons[0] ?? [],
-      }
-    : {
-        type: "MultiPolygon",
-        coordinates: polygons,
-      };
-}
-
 function includeCoordinate(bounds: QuickstartBounds | undefined, coordinate: QuickstartPosition): QuickstartBounds {
   if (!bounds) {
     return {
@@ -305,81 +142,22 @@ export function mergeBounds(boundsList: readonly (QuickstartBounds | undefined)[
   return merged;
 }
 
+/**
+ * Convert a contract feature's Esri geometry into the quickstart GeoJSON shape.
+ *
+ * Conversion is delegated to the SDK's shared {@link esriGeometryToGeoJSON}
+ * utility; this wrapper only narrows the SDK's `number[]` coordinates into the
+ * `[number, number]` tuples the quickstart map code uses.
+ */
 function convertGeometry(geometry: HonuaFeature["geometry"]): QuickstartGeoJsonGeometry | null {
-  if (!geometry) {
+  const converted = esriGeometryToGeoJSON(geometry);
+  if (!converted) {
     return null;
   }
-
-  if ("x" in geometry && "y" in geometry && typeof geometry.x === "number" && typeof geometry.y === "number") {
-    return {
-      type: "Point",
-      coordinates: [geometry.x, geometry.y],
-    };
-  }
-
-  if ("points" in geometry && Array.isArray(geometry.points)) {
-    const coordinates = collectFinitePositions(geometry.points);
-    if (coordinates.length < 1) {
-      return null;
-    }
-
-    return {
-      type: "MultiPoint",
-      coordinates,
-    };
-  }
-
-  if ("paths" in geometry && Array.isArray(geometry.paths)) {
-    const coordinates = collectPositionSets(geometry.paths);
-    if (coordinates.length < 1) {
-      return null;
-    }
-
-    return coordinates.length === 1
-      ? {
-          type: "LineString",
-          coordinates: coordinates[0] ?? [],
-        }
-      : {
-          type: "MultiLineString",
-          coordinates,
-        };
-  }
-
-  if ("rings" in geometry && Array.isArray(geometry.rings)) {
-    const coordinates = collectPositionSets(geometry.rings);
-    if (coordinates.length < 1) {
-      return null;
-    }
-
-    return convertPolygonRings(coordinates);
-  }
-
-  if (
-    "xmin" in geometry &&
-    "ymin" in geometry &&
-    "xmax" in geometry &&
-    "ymax" in geometry &&
-    typeof geometry.xmin === "number" &&
-    typeof geometry.ymin === "number" &&
-    typeof geometry.xmax === "number" &&
-    typeof geometry.ymax === "number"
-  ) {
-    return {
-      type: "Polygon",
-      coordinates: [
-        [
-          [geometry.xmin, geometry.ymin],
-          [geometry.xmax, geometry.ymin],
-          [geometry.xmax, geometry.ymax],
-          [geometry.xmin, geometry.ymax],
-          [geometry.xmin, geometry.ymin],
-        ],
-      ],
-    };
-  }
-
-  return null;
+  // The SDK emits GeoJSON with `number[]` positions; the quickstart map code
+  // works with `[number, number]` tuples. The structures are identical at
+  // runtime, so a single cast keeps the quickstart types intact.
+  return converted as unknown as QuickstartGeoJsonGeometry;
 }
 
 export function convertEsriFeaturesToGeoJson(

--- a/src/contract/source.ts
+++ b/src/contract/source.ts
@@ -1212,11 +1212,14 @@ export function wmtsSource<T>(descriptor: SourceDescriptor, client: HonuaClient,
  * Adapter factory for a STAC API search endpoint.
  *
  * The canonical `Source.query()` runs a `POST /search` against the STAC root,
- * with `Query.spatialFilter.bbox` and `Query.where` translated into STAC's
- * `bbox` / `datetime` / `filter` parameters.
+ * with `Query.spatialFilter` (e.g. an `envelope(...)` bounding box) and
+ * `Query.where` translated into STAC's `bbox` / `datetime` / `filter`
+ * parameters.
  *
  * @example
  * ```ts
+ * import { envelope } from "@honua/sdk-js";
+ *
  * const dataset = createDataset({
  *   id: "imagery",
  *   client,
@@ -1229,7 +1232,7 @@ export function wmtsSource<T>(descriptor: SourceDescriptor, client: HonuaClient,
  * });
  * const result = await dataset.source("stac-search")!.query({
  *   where: "collections IN ('landsat-c2-l2')",
- *   spatialFilter: { kind: "bbox", bbox: [-158.5, 21.2, -157.6, 21.7] },
+ *   spatialFilter: envelope(-158.5, 21.2, -157.6, 21.7),
  * });
  * ```
  */

--- a/src/contract/types.ts
+++ b/src/contract/types.ts
@@ -436,12 +436,17 @@ export interface AggregationMetric {
  * into a `QueryFeaturesRequest`, `MapLayerQueryRequest`, `OgcItemsRequest`,
  * or the corresponding WFS / OData request.
  *
+ * `spatialFilter` is a `SpatialFilter` produced by the spatial-filter builders
+ * (`envelope`, `point`, `polygon`, `buffer`, …), not an inline literal.
+ *
  * @example
  * ```ts
+ * import { envelope } from "@honua/sdk-js";
+ *
  * const query: Query = {
  *   where: "STATUS = 'ACTIVE'",
  *   outFields: ["OBJECTID", "NAME"],
- *   spatialFilter: { kind: "bbox", bbox: [-158.5, 21.2, -157.6, 21.7] },
+ *   spatialFilter: envelope(-158.5, 21.2, -157.6, 21.7),
  *   orderBy: [{ field: "REPORTED_AT", direction: "desc" }],
  *   pagination: { limit: 500 },
  *   returnGeometry: true,

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -18,7 +18,7 @@ import { HonuaOgcMaps } from "./ogc-maps.js";
 import { HonuaOgcProcesses } from "./ogc-processes.js";
 import { HonuaOgcRecords } from "./ogc-records.js";
 import { HonuaOgcTiles } from "./ogc-tiles.js";
-import { stripQuery, trimTrailingSlashes } from "./path-utils.js";
+import { encodeServiceIdPath, stripQuery, trimTrailingSlashes } from "./path-utils.js";
 import { decodePbfQueryResponse, isPbfResponse } from "./pbf-decoder.js";
 import {
   type HonuaProcessRunner,
@@ -1171,7 +1171,7 @@ export class HonuaClient {
     options: HonuaMetadataRequestOptions = {},
   ): Promise<HonuaLayerMetadata> {
     const query = new URLSearchParams({ f: "json" });
-    const path = `/rest/services/${encodeURIComponent(serviceId)}/FeatureServer/${layerId}?${query.toString()}`;
+    const path = `/rest/services/${encodeServiceIdPath(serviceId)}/FeatureServer/${layerId}?${query.toString()}`;
     return this.requestCachedMetadataJson<HonuaLayerMetadata>(
       `geoservices-feature:${serviceId}:${layerId}`,
       path,
@@ -1184,7 +1184,7 @@ export class HonuaClient {
     options: HonuaMetadataRequestOptions = {},
   ): Promise<HonuaServiceMetadata> {
     const query = new URLSearchParams({ f: "json" });
-    const path = `/rest/services/${encodeURIComponent(serviceId)}/FeatureServer?${query.toString()}`;
+    const path = `/rest/services/${encodeServiceIdPath(serviceId)}/FeatureServer?${query.toString()}`;
     return this.requestCachedMetadataJson<HonuaServiceMetadata>(
       `geoservices-feature:${serviceId}:service`,
       path,
@@ -1935,7 +1935,7 @@ export class HonuaClient {
     options: HonuaMetadataRequestOptions = {},
   ): Promise<HonuaServiceMetadata> {
     const query = new URLSearchParams({ f: "json" });
-    const path = `/rest/services/${encodeURIComponent(serviceId)}/MapServer?${query.toString()}`;
+    const path = `/rest/services/${encodeServiceIdPath(serviceId)}/MapServer?${query.toString()}`;
     return this.requestCachedMetadataJson<HonuaServiceMetadata>(`geoservices-map:${serviceId}:service`, path, options);
   }
 
@@ -1945,7 +1945,7 @@ export class HonuaClient {
     options: HonuaMetadataRequestOptions = {},
   ): Promise<HonuaLayerMetadata> {
     const query = new URLSearchParams({ f: "json" });
-    const path = `/rest/services/${encodeURIComponent(serviceId)}/MapServer/${layerId}?${query.toString()}`;
+    const path = `/rest/services/${encodeServiceIdPath(serviceId)}/MapServer/${layerId}?${query.toString()}`;
     return this.requestCachedMetadataJson<HonuaLayerMetadata>(`geoservices-map:${serviceId}:${layerId}`, path, options);
   }
 
@@ -2002,7 +2002,7 @@ export class HonuaClient {
     serializeQueryParams(params, request);
     appendQueryExtraParams(params, request);
 
-    const path = `/rest/services/${encodeURIComponent(request.serviceId)}/FeatureServer/${request.layerId}/query`;
+    const path = `/rest/services/${encodeServiceIdPath(request.serviceId)}/FeatureServer/${request.layerId}/query`;
 
     if (usePbf) {
       return this.requestBinaryWithJsonFallback(
@@ -2046,7 +2046,7 @@ export class HonuaClient {
     serializeQueryParams(params, request);
     appendQueryExtraParams(params, request);
 
-    const path = `/rest/services/${encodeURIComponent(request.serviceId)}/MapServer/${request.layerId}/query`;
+    const path = `/rest/services/${encodeServiceIdPath(request.serviceId)}/MapServer/${request.layerId}/query`;
     if (method === "GET") {
       return this.requestJson(
         "GET",
@@ -2070,7 +2070,7 @@ export class HonuaClient {
   }
 
   public async applyEdits(request: ApplyEditsRequest): Promise<HonuaApplyEditsResponse> {
-    const path = `/rest/services/${encodeURIComponent(request.serviceId)}/FeatureServer/${request.layerId}/applyEdits`;
+    const path = `/rest/services/${encodeServiceIdPath(request.serviceId)}/FeatureServer/${request.layerId}/applyEdits`;
     const params = new URLSearchParams();
     params.set("f", "json");
     params.set("rollbackOnFailure", String(request.rollbackOnFailure ?? true));
@@ -2119,7 +2119,7 @@ export class HonuaClient {
     }
 
     const path =
-      `/rest/services/${encodeURIComponent(request.serviceId)}` +
+      `/rest/services/${encodeServiceIdPath(request.serviceId)}` +
       `/FeatureServer/${request.layerId}/queryRelatedRecords`;
     if (method === "GET") {
       return this.requestJson(
@@ -2165,7 +2165,7 @@ export class HonuaClient {
     }
 
     const path =
-      `/rest/services/${encodeURIComponent(request.serviceId)}` + `/MapServer/${request.layerId}/queryRelatedRecords`;
+      `/rest/services/${encodeServiceIdPath(request.serviceId)}` + `/MapServer/${request.layerId}/queryRelatedRecords`;
     if (method === "GET") {
       return this.requestJson(
         "GET",
@@ -2222,7 +2222,7 @@ export class HonuaClient {
       }
     }
 
-    const path = `/rest/services/${encodeURIComponent(request.serviceId)}/MapServer/export`;
+    const path = `/rest/services/${encodeServiceIdPath(request.serviceId)}/MapServer/export`;
     if (method === "GET") {
       return this.requestJson("GET", `${path}?${params.toString()}`) as Promise<HonuaExportMapResponse>;
     }
@@ -2250,7 +2250,7 @@ export class HonuaClient {
       }
     }
 
-    const path = `/rest/services/${encodeURIComponent(request.serviceId)}/MapServer/legend`;
+    const path = `/rest/services/${encodeServiceIdPath(request.serviceId)}/MapServer/legend`;
     return this.requestJson("GET", `${path}?${params.toString()}`) as Promise<HonuaLegendResponse>;
   }
 
@@ -2289,7 +2289,7 @@ export class HonuaClient {
       }
     }
 
-    const path = `/rest/services/${encodeURIComponent(request.serviceId)}/MapServer/identify`;
+    const path = `/rest/services/${encodeServiceIdPath(request.serviceId)}/MapServer/identify`;
     if (method === "GET") {
       return this.requestJson("GET", `${path}?${params.toString()}`) as Promise<HonuaIdentifyResponse>;
     }
@@ -2350,7 +2350,7 @@ export class HonuaClient {
       }
     }
 
-    const path = `/rest/services/${encodeURIComponent(request.serviceId)}/MapServer/find`;
+    const path = `/rest/services/${encodeServiceIdPath(request.serviceId)}/MapServer/find`;
     if (method === "GET") {
       return this.requestJson("GET", `${path}?${params.toString()}`) as Promise<HonuaFindResponse>;
     }
@@ -3771,12 +3771,12 @@ function stacFieldsCsv(fields: StacSearchRequest["fields"] | undefined): string 
 
 /** Canonical WMS endpoint path. honua-server publishes both `/rest/services/{id}/MapServer/WMS` and `/ogc/services/{id}/wms`; the SDK targets the GeoServices-aliased path because every Honua deployment exposes it. */
 function wmsBasePath(serviceId: string): string {
-  return `/rest/services/${encodeURIComponent(serviceId)}/MapServer/WMS`;
+  return `/rest/services/${encodeServiceIdPath(serviceId)}/MapServer/WMS`;
 }
 
 /** Canonical WMTS endpoint path. */
 function wmtsBasePath(serviceId: string): string {
-  return `/rest/services/${encodeURIComponent(serviceId)}/MapServer/WMTS`;
+  return `/rest/services/${encodeServiceIdPath(serviceId)}/MapServer/WMTS`;
 }
 
 /**

--- a/src/core/esri-geojson.ts
+++ b/src/core/esri-geojson.ts
@@ -1,0 +1,333 @@
+/**
+ * Convert Esri-JSON geometry (as returned by `queryFeatures` and contract
+ * {@link HonuaFeature} results) into standard GeoJSON geometry.
+ *
+ * Esri encodes geometry as `{ x, y }` points, `{ paths }` polylines,
+ * `{ rings }` polygons, `{ points }` multipoints, and `{ xmin, ymin, xmax,
+ * ymax }` envelopes. GeoJSON consumers (MapLibre, Leaflet, turf, etc.) expect
+ * `Point` / `LineString` / `Polygon` and their `Multi*` variants. This module
+ * provides that translation as a first-class, dependency-free utility.
+ *
+ * Polygon rings are grouped following the Esri convention where clockwise
+ * (positive signed area) rings are exterior and counter-clockwise rings are
+ * holes, producing `Polygon` for a single exterior ring and `MultiPolygon`
+ * when several exterior rings are present.
+ *
+ * @module
+ */
+
+import type {
+  GeoJsonGeometry,
+  GeoJsonMultiLineString,
+  GeoJsonMultiPolygon,
+  GeoJsonPolygon,
+} from "../expr/expression.js";
+import type { EsriGeometry, GeoJsonFeature, HonuaFeature } from "./types.js";
+
+type Position = [number, number, ...number[]];
+
+function isFinitePosition(value: unknown): value is Position {
+  return (
+    Array.isArray(value) &&
+    value.length >= 2 &&
+    typeof value[0] === "number" &&
+    Number.isFinite(value[0]) &&
+    typeof value[1] === "number" &&
+    Number.isFinite(value[1])
+  );
+}
+
+function collectFinitePositions(value: unknown): Position[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(isFinitePosition);
+}
+
+function collectPositionSets(value: unknown): Position[][] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((entry) => collectFinitePositions(entry)).filter((entry) => entry.length > 0);
+}
+
+function computeRingSignedArea(ring: readonly Position[]): number {
+  if (ring.length < 3) {
+    return 0;
+  }
+
+  let area = 0;
+  for (let index = 0; index < ring.length; index += 1) {
+    const current = ring[index];
+    const next = ring[(index + 1) % ring.length];
+    if (!current || !next) {
+      continue;
+    }
+    area += current[0] * next[1] - next[0] * current[1];
+  }
+
+  return area / 2;
+}
+
+/**
+ * Esri uses clockwise (negative signed area in screen/standard math
+ * orientation) rings for exterior boundaries and counter-clockwise rings for
+ * holes.
+ */
+function isExteriorRing(ring: readonly Position[]): boolean {
+  return computeRingSignedArea(ring) < 0;
+}
+
+function isPointOnSegment(point: Position, segmentStart: Position, segmentEnd: Position): boolean {
+  const epsilon = 1e-9;
+  const crossProduct =
+    (point[0] - segmentStart[0]) * (segmentEnd[1] - segmentStart[1]) -
+    (point[1] - segmentStart[1]) * (segmentEnd[0] - segmentStart[0]);
+
+  if (Math.abs(crossProduct) > epsilon) {
+    return false;
+  }
+
+  const dotProduct =
+    (point[0] - segmentStart[0]) * (segmentEnd[0] - segmentStart[0]) +
+    (point[1] - segmentStart[1]) * (segmentEnd[1] - segmentStart[1]);
+  if (dotProduct < -epsilon) {
+    return false;
+  }
+
+  const segmentLengthSquared =
+    (segmentEnd[0] - segmentStart[0]) * (segmentEnd[0] - segmentStart[0]) +
+    (segmentEnd[1] - segmentStart[1]) * (segmentEnd[1] - segmentStart[1]);
+
+  return dotProduct - segmentLengthSquared <= epsilon;
+}
+
+function isPointInsideRing(point: Position, ring: readonly Position[]): boolean {
+  if (ring.length < 3) {
+    return false;
+  }
+
+  let isInside = false;
+  for (let index = 0, previousIndex = ring.length - 1; index < ring.length; previousIndex = index, index += 1) {
+    const current = ring[index];
+    const previous = ring[previousIndex];
+    if (!current || !previous) {
+      continue;
+    }
+
+    if (isPointOnSegment(point, previous, current)) {
+      return true;
+    }
+
+    const intersects =
+      current[1] > point[1] !== previous[1] > point[1] &&
+      point[0] < ((previous[0] - current[0]) * (point[1] - current[1])) / (previous[1] - current[1]) + current[0];
+    if (intersects) {
+      isInside = !isInside;
+    }
+  }
+
+  return isInside;
+}
+
+function findContainingPolygonIndex(
+  polygons: readonly Position[][][],
+  outerAreas: readonly number[],
+  ring: readonly Position[],
+): number {
+  const samplePoint = ring[0];
+  if (!samplePoint) {
+    return -1;
+  }
+
+  let containingPolygonIndex = -1;
+  let smallestContainingArea = Number.POSITIVE_INFINITY;
+
+  for (let index = 0; index < polygons.length; index += 1) {
+    const polygon = polygons[index];
+    const outerRing = polygon?.[0];
+    const outerArea = outerAreas[index];
+    if (!outerRing || outerArea === undefined || !isPointInsideRing(samplePoint, outerRing)) {
+      continue;
+    }
+
+    if (outerArea < smallestContainingArea) {
+      smallestContainingArea = outerArea;
+      containingPolygonIndex = index;
+    }
+  }
+
+  return containingPolygonIndex;
+}
+
+function convertPolygonRings(rings: readonly Position[][]): GeoJsonPolygon | GeoJsonMultiPolygon {
+  const polygons: Position[][][] = [];
+  const outerAreas: number[] = [];
+  const interiorRings: Position[][] = [];
+
+  for (const ring of rings) {
+    if (isExteriorRing(ring)) {
+      polygons.push([ring]);
+      outerAreas.push(Math.abs(computeRingSignedArea(ring)));
+      continue;
+    }
+
+    interiorRings.push(ring);
+  }
+
+  for (const ring of interiorRings) {
+    const containingPolygonIndex = findContainingPolygonIndex(polygons, outerAreas, ring);
+
+    if (containingPolygonIndex < 0) {
+      polygons.push([ring]);
+      outerAreas.push(Math.abs(computeRingSignedArea(ring)));
+      continue;
+    }
+
+    polygons[containingPolygonIndex]?.push(ring);
+  }
+
+  return polygons.length === 1
+    ? {
+        type: "Polygon",
+        coordinates: polygons[0] ?? [],
+      }
+    : {
+        type: "MultiPolygon",
+        coordinates: polygons,
+      };
+}
+
+function hasNumber(geometry: Record<string, unknown>, key: string): boolean {
+  return typeof geometry[key] === "number" && Number.isFinite(geometry[key]);
+}
+
+/**
+ * Convert a single Esri-JSON geometry into a GeoJSON geometry.
+ *
+ * Supports Esri point (`{ x, y }`), multipoint (`{ points }`), polyline
+ * (`{ paths }`), polygon (`{ rings }`), and envelope (`{ xmin, ymin, xmax,
+ * ymax }`) shapes. Returns `null` for `null`/`undefined` input and for
+ * geometries that contain no finite coordinates (e.g. empty `rings`/`paths`).
+ *
+ * @param geometry Esri geometry, the `geometry` field of a {@link HonuaFeature},
+ *   or `null`/`undefined`.
+ * @returns The equivalent GeoJSON geometry, or `null` when the input is empty
+ *   or unrecognized.
+ */
+export function esriGeometryToGeoJSON(
+  geometry: EsriGeometry | Record<string, unknown> | null | undefined,
+): GeoJsonGeometry | null {
+  if (!geometry || typeof geometry !== "object") {
+    return null;
+  }
+
+  const candidate = geometry as Record<string, unknown>;
+
+  if (hasNumber(candidate, "x") && hasNumber(candidate, "y")) {
+    return {
+      type: "Point",
+      coordinates: [candidate.x as number, candidate.y as number],
+    };
+  }
+
+  if (Array.isArray(candidate.points)) {
+    const coordinates = collectFinitePositions(candidate.points);
+    if (coordinates.length < 1) {
+      return null;
+    }
+    return {
+      type: "MultiPoint",
+      coordinates,
+    };
+  }
+
+  if (Array.isArray(candidate.paths)) {
+    const coordinates = collectPositionSets(candidate.paths);
+    if (coordinates.length < 1) {
+      return null;
+    }
+    return coordinates.length === 1
+      ? {
+          type: "LineString",
+          coordinates: coordinates[0] ?? [],
+        }
+      : ({
+          type: "MultiLineString",
+          coordinates,
+        } satisfies GeoJsonMultiLineString);
+  }
+
+  if (Array.isArray(candidate.rings)) {
+    const coordinates = collectPositionSets(candidate.rings);
+    if (coordinates.length < 1) {
+      return null;
+    }
+    return convertPolygonRings(coordinates);
+  }
+
+  if (
+    hasNumber(candidate, "xmin") &&
+    hasNumber(candidate, "ymin") &&
+    hasNumber(candidate, "xmax") &&
+    hasNumber(candidate, "ymax")
+  ) {
+    const xmin = candidate.xmin as number;
+    const ymin = candidate.ymin as number;
+    const xmax = candidate.xmax as number;
+    const ymax = candidate.ymax as number;
+    return {
+      type: "Polygon",
+      coordinates: [
+        [
+          [xmin, ymin],
+          [xmax, ymin],
+          [xmax, ymax],
+          [xmin, ymax],
+          [xmin, ymin],
+        ],
+      ],
+    };
+  }
+
+  return null;
+}
+
+function readFeatureId(feature: HonuaFeature): string | number | undefined {
+  const attributes = feature.attributes ?? {};
+  const candidates = [attributes.OBJECTID, attributes.objectid, attributes.id, attributes.ID, attributes.FID];
+
+  for (const value of candidates) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Convert a contract {@link HonuaFeature} (Esri attributes + geometry) into a
+ * GeoJSON `Feature`.
+ *
+ * The feature `id` is derived from common Esri identifier attributes
+ * (`OBJECTID`, `objectid`, `id`, `ID`, `FID`) when present, and the geometry is
+ * converted with {@link esriGeometryToGeoJSON} (yielding `null` for missing or
+ * empty geometry).
+ *
+ * @param feature A contract feature with Esri-shaped `attributes` and
+ *   `geometry`.
+ * @returns The equivalent GeoJSON feature.
+ */
+export function esriFeatureToGeoJSON(feature: HonuaFeature): GeoJsonFeature {
+  const id = readFeatureId(feature);
+  return {
+    type: "Feature",
+    ...(id === undefined ? {} : { id }),
+    geometry: esriGeometryToGeoJSON(feature.geometry),
+    properties: feature.attributes ?? {},
+  };
+}

--- a/src/core/ogc-tiles.ts
+++ b/src/core/ogc-tiles.ts
@@ -9,6 +9,7 @@
  */
 
 import type { HonuaClient } from "./client.js";
+import { encodePathSegments, trimTrailingSlashes } from "./path-utils.js";
 import type {
   HonuaOgcConformanceResponse,
   HonuaOgcLandingResponse,
@@ -18,13 +19,47 @@ import type {
   HonuaOgcTilesetMetadata,
   HonuaOgcTilesetsResponse,
   OgcMetadataRequest,
+  OgcTileMatrixSetId,
   OgcTileRequest,
   OgcTilesetRequest,
   OgcTilesetsRequest,
 } from "./types.js";
 
+/** Default OGC tile-matrix-set used when none is specified (Web Mercator XYZ). */
+export const DEFAULT_OGC_TILE_MATRIX_SET: OgcTileMatrixSetId = "WebMercatorQuad";
+
 export interface HonuaOgcTilesOptions {
   client: HonuaClient;
+}
+
+/**
+ * Structural shape of a MapLibre `VectorSourceSpecification` for tiled
+ * vector data. Declared locally so the SDK does not take a runtime or type
+ * dependency on `maplibre-gl` (a peer); the object is assignable to
+ * MapLibre's `VectorSourceSpecification`.
+ */
+export interface MapLibreVectorSourceSpec {
+  type: "vector";
+  tiles: string[];
+  minzoom?: number;
+  maxzoom?: number;
+  scheme?: "xyz";
+}
+
+/** Options for {@link HonuaOgcTiles.getMapLibreVectorSource}. */
+export interface HonuaMapLibreVectorSourceOptions {
+  /** Tile-matrix-set to template against. Defaults to `WebMercatorQuad`. */
+  tileMatrixSetId?: OgcTileMatrixSetId;
+  /** Override the `minzoom` of the produced source. */
+  minzoom?: number;
+  /** Override the `maxzoom` of the produced source. */
+  maxzoom?: number;
+}
+
+/** Result of {@link HonuaOgcTiles.getMapLibreConfig}. */
+export interface HonuaMapLibreTilesConfig {
+  source: MapLibreVectorSourceSpec;
+  sourceLayer: string;
 }
 
 export interface HonuaOgcTilesetOptions {
@@ -85,6 +120,65 @@ export class HonuaOgcTiles {
 
   public async tile(request: OgcTileRequest): Promise<HonuaOgcTileResponse> {
     return this.client.fetchOgcTile(request);
+  }
+
+  /**
+   * Build a MapLibre-ready vector source definition for a tiled collection.
+   *
+   * Produces a `{ type: "vector", tiles: ["…/{z}/{y}/{x}"] }` object whose
+   * tile URL points at the canonical OGC API Tiles collection-tile route on
+   * the SDK's configured `baseUrl`. The MapLibre `{z}/{y}/{x}` placeholders
+   * are kept literal (the braces are not percent-encoded) while the
+   * collection / service identifier is encoded per path segment so
+   * folder-prefixed identifiers like `myFolder/parcels` serialize correctly.
+   *
+   * No network request is made; this is a pure URL-template builder. Pass
+   * `minzoom` / `maxzoom` to constrain the source, otherwise MapLibre's
+   * defaults apply.
+   */
+  public getMapLibreVectorSource(
+    serviceId: string,
+    options: HonuaMapLibreVectorSourceOptions = {},
+  ): MapLibreVectorSourceSpec {
+    const tileMatrixSetId = options.tileMatrixSetId ?? DEFAULT_OGC_TILE_MATRIX_SET;
+    const baseUrl = trimTrailingSlashes(this.client.serverBaseUrl);
+    const collection = encodePathSegments(serviceId);
+    const matrixSet = encodeURIComponent(tileMatrixSetId);
+    const template = `${baseUrl}/ogc/tiles/collections/${collection}/tiles/${matrixSet}/{z}/{y}/{x}`;
+    const source: MapLibreVectorSourceSpec = {
+      type: "vector",
+      tiles: [template],
+      scheme: "xyz",
+    };
+    if (options.minzoom !== undefined) source.minzoom = options.minzoom;
+    if (options.maxzoom !== undefined) source.maxzoom = options.maxzoom;
+    return source;
+  }
+
+  /**
+   * Resolve the `source-layer` name to use in a MapLibre layer that renders
+   * the collection's vector tiles. The Honua server names the MVT layer after
+   * the collection identifier; for folder-prefixed identifiers the trailing
+   * segment is the layer name (the folder is a routing prefix, not part of
+   * the layer name baked into the tile).
+   */
+  public getDefaultSourceLayer(serviceId: string): string {
+    const segments = serviceId.split("/");
+    return segments[segments.length - 1] ?? serviceId;
+  }
+
+  /**
+   * Convenience wrapper returning both the MapLibre vector {@link source}
+   * object and the {@link sourceLayer} name to wire into a layer definition.
+   */
+  public getMapLibreConfig(
+    serviceId: string,
+    options: HonuaMapLibreVectorSourceOptions = {},
+  ): HonuaMapLibreTilesConfig {
+    return {
+      source: this.getMapLibreVectorSource(serviceId, options),
+      sourceLayer: this.getDefaultSourceLayer(serviceId),
+    };
   }
 }
 

--- a/src/core/path-utils.ts
+++ b/src/core/path-utils.ts
@@ -77,3 +77,25 @@ export function stripQuery(value: string): string {
   const index = value.indexOf("?");
   return index < 0 ? value : value.slice(0, index);
 }
+
+/**
+ * Percent-encode a path that may contain `/` separators, encoding each
+ * segment independently so the separators survive.
+ *
+ * `encodeURIComponent("a/b")` returns `a%2Fb`, which is wrong for
+ * folder-prefixed identifiers such as `myFolder/parcels` that must serialize
+ * as `myFolder/parcels` on the wire. Splitting on `/` and encoding each
+ * segment keeps the separators literal while still escaping reserved
+ * characters inside each segment. Empty segments (leading/trailing/double
+ * slashes) are preserved verbatim so callers retain full control over the
+ * resulting path shape.
+ */
+export function encodePathSegments(value: string): string {
+  if (!value.includes("/")) {
+    return encodeURIComponent(value);
+  }
+  return value
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}

--- a/src/core/path-utils.ts
+++ b/src/core/path-utils.ts
@@ -77,3 +77,31 @@ export function stripQuery(value: string): string {
   const index = value.indexOf("?");
   return index < 0 ? value : value.slice(0, index);
 }
+
+/**
+ * Encode an Esri-style `serviceId` for use as a URL path segment, preserving
+ * folder structure.
+ *
+ * Esri/GeoServices services may be folder-organized, e.g.
+ * `MyFolder/MyService`. Naively passing the whole id through
+ * `encodeURIComponent` percent-encodes the `/` separator (`%2F`), collapsing
+ * the folder and service into a single path segment that the server cannot
+ * route. This helper splits on `/`, encodes each non-empty segment
+ * individually, and rejoins with `/` so the folder path is preserved while
+ * special characters within a segment (spaces, `&`, etc.) are still encoded.
+ *
+ * A plain `serviceId` without slashes behaves exactly like
+ * `encodeURIComponent(serviceId)`. Empty segments produced by leading,
+ * trailing, or doubled slashes are dropped so the result never contains
+ * stray `/` runs.
+ */
+export function encodeServiceIdPath(serviceId: string): string {
+  if (!serviceId.includes("/")) {
+    return encodeURIComponent(serviceId);
+  }
+  return serviceId
+    .split("/")
+    .filter((segment) => segment.length > 0)
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}

--- a/src/core/surfaces.ts
+++ b/src/core/surfaces.ts
@@ -27,6 +27,7 @@ import type {
 import type { SourceId } from "../contract/types.js";
 import type { HonuaMetadataRequestOptions } from "./cache-state.js";
 import type { HonuaClient } from "./client.js";
+import { encodeServiceIdPath } from "./path-utils.js";
 import type {
   ApplyEditsRequest,
   ExportMapRequest,
@@ -273,7 +274,7 @@ export class HonuaService {
   public async request<T = unknown>(request: HonuaServiceRequest): Promise<T> {
     return this.client.request<T>({
       ...request,
-      path: `/rest/services/${encodeURIComponent(this.serviceId)}/${normalizeServicePath(request.path)}`,
+      path: `/rest/services/${encodeServiceIdPath(this.serviceId)}/${normalizeServicePath(request.path)}`,
     });
   }
 
@@ -496,7 +497,7 @@ export class HonuaFeatureLayer<T = Record<string, unknown>> {
     assertFeatureServerH3SpatialAggregationRequest(normalizedRequest);
 
     const plan = createFeatureServerH3AggregationPlan(normalizedRequest, request.kRingDistance);
-    const path = `/rest/services/${encodeURIComponent(this.serviceId)}/FeatureServer/${this.layerId}/queryH3`;
+    const path = `/rest/services/${encodeServiceIdPath(this.serviceId)}/FeatureServer/${this.layerId}/queryH3`;
     const method = request.method ?? "POST";
     const response =
       method === "GET"
@@ -550,7 +551,7 @@ export class HonuaFeatureLayer<T = Record<string, unknown>> {
   ): Promise<HonuaQueryAttachmentsResponse> {
     const method: QueryMethod = request.method ?? "GET";
     const path =
-      `/rest/services/${encodeURIComponent(this.serviceId)}` + `/FeatureServer/${this.layerId}/queryAttachments`;
+      `/rest/services/${encodeServiceIdPath(this.serviceId)}` + `/FeatureServer/${this.layerId}/queryAttachments`;
     const query = {
       ...(request.objectIds === undefined
         ? {}
@@ -590,7 +591,7 @@ export class HonuaFeatureLayer<T = Record<string, unknown>> {
     return this.client.request({
       method: "GET",
       path:
-        `/rest/services/${encodeURIComponent(this.serviceId)}` +
+        `/rest/services/${encodeServiceIdPath(this.serviceId)}` +
         `/FeatureServer/${this.layerId}/${request.objectId}/attachments`,
       responseFormat: request.responseFormat ?? "json",
       query: request.extraParams,
@@ -609,7 +610,7 @@ export class HonuaFeatureLayer<T = Record<string, unknown>> {
     return this.client.request<HonuaDeleteAttachmentsResponse>({
       method: "POST",
       path:
-        `/rest/services/${encodeURIComponent(this.serviceId)}` +
+        `/rest/services/${encodeServiceIdPath(this.serviceId)}` +
         `/FeatureServer/${this.layerId}/${request.objectId}/deleteAttachments`,
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
@@ -624,7 +625,7 @@ export class HonuaFeatureLayer<T = Record<string, unknown>> {
     return this.client.request<HonuaAddAttachmentResponse>({
       method: "POST",
       path:
-        `/rest/services/${encodeURIComponent(this.serviceId)}` +
+        `/rest/services/${encodeServiceIdPath(this.serviceId)}` +
         `/FeatureServer/${this.layerId}/${request.objectId}/addAttachment`,
       responseFormat: request.responseFormat ?? "json",
       query: request.extraParams,
@@ -641,7 +642,7 @@ export class HonuaFeatureLayer<T = Record<string, unknown>> {
     return this.client.request<HonuaUpdateAttachmentResponse>({
       method: "POST",
       path:
-        `/rest/services/${encodeURIComponent(this.serviceId)}` +
+        `/rest/services/${encodeServiceIdPath(this.serviceId)}` +
         `/FeatureServer/${this.layerId}/${request.objectId}/updateAttachment`,
       responseFormat: request.responseFormat ?? "json",
       query: request.extraParams,
@@ -654,7 +655,7 @@ export class HonuaFeatureLayer<T = Record<string, unknown>> {
     return this.client.request<T>({
       ...request,
       path:
-        `/rest/services/${encodeURIComponent(this.serviceId)}` +
+        `/rest/services/${encodeServiceIdPath(this.serviceId)}` +
         `/FeatureServer/${this.layerId}/${normalizeLayerPath(request.path)}`,
     });
   }
@@ -879,7 +880,8 @@ export class HonuaMapService {
   public async request<T = unknown>(request: HonuaMapServiceRequest): Promise<T> {
     return this.client.request<T>({
       ...request,
-      path: `/rest/services/${encodeURIComponent(this.serviceId)}` + `/MapServer/${normalizeServicePath(request.path)}`,
+      path:
+        `/rest/services/${encodeServiceIdPath(this.serviceId)}` + `/MapServer/${normalizeServicePath(request.path)}`,
     });
   }
 }
@@ -1053,7 +1055,7 @@ export class HonuaMapLayer {
     return this.client.request<T>({
       ...request,
       path:
-        `/rest/services/${encodeURIComponent(this.serviceId)}` +
+        `/rest/services/${encodeServiceIdPath(this.serviceId)}` +
         `/MapServer/${this.layerId}/${normalizeLayerPath(request.path)}`,
     });
   }
@@ -1371,7 +1373,7 @@ export class HonuaImageService {
   public async metadata(): Promise<HonuaServiceMetadata> {
     return this.client.request<HonuaServiceMetadata>({
       method: "GET",
-      path: `/rest/services/${encodeURIComponent(this.serviceId)}/ImageServer`,
+      path: `/rest/services/${encodeServiceIdPath(this.serviceId)}/ImageServer`,
       responseFormat: "json",
     });
   }
@@ -1411,7 +1413,7 @@ export class HonuaImageService {
     params: Record<string, string | number | boolean>,
   ): Promise<R> {
     const method: QueryMethod = request.method ?? "GET";
-    const path = `/rest/services/${encodeURIComponent(this.serviceId)}/ImageServer/${op}`;
+    const path = `/rest/services/${encodeServiceIdPath(this.serviceId)}/ImageServer/${op}`;
     const responseFormat = request.responseFormat ?? "json";
     if (method === "GET") {
       return this.client.request<R>({ method: "GET", path, responseFormat, query: params, signal: request.signal });
@@ -1431,14 +1433,14 @@ export class HonuaImageService {
     col: number,
     format: "png" | "jpg" | "jpeg" | "tif" | "tiff" = "png",
   ): string {
-    const path = `/rest/services/${encodeURIComponent(this.serviceId)}/ImageServer/tile/${level}/${row}/${col}`;
+    const path = `/rest/services/${encodeServiceIdPath(this.serviceId)}/ImageServer/tile/${level}/${row}/${col}`;
     return `${this.client.serverBaseUrl}${path}?f=${format}`;
   }
 
   public async legend(): Promise<HonuaLegendResponse> {
     return this.client.request<HonuaLegendResponse>({
       method: "GET",
-      path: `/rest/services/${encodeURIComponent(this.serviceId)}/ImageServer/legend`,
+      path: `/rest/services/${encodeServiceIdPath(this.serviceId)}/ImageServer/legend`,
       responseFormat: "json",
     });
   }
@@ -1863,7 +1865,7 @@ export class HonuaGeoprocessingService {
 
   private taskPath(suffix: string): string {
     const taskSegment = this.taskName ? `/${encodeURIComponent(this.taskName)}` : "";
-    return `/rest/services/${encodeURIComponent(this.serviceId)}/GPServer${taskSegment}/${suffix}`;
+    return `/rest/services/${encodeServiceIdPath(this.serviceId)}/GPServer${taskSegment}/${suffix}`;
   }
 }
 

--- a/src/esri-compat/feature-layer.ts
+++ b/src/esri-compat/feature-layer.ts
@@ -1,4 +1,5 @@
 import { HonuaClient } from "../core/client.js";
+import { encodeServiceIdPath } from "../core/path-utils.js";
 import type {
   ApplyEditsRequest,
   HonuaAddAttachmentResponse,
@@ -603,7 +604,7 @@ export class FeatureLayerCompat {
   public queryAttachments(options: FeatureLayerQueryAttachmentsOptions = {}): Promise<HonuaQueryAttachmentsResponse> {
     return this.client.request({
       method: options.method ?? "GET",
-      path: `/rest/services/${encodeURIComponent(this.serviceId)}/FeatureServer/${this.layerId}/queryAttachments`,
+      path: `/rest/services/${encodeServiceIdPath(this.serviceId)}/FeatureServer/${this.layerId}/queryAttachments`,
       responseFormat: options.responseFormat ?? "json",
       query: {
         ...(options.objectIds === undefined
@@ -621,7 +622,7 @@ export class FeatureLayerCompat {
     return this.client.request({
       method: "GET",
       path:
-        `/rest/services/${encodeURIComponent(this.serviceId)}` +
+        `/rest/services/${encodeServiceIdPath(this.serviceId)}` +
         `/FeatureServer/${this.layerId}/${options.objectId}/attachments`,
       responseFormat: options.responseFormat ?? "json",
       query: options.extraParams,
@@ -644,7 +645,7 @@ export class FeatureLayerCompat {
     return this.client.request({
       method: "POST",
       path:
-        `/rest/services/${encodeURIComponent(this.serviceId)}` +
+        `/rest/services/${encodeServiceIdPath(this.serviceId)}` +
         `/FeatureServer/${this.layerId}/${options.objectId}/deleteAttachments`,
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
@@ -664,7 +665,7 @@ export class FeatureLayerCompat {
       this.client.request({
         method: "POST",
         path:
-          `/rest/services/${encodeURIComponent(this.serviceId)}` +
+          `/rest/services/${encodeServiceIdPath(this.serviceId)}` +
           `/FeatureServer/${this.layerId}/${options.objectId}/addAttachment`,
         responseFormat: options.responseFormat ?? "json",
         query: options.extraParams,
@@ -688,7 +689,7 @@ export class FeatureLayerCompat {
       return this.client.request({
         method: "POST",
         path:
-          `/rest/services/${encodeURIComponent(this.serviceId)}` +
+          `/rest/services/${encodeServiceIdPath(this.serviceId)}` +
           `/FeatureServer/${this.layerId}/${options.objectId}/updateAttachment`,
         responseFormat: options.responseFormat ?? "json",
         query: options.extraParams,

--- a/src/esri-compat/tile-layer.ts
+++ b/src/esri-compat/tile-layer.ts
@@ -1,4 +1,5 @@
 import { HonuaClient } from "../core/client.js";
+import { encodeServiceIdPath } from "../core/path-utils.js";
 import type { HonuaServiceMetadata } from "../core/types.js";
 import { CompatEventBus, resolveCompatEventBus, safeInvokeCompatListener } from "./event-bus.js";
 import { parseMapServiceUrl } from "./url.js";
@@ -181,7 +182,7 @@ export class TileLayerCompat {
   }
 
   public getTileUrl(level: number, row: number, col: number): string {
-    return `${this.baseUrl}/rest/services/${encodeURIComponent(this.serviceId)}/MapServer/tile/${level}/${row}/${col}`;
+    return `${this.baseUrl}/rest/services/${encodeServiceIdPath(this.serviceId)}/MapServer/tile/${level}/${row}/${col}`;
   }
 
   private notifyWatchers(propertyName: string, value: unknown): void {

--- a/src/geocoding/index.ts
+++ b/src/geocoding/index.ts
@@ -30,7 +30,7 @@
  */
 
 import { HonuaAbortError, HonuaHttpError, HonuaNetworkError, HonuaTimeoutError } from "../core/errors.js";
-import { trimTrailingSlashes } from "../core/path-utils.js";
+import { encodeServiceIdPath, trimTrailingSlashes } from "../core/path-utils.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -298,7 +298,7 @@ export class HonuaGeocodingClient {
   // -------------------------------------------------------------------------
 
   private serviceBasePath(): string {
-    return `${this.baseUrl}/rest/services/${encodeURIComponent(this.locatorName)}/GeocodeServer`;
+    return `${this.baseUrl}/rest/services/${encodeServiceIdPath(this.locatorName)}/GeocodeServer`;
   }
 
   private async request<T>(url: string): Promise<T> {

--- a/src/honua.ts
+++ b/src/honua.ts
@@ -284,6 +284,7 @@ export type { SpatialFilter } from "./core/spatial-filter.js";
 export { batchQuery } from "./core/batch.js";
 export type { BatchQueryItem, BatchQueryOptions, BatchQueryResult } from "./core/batch.js";
 export { decodePbfQueryResponse, isPbfResponse } from "./core/pbf-decoder.js";
+export { esriFeatureToGeoJSON, esriGeometryToGeoJSON } from "./core/esri-geojson.js";
 export {
   createHonuaOgcFeatures,
   createHonuaService,

--- a/src/honua.ts
+++ b/src/honua.ts
@@ -300,15 +300,19 @@ export {
 } from "./core/surfaces.js";
 export {
   createHonuaOgcTiles,
+  DEFAULT_OGC_TILE_MATRIX_SET,
   HonuaOgcTiles,
   HonuaOgcTileset,
 } from "./core/ogc-tiles.js";
 export type {
+  HonuaMapLibreTilesConfig,
+  HonuaMapLibreVectorSourceOptions,
   HonuaOgcCollectionTileRequest,
   HonuaOgcCollectionTilesetRequest,
   HonuaOgcCollectionTilesetsRequest,
   HonuaOgcTilesOptions,
   HonuaOgcTilesetOptions,
+  MapLibreVectorSourceSpec,
 } from "./core/ogc-tiles.js";
 export {
   createHonuaOgcMaps,

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export type { SpatialFilter } from "./core/spatial-filter.js";
 export { batchQuery } from "./core/batch.js";
 export type { BatchQueryItem, BatchQueryOptions, BatchQueryResult } from "./core/batch.js";
 export { decodePbfQueryResponse, isPbfResponse } from "./core/pbf-decoder.js";
+export { esriFeatureToGeoJSON, esriGeometryToGeoJSON } from "./core/esri-geojson.js";
 export {
   compileRuntimeStyleFilter,
   createFilterRegistry,

--- a/src/index.ts
+++ b/src/index.ts
@@ -399,15 +399,19 @@ export {
 } from "./core/surfaces.js";
 export {
   createHonuaOgcTiles,
+  DEFAULT_OGC_TILE_MATRIX_SET,
   HonuaOgcTiles,
   HonuaOgcTileset,
 } from "./core/ogc-tiles.js";
 export type {
+  HonuaMapLibreTilesConfig,
+  HonuaMapLibreVectorSourceOptions,
   HonuaOgcCollectionTileRequest,
   HonuaOgcCollectionTilesetRequest,
   HonuaOgcCollectionTilesetsRequest,
   HonuaOgcTilesOptions,
   HonuaOgcTilesetOptions,
+  MapLibreVectorSourceSpec,
 } from "./core/ogc-tiles.js";
 export {
   createHonuaOgcMaps,

--- a/src/map/feature-service-adapter.ts
+++ b/src/map/feature-service-adapter.ts
@@ -1,0 +1,335 @@
+/**
+ * MapLibre runtime adapter for Honua feature-service sources.
+ *
+ * {@link createHonuaFeatureServiceLayer} (and the migration codemod) emit a
+ * custom `honua-feature-service` source type that MapLibre's renderer does not
+ * understand — adding it to a `maplibre-gl` `Map` directly is a silent no-op.
+ *
+ * This module bridges that gap. It fetches features through the SDK query path
+ * ({@link HonuaFeatureLayer}) and converts the Esri feature set into a standard
+ * GeoJSON `FeatureCollection`, then exposes it as a plain MapLibre `geojson`
+ * source spec that the renderer renders natively. Callers either:
+ *
+ *  - call {@link loadHonuaFeatureServiceGeoJson} to obtain a `geojson` source
+ *    spec they add to their style themselves, or
+ *  - call {@link registerHonuaFeatureServiceSources} to walk a {@link HonuaMap}
+ *    and live-patch every `honua-feature-service` source on a real MapLibre map
+ *    into a fetched `geojson` source.
+ *
+ * Raster Honua sources (`honua-map-service`, tile services) already project
+ * onto MapLibre-native sources and need no adapter; this fills in the feature
+ * (vector) asymmetry.
+ *
+ * @module
+ */
+
+import type { HonuaClient } from "../core/client.js";
+import { HonuaFeatureLayer } from "../core/surfaces.js";
+import type { HonuaFeatureLayerQueryAllRequest } from "../core/surfaces.js";
+import type { EsriGeometryType } from "../core/types.js";
+import { parseFeatureLayerUrl } from "../esri-compat/url.js";
+import type { HonuaMap } from "./honua-map.js";
+
+/** A GeoJSON geometry produced by the adapter. */
+export interface AdapterGeoJsonGeometry {
+  type: string;
+  coordinates: unknown;
+}
+
+/** A GeoJSON feature produced by the adapter. */
+export interface AdapterGeoJsonFeature {
+  type: "Feature";
+  id?: string | number;
+  geometry: AdapterGeoJsonGeometry | null;
+  properties: Record<string, unknown>;
+}
+
+/** A GeoJSON feature collection produced by the adapter. */
+export interface AdapterGeoJsonFeatureCollection {
+  type: "FeatureCollection";
+  features: AdapterGeoJsonFeature[];
+}
+
+/** A standard MapLibre `geojson` source specification. */
+export interface MapLibreGeoJsonSourceSpecification {
+  type: "geojson";
+  data: AdapterGeoJsonFeatureCollection;
+  attribution?: string;
+}
+
+/** Options controlling how the adapter fetches feature-service data. */
+export interface LoadHonuaFeatureServiceGeoJsonOptions {
+  /** Server-side WHERE clause. Defaults to `"1=1"`. */
+  definitionExpression?: string;
+  /** Fields to request. Defaults to all (`["*"]`). */
+  outFields?: string[];
+  /** Output spatial reference WKID. GeoJSON requires `4326`; defaults to it. */
+  outSR?: number;
+  /** Page size for paginated fetching. */
+  pageSize?: number;
+  /** Maximum pages to fetch. */
+  maxPages?: number;
+  /** Attribution to attach to the produced source spec. */
+  attribution?: string;
+  /** Abort signal forwarded to the query. */
+  signal?: AbortSignal;
+}
+
+/**
+ * The minimal MapLibre `Map` surface the adapter mutates. Any object exposing
+ * these methods — including a real `maplibre-gl` `Map` — satisfies it.
+ */
+export interface FeatureServiceAdapterMap {
+  getSource(id: string): unknown;
+  addSource(id: string, source: unknown): void;
+  removeSource(id: string): void;
+}
+
+interface MapLibreGeoJsonSourceHandle {
+  setData(data: AdapterGeoJsonFeatureCollection): void;
+}
+
+/**
+ * Convert a single Esri geometry into a GeoJSON geometry.
+ *
+ * Handles the geometry kinds a feature-service query returns (point,
+ * multipoint, polyline, polygon, envelope). Returns `null` when the geometry is
+ * absent or unrecognised so the feature still renders attribute-only.
+ */
+export function esriGeometryToGeoJson(
+  geometry: Record<string, unknown> | null | undefined,
+  geometryType: EsriGeometryType | undefined,
+): AdapterGeoJsonGeometry | null {
+  if (!geometry) {
+    return null;
+  }
+
+  // Point geometries are recognisable structurally even without a declared
+  // type (queries that elide geometryType still return {x, y}).
+  if (geometryType === "esriGeometryPoint" || (geometry.x !== undefined && geometry.y !== undefined)) {
+    const x = asFiniteNumber(geometry.x);
+    const y = asFiniteNumber(geometry.y);
+    if (x === undefined || y === undefined) return null;
+    return { type: "Point", coordinates: [x, y] };
+  }
+
+  if (geometryType === "esriGeometryMultipoint") {
+    const points = asArray(geometry.points)
+      .map(asCoordinatePair)
+      .filter((value): value is [number, number] => value !== undefined);
+    return { type: "MultiPoint", coordinates: points };
+  }
+
+  if (geometryType === "esriGeometryPolyline") {
+    const paths = asArray(geometry.paths)
+      .map(asCoordinateArray)
+      .filter((path) => path.length > 0);
+    if (paths.length === 1) {
+      return { type: "LineString", coordinates: paths[0] };
+    }
+    return { type: "MultiLineString", coordinates: paths };
+  }
+
+  if (geometryType === "esriGeometryPolygon") {
+    const rings = asArray(geometry.rings)
+      .map(asCoordinateArray)
+      .filter((ring) => ring.length > 0);
+    // MapLibre does not enforce GeoJSON ring winding for rendering, so the
+    // adapter passes Esri rings through as a Polygon without re-nesting.
+    return { type: "Polygon", coordinates: rings };
+  }
+
+  if (geometryType === "esriGeometryEnvelope") {
+    const xmin = asFiniteNumber(geometry.xmin);
+    const ymin = asFiniteNumber(geometry.ymin);
+    const xmax = asFiniteNumber(geometry.xmax);
+    const ymax = asFiniteNumber(geometry.ymax);
+    if (xmin === undefined || ymin === undefined || xmax === undefined || ymax === undefined) {
+      return null;
+    }
+    return {
+      type: "Polygon",
+      coordinates: [
+        [
+          [xmin, ymin],
+          [xmax, ymin],
+          [xmax, ymax],
+          [xmin, ymax],
+          [xmin, ymin],
+        ],
+      ],
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Convert an array of Esri features (attributes + geometry) into a GeoJSON
+ * `FeatureCollection`.
+ */
+export function esriFeaturesToGeoJson(
+  features: ReadonlyArray<{ attributes?: Record<string, unknown>; geometry?: Record<string, unknown> | null }>,
+  geometryType: EsriGeometryType | undefined,
+): AdapterGeoJsonFeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: features.map((feature) => ({
+      type: "Feature",
+      geometry: esriGeometryToGeoJson(feature.geometry ?? null, geometryType),
+      properties: { ...(feature.attributes ?? {}) },
+    })),
+  };
+}
+
+/**
+ * Fetch a Honua feature-service layer through the SDK and return a standard
+ * MapLibre `geojson` source specification that the renderer renders natively.
+ *
+ * @example
+ * ```ts
+ * const source = await loadHonuaFeatureServiceGeoJson(client, layer.source.url);
+ * map.addSource(layer.sourceId, source);
+ * map.addLayer(layer.layer);
+ * ```
+ */
+export async function loadHonuaFeatureServiceGeoJson(
+  client: HonuaClient,
+  url: string,
+  options: LoadHonuaFeatureServiceGeoJsonOptions = {},
+): Promise<MapLibreGeoJsonSourceSpecification> {
+  const parsed = parseFeatureLayerUrl(url);
+  const layer = new HonuaFeatureLayer({
+    client,
+    serviceId: parsed.serviceId,
+    layerId: parsed.layerId,
+  });
+
+  // GeoJSON is lon/lat (WGS84). Default outSR to 4326 so the rendered
+  // coordinates land where MapLibre expects them.
+  const outSR = options.outSR ?? 4326;
+  const request: HonuaFeatureLayerQueryAllRequest = {
+    where: options.definitionExpression ?? "1=1",
+    outFields: options.outFields ?? ["*"],
+    returnGeometry: true,
+    outSr: outSR,
+    ...(options.pageSize !== undefined ? { pageSize: options.pageSize } : {}),
+    ...(options.maxPages !== undefined ? { maxPages: options.maxPages } : {}),
+    ...(options.signal ? { signal: options.signal } : {}),
+  };
+
+  const metadataPromise = layer.metadata(options.signal ? { signal: options.signal } : {}).catch(() => undefined);
+  const features = await layer.queryFeaturesAll(request);
+  const geometryType = (await metadataPromise)?.geometryType;
+
+  const data = esriFeaturesToGeoJson(
+    features as ReadonlyArray<{ attributes?: Record<string, unknown>; geometry?: Record<string, unknown> | null }>,
+    geometryType,
+  );
+
+  return {
+    type: "geojson",
+    data,
+    ...(options.attribution ? { attribution: options.attribution } : {}),
+  };
+}
+
+/** Result of {@link registerHonuaFeatureServiceSources}. */
+export interface RegisterHonuaFeatureServiceSourcesResult {
+  /** Source ids that were fetched and wired as `geojson` sources. */
+  registered: string[];
+  /** Source ids that failed to load, with the error encountered. */
+  failed: Array<{ sourceId: string; error: unknown }>;
+}
+
+/**
+ * Walk a {@link HonuaMap} and replace every `honua-feature-service` source on a
+ * real MapLibre map with a fetched standard `geojson` source so feature layers
+ * actually render.
+ *
+ * Existing `geojson` sources are updated in place via `setData`; otherwise a new
+ * source is added. Layers should be added by the caller (or already present in
+ * the style) — this only manages the data sources.
+ *
+ * @param map - A `maplibre-gl` `Map` (or any {@link FeatureServiceAdapterMap}).
+ * @param honuaMap - The {@link HonuaMap} whose feature-service sources to wire.
+ * @param client - The Honua client used to fetch features.
+ */
+export async function registerHonuaFeatureServiceSources(
+  map: FeatureServiceAdapterMap,
+  honuaMap: HonuaMap,
+  client: HonuaClient,
+  options: LoadHonuaFeatureServiceGeoJsonOptions = {},
+): Promise<RegisterHonuaFeatureServiceSourcesResult> {
+  const registered: string[] = [];
+  const failed: Array<{ sourceId: string; error: unknown }> = [];
+
+  for (const sourceId of honuaMap.sourceIds) {
+    const spec = honuaMap.getSourceSpec(sourceId);
+    if (!spec || spec.type !== "honua-feature-service") {
+      continue;
+    }
+    const url = (spec as { url?: unknown }).url;
+    if (typeof url !== "string" || url.length === 0) {
+      failed.push({ sourceId, error: new Error(`feature-service source "${sourceId}" is missing url`) });
+      continue;
+    }
+
+    try {
+      const source = await loadHonuaFeatureServiceGeoJson(client, url, {
+        ...options,
+        ...(typeof (spec as { definitionExpression?: unknown }).definitionExpression === "string"
+          ? { definitionExpression: (spec as { definitionExpression: string }).definitionExpression }
+          : {}),
+        ...(Array.isArray((spec as { outFields?: unknown }).outFields)
+          ? { outFields: (spec as { outFields: string[] }).outFields }
+          : {}),
+        ...(typeof (spec as { outSR?: unknown }).outSR === "number"
+          ? { outSR: (spec as { outSR: number }).outSR }
+          : {}),
+        ...(typeof (spec as { attribution?: unknown }).attribution === "string"
+          ? { attribution: (spec as { attribution: string }).attribution }
+          : {}),
+      });
+
+      const existing = map.getSource(sourceId);
+      if (existing && typeof (existing as MapLibreGeoJsonSourceHandle).setData === "function") {
+        (existing as MapLibreGeoJsonSourceHandle).setData(source.data);
+      } else {
+        if (existing) {
+          map.removeSource(sourceId);
+        }
+        map.addSource(sourceId, source);
+      }
+      registered.push(sourceId);
+    } catch (error) {
+      failed.push({ sourceId, error });
+    }
+  }
+
+  return { registered, failed };
+}
+
+// ── Coercion helpers ─────────────────────────────────────────
+
+function asFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function asCoordinatePair(value: unknown): [number, number] | undefined {
+  if (!Array.isArray(value) || value.length < 2) return undefined;
+  const x = asFiniteNumber(value[0]);
+  const y = asFiniteNumber(value[1]);
+  if (x === undefined || y === undefined) return undefined;
+  return [x, y];
+}
+
+function asCoordinateArray(value: unknown): [number, number][] {
+  return asArray(value)
+    .map(asCoordinatePair)
+    .filter((pair): pair is [number, number] => pair !== undefined);
+}

--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -41,6 +41,21 @@ export type {
   HonuaMapServiceLayerOptions,
   HonuaTileServiceLayerOptions,
 } from "./maplibre-target.js";
+export {
+  esriFeaturesToGeoJson,
+  esriGeometryToGeoJson,
+  loadHonuaFeatureServiceGeoJson,
+  registerHonuaFeatureServiceSources,
+} from "./feature-service-adapter.js";
+export type {
+  AdapterGeoJsonFeature,
+  AdapterGeoJsonFeatureCollection,
+  AdapterGeoJsonGeometry,
+  FeatureServiceAdapterMap,
+  LoadHonuaFeatureServiceGeoJsonOptions,
+  MapLibreGeoJsonSourceSpecification,
+  RegisterHonuaFeatureServiceSourcesResult,
+} from "./feature-service-adapter.js";
 export { webmapJsonToMapLibreStyle } from "./webmap-maplibre.js";
 export type {
   WebMapJsonToMapLibreStyleOptions,

--- a/src/map/maplibre-target.ts
+++ b/src/map/maplibre-target.ts
@@ -87,6 +87,19 @@ export interface HonuaMapLibreMapOptions {
 
 /**
  * Create a Honua feature-service source and a default MapLibre render layer.
+ *
+ * The returned `source` carries the custom `honua-feature-service` type, which
+ * MapLibre's renderer does not understand on its own — adding it to a
+ * `maplibre-gl` `Map` directly is a silent no-op. To render it, run the layer's
+ * source through the MapLibre runtime adapter
+ * (`loadHonuaFeatureServiceGeoJson` / `registerHonuaFeatureServiceSources` from
+ * `@honua/sdk-js/map`), which fetches features via the SDK and produces a
+ * standard `geojson` source. This differs from
+ * {@link createHonuaTileServiceLayer}, which emits a native MapLibre `raster`
+ * source that renders without an adapter.
+ *
+ * @see loadHonuaFeatureServiceGeoJson
+ * @see registerHonuaFeatureServiceSources
  */
 export function createHonuaFeatureServiceLayer(options: HonuaFeatureServiceLayerOptions): HonuaMapLibreLayerDefinition {
   const sourceId = normalizeLayerId(options.id, options.title, options.url, "feature-service");

--- a/src/migration/reconcile.ts
+++ b/src/migration/reconcile.ts
@@ -1,4 +1,4 @@
-import { trimTrailingSlashes } from "../core/path-utils.js";
+import { encodeServiceIdPath, trimTrailingSlashes } from "../core/path-utils.js";
 
 export interface LayerReconciliationOptions {
   sourceBaseUrl: string;
@@ -195,7 +195,7 @@ async function fetchJson(fetchFn: typeof fetch, url: string): Promise<QueryFeatu
 function buildQueryUrl(baseUrl: string, serviceId: string, layerId: number, params: Record<string, string>): string {
   const query = new URLSearchParams(params);
   return (
-    `${normalizeBaseUrl(baseUrl)}/rest/services/${encodeURIComponent(serviceId)}` +
+    `${normalizeBaseUrl(baseUrl)}/rest/services/${encodeServiceIdPath(serviceId)}` +
     `/FeatureServer/${layerId}/query?${query.toString()}`
   );
 }

--- a/test/contract/ogc-tiles-maplibre.test.ts
+++ b/test/contract/ogc-tiles-maplibre.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit coverage for the MapLibre vector-source helpers on the OGC API Tiles
+ * surface. Asserts the produced source object shape, that the `{z}/{y}/{x}`
+ * placeholders survive intact, correct OGC tile-route templating, and
+ * source-layer resolution (including folder-prefixed identifiers).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { HonuaClient } from "../../src/core/client.js";
+import { DEFAULT_OGC_TILE_MATRIX_SET, HonuaOgcTiles } from "../../src/core/ogc-tiles.js";
+
+function makeTiles(baseUrl = "https://mock.honua.test"): HonuaOgcTiles {
+  const client = new HonuaClient({ baseUrl, fetchFn: async () => new Response(null, { status: 404 }) });
+  return new HonuaOgcTiles({ client });
+}
+
+describe("ogc-tiles / maplibre vector source helpers", () => {
+  it("builds a maplibre vector source with the canonical OGC tile template", () => {
+    const source = makeTiles().getMapLibreVectorSource("parcels");
+    expect(source.type).toBe("vector");
+    expect(source.scheme).toBe("xyz");
+    expect(source.tiles).toEqual([
+      "https://mock.honua.test/ogc/tiles/collections/parcels/tiles/WebMercatorQuad/{z}/{y}/{x}",
+    ]);
+  });
+
+  it("keeps the {z}/{y}/{x} placeholders literal (braces not encoded)", () => {
+    const [template] = makeTiles().getMapLibreVectorSource("parcels").tiles;
+    expect(template).toContain("/{z}/{y}/{x}");
+    expect(template).not.toContain("%7B");
+    expect(template).not.toContain("%7D");
+  });
+
+  it("uses WebMercatorQuad as the default tile-matrix-set", () => {
+    expect(DEFAULT_OGC_TILE_MATRIX_SET).toBe("WebMercatorQuad");
+    const [template] = makeTiles().getMapLibreVectorSource("parcels").tiles;
+    expect(template).toContain("/tiles/WebMercatorQuad/");
+  });
+
+  it("honors an explicit tile-matrix-set and zoom overrides", () => {
+    const source = makeTiles().getMapLibreVectorSource("parcels", {
+      tileMatrixSetId: "WorldCRS84Quad",
+      minzoom: 2,
+      maxzoom: 14,
+    });
+    expect(source.tiles[0]).toContain("/tiles/WorldCRS84Quad/{z}/{y}/{x}");
+    expect(source.minzoom).toBe(2);
+    expect(source.maxzoom).toBe(14);
+  });
+
+  it("omits zoom bounds when not supplied", () => {
+    const source = makeTiles().getMapLibreVectorSource("parcels");
+    expect(source.minzoom).toBeUndefined();
+    expect(source.maxzoom).toBeUndefined();
+  });
+
+  it("respects the client base URL including a path prefix", () => {
+    const [template] = makeTiles("https://host.example/honua/").getMapLibreVectorSource("parcels").tiles;
+    expect(template).toBe("https://host.example/honua/ogc/tiles/collections/parcels/tiles/WebMercatorQuad/{z}/{y}/{x}");
+  });
+
+  it("encodes folder-prefixed identifiers per segment, keeping separators", () => {
+    const [template] = makeTiles().getMapLibreVectorSource("my Folder/parcels v2").tiles;
+    expect(template).toBe(
+      "https://mock.honua.test/ogc/tiles/collections/my%20Folder/parcels%20v2/tiles/WebMercatorQuad/{z}/{y}/{x}",
+    );
+  });
+
+  it("resolves the source-layer name from the identifier", () => {
+    const tiles = makeTiles();
+    expect(tiles.getDefaultSourceLayer("parcels")).toBe("parcels");
+    expect(tiles.getDefaultSourceLayer("myFolder/parcels")).toBe("parcels");
+  });
+
+  it("returns a combined source + source-layer config", () => {
+    const config = makeTiles().getMapLibreConfig("myFolder/parcels", { maxzoom: 16 });
+    expect(config.sourceLayer).toBe("parcels");
+    expect(config.source.type).toBe("vector");
+    expect(config.source.maxzoom).toBe(16);
+    expect(config.source.tiles[0]).toBe(
+      "https://mock.honua.test/ogc/tiles/collections/myFolder/parcels/tiles/WebMercatorQuad/{z}/{y}/{x}",
+    );
+  });
+});

--- a/test/core-client.test.ts
+++ b/test/core-client.test.ts
@@ -842,7 +842,7 @@ describe("HonuaClient", () => {
     expect(requestedUrls[1]).toBe("https://example.test/rest/services/default/FeatureServer/12?f=json");
   });
 
-  it("encodes special characters in serviceId paths", async () => {
+  it("encodes special characters per segment while preserving folder slashes in serviceId paths", async () => {
     let requestedUrl: string | undefined;
     const client = new HonuaClient({
       baseUrl: "https://example.test",
@@ -857,7 +857,9 @@ describe("HonuaClient", () => {
       layerId: 0,
     });
 
-    expect(requestedUrl).toContain("/rest/services/Public%20Works%2FUtilities%20%26%20More/FeatureServer/0/query?");
+    // Folder-organized service ids keep the `/` separator (so the server can
+    // route them) while reserved characters inside each segment stay encoded.
+    expect(requestedUrl).toContain("/rest/services/Public%20Works/Utilities%20%26%20More/FeatureServer/0/query?");
   });
 
   it("returns empty object for empty responses and raw text for non-JSON responses", async () => {

--- a/test/esri-geojson.test.ts
+++ b/test/esri-geojson.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from "vitest";
+
+import { esriFeatureToGeoJSON, esriGeometryToGeoJSON } from "../src/index.js";
+import type { HonuaFeature } from "../src/index.js";
+
+describe("esriGeometryToGeoJSON", () => {
+  it("returns null for null/undefined geometry", () => {
+    expect(esriGeometryToGeoJSON(null)).toBeNull();
+    expect(esriGeometryToGeoJSON(undefined)).toBeNull();
+  });
+
+  it("returns null for unrecognized geometry shapes", () => {
+    expect(esriGeometryToGeoJSON({} as Record<string, unknown>)).toBeNull();
+    expect(esriGeometryToGeoJSON({ foo: "bar" } as Record<string, unknown>)).toBeNull();
+  });
+
+  it("converts an Esri point", () => {
+    expect(esriGeometryToGeoJSON({ x: -122.5, y: 37.7 })).toEqual({
+      type: "Point",
+      coordinates: [-122.5, 37.7],
+    });
+  });
+
+  it("converts an Esri multipoint", () => {
+    expect(
+      esriGeometryToGeoJSON({
+        points: [
+          [-122.5, 37.7],
+          [-122.4, 37.8],
+        ],
+      }),
+    ).toEqual({
+      type: "MultiPoint",
+      coordinates: [
+        [-122.5, 37.7],
+        [-122.4, 37.8],
+      ],
+    });
+  });
+
+  it("returns null for an empty multipoint", () => {
+    expect(esriGeometryToGeoJSON({ points: [] })).toBeNull();
+  });
+
+  it("converts a single-path polyline to a LineString", () => {
+    expect(
+      esriGeometryToGeoJSON({
+        paths: [
+          [
+            [0, 0],
+            [1, 1],
+            [2, 0],
+          ],
+        ],
+      }),
+    ).toEqual({
+      type: "LineString",
+      coordinates: [
+        [0, 0],
+        [1, 1],
+        [2, 0],
+      ],
+    });
+  });
+
+  it("converts a multi-path polyline to a MultiLineString", () => {
+    expect(
+      esriGeometryToGeoJSON({
+        paths: [
+          [
+            [0, 0],
+            [1, 1],
+          ],
+          [
+            [2, 2],
+            [3, 3],
+          ],
+        ],
+      }),
+    ).toEqual({
+      type: "MultiLineString",
+      coordinates: [
+        [
+          [0, 0],
+          [1, 1],
+        ],
+        [
+          [2, 2],
+          [3, 3],
+        ],
+      ],
+    });
+  });
+
+  it("returns null for empty paths", () => {
+    expect(esriGeometryToGeoJSON({ paths: [] })).toBeNull();
+  });
+
+  it("converts a single-ring polygon", () => {
+    // Esri exterior rings are clockwise (negative signed area).
+    const result = esriGeometryToGeoJSON({
+      rings: [
+        [
+          [0, 0],
+          [0, 4],
+          [4, 4],
+          [4, 0],
+          [0, 0],
+        ],
+      ],
+    });
+    expect(result).toEqual({
+      type: "Polygon",
+      coordinates: [
+        [
+          [0, 0],
+          [0, 4],
+          [4, 4],
+          [4, 0],
+          [0, 0],
+        ],
+      ],
+    });
+  });
+
+  it("converts a polygon with a hole (interior ring)", () => {
+    // Clockwise exterior ring + counter-clockwise interior ring (hole).
+    const result = esriGeometryToGeoJSON({
+      rings: [
+        [
+          [0, 0],
+          [0, 10],
+          [10, 10],
+          [10, 0],
+          [0, 0],
+        ],
+        [
+          [2, 2],
+          [4, 2],
+          [4, 4],
+          [2, 4],
+          [2, 2],
+        ],
+      ],
+    });
+    expect(result).toEqual({
+      type: "Polygon",
+      coordinates: [
+        [
+          [0, 0],
+          [0, 10],
+          [10, 10],
+          [10, 0],
+          [0, 0],
+        ],
+        [
+          [2, 2],
+          [4, 2],
+          [4, 4],
+          [2, 4],
+          [2, 2],
+        ],
+      ],
+    });
+  });
+
+  it("converts multiple exterior rings to a MultiPolygon", () => {
+    const result = esriGeometryToGeoJSON({
+      rings: [
+        [
+          [0, 0],
+          [0, 2],
+          [2, 2],
+          [2, 0],
+          [0, 0],
+        ],
+        [
+          [10, 10],
+          [10, 12],
+          [12, 12],
+          [12, 10],
+          [10, 10],
+        ],
+      ],
+    });
+    expect(result).toEqual({
+      type: "MultiPolygon",
+      coordinates: [
+        [
+          [
+            [0, 0],
+            [0, 2],
+            [2, 2],
+            [2, 0],
+            [0, 0],
+          ],
+        ],
+        [
+          [
+            [10, 10],
+            [10, 12],
+            [12, 12],
+            [12, 10],
+            [10, 10],
+          ],
+        ],
+      ],
+    });
+  });
+
+  it("returns null for empty rings", () => {
+    expect(esriGeometryToGeoJSON({ rings: [] })).toBeNull();
+  });
+
+  it("converts an Esri envelope to a closed polygon", () => {
+    expect(
+      esriGeometryToGeoJSON({
+        xmin: 0,
+        ymin: 0,
+        xmax: 10,
+        ymax: 5,
+      }),
+    ).toEqual({
+      type: "Polygon",
+      coordinates: [
+        [
+          [0, 0],
+          [10, 0],
+          [10, 5],
+          [0, 5],
+          [0, 0],
+        ],
+      ],
+    });
+  });
+
+  it("ignores non-finite coordinates inside paths", () => {
+    expect(
+      esriGeometryToGeoJSON({
+        paths: [
+          [
+            [0, 0],
+            [Number.NaN, 1],
+            [2, 2],
+          ],
+        ],
+      }),
+    ).toEqual({
+      type: "LineString",
+      coordinates: [
+        [0, 0],
+        [2, 2],
+      ],
+    });
+  });
+});
+
+describe("esriFeatureToGeoJSON", () => {
+  it("converts attributes and geometry to a GeoJSON Feature", () => {
+    const feature: HonuaFeature = {
+      attributes: { OBJECTID: 42, name: "Station" },
+      geometry: { x: -122.5, y: 37.7 },
+    };
+    expect(esriFeatureToGeoJSON(feature)).toEqual({
+      type: "Feature",
+      id: 42,
+      geometry: { type: "Point", coordinates: [-122.5, 37.7] },
+      properties: { OBJECTID: 42, name: "Station" },
+    });
+  });
+
+  it("derives the id from common Esri identifier attributes", () => {
+    expect(
+      esriFeatureToGeoJSON({
+        attributes: { id: "abc" },
+        geometry: { x: 1, y: 2 },
+      }).id,
+    ).toBe("abc");
+  });
+
+  it("omits the id when no identifier attribute is present", () => {
+    const result = esriFeatureToGeoJSON({
+      attributes: { name: "no id" },
+      geometry: { x: 1, y: 2 },
+    });
+    expect(result.id).toBeUndefined();
+    expect(result.properties).toEqual({ name: "no id" });
+  });
+
+  it("emits null geometry for features without geometry", () => {
+    const result = esriFeatureToGeoJSON({
+      attributes: { OBJECTID: 1 },
+      geometry: null,
+    });
+    expect(result.geometry).toBeNull();
+  });
+
+  it("emits null geometry for empty rings", () => {
+    const result = esriFeatureToGeoJSON({
+      attributes: { OBJECTID: 1 },
+      geometry: { rings: [] },
+    });
+    expect(result.geometry).toBeNull();
+  });
+});

--- a/test/feature-service-adapter.test.ts
+++ b/test/feature-service-adapter.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { HonuaClient, HonuaMap } from "../src/index.js";
+import {
+  esriFeaturesToGeoJson,
+  esriGeometryToGeoJson,
+  loadHonuaFeatureServiceGeoJson,
+  registerHonuaFeatureServiceSources,
+} from "../src/map/index.js";
+import { createHonuaFeatureServiceLayer, createHonuaTileServiceLayer } from "../src/map/maplibre-target.js";
+
+const FEATURE_URL = "https://gis.example.com/rest/services/parcels/FeatureServer/0";
+
+function makeClient(): HonuaClient {
+  return new HonuaClient({ baseUrl: "https://gis.example.com" });
+}
+
+describe("esriGeometryToGeoJson", () => {
+  it("converts a point geometry", () => {
+    expect(esriGeometryToGeoJson({ x: -157.8, y: 21.3 }, "esriGeometryPoint")).toEqual({
+      type: "Point",
+      coordinates: [-157.8, 21.3],
+    });
+  });
+
+  it("infers a point from structure when geometryType is absent", () => {
+    expect(esriGeometryToGeoJson({ x: 1, y: 2 }, undefined)).toEqual({
+      type: "Point",
+      coordinates: [1, 2],
+    });
+  });
+
+  it("converts a single-path polyline to LineString", () => {
+    expect(
+      esriGeometryToGeoJson(
+        {
+          paths: [
+            [
+              [0, 0],
+              [1, 1],
+            ],
+          ],
+        },
+        "esriGeometryPolyline",
+      ),
+    ).toEqual({
+      type: "LineString",
+      coordinates: [
+        [0, 0],
+        [1, 1],
+      ],
+    });
+  });
+
+  it("converts a multi-path polyline to MultiLineString", () => {
+    const result = esriGeometryToGeoJson(
+      {
+        paths: [
+          [
+            [0, 0],
+            [1, 1],
+          ],
+          [
+            [2, 2],
+            [3, 3],
+          ],
+        ],
+      },
+      "esriGeometryPolyline",
+    );
+    expect(result?.type).toBe("MultiLineString");
+  });
+
+  it("converts a polygon's rings", () => {
+    const result = esriGeometryToGeoJson(
+      {
+        rings: [
+          [
+            [0, 0],
+            [1, 0],
+            [1, 1],
+            [0, 0],
+          ],
+        ],
+      },
+      "esriGeometryPolygon",
+    );
+    expect(result).toEqual({
+      type: "Polygon",
+      coordinates: [
+        [
+          [0, 0],
+          [1, 0],
+          [1, 1],
+          [0, 0],
+        ],
+      ],
+    });
+  });
+
+  it("returns null for missing geometry", () => {
+    expect(esriGeometryToGeoJson(null, "esriGeometryPoint")).toBeNull();
+    expect(esriGeometryToGeoJson(undefined, "esriGeometryPolygon")).toBeNull();
+  });
+});
+
+describe("esriFeaturesToGeoJson", () => {
+  it("builds a standard FeatureCollection", () => {
+    const fc = esriFeaturesToGeoJson([{ attributes: { id: 1 }, geometry: { x: 0, y: 0 } }], "esriGeometryPoint");
+    expect(fc).toEqual({
+      type: "FeatureCollection",
+      features: [{ type: "Feature", geometry: { type: "Point", coordinates: [0, 0] }, properties: { id: 1 } }],
+    });
+  });
+});
+
+describe("loadHonuaFeatureServiceGeoJson", () => {
+  it("fetches features via the SDK and returns a maplibre-understood geojson source", async () => {
+    const client = makeClient();
+    const queryFeatures = vi.spyOn(client, "queryFeatures").mockResolvedValueOnce({
+      features: [{ attributes: { OBJECTID: 1, name: "A" }, geometry: { x: -157, y: 21 } }],
+    } as never);
+    vi.spyOn(client, "getLayerMetadata").mockResolvedValue({
+      id: 0,
+      name: "parcels",
+      geometryType: "esriGeometryPoint",
+    } as never);
+
+    const source = await loadHonuaFeatureServiceGeoJson(client, FEATURE_URL);
+
+    // MapLibre understands the "geojson" source type natively.
+    expect(source.type).toBe("geojson");
+    expect(source.data).toEqual({
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [-157, 21] },
+          properties: { OBJECTID: 1, name: "A" },
+        },
+      ],
+    });
+    // GeoJSON requires WGS84, so the query defaults outSr to 4326.
+    expect(queryFeatures).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: "parcels", layerId: 0, outSr: 4326 }),
+    );
+  });
+});
+
+describe("registerHonuaFeatureServiceSources", () => {
+  it("patches feature-service sources on a maplibre map into geojson sources", async () => {
+    const client = makeClient();
+    vi.spyOn(client, "queryFeatures").mockResolvedValue({
+      features: [{ attributes: { OBJECTID: 7 }, geometry: { x: 1, y: 2 } }],
+    } as never);
+    vi.spyOn(client, "getLayerMetadata").mockResolvedValue({
+      id: 0,
+      name: "parcels",
+      geometryType: "esriGeometryPoint",
+    } as never);
+
+    const honuaMap = new HonuaMap({ client });
+    honuaMap.addSource("parcels", { type: "honua-feature-service", url: FEATURE_URL });
+    honuaMap.addSource("osm", { type: "raster", tiles: ["https://t/{z}/{x}/{y}.png"] } as never);
+
+    const added: Array<{ id: string; source: { type: string } }> = [];
+    const fakeMap = {
+      getSource: () => undefined,
+      addSource: (id: string, source: unknown) => {
+        added.push({ id, source: source as { type: string } });
+      },
+      removeSource: () => {},
+    };
+
+    const result = await registerHonuaFeatureServiceSources(fakeMap, honuaMap, client);
+
+    expect(result.registered).toEqual(["parcels"]);
+    expect(result.failed).toEqual([]);
+    // Only the feature-service source is wired; the raster source is left alone.
+    expect(added).toHaveLength(1);
+    expect(added[0].id).toBe("parcels");
+    expect(added[0].source.type).toBe("geojson");
+  });
+
+  it("updates an existing geojson source in place via setData", async () => {
+    const client = makeClient();
+    vi.spyOn(client, "queryFeatures").mockResolvedValue({
+      features: [{ attributes: { OBJECTID: 1 }, geometry: { x: 0, y: 0 } }],
+    } as never);
+    vi.spyOn(client, "getLayerMetadata").mockResolvedValue({
+      id: 0,
+      name: "parcels",
+      geometryType: "esriGeometryPoint",
+    } as never);
+
+    const honuaMap = new HonuaMap({ client });
+    honuaMap.addSource("parcels", { type: "honua-feature-service", url: FEATURE_URL });
+
+    const setData = vi.fn();
+    const fakeMap = {
+      getSource: () => ({ setData }),
+      addSource: vi.fn(),
+      removeSource: vi.fn(),
+    };
+
+    const result = await registerHonuaFeatureServiceSources(fakeMap, honuaMap, client);
+
+    expect(result.registered).toEqual(["parcels"]);
+    expect(setData).toHaveBeenCalledTimes(1);
+    expect(fakeMap.addSource).not.toHaveBeenCalled();
+  });
+});
+
+describe("helper source asymmetry", () => {
+  it("tile-service helper emits a native raster source while feature-service emits a custom type", () => {
+    const tile = createHonuaTileServiceLayer({
+      url: "https://gis.example.com/rest/services/imagery/MapServer",
+    });
+    expect(tile.source.type).toBe("raster");
+
+    const feature = createHonuaFeatureServiceLayer({ url: FEATURE_URL });
+    // The custom type is not renderable by MapLibre without the adapter.
+    expect(feature.source.type).toBe("honua-feature-service");
+  });
+});

--- a/test/path-utils.test.ts
+++ b/test/path-utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { encodeServiceIdPath } from "../src/core/path-utils.js";
+
+describe("encodeServiceIdPath", () => {
+  it("encodes a flat serviceId exactly like encodeURIComponent", () => {
+    expect(encodeServiceIdPath("MyService")).toBe("MyService");
+    expect(encodeServiceIdPath("My Service")).toBe(encodeURIComponent("My Service"));
+    expect(encodeServiceIdPath("My Service")).toBe("My%20Service");
+  });
+
+  it("preserves the slash between folder and service segments", () => {
+    expect(encodeServiceIdPath("MyFolder/MyService")).toBe("MyFolder/MyService");
+  });
+
+  it("supports deeply nested folder paths", () => {
+    expect(encodeServiceIdPath("a/b/c/Service")).toBe("a/b/c/Service");
+  });
+
+  it("percent-encodes special characters within each segment but keeps the separator", () => {
+    expect(encodeServiceIdPath("My Folder/My Service")).toBe("My%20Folder/My%20Service");
+    expect(encodeServiceIdPath("Pub & Roads/Layer A")).toBe("Pub%20%26%20Roads/Layer%20A");
+  });
+
+  it("drops empty segments from leading, trailing, or doubled slashes", () => {
+    expect(encodeServiceIdPath("/MyFolder/MyService/")).toBe("MyFolder/MyService");
+    expect(encodeServiceIdPath("MyFolder//MyService")).toBe("MyFolder/MyService");
+  });
+});


### PR DESCRIPTION
## Summary

Resolves a cohesive cluster of SDK consumption issues surfaced while building the honua-site Maui demo page (honua-site#46). All five make the SDK easier to consume from a MapLibre / browser context and remove the Esri-migration friction the SDK is meant to eliminate.

Closes #264, #265, #266, #267, #268.

## Changes

### #264 — Export Esri-JSON → GeoJSON converter as a public utility
- New `src/core/esri-geojson.ts` exporting `esriGeometryToGeoJSON` and `esriFeatureToGeoJSON` (point / multipoint / polyline / polygon-with-holes / MultiPolygon / envelope; null-safe).
- Exported from both public surface roots (`@honua/sdk-js`, `@honua/sdk-js/honua`).
- `examples/maplibre-quickstart` now delegates to the SDK instead of carrying a ~280-line private copy.

### #265 — Folder-prefixed `serviceId` no longer silently broken
- New `encodeServiceIdPath` in `core/path-utils.ts`: splits on `/`, encodes each segment, preserves the separator so `MyFolder/MyService` routes correctly. Flat ids are byte-for-byte unchanged.
- Applied at every URL path-building site (client, surfaces, esri-compat feature/tile layers, geocoding locator, migration reconcile). Query-param encoding intentionally left as-is.

### #266 — Correct stale `spatialFilter` JSDoc
- `contract/types.ts` and `contract/source.ts` JSDoc now shows the real `envelope()` / `point()` builder API instead of the non-functional `{ kind: "bbox", ... }` literal. Builders were already top-level exports.

### #267 — Working MapLibre runtime adapter for feature-service layers
- New `src/map/feature-service-adapter.ts` (`@honua/sdk-js/map`): `loadHonuaFeatureServiceGeoJson` and `registerHonuaFeatureServiceSources` fetch features through the SDK and expose them as a native MapLibre `geojson` source, so the previously no-op `honua-feature-service` source renders. Asymmetry vs. the raster helper documented.

### #268 — MapLibre vector-tile source helpers for OGC tiles
- `HonuaOgcTiles` gains `getMapLibreVectorSource`, `getDefaultSourceLayer`, and `getMapLibreConfig` (via `client.ogcTiles()`). Returns a MapLibre-ready vector source spec with `{z}/{y}/{x}` template intact; no hard `maplibre-gl` runtime dependency.

## Validation

Each issue was implemented in an isolated worktree, then merged here. On the integration branch:
- `npm run typecheck` — clean
- `npm run check` (Biome, 620 files) — clean
- `npm run build` — clean
- `npm run verify:split-packages` — ok
- `npm test` — **209 files / 2266 tests pass**

One pre-existing test (`core-client.test.ts`) asserted the old buggy single-segment `serviceId` encoding; it was updated to verify the corrected folder-path behavior. New unit tests added for the converter, path-segment encoding, the feature-service adapter, and the OGC vector-tile helpers.
