### PR TITLE
feat(sdk): control kit completion, realtime/imagery helpers, browser bundle, contract audits (#274,#280,#279,#283,#273,#263,#233,#228)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,33 @@ can migrate file-by-file.
 npm install @honua/sdk-js
 ```
 
+### Build-less / CDN usage
+
+For static sites, prototypes, or CSP-strict pages that can't run a bundler, a
+prebuilt browser bundle is published under `dist/browser/`. Drop in the
+minified IIFE build and use the global `window.HonuaSDK`:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@honua/sdk-js/dist/browser/honua-sdk.min.js"></script>
+<script>
+  const client = new HonuaSDK.HonuaClient({ baseUrl: "https://your-honua-server.example" });
+  // window.HonuaSDK exposes the same public API as `import ... from "@honua/sdk-js"`.
+</script>
+```
+
+Or, for native ES module imports via an ESM CDN:
+
+```html
+<script type="module">
+  import { HonuaClient } from "https://esm.sh/@honua/sdk-js/browser";
+  const client = new HonuaClient({ baseUrl: "https://your-honua-server.example" });
+</script>
+```
+
+The runtime peers (`maplibre-gl`, `cesium`, `@bufbuild/*`, `@connectrpc/*`) are
+kept external — load them yourself when you need map rendering or gRPC
+transport. See [`docs/browser-bundle.md`](./docs/browser-bundle.md) for details.
+
 ## 60-second quickstart
 
 The canonical surface is protocol-neutral: build a `Dataset` over one or more

--- a/docs/browser-bundle.md
+++ b/docs/browser-bundle.md
@@ -1,0 +1,98 @@
+# Prebuilt browser bundle (CDN / build-less)
+
+`@honua/sdk-js` ships ESM + TypeScript types as its canonical output, intended
+for consumption through a bundler (Vite, webpack, esbuild, Rollup) or Node.
+For static sites, quick prototypes, and CSP-strict pages that cannot run their
+own bundler, the package also publishes a **prebuilt, self-contained browser
+bundle** under `dist/browser/`.
+
+This is an *additive* artifact — it does not change the ESM/`exports`/types
+surface. Production apps should keep importing from `@honua/sdk-js` (and its
+subpaths) through their bundler; the browser bundle exists only for build-less
+consumers.
+
+## Artifacts
+
+| File | Format | Use |
+| --- | --- | --- |
+| `dist/browser/honua-sdk.min.js` | minified IIFE (`globalName: HonuaSDK`) | `<script>` tags, unpkg, jsDelivr |
+| `dist/browser/honua-sdk.esm.js` | minified ESM | `<script type="module">`, esm.sh, native CDN imports |
+
+Both ship with `.map` sourcemaps. The bundle targets `es2020`.
+
+The `package.json` `browser`, `unpkg`, and `jsdelivr` fields point at the IIFE
+build, and the `./browser` subpath export points at the ESM build, so ESM CDNs
+that resolve subpaths (e.g. esm.sh) can serve it directly.
+
+## Usage — global `<script>` (IIFE)
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@honua/sdk-js/dist/browser/honua-sdk.min.js"></script>
+<script>
+  // The whole public API of `@honua/sdk-js` is on window.HonuaSDK.
+  const client = new HonuaSDK.HonuaClient({
+    baseUrl: "https://your-honua-server.example",
+  });
+
+  const dataset = HonuaSDK.createDataset({
+    id: "parcels",
+    client,
+    sources: [{ id: "parcels-fs", protocol: "geoservices", url: "https://.../FeatureServer/0" }],
+  });
+</script>
+```
+
+unpkg works the same way:
+
+```html
+<script src="https://unpkg.com/@honua/sdk-js/dist/browser/honua-sdk.min.js"></script>
+```
+
+## Usage — native ES module (ESM)
+
+```html
+<script type="module">
+  import { HonuaClient, createDataset } from "https://esm.sh/@honua/sdk-js/browser";
+
+  const client = new HonuaClient({ baseUrl: "https://your-honua-server.example" });
+</script>
+```
+
+## What's bundled vs. external
+
+The bundle is focused on the **core SDK public API** (everything re-exported
+from `src/index.ts`). The sole real runtime dependency,
+`@maplibre/maplibre-gl-style-spec`, is bundled in.
+
+The heavy runtime *peers* are kept **external** so the artifact stays small and
+does not inline multi-megabyte map/protobuf runtimes:
+
+- `maplibre-gl`
+- `cesium`
+- `@bufbuild/protobuf`
+- `@connectrpc/connect`
+- `@connectrpc/connect-web`
+
+If you use a part of the SDK that needs one of these (e.g. the MapLibre runtime
+or gRPC transport), load that peer yourself — for the IIFE build, ensure it is
+available on the page before the code path that needs it runs.
+
+## Building the bundle
+
+```bash
+npm run build          # canonical tsc ESM + types output (dist/src)
+npm run build:browser  # esbuild → dist/browser/*.js (+ .map)
+```
+
+`scripts/build-browser-bundle.mjs` bundles straight from `src/index.ts` using
+the locally installed `esbuild`, so it does not strictly require `npm run build`
+to have run first — but `npm run build:browser` is the documented entry point.
+It is intentionally **not** wired into the CI `build` step so an esbuild option
+mismatch can never break the main release build; run it explicitly (or at
+publish time) to produce the artifact. The script smoke-checks that the IIFE
+build defines the `HonuaSDK` global and prints the output sizes.
+
+> Note: `dist/` is gitignored. The browser bundle is produced at build/publish
+> time, not committed to source control. The `files` array in `package.json`
+> includes `dist/browser` so the artifact is included in the published npm
+> tarball.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -593,6 +593,38 @@ const search = await client.stac().search({
 });
 ```
 
+### STAC in the browser bundle
+
+`HonuaStacSearch` is part of the browser-safe surface — import it (or call
+`client.stac()`) instead of hand-writing `fetch` against STAC endpoints. It is
+re-exported from both the root barrel (`@honua/sdk-js`) and the
+`@honua/sdk-js/honua` subpath, so it bundles with esbuild/Vite/Rollup like the
+rest of the client:
+
+```ts
+// Browser app (esbuild / Vite / Rollup). No Node-only imports.
+import { HonuaClient, HonuaStacSearch } from "@honua/sdk-js";
+
+const client = new HonuaClient({ baseUrl: "https://example.test" });
+
+// Either construct it directly…
+const stac = new HonuaStacSearch({ client });
+// …or get the same instance from the client:
+const sameStac = client.stac();
+
+const landing = await stac.landing();
+const items = await stac.search({
+  bbox: [-122, 37, -120, 38],
+  collections: ["sentinel-2"],
+  datetime: "2026-01-01/2026-06-01",
+});
+
+// `searchAll` paginates for you (bounded by `maxPages`):
+for await (const item of stac.searchStream({ collections: ["sentinel-2"] })) {
+  // …
+}
+```
+
 See [`docs/ogc-api.md`](./docs/ogc-api.md) for the full developer
 reference, [`docs/shared-client-contract.md`](./docs/shared-client-contract.md)
 for the canonical `Source` / `IJobRun` model, and

--- a/docs/realtime-subscriptions.md
+++ b/docs/realtime-subscriptions.md
@@ -85,6 +85,36 @@ const tombstones = selectRealtimeFeatureTombstones(store.state, { sourceId: "inc
 
 Use `reconcileRealtimeSelection(view, state)` with an `ExplorationViewController` to remove deleted or missing features from shared map/table/detail selection.
 
+## honua-server Preset
+
+honua-server exposes live feature changes at `/api/v1/streaming/features`. That endpoint expects `serviceId=` / `layers=` query params (not the default `sourceId=` / `layerId=`) and emits its own feature-change envelopes. The `honuaServerRealtimePreset` packages the matching `encodeRequest` and `decodeEvent` hooks so consumers do not re-write the adapter:
+
+```ts
+import {
+  createRealtimeServerSentEventsTransport,
+  honuaServerRealtimePreset,
+} from "@honua/sdk-js/realtime";
+
+const transport = createRealtimeServerSentEventsTransport({
+  url: "https://honua.example/api/v1/streaming/features",
+  ...honuaServerRealtimePreset(),
+});
+```
+
+Or use the convenience factory, which appends the default streaming path to a server origin:
+
+```ts
+import { createHonuaServerRealtimeSubscription } from "@honua/sdk-js/realtime";
+
+const transport = createHonuaServerRealtimeSubscription({
+  baseUrl: "https://honua.example",
+});
+
+store.connect(transport, { sourceId: "incidents", layerId: "0", mode: "snapshot-then-delta" });
+```
+
+The preset decodes honua-server feature-change envelopes (`{ op: "insert" | "update" | "delete", featureId, feature, ... }`, batched under `changes` or inlined) into SDK `delta` events, carrying `serviceId` through as the event `sourceId`. Status, heartbeat, and error envelopes that already use the SDK vocabulary pass through unchanged. The default `sourceId=` / `layerId=` encoder remains the transport default; the preset is opt-in.
+
 ## Adapter Expectations
 
 SSE adapters should emit `snapshot` or `delta` after open, `heartbeat` for server keepalives, `status: "reconnecting"` before retry, and `error` only when the stream cannot recover. WebSocket adapters should use the same event vocabulary for server messages and close codes. Delta polling adapters should emit `delta` batches, preserve server ordering, and pass cursor/timestamp/delta-token checkpoints through `checkpoint`.

--- a/examples/terrain-rgb-elevation/src/model.ts
+++ b/examples/terrain-rgb-elevation/src/model.ts
@@ -1,4 +1,4 @@
-import { type HonuaClient, HonuaImageService } from "@honua/sdk-js/honua";
+import { type HonuaClient, HonuaImageService, decodeTerrainRgbElevation } from "@honua/sdk-js/honua";
 import type { SceneRuntimePrimitive } from "@honua/sdk-js/scene-workspace";
 
 import { createFixtureTerrainElevationDataset } from "./fixtures.js";
@@ -110,9 +110,10 @@ export function buildTerrainRgbTileUrlTemplate(
     .replace(`/${levelSentinel}/${rowSentinel}/${colSentinel}`, "/{z}/{y}/{x}");
 }
 
-export function decodeTerrainRgbElevation(red: number, green: number, blue: number): number {
-  return -10_000 + (red * 256 * 256 + green * 256 + blue) * 0.1;
-}
+// Re-exported from the SDK (`@honua/sdk-js`) so the demo and its smoke tests
+// keep their existing import surface while the decode formula lives in one
+// shared, tested place. See `decodeTerrainRgbElevation` in core/terrain-elevation.
+export { decodeTerrainRgbElevation };
 
 export async function lookupTerrainElevation(
   plan: TerrainRenderPlan,

--- a/examples/web-components-basic/README.md
+++ b/examples/web-components-basic/README.md
@@ -23,6 +23,43 @@ off in the layer list, and `auto-refresh` re-derives on the map's `styledata`
 events. Themed via `::part(root)` / `::part(section-title)` / `::part(row)` /
 `::part(swatch)`.
 
+## Measure and sketch require a geometry provider
+
+`<honua-measure-control>` and `<honua-sketch-control>` draw on the map, so they
+need a drawing backend. The SDK never bundles one (it has no hard dependency on
+maplibre-gl-draw or any other drawing library). Instead, the controller exposes
+a pluggable seam: pass a `measurementGeometry` and/or `sketchGeometry` provider
+to `createHonuaWebComponentController(...)`.
+
+```ts
+import { createHonuaWebComponentController } from "@honua/sdk-js/web-components";
+import type { HonuaMeasureProvider, HonuaSketchProvider } from "@honua/sdk-js/web-components";
+
+const measurementGeometry: HonuaMeasureProvider = {
+  // Adapt maplibre-gl-draw (or any drawing tool) here.
+  startMode(mode) {
+    /* enter distance/area mode; return { mode, coordinates, distance/area } */
+  },
+  stop() {
+    /* leave drawing mode */
+  },
+};
+
+const controller = createHonuaWebComponentController({
+  mapPackage,
+  measurementGeometry,
+  sketchGeometry: { startMode(mode) {/* ... */} } satisfies HonuaSketchProvider,
+});
+```
+
+When a provider is supplied the control's mode buttons become enabled, switching
+mode activates the provider, and the control emits `honua-measure-change` /
+`honua-sketch-change` with real geometry (and, for measuring, distance/area).
+
+This basic sample wires the bare in-memory controller **without** a provider, so
+both controls render disabled by design with a "configure a provider" message —
+that is the expected state, not a bug. Supply the providers above to enable them.
+
 ```bash
 npm run demo:web-components
 ```

--- a/package.json
+++ b/package.json
@@ -37,10 +37,17 @@
   ],
   "type": "module",
   "types": "./dist/src/index.d.ts",
+  "browser": "./dist/browser/honua-sdk.min.js",
+  "unpkg": "./dist/browser/honua-sdk.min.js",
+  "jsdelivr": "./dist/browser/honua-sdk.min.js",
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
       "default": "./dist/src/index.js"
+    },
+    "./browser": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/browser/honua-sdk.esm.js"
     },
     "./honua": {
       "types": "./dist/src/honua.d.ts",
@@ -182,6 +189,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "npm run clean --silent && tsc -p tsconfig.json",
+    "build:browser": "node scripts/build-browser-bundle.mjs",
     "build:split-packages": "npm run build --silent && node scripts/prepare-split-packages.mjs",
     "verify:split-packages": "npm run build:split-packages --silent && node scripts/verify-split-packages.mjs",
     "pack:split-packages": "npm run build:split-packages --silent && npm pack ./dist/packages/honua-sdk && npm pack ./dist/packages/honua-sdk-esri-compat && npm pack ./dist/packages/honua-migrate",
@@ -355,6 +363,7 @@
   },
   "files": [
     "dist/src",
+    "dist/browser",
     "README.md",
     "CHANGELOG.md"
   ],

--- a/scripts/build-browser-bundle.mjs
+++ b/scripts/build-browser-bundle.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+/**
+ * Build prebuilt browser bundles for build-less / CDN consumers (issue #263).
+ *
+ * Produces two additive artifacts under `dist/browser/` from the public entry
+ * (`src/index.ts`) without touching the canonical ESM + types output emitted by
+ * `tsc`:
+ *
+ *   - `dist/browser/honua-sdk.min.js`  — minified IIFE, exposes `window.HonuaSDK`
+ *     (for `<script>` / unpkg / jsdelivr usage).
+ *   - `dist/browser/honua-sdk.esm.js`  — minified ESM bundle (for esm.sh /
+ *     native `<script type="module">` imports).
+ *
+ * The heavy runtime peers (maplibre-gl, cesium, the @bufbuild / @connectrpc
+ * stack) are kept EXTERNAL so the bundle stays focused on the core SDK and does
+ * not inline multi-megabyte map/protobuf runtimes. The sole real dependency,
+ * `@maplibre/maplibre-gl-style-spec`, is bundled.
+ *
+ * esbuild is used directly from `node_modules` (it must already be installed);
+ * it is intentionally NOT a package.json dependency so building this artifact
+ * never forces an install in the shared dev environment.
+ *
+ * Run with: `npm run build:browser`
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import * as esbuild from "esbuild";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(SCRIPT_DIR, "..");
+const ENTRY = path.join(PROJECT_ROOT, "src", "index.ts");
+const OUT_DIR = path.join(PROJECT_ROOT, "dist", "browser");
+
+const GLOBAL_NAME = "HonuaSDK";
+
+/**
+ * Runtime peers that consumers are expected to provide themselves (matches the
+ * `peerDependencies` in package.json). Marking them external keeps the bundle
+ * lean and avoids inlining map/protobuf runtimes that ship separately.
+ */
+const EXTERNAL = [
+  "maplibre-gl",
+  "cesium",
+  "@bufbuild/protobuf",
+  "@connectrpc/connect",
+  "@connectrpc/connect-web",
+];
+
+const SHARED_OPTIONS = {
+  entryPoints: [ENTRY],
+  bundle: true,
+  minify: true,
+  sourcemap: true,
+  platform: "browser",
+  target: ["es2020"],
+  external: EXTERNAL,
+  legalComments: "none",
+};
+
+function formatSize(bytes) {
+  return `${(bytes / 1024).toFixed(1)} KiB`;
+}
+
+async function main() {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+
+  const iifeOut = path.join(OUT_DIR, "honua-sdk.min.js");
+  const esmOut = path.join(OUT_DIR, "honua-sdk.esm.js");
+
+  await esbuild.build({
+    ...SHARED_OPTIONS,
+    format: "iife",
+    globalName: GLOBAL_NAME,
+    outfile: iifeOut,
+  });
+
+  await esbuild.build({
+    ...SHARED_OPTIONS,
+    format: "esm",
+    outfile: esmOut,
+  });
+
+  // Smoke check: the IIFE bundle must declare the global the docs promise.
+  const iifeSource = fs.readFileSync(iifeOut, "utf8");
+  if (!iifeSource.includes(GLOBAL_NAME)) {
+    throw new Error(`Expected IIFE bundle to define the "${GLOBAL_NAME}" global, but it was not found.`);
+  }
+
+  for (const file of [iifeOut, esmOut]) {
+    const { size } = fs.statSync(file);
+    process.stdout.write(`  ${path.relative(PROJECT_ROOT, file)}  ${formatSize(size)}\n`);
+  }
+  process.stdout.write(`Browser bundles written to ${path.relative(PROJECT_ROOT, OUT_DIR)}/\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+  process.exit(1);
+});

--- a/src/controls/basemap-switcher.ts
+++ b/src/controls/basemap-switcher.ts
@@ -49,6 +49,7 @@ import {
   resolveHonuaMapFromContext,
 } from "./element-utils.js";
 import { HonuaLegendElement } from "./legend.js";
+import { HonuaSwipeControlElement } from "./swipe-control.js";
 import type {
   HonuaBasemapDefinition,
   HonuaBasemapKind,
@@ -334,7 +335,7 @@ export class HonuaBasemapSwitcherElement extends HTMLElementBase {
 
 /**
  * Registers the controls-entry custom elements (`honua-basemap-switcher`,
- * `honua-legend`). Invoked automatically on import when a global
+ * `honua-legend`, `honua-swipe-control`). Invoked automatically on import when a global
  * `customElements` registry is present; call explicitly when using a scoped
  * registry.
  *
@@ -349,6 +350,9 @@ export function defineHonuaControls(registry = globalDom.customElements): void {
   }
   if (!registry.get("honua-legend")) {
     registry.define("honua-legend", HonuaLegendElement);
+  }
+  if (!registry.get("honua-swipe-control")) {
+    registry.define("honua-swipe-control", HonuaSwipeControlElement);
   }
 }
 

--- a/src/controls/basemap-switcher.ts
+++ b/src/controls/basemap-switcher.ts
@@ -48,6 +48,7 @@ import {
   listenForHonuaMapReady,
   resolveHonuaMapFromContext,
 } from "./element-utils.js";
+import { HonuaLayerListElement } from "./layer-list.js";
 import { HonuaLegendElement } from "./legend.js";
 import type {
   HonuaBasemapDefinition,
@@ -334,7 +335,7 @@ export class HonuaBasemapSwitcherElement extends HTMLElementBase {
 
 /**
  * Registers the controls-entry custom elements (`honua-basemap-switcher`,
- * `honua-legend`). Invoked automatically on import when a global
+ * `honua-legend`, `honua-layer-list`). Invoked automatically on import when a global
  * `customElements` registry is present; call explicitly when using a scoped
  * registry.
  *
@@ -349,6 +350,9 @@ export function defineHonuaControls(registry = globalDom.customElements): void {
   }
   if (!registry.get("honua-legend")) {
     registry.define("honua-legend", HonuaLegendElement);
+  }
+  if (!registry.get("honua-layer-list")) {
+    registry.define("honua-layer-list", HonuaLayerListElement);
   }
 }
 

--- a/src/controls/basemap-switcher.ts
+++ b/src/controls/basemap-switcher.ts
@@ -48,7 +48,6 @@ import {
   listenForHonuaMapReady,
   resolveHonuaMapFromContext,
 } from "./element-utils.js";
-import { HonuaLayerListElement } from "./layer-list.js";
 import { HonuaLegendElement } from "./legend.js";
 import { HonuaSwipeControlElement } from "./swipe-control.js";
 import type {
@@ -336,14 +335,17 @@ export class HonuaBasemapSwitcherElement extends HTMLElementBase {
 
 /**
  * Registers the controls-entry custom elements (`honua-basemap-switcher`,
- * `honua-legend`, `honua-layer-list`, `honua-swipe-control`). Invoked
- * automatically on import when a global
- * `customElements` registry is present; call explicitly when using a scoped
- * registry.
+ * `honua-legend`, `honua-swipe-control`). Invoked automatically on import when
+ * a global `customElements` registry is present; call explicitly when using a
+ * scoped registry.
  *
  * Registrations are skipped for tag names that are already defined. In
  * particular the `web-components` entry registers its own (controller-driven)
  * `honua-legend`; whichever entry is imported first owns that tag.
+ *
+ * `honua-layer-list` is intentionally NOT registered here — it collides with
+ * the `web-components` kit's own controller-driven `honua-layer-list`, so it is
+ * opt-in via {@link defineHonuaLayerList}.
  */
 export function defineHonuaControls(registry = globalDom.customElements): void {
   if (!registry) return;
@@ -352,9 +354,6 @@ export function defineHonuaControls(registry = globalDom.customElements): void {
   }
   if (!registry.get("honua-legend")) {
     registry.define("honua-legend", HonuaLegendElement);
-  }
-  if (!registry.get("honua-layer-list")) {
-    registry.define("honua-layer-list", HonuaLayerListElement);
   }
   if (!registry.get("honua-swipe-control")) {
     registry.define("honua-swipe-control", HonuaSwipeControlElement);

--- a/src/controls/index.ts
+++ b/src/controls/index.ts
@@ -2,7 +2,7 @@
  * Native Honua UI control kit (`@honua/sdk-js/controls`) — optional,
  * framework-free custom elements for apps built on the native lane
  * (HonuaClient + MapLibre). Tracked by issue #274; ships the basemap
- * switcher and the legend, with a layer list to follow.
+ * switcher, the legend, and the layer list.
  *
  * This entry is intentionally independent of the SDK core bundle (the same
  * posture as `@honua/sdk-js/esri-compat`): it imports nothing from
@@ -22,6 +22,7 @@ import "./basemap-switcher.js";
 
 export { HonuaBasemapStyleBinding } from "./basemap-style-binding.js";
 export { HonuaBasemapSwitcherElement, defineHonuaControls } from "./basemap-switcher.js";
+export { HonuaLayerListElement } from "./layer-list.js";
 export { HonuaLegendDeriveError, deriveLegendEntries } from "./legend-derive.js";
 export type { HonuaLegendDeriveErrorCode } from "./legend-derive.js";
 export { HonuaLegendElement } from "./legend.js";
@@ -31,6 +32,9 @@ export type {
   HonuaBasemapLayerSpecification,
   HonuaBasemapSwitcherChangeDetail,
   HonuaBasemapSwitcherMap,
+  HonuaLayerListChangeDetail,
+  HonuaLayerListMap,
+  HonuaLayerListOverlay,
   HonuaLegendEntry,
   HonuaLegendMap,
   HonuaLegendSection,

--- a/src/controls/index.ts
+++ b/src/controls/index.ts
@@ -9,9 +9,12 @@
  * `src/core`/`src/runtime` and has no dependency on `maplibre-gl` — controls
  * drive any MapLibre `Map` through a duck-typed interface.
  *
- * Importing this module registers the shipped custom elements when a browser
- * `customElements` registry is present. Node imports are safe; call
- * `defineHonuaControls()` explicitly when using a scoped registry.
+ * Importing this module registers the basemap switcher, legend, and swipe
+ * control when a browser `customElements` registry is present. Node imports are
+ * safe; call `defineHonuaControls()` explicitly when using a scoped registry.
+ * The layer list is opt-in via {@link defineHonuaLayerList} because its tag
+ * (`honua-layer-list`) collides with the `web-components` kit's own
+ * controller-driven element.
  *
  * @experimental This entrypoint is not yet covered by the SDK's semver
  *   contract — the surface may change in any minor release prior to `1.0.0`.
@@ -23,7 +26,7 @@ import "./swipe-control.js";
 
 export { HonuaBasemapStyleBinding } from "./basemap-style-binding.js";
 export { HonuaBasemapSwitcherElement, defineHonuaControls } from "./basemap-switcher.js";
-export { HonuaLayerListElement } from "./layer-list.js";
+export { HonuaLayerListElement, defineHonuaLayerList } from "./layer-list.js";
 export { HonuaLegendDeriveError, deriveLegendEntries } from "./legend-derive.js";
 export type { HonuaLegendDeriveErrorCode } from "./legend-derive.js";
 export { HonuaLegendElement } from "./legend.js";

--- a/src/controls/index.ts
+++ b/src/controls/index.ts
@@ -19,12 +19,14 @@
  */
 
 import "./basemap-switcher.js";
+import "./swipe-control.js";
 
 export { HonuaBasemapStyleBinding } from "./basemap-style-binding.js";
 export { HonuaBasemapSwitcherElement, defineHonuaControls } from "./basemap-switcher.js";
 export { HonuaLegendDeriveError, deriveLegendEntries } from "./legend-derive.js";
 export type { HonuaLegendDeriveErrorCode } from "./legend-derive.js";
 export { HonuaLegendElement } from "./legend.js";
+export { HonuaSwipeControlElement, defineHonuaSwipeControl } from "./swipe-control.js";
 export type {
   HonuaBasemapDefinition,
   HonuaBasemapKind,
@@ -36,4 +38,7 @@ export type {
   HonuaLegendSection,
   HonuaLegendSwatchColor,
   HonuaLegendSwatchShape,
+  HonuaSwipeChangeDetail,
+  HonuaSwipeMap,
+  HonuaSwipeOrientation,
 } from "./types.js";

--- a/src/controls/layer-list.ts
+++ b/src/controls/layer-list.ts
@@ -1,0 +1,362 @@
+/**
+ * `<honua-layer-list>` — framework-free custom element rendering a checkbox
+ * row per overlay so users can toggle MapLibre overlay layers on and off
+ * (issue #280, closing umbrella #274).
+ *
+ * Each overlay groups one or more style layer ids; toggling a row writes each
+ * layer's `visibility` layout property (`"visible"` / `"none"`) on the map.
+ * The element never imports `maplibre-gl` or the SDK core — it drives any
+ * MapLibre `Map` through the duck-typed {@link HonuaLayerListMap} interface,
+ * keeping the `@honua/sdk-js/controls` entry independent of the core bundle.
+ *
+ * ## Input modes
+ * - **Property** (preferred) — assign the `overlays` property a
+ *   {@link HonuaLayerListOverlay} array.
+ * - **Attribute** — set the `overlays` attribute to a JSON array of the same
+ *   shape (matching how `<honua-basemap-switcher>` accepts `bases` JSON).
+ *
+ * ## Wiring
+ * - `element.map = map` (any MapLibre `Map`) or `element.connect(map)`;
+ * - declaratively via `for="<honua-map id>"` — same idiom as
+ *   `<honua-basemap-switcher>` / `<honua-legend>` (resolves `.map` from the
+ *   referenced element and listens for `honua-map-ready`).
+ *
+ * ## Reactivity
+ * - With the `auto-refresh` attribute the element subscribes to the map's
+ *   `styledata` event while connected and re-syncs each checkbox's checked
+ *   state from the map's current `visibility` (external style edits,
+ *   visibility toggled elsewhere, layers seeded later).
+ *
+ * ## Attributes
+ * - `overlays` — JSON array of {@link HonuaLayerListOverlay} (the `overlays`
+ *   property is preferred for non-trivial configs).
+ * - `for` — id of the map-providing element, see Wiring.
+ * - `label` — accessible name of the list (default "Layers").
+ * - `auto-refresh` — boolean; see Reactivity.
+ *
+ * ## CSS parts
+ * `root`, `row`, `checkbox`, `label`, and `badge` (the "not seeded" hint
+ * shown on a disabled row whose style layers are all missing). Structural CSS
+ * only — theme via `::part()`.
+ *
+ * ## Accessibility
+ * Rows are real `<label>` + `<input type="checkbox">` pairs; an overlay whose
+ * style layers are all missing renders disabled with a `badge` part/slot.
+ */
+
+import {
+  HTMLElementBase,
+  escapeAttribute,
+  escapeHtml,
+  globalDom,
+  listenForHonuaMapReady,
+  resolveHonuaMapFromContext,
+} from "./element-utils.js";
+import type { HonuaLayerListChangeDetail, HonuaLayerListMap, HonuaLayerListOverlay } from "./types.js";
+
+/**
+ * Custom element implementing the overlay layer list. Registered as
+ * `honua-layer-list` by `defineHonuaControls` (which runs automatically on
+ * import of the controls entry when a `customElements` registry exists).
+ */
+export class HonuaLayerListElement extends HTMLElementBase {
+  public static get observedAttributes(): string[] {
+    return ["overlays", "for", "label", "auto-refresh"];
+  }
+
+  #map: HonuaLayerListMap | undefined;
+  #overlays: readonly HonuaLayerListOverlay[] = [];
+  #connected = false;
+  #disposeMapReadyListener: (() => void) | undefined;
+  #styledataListener: (() => void) | undefined;
+
+  /** The MapLibre map this list toggles overlay visibility on. */
+  public get map(): HonuaLayerListMap | undefined {
+    return this.#map;
+  }
+
+  public set map(map: HonuaLayerListMap | undefined) {
+    if (this.#map === map) return;
+    this.#unsubscribeStyledata();
+    this.#map = map;
+    this.#subscribeStyledata();
+    this.render();
+  }
+
+  /** Wires the list to a MapLibre map. Equivalent to setting `.map`. */
+  public connect(map: HonuaLayerListMap): void {
+    this.map = map;
+  }
+
+  /** The registered overlay definitions. */
+  public get overlays(): readonly HonuaLayerListOverlay[] {
+    return this.#overlays;
+  }
+
+  public set overlays(overlays: readonly HonuaLayerListOverlay[]) {
+    this.#overlays = normalizeOverlays(overlays);
+    this.render();
+  }
+
+  /** Refresh automatically on the map's `styledata` event. Reflects `auto-refresh`. */
+  public get autoRefresh(): boolean {
+    return this.#hasAttr("auto-refresh");
+  }
+
+  public set autoRefresh(value: boolean) {
+    if (typeof this.setAttribute !== "function") return;
+    if (value) this.setAttribute("auto-refresh", "");
+    else this.removeAttribute?.("auto-refresh");
+  }
+
+  /** Re-syncs checkbox state from the map and re-renders. */
+  public refresh(): void {
+    this.render();
+  }
+
+  /**
+   * Shows or hides the overlay with the given id, writing each of its style
+   * layers' `visibility`. Returns `true` when the overlay was found and at
+   * least one of its layers exists on the map. Dispatches `change`.
+   */
+  public setVisible(overlayId: string, visible: boolean): boolean {
+    const overlay = this.#overlays.find((candidate) => candidate.id === overlayId);
+    if (!overlay) return false;
+    const map = this.#map;
+    if (!map) return false;
+    let applied = false;
+    for (const layerId of overlay.layers) {
+      if (!this.#layerExists(layerId)) continue;
+      map.setLayoutProperty(layerId, "visibility", visible ? "visible" : "none");
+      applied = true;
+    }
+    if (!applied) return false;
+    this.#syncRow(overlayId);
+    this.#dispatchChange({ id: overlayId, visible });
+    return true;
+  }
+
+  public attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null): void {
+    if (name === "overlays") {
+      const parsed = parseOverlays(newValue);
+      if (parsed) this.overlays = parsed;
+      return;
+    }
+    if (name === "for") {
+      this.#resolveMapFromContext();
+      return;
+    }
+    if (name === "auto-refresh") {
+      if (newValue === null) this.#unsubscribeStyledata();
+      else this.#subscribeStyledata();
+      return;
+    }
+    // "label" only changes the rendering.
+    this.render();
+  }
+
+  public connectedCallback(): void {
+    this.#connected = true;
+    this.#ensureShadowRoot();
+    this.#listenForMapReady();
+    this.#resolveMapFromContext();
+    this.#subscribeStyledata();
+    this.render();
+  }
+
+  public disconnectedCallback(): void {
+    this.#connected = false;
+    this.#disposeMapReadyListener?.();
+    this.#disposeMapReadyListener = undefined;
+    this.#unsubscribeStyledata();
+  }
+
+  // ── map wiring (matches the `for` + ready-event idiom) ──────
+
+  #listenForMapReady(): void {
+    if (this.#disposeMapReadyListener) return;
+    this.#disposeMapReadyListener = listenForHonuaMapReady(this, (map) => {
+      const forId = this.#attr("for");
+      if (!forId && this.map) return;
+      this.map = map as HonuaLayerListMap;
+    });
+  }
+
+  #resolveMapFromContext(): void {
+    if (this.map) return;
+    const map = resolveHonuaMapFromContext(this);
+    if (map) this.map = map as HonuaLayerListMap;
+  }
+
+  #subscribeStyledata(): void {
+    if (this.#styledataListener || !this.#connected || !this.autoRefresh) return;
+    const map = this.#map;
+    if (!map || typeof map.on !== "function") return;
+    const listener = () => this.refresh();
+    map.on("styledata", listener);
+    this.#styledataListener = listener;
+  }
+
+  #unsubscribeStyledata(): void {
+    const listener = this.#styledataListener;
+    if (!listener) return;
+    this.#styledataListener = undefined;
+    this.#map?.off?.("styledata", listener);
+  }
+
+  // ── overlay state ──────────────────────────────────────────
+
+  /** Whether a style layer is present on the current map (drives not-seeded). */
+  #layerExists(layerId: string): boolean {
+    const map = this.#map;
+    if (!map?.getLayer) return false;
+    return map.getLayer(layerId) != null;
+  }
+
+  /** True when at least one of the overlay's style layers exists on the map. */
+  #isSeeded(overlay: HonuaLayerListOverlay): boolean {
+    return overlay.layers.some((layerId) => this.#layerExists(layerId));
+  }
+
+  /**
+   * Whether an overlay reads as visible: visible unless every present layer's
+   * `visibility` is `"none"`. Unseeded overlays read as unchecked.
+   */
+  #isVisible(overlay: HonuaLayerListOverlay): boolean {
+    const map = this.#map;
+    if (!map) return false;
+    for (const layerId of overlay.layers) {
+      if (!this.#layerExists(layerId)) continue;
+      if (map.getLayoutProperty?.(layerId, "visibility") !== "none") return true;
+    }
+    return false;
+  }
+
+  // ── rendering ──────────────────────────────────────────────
+
+  #ensureShadowRoot(): void {
+    if (!this.shadowRoot && typeof this.attachShadow === "function") {
+      this.attachShadow({ mode: "open" });
+    }
+  }
+
+  protected render(): void {
+    const root = this.shadowRoot;
+    if (!root) return;
+    const label = this.#attr("label") ?? "Layers";
+    root.innerHTML = `
+      <style>${structuralStyles()}</style>
+      <div part="root" class="root" role="group" aria-label="${escapeAttribute(label)}">
+        ${this.#overlays.map((overlay) => this.#renderRow(overlay)).join("")}
+      </div>
+    `;
+    this.#bindRows(root);
+  }
+
+  #renderRow(overlay: HonuaLayerListOverlay): string {
+    const seeded = this.#isSeeded(overlay);
+    const checked = seeded && this.#isVisible(overlay);
+    const attribution = overlay.attribution
+      ? `<span part="attribution" class="attribution">${escapeHtml(overlay.attribution)}</span>`
+      : "";
+    const badge = seeded ? "" : `<span part="badge" class="badge"><slot name="not-seeded">Not seeded</slot></span>`;
+    return `
+      <label part="row" class="row" data-overlay-id="${escapeAttribute(overlay.id)}"${seeded ? "" : " data-not-seeded"}>
+        <input
+          part="checkbox"
+          class="checkbox"
+          type="checkbox"
+          ${checked ? "checked" : ""}
+          ${seeded ? "" : "disabled"}
+          data-overlay-id="${escapeAttribute(overlay.id)}"
+        />
+        <span part="label" class="label">${escapeHtml(overlay.label)}</span>
+        ${attribution}
+        ${badge}
+      </label>
+    `;
+  }
+
+  #bindRows(root: ShadowRoot): void {
+    root.querySelectorAll<HTMLInputElement>("input[data-overlay-id]").forEach((input) => {
+      input.addEventListener("change", () => {
+        const overlayId = input.dataset.overlayId;
+        if (overlayId) this.setVisible(overlayId, input.checked);
+      });
+    });
+  }
+
+  /** Re-syncs a single row's checked state in place (preserves focus). */
+  #syncRow(overlayId: string): void {
+    const root = this.shadowRoot;
+    if (!root || typeof root.querySelector !== "function") return;
+    const overlay = this.#overlays.find((candidate) => candidate.id === overlayId);
+    if (!overlay) return;
+    const input = root.querySelector<HTMLInputElement>(`input[data-overlay-id="${cssEscape(overlayId)}"]`);
+    if (input) input.checked = this.#isSeeded(overlay) && this.#isVisible(overlay);
+  }
+
+  // ── attribute helpers (safe under Node test stubs) ──────────
+
+  #attr(name: string): string | null {
+    return typeof this.getAttribute === "function" ? this.getAttribute(name) : null;
+  }
+
+  #hasAttr(name: string): boolean {
+    if (typeof this.hasAttribute === "function") return this.hasAttribute(name);
+    return this.#attr(name) !== null;
+  }
+
+  #dispatchChange(detail: HonuaLayerListChangeDetail): void {
+    if (!globalDom.CustomEvent || typeof this.dispatchEvent !== "function") return;
+    this.dispatchEvent(new globalDom.CustomEvent("change", { bubbles: true, composed: true, detail }));
+  }
+}
+
+function normalizeOverlays(value: readonly HonuaLayerListOverlay[]): HonuaLayerListOverlay[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item): HonuaLayerListOverlay[] => {
+    if (!item || typeof item !== "object") return [];
+    const candidate = item as Partial<HonuaLayerListOverlay>;
+    if (typeof candidate.id !== "string" || typeof candidate.label !== "string") return [];
+    const layers = Array.isArray(candidate.layers)
+      ? candidate.layers.filter((layer): layer is string => typeof layer === "string")
+      : [];
+    return [
+      {
+        id: candidate.id,
+        label: candidate.label,
+        layers,
+        ...(typeof candidate.attribution === "string" ? { attribution: candidate.attribution } : {}),
+      },
+    ];
+  });
+}
+
+function parseOverlays(value: string | null): readonly HonuaLayerListOverlay[] | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!Array.isArray(parsed)) return undefined;
+    return normalizeOverlays(parsed as HonuaLayerListOverlay[]);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Minimal CSS identifier escape for the attribute selector in `#syncRow`. */
+function cssEscape(value: string): string {
+  return value.replace(/["\\]/g, "\\$&");
+}
+
+/** Structural-only styles; theme via `::part(root)`, `::part(row)`, `::part(checkbox)`, ... */
+function structuralStyles(): string {
+  return `
+    :host { display: block; }
+    .root { display: flex; flex-direction: column; }
+    .row { display: flex; align-items: center; gap: 0.5em; }
+    .checkbox { flex: none; }
+    .badge { font-size: 0.75em; }
+    [data-not-seeded] { cursor: not-allowed; }
+  `;
+}

--- a/src/controls/layer-list.ts
+++ b/src/controls/layer-list.ts
@@ -313,6 +313,30 @@ export class HonuaLayerListElement extends HTMLElementBase {
   }
 }
 
+/**
+ * Registers the layer-list custom element (`honua-layer-list`). Skips the
+ * registration when the tag is already defined.
+ *
+ * Unlike the other controls-kit elements, this is **opt-in** and is NOT run by
+ * the blanket `defineHonuaControls()` / module-load auto-registration. The
+ * `web-components` entry ships its own (controller-driven) `honua-layer-list`
+ * under the same tag, and that kit auto-registers on import. Auto-registering
+ * the controls variant too would let it silently win the tag in apps that load
+ * both kits (the order is import-dependent), so callers who want the native,
+ * overlay-definition-driven layer list register it explicitly:
+ *
+ * ```ts
+ * import { defineHonuaLayerList } from "@honua/sdk-js/controls";
+ * defineHonuaLayerList();
+ * ```
+ */
+export function defineHonuaLayerList(registry = globalDom.customElements): void {
+  if (!registry) return;
+  if (!registry.get("honua-layer-list")) {
+    registry.define("honua-layer-list", HonuaLayerListElement);
+  }
+}
+
 function normalizeOverlays(value: readonly HonuaLayerListOverlay[]): HonuaLayerListOverlay[] {
   if (!Array.isArray(value)) return [];
   return value.flatMap((item): HonuaLayerListOverlay[] => {

--- a/src/controls/swipe-control.ts
+++ b/src/controls/swipe-control.ts
@@ -1,0 +1,390 @@
+/**
+ * `<honua-swipe-control>` — framework-free custom element implementing the
+ * dual-map "swipe"/compare trick (issue #279, candidate third control for the
+ * native kit, #274).
+ *
+ * Two MapLibre maps are stacked (the host positions them; the control does
+ * not own layout) and the control clips the **top** map against the **bottom**
+ * map along a draggable divider via CSS `clip-path`. Dragging the divider (or
+ * using the keyboard) reveals more or less of each map and emits a `change`
+ * event with the divider position.
+ *
+ * Like the other controls, this element imports nothing from `maplibre-gl` or
+ * the SDK core — it drives any MapLibre `Map` through the duck-typed
+ * {@link HonuaSwipeMap} interface (it only needs `getContainer()`), so the
+ * `@honua/sdk-js/controls` entry stays bundle-independent. Node imports are
+ * safe; the element no-ops without a DOM.
+ *
+ * ## Wiring
+ * - `element.topMap = map` / `element.bottomMap = map`, or
+ *   `element.connect(topMap, bottomMap)`. The top map is the one that gets
+ *   clipped; the bottom map shows through the revealed region.
+ *
+ * ## Attributes
+ * - `position` — divider position as a percentage 0–100 (default 50).
+ * - `orientation` — `"vertical"` (default) or `"horizontal"`.
+ * - `label` — accessible name of the divider (default "Compare maps").
+ *
+ * ## Events
+ * - `change` — `CustomEvent<HonuaSwipeChangeDetail>` (bubbles, composed)
+ *   whenever the divider position changes: drag, keyboard, or programmatic
+ *   `position` assignment.
+ *
+ * ## CSS parts
+ * - `divider` — the full-length divider line.
+ * - `handle` — the draggable grip on the divider.
+ *
+ * ## Accessibility
+ * The divider is an ARIA slider (`role="slider"`, `aria-valuenow/min/max`,
+ * `aria-orientation`) with arrow-key control (ArrowLeft/ArrowRight or
+ * ArrowUp/ArrowDown step by 1, Home/End jump to 0/100, with Shift = 10).
+ *
+ * @module
+ */
+
+import { HTMLElementBase, escapeAttribute, globalDom } from "./element-utils.js";
+import type { HonuaSwipeChangeDetail, HonuaSwipeMap, HonuaSwipeOrientation } from "./types.js";
+
+const DEFAULT_POSITION = 50;
+const STEP = 1;
+const STEP_LARGE = 10;
+
+/**
+ * Custom element implementing the dual-map swipe/compare divider. Registered
+ * as `honua-swipe-control` by {@link defineHonuaSwipeControl} (which runs
+ * automatically on import when a `customElements` registry exists).
+ */
+export class HonuaSwipeControlElement extends HTMLElementBase {
+  public static get observedAttributes(): string[] {
+    return ["position", "orientation", "label"];
+  }
+
+  #topMap: HonuaSwipeMap | undefined;
+  #bottomMap: HonuaSwipeMap | undefined;
+  #position = DEFAULT_POSITION;
+  #rendered = false;
+  #dragging = false;
+  #disposeDrag: (() => void) | undefined;
+
+  /** The clipped (overlay) map. Reapplies the clip when assigned. */
+  public get topMap(): HonuaSwipeMap | undefined {
+    return this.#topMap;
+  }
+
+  public set topMap(map: HonuaSwipeMap | undefined) {
+    this.#clearClip(this.#topMap);
+    this.#topMap = map;
+    this.#applyClip();
+  }
+
+  /** The underlying map revealed by the clip. */
+  public get bottomMap(): HonuaSwipeMap | undefined {
+    return this.#bottomMap;
+  }
+
+  public set bottomMap(map: HonuaSwipeMap | undefined) {
+    this.#bottomMap = map;
+  }
+
+  /** Wires both maps at once. The first map is clipped against the second. */
+  public connect(topMap: HonuaSwipeMap, bottomMap?: HonuaSwipeMap): void {
+    this.topMap = topMap;
+    if (bottomMap) this.bottomMap = bottomMap;
+  }
+
+  /** Divider position as a percentage 0–100. Reflects the `position` attribute. */
+  public get position(): number {
+    return this.#position;
+  }
+
+  public set position(value: number) {
+    this.#setPosition(value, true);
+  }
+
+  /** Divider orientation. Reflects the `orientation` attribute. */
+  public get orientation(): HonuaSwipeOrientation {
+    return this.#attr("orientation") === "horizontal" ? "horizontal" : "vertical";
+  }
+
+  public set orientation(value: HonuaSwipeOrientation) {
+    if (typeof this.setAttribute !== "function") return;
+    this.setAttribute("orientation", value === "horizontal" ? "horizontal" : "vertical");
+  }
+
+  public attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null): void {
+    if (name === "position") {
+      const parsed = newValue === null ? DEFAULT_POSITION : Number(newValue);
+      if (Number.isFinite(parsed)) this.#setPosition(parsed, false);
+      return;
+    }
+    if (name === "orientation") {
+      this.#updateDividerDom();
+      this.#applyClip();
+      return;
+    }
+    if (name === "label") {
+      this.#updateDividerDom();
+    }
+  }
+
+  public connectedCallback(): void {
+    this.#ensureShadowRoot();
+    this.render();
+    this.#applyClip();
+  }
+
+  public disconnectedCallback(): void {
+    this.#disposeDrag?.();
+    this.#disposeDrag = undefined;
+  }
+
+  // ── position ───────────────────────────────────────────────
+
+  #setPosition(value: number, fromProperty: boolean): void {
+    const next = clampPercent(value);
+    const changed = next !== this.#position;
+    this.#position = next;
+    if (fromProperty) this.#reflectPosition(next);
+    this.#updateDividerDom();
+    this.#applyClip();
+    if (changed) this.#dispatchChange();
+  }
+
+  // ── clip-path application ──────────────────────────────────
+
+  #applyClip(): void {
+    const container = this.#topMap?.getContainer?.();
+    if (!container?.style) return;
+    const pct = `${this.#position}%`;
+    // Reveal the top map only on the trailing side of the divider so the
+    // bottom map shows through on the leading side.
+    container.style.clipPath =
+      this.orientation === "horizontal"
+        ? `inset(${pct} 0 0 0)` // hide the top portion above the divider
+        : `inset(0 0 0 ${pct})`; // hide the left portion before the divider
+  }
+
+  #clearClip(map: HonuaSwipeMap | undefined): void {
+    const container = map?.getContainer?.();
+    if (container?.style) container.style.clipPath = "";
+  }
+
+  // ── rendering ──────────────────────────────────────────────
+
+  #ensureShadowRoot(): void {
+    if (!this.shadowRoot && typeof this.attachShadow === "function") {
+      this.attachShadow({ mode: "open" });
+    }
+  }
+
+  protected render(): void {
+    const root = this.shadowRoot;
+    if (!root) return;
+    if (this.#rendered) {
+      this.#updateDividerDom();
+      return;
+    }
+    root.innerHTML = `
+      <style>${structuralStyles()}</style>
+      <div
+        part="divider"
+        class="divider"
+        role="slider"
+        tabindex="0"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow="${this.#position}"
+        aria-orientation="${this.orientation}"
+        aria-label="${escapeAttribute(this.#label())}"
+      >
+        <span part="handle" class="handle" aria-hidden="true"></span>
+      </div>
+    `;
+    this.#rendered = true;
+    this.#bindDivider(root);
+    this.#updateDividerDom();
+  }
+
+  #divider(): HTMLElement | null {
+    const root = this.shadowRoot;
+    if (!root || typeof root.querySelector !== "function") return null;
+    return root.querySelector<HTMLElement>(".divider");
+  }
+
+  #updateDividerDom(): void {
+    const divider = this.#divider();
+    if (!divider?.style) return;
+    const pct = `${this.#position}%`;
+    if (this.orientation === "horizontal") {
+      divider.style.left = "0";
+      divider.style.top = pct;
+    } else {
+      divider.style.top = "0";
+      divider.style.left = pct;
+    }
+    divider.classList?.toggle("divider-horizontal", this.orientation === "horizontal");
+    divider.setAttribute?.("aria-valuenow", String(this.#position));
+    divider.setAttribute?.("aria-orientation", this.orientation);
+    divider.setAttribute?.("aria-label", this.#label());
+  }
+
+  // ── interaction ────────────────────────────────────────────
+
+  #bindDivider(root: ShadowRoot): void {
+    const divider = root.querySelector<HTMLElement>(".divider");
+    if (!divider) return;
+    divider.addEventListener("pointerdown", (event) => this.#onPointerDown(event as PointerEvent));
+    divider.addEventListener("keydown", (event) => this.#onKeyDown(event as KeyboardEvent));
+  }
+
+  #onPointerDown(event: PointerEvent): void {
+    if (typeof this.getBoundingClientRect !== "function") return;
+    this.#dragging = true;
+    const divider = this.#divider();
+    divider?.setPointerCapture?.(event.pointerId);
+    event.preventDefault?.();
+    const move = (moveEvent: Event): void => {
+      if (this.#dragging) this.#setPositionFromPointer(moveEvent as PointerEvent);
+    };
+    const up = (upEvent: Event): void => {
+      this.#dragging = false;
+      divider?.releasePointerCapture?.((upEvent as PointerEvent).pointerId);
+      this.#disposeDrag?.();
+      this.#disposeDrag = undefined;
+    };
+    const owner = (divider as EventTarget | null) ?? this;
+    owner.addEventListener("pointermove", move as EventListener);
+    owner.addEventListener("pointerup", up as EventListener);
+    owner.addEventListener("pointercancel", up as EventListener);
+    this.#disposeDrag = () => {
+      owner.removeEventListener("pointermove", move as EventListener);
+      owner.removeEventListener("pointerup", up as EventListener);
+      owner.removeEventListener("pointercancel", up as EventListener);
+    };
+    this.#setPositionFromPointer(event);
+  }
+
+  #setPositionFromPointer(event: PointerEvent): void {
+    const rect = this.getBoundingClientRect();
+    if (!rect) return;
+    const ratio =
+      this.orientation === "horizontal"
+        ? rect.height === 0
+          ? 0
+          : (event.clientY - rect.top) / rect.height
+        : rect.width === 0
+          ? 0
+          : (event.clientX - rect.left) / rect.width;
+    this.#setPosition(ratio * 100, true);
+  }
+
+  #onKeyDown(event: KeyboardEvent): void {
+    const horizontal = this.orientation === "horizontal";
+    const step = event.shiftKey ? STEP_LARGE : STEP;
+    let next: number;
+    switch (event.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        next = this.#position + step;
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        next = this.#position - step;
+        break;
+      case "Home":
+        next = horizontal ? 100 : 0;
+        break;
+      case "End":
+        next = horizontal ? 0 : 100;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault?.();
+    this.#setPosition(next, true);
+  }
+
+  // ── helpers ────────────────────────────────────────────────
+
+  #label(): string {
+    return this.#attr("label") ?? "Compare maps";
+  }
+
+  #attr(name: string): string | null {
+    return typeof this.getAttribute === "function" ? this.getAttribute(name) : null;
+  }
+
+  #reflectPosition(value: number): void {
+    if (typeof this.setAttribute !== "function" || typeof this.getAttribute !== "function") return;
+    const serialized = String(value);
+    if (this.getAttribute("position") !== serialized) this.setAttribute("position", serialized);
+  }
+
+  #dispatchChange(): void {
+    if (!globalDom.CustomEvent || typeof this.dispatchEvent !== "function") return;
+    const detail: HonuaSwipeChangeDetail = { position: this.#position, orientation: this.orientation };
+    this.dispatchEvent(new globalDom.CustomEvent("change", { bubbles: true, composed: true, detail }));
+  }
+}
+
+/**
+ * Registers the swipe control custom element (`honua-swipe-control`). Invoked
+ * automatically on import when a global `customElements` registry is present;
+ * call explicitly when using a scoped registry. Skips the registration when
+ * the tag is already defined.
+ */
+export function defineHonuaSwipeControl(registry = globalDom.customElements): void {
+  if (!registry) return;
+  if (!registry.get("honua-swipe-control")) {
+    registry.define("honua-swipe-control", HonuaSwipeControlElement);
+  }
+}
+
+if (globalDom.customElements) {
+  defineHonuaSwipeControl(globalDom.customElements);
+}
+
+function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_POSITION;
+  return Math.min(100, Math.max(0, Math.round(value)));
+}
+
+/** Structural-only styles; theme via `::part(divider)` / `::part(handle)`. */
+function structuralStyles(): string {
+  return `
+    :host { position: absolute; inset: 0; pointer-events: none; display: block; }
+    .divider {
+      position: absolute;
+      top: 0;
+      block-size: 100%;
+      inline-size: 0;
+      border-inline-start: 2px solid currentColor;
+      transform: translateX(-1px);
+      cursor: ew-resize;
+      pointer-events: auto;
+      touch-action: none;
+    }
+    .divider-horizontal {
+      inline-size: 100%;
+      block-size: 0;
+      border-inline-start: none;
+      border-block-start: 2px solid currentColor;
+      transform: translateY(-1px);
+      cursor: ns-resize;
+    }
+    .handle {
+      position: absolute;
+      inset-block-start: 50%;
+      inset-inline-start: 0;
+      inline-size: 1.5em;
+      block-size: 1.5em;
+      transform: translate(-50%, -50%);
+      border-radius: 50%;
+      background: currentColor;
+    }
+    .divider-horizontal .handle {
+      inset-block-start: 0;
+      inset-inline-start: 50%;
+    }
+  `;
+}

--- a/src/controls/types.ts
+++ b/src/controls/types.ts
@@ -103,6 +103,53 @@ export interface HonuaBasemapSwitcherChangeDetail {
 }
 
 /**
+ * One overlay option rendered as a toggle row by `<honua-layer-list>`. An
+ * overlay groups one or more MapLibre style layer ids that are shown/hidden
+ * together (their `visibility` layout property is toggled in lock-step).
+ */
+export interface HonuaLayerListOverlay {
+  /** Stable identifier emitted in `change` events. */
+  readonly id: string;
+  /** Human-readable label rendered next to the checkbox. */
+  readonly label: string;
+  /** Style layer ids toggled together when the overlay is toggled. */
+  readonly layers: readonly string[];
+  /** Optional attribution text (purely descriptive; rendered as a row hint). */
+  readonly attribution?: string;
+}
+
+/**
+ * Minimal duck-typed subset of `maplibre-gl.Map` required by
+ * `<honua-layer-list>`. Any MapLibre-GL `Map` instance satisfies this
+ * interface, and tests can pass a plain stub (same posture as
+ * {@link HonuaBasemapSwitcherMap} and {@link HonuaLegendMap}).
+ */
+export interface HonuaLayerListMap {
+  /** Returns a truthy handle when the layer exists (drives the not-seeded state). */
+  getLayer?(id: string): unknown;
+  /** Reads a layout property; used to sync checkbox state from the map. */
+  getLayoutProperty?(layerId: string, name: string): unknown;
+  /** Sets a layout property; used to toggle `visibility` per overlay layer. */
+  setLayoutProperty(layerId: string, name: string, value: unknown): void;
+  /** Subscribes to map events; used for `auto-refresh` on `styledata`. */
+  on?(type: string, listener: (event?: unknown) => void): unknown;
+  /** Unsubscribes a listener registered with `on`. */
+  off?(type: string, listener: (event?: unknown) => void): unknown;
+}
+
+/**
+ * Detail payload of the `change` CustomEvent dispatched by
+ * `<honua-layer-list>` whenever an overlay is toggled (user interaction or
+ * programmatic `setVisible`).
+ */
+export interface HonuaLayerListChangeDetail {
+  /** Id of the toggled overlay. */
+  readonly id: string;
+  /** Whether the overlay's layers are now visible. */
+  readonly visible: boolean;
+}
+
+/**
  * Swatch geometry rendered for a legend entry by `<honua-legend>`:
  * - `"fill"` — square swatch (polygon fills); supports an outline color.
  * - `"line"` — short horizontal bar (line layers).

--- a/src/controls/types.ts
+++ b/src/controls/types.ts
@@ -103,6 +103,39 @@ export interface HonuaBasemapSwitcherChangeDetail {
 }
 
 /**
+ * Orientation of the divider rendered by `<honua-swipe-control>`:
+ * - `"vertical"` — a vertical divider that moves left/right, clipping the top
+ *   map's left edge (the default; a left/right comparison).
+ * - `"horizontal"` — a horizontal divider that moves up/down, clipping the top
+ *   map's top edge (a top/bottom comparison).
+ */
+export type HonuaSwipeOrientation = "vertical" | "horizontal";
+
+/**
+ * Detail payload of the `change` CustomEvent dispatched by
+ * `<honua-swipe-control>` whenever the divider position changes (user drag,
+ * keyboard, or programmatic `position` assignment).
+ */
+export interface HonuaSwipeChangeDetail {
+  /** Divider position as a percentage 0–100 of the control's width/height. */
+  readonly position: number;
+  /** Current divider orientation. */
+  readonly orientation: HonuaSwipeOrientation;
+}
+
+/**
+ * Minimal duck-typed subset of `maplibre-gl.Map` required by
+ * `<honua-swipe-control>`. The control only needs each map's canvas
+ * container so it can apply a CSS `clip-path` to the top map; any MapLibre-GL
+ * `Map` instance satisfies this interface, and tests can pass a plain stub
+ * (same posture as {@link HonuaBasemapSwitcherMap}).
+ */
+export interface HonuaSwipeMap {
+  /** Returns the map's outermost container element (clip target). */
+  getContainer(): HTMLElement;
+}
+
+/**
  * Swatch geometry rendered for a legend entry by `<honua-legend>`:
  * - `"fill"` — square swatch (polygon fills); supports an outline color.
  * - `"line"` — short horizontal bar (line layers).

--- a/src/core/terrain-elevation.ts
+++ b/src/core/terrain-elevation.ts
@@ -1,0 +1,230 @@
+/**
+ * Pure, DOM-free helpers for decoding RGB-encoded elevation tiles and
+ * sampling an elevation profile along a line.
+ *
+ * Two encodings dominate Terrain-RGB / raster-DEM tiles in the wild:
+ *
+ * - **Mapbox Terrain-RGB** — `elevation = -10000 + ((R*256*256 + G*256 + B) * 0.1)`
+ *   metres. This is the encoding MapLibre's `raster-dem` source uses with
+ *   `encoding: "mapbox"`.
+ * - **Terrarium (Mapzen / AWS Terrain Tiles)** — `elevation = (R*256 + G + B/256) - 32768`
+ *   metres, used by MapLibre with `encoding: "terrarium"`.
+ *
+ * These functions are intentionally free of any map or DOM dependency so
+ * they can run anywhere (browser, Node, workers) and be unit-tested against
+ * known pixel → elevation values. `sampleElevationProfile` walks a line and
+ * resolves an elevation at each sampled coordinate through a caller-supplied
+ * accessor (e.g. a decoded raster lookup or a server elevation endpoint),
+ * returning per-sample distance + elevation plus gain/loss summary stats.
+ *
+ * @module
+ */
+
+/** Mean Earth radius in metres, used for great-circle distance. */
+const EARTH_RADIUS_METERS = 6_371_000;
+
+/** A `[longitude, latitude]` coordinate pair in degrees (WGS84). */
+export type ElevationCoordinate = readonly [longitude: number, latitude: number];
+
+/**
+ * Decodes a single Mapbox Terrain-RGB pixel into metres above sea level.
+ *
+ * `height = -10000 + ((R * 256 * 256 + G * 256 + B) * 0.1)`
+ *
+ * Channel values are clamped to the 0–255 byte range, so callers may pass
+ * raw `ImageData`/`Uint8ClampedArray` samples directly.
+ */
+export function decodeTerrainRgbElevation(red: number, green: number, blue: number): number {
+  const r = clampByte(red);
+  const g = clampByte(green);
+  const b = clampByte(blue);
+  return -10_000 + (r * 256 * 256 + g * 256 + b) * 0.1;
+}
+
+/**
+ * Decodes a single Terrarium (Mapzen / AWS Terrain Tiles) pixel into metres
+ * above sea level.
+ *
+ * `height = (R * 256 + G + B / 256) - 32768`
+ *
+ * Channel values are clamped to the 0–255 byte range.
+ */
+export function decodeTerrariumElevation(red: number, green: number, blue: number): number {
+  const r = clampByte(red);
+  const g = clampByte(green);
+  const b = clampByte(blue);
+  return r * 256 + g + b / 256 - 32_768;
+}
+
+/** Terrain-RGB pixel encodings supported by {@link decodeElevationPixel}. */
+export type TerrainElevationEncoding = "mapbox" | "terrarium";
+
+/**
+ * Decodes a Terrain-RGB pixel using the named encoding. Convenience wrapper
+ * over {@link decodeTerrainRgbElevation} / {@link decodeTerrariumElevation}
+ * for code that carries a MapLibre `raster-dem` `encoding` value.
+ */
+export function decodeElevationPixel(
+  encoding: TerrainElevationEncoding,
+  red: number,
+  green: number,
+  blue: number,
+): number {
+  return encoding === "terrarium"
+    ? decodeTerrariumElevation(red, green, blue)
+    : decodeTerrainRgbElevation(red, green, blue);
+}
+
+/** One sampled point of an elevation profile. */
+export interface ElevationProfileSample {
+  /** Sampled coordinate `[longitude, latitude]`. */
+  readonly coordinate: ElevationCoordinate;
+  /** Cumulative great-circle distance from the line start, in metres. */
+  readonly distanceMeters: number;
+  /** Elevation in metres returned by the sampler for this coordinate. */
+  readonly elevationMeters: number;
+}
+
+/** An elevation profile sampled along a line. */
+export interface ElevationProfile {
+  /** The line that was sampled (the input, verbatim). */
+  readonly line: readonly ElevationCoordinate[];
+  /** The sampled points, ordered from line start to end. */
+  readonly samples: readonly ElevationProfileSample[];
+  /** Total great-circle length of the line, in metres. */
+  readonly totalDistanceMeters: number;
+  /** Lowest sampled elevation, in metres (0 when there are no samples). */
+  readonly minElevationMeters: number;
+  /** Highest sampled elevation, in metres (0 when there are no samples). */
+  readonly maxElevationMeters: number;
+  /** Cumulative elevation gain across consecutive samples, in metres. */
+  readonly gainMeters: number;
+  /** Cumulative elevation loss across consecutive samples, in metres. */
+  readonly lossMeters: number;
+}
+
+/**
+ * Resolves an elevation (metres) for a sampled coordinate. May be sync or
+ * async — a decoded raster lookup, a server elevation endpoint, or anything
+ * else. Receives the sample index and cumulative distance for convenience.
+ * Return a non-finite value (e.g. `NaN`) to mark a coordinate as no-data; it
+ * is treated as `0` in the profile summary.
+ */
+export type ElevationSampler = (
+  coordinate: ElevationCoordinate,
+  context: { readonly index: number; readonly distanceMeters: number },
+) => number | Promise<number>;
+
+/** Options for {@link sampleElevationProfile}. */
+export interface SampleElevationProfileOptions {
+  /** The polyline to sample, as `[lon, lat]` vertices (>= 2 required). */
+  readonly line: readonly ElevationCoordinate[];
+  /** How elevation is resolved at each sampled coordinate. */
+  readonly sampler: ElevationSampler;
+  /**
+   * Number of evenly spaced samples (including both endpoints). Defaults to
+   * `Math.max(2, line.length)`. Clamped to a minimum of 2.
+   */
+  readonly sampleCount?: number;
+}
+
+/**
+ * Samples elevation at evenly spaced points along a line and returns a
+ * profile with per-sample distance + elevation plus gain/loss/min/max stats.
+ *
+ * The line is resampled into `sampleCount` points spaced by equal
+ * great-circle distance (not by vertex), so the profile is independent of how
+ * densely the input line is digitized. Elevation at each point comes from the
+ * supplied {@link ElevationSampler}; samplers may be async and are awaited in
+ * order. No DOM or map dependency.
+ *
+ * @throws {RangeError} when `line` has fewer than two coordinates.
+ */
+export async function sampleElevationProfile(options: SampleElevationProfileOptions): Promise<ElevationProfile> {
+  const { line, sampler } = options;
+  if (line.length < 2) {
+    throw new RangeError("sampleElevationProfile requires a line with at least two coordinates.");
+  }
+
+  const segmentLengths = line.slice(1).map((point, index) => haversineMeters(line[index]!, point));
+  const totalDistanceMeters = segmentLengths.reduce((sum, value) => sum + value, 0);
+  const sampleCount = Math.max(2, Math.trunc(options.sampleCount ?? Math.max(2, line.length)));
+
+  const samples: ElevationProfileSample[] = [];
+  for (let index = 0; index < sampleCount; index += 1) {
+    const distanceMeters = totalDistanceMeters * (index / (sampleCount - 1));
+    const coordinate = interpolateAlongLine(line, segmentLengths, distanceMeters);
+    const elevation = await sampler(coordinate, { index, distanceMeters });
+    samples.push({
+      coordinate,
+      distanceMeters,
+      elevationMeters: Number.isFinite(elevation) ? elevation : 0,
+    });
+  }
+
+  return summarize(line, samples, totalDistanceMeters);
+}
+
+function summarize(
+  line: readonly ElevationCoordinate[],
+  samples: readonly ElevationProfileSample[],
+  totalDistanceMeters: number,
+): ElevationProfile {
+  const elevations = samples.map((sample) => sample.elevationMeters);
+  let gainMeters = 0;
+  let lossMeters = 0;
+  for (let index = 1; index < elevations.length; index += 1) {
+    const delta = elevations[index]! - elevations[index - 1]!;
+    if (delta > 0) gainMeters += delta;
+    else lossMeters += Math.abs(delta);
+  }
+  return {
+    line,
+    samples,
+    totalDistanceMeters,
+    minElevationMeters: elevations.length > 0 ? Math.min(...elevations) : 0,
+    maxElevationMeters: elevations.length > 0 ? Math.max(...elevations) : 0,
+    gainMeters,
+    lossMeters,
+  };
+}
+
+function interpolateAlongLine(
+  line: readonly ElevationCoordinate[],
+  segmentLengths: readonly number[],
+  targetDistance: number,
+): ElevationCoordinate {
+  let traversed = 0;
+  for (let index = 0; index < segmentLengths.length; index += 1) {
+    const segmentLength = segmentLengths[index]!;
+    if (targetDistance <= traversed + segmentLength || index === segmentLengths.length - 1) {
+      const start = line[index]!;
+      const end = line[index + 1]!;
+      const ratio = segmentLength === 0 ? 0 : (targetDistance - traversed) / segmentLength;
+      return [start[0] + (end[0] - start[0]) * ratio, start[1] + (end[1] - start[1]) * ratio];
+    }
+    traversed += segmentLength;
+  }
+  return line.at(-1)!;
+}
+
+/** Great-circle distance between two `[lon, lat]` coordinates, in metres. */
+export function haversineMeters([lon1, lat1]: ElevationCoordinate, [lon2, lat2]: ElevationCoordinate): number {
+  const phi1 = degreesToRadians(lat1);
+  const phi2 = degreesToRadians(lat2);
+  const deltaPhi = degreesToRadians(lat2 - lat1);
+  const deltaLambda = degreesToRadians(lon2 - lon1);
+  const a = Math.sin(deltaPhi / 2) ** 2 + Math.cos(phi1) * Math.cos(phi2) * Math.sin(deltaLambda / 2) ** 2;
+  return EARTH_RADIUS_METERS * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function degreesToRadians(value: number): number {
+  return (value * Math.PI) / 180;
+}
+
+function clampByte(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 255) return 255;
+  return value;
+}

--- a/src/honua.ts
+++ b/src/honua.ts
@@ -286,6 +286,21 @@ export type { BatchQueryItem, BatchQueryOptions, BatchQueryResult } from "./core
 export { decodePbfQueryResponse, isPbfResponse } from "./core/pbf-decoder.js";
 export { esriFeatureToGeoJSON, esriGeometryToGeoJSON } from "./core/esri-geojson.js";
 export {
+  decodeElevationPixel,
+  decodeTerrainRgbElevation,
+  decodeTerrariumElevation,
+  haversineMeters,
+  sampleElevationProfile,
+} from "./core/terrain-elevation.js";
+export type {
+  ElevationCoordinate,
+  ElevationProfile,
+  ElevationProfileSample,
+  ElevationSampler,
+  SampleElevationProfileOptions,
+  TerrainElevationEncoding,
+} from "./core/terrain-elevation.js";
+export {
   createHonuaOgcFeatures,
   createHonuaService,
   HonuaFeatureLayer,

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,21 @@ export type { BatchQueryItem, BatchQueryOptions, BatchQueryResult } from "./core
 export { decodePbfQueryResponse, isPbfResponse } from "./core/pbf-decoder.js";
 export { esriFeatureToGeoJSON, esriGeometryToGeoJSON } from "./core/esri-geojson.js";
 export {
+  decodeElevationPixel,
+  decodeTerrainRgbElevation,
+  decodeTerrariumElevation,
+  haversineMeters,
+  sampleElevationProfile,
+} from "./core/terrain-elevation.js";
+export type {
+  ElevationCoordinate,
+  ElevationProfile,
+  ElevationProfileSample,
+  ElevationSampler,
+  SampleElevationProfileOptions,
+  TerrainElevationEncoding,
+} from "./core/terrain-elevation.js";
+export {
   compileRuntimeStyleFilter,
   createFilterRegistry,
   parseFilterRegistry,

--- a/src/realtime/honua-server.ts
+++ b/src/realtime/honua-server.ts
@@ -35,6 +35,7 @@
  */
 
 import type { FeatureId } from "../contract/types.js";
+import { trimTrailingSlashes } from "../core/path-utils.js";
 import { createRealtimeServerSentEventsTransport } from "./sse.js";
 import type { RealtimeServerSentEventsTransportOptions } from "./sse.js";
 import type {
@@ -240,7 +241,9 @@ function resolveStreamingUrl(baseUrl: string | undefined): string {
   if (!baseUrl) {
     throw new Error("createHonuaServerRealtimeSubscription requires either `url` or `baseUrl`.");
   }
-  return `${baseUrl.replace(/\/+$/, "")}${HONUA_SERVER_STREAMING_FEATURES_PATH}`;
+  // Linear trim (no anchored `\/+$` regex) to avoid polynomial backtracking on
+  // adversarial input — mirrors the rest of the SDK's path handling.
+  return `${trimTrailingSlashes(baseUrl)}${HONUA_SERVER_STREAMING_FEATURES_PATH}`;
 }
 
 function collectChanges<TFeature>(

--- a/src/realtime/honua-server.ts
+++ b/src/realtime/honua-server.ts
@@ -1,0 +1,266 @@
+/**
+ * First-party realtime preset for honua-server's
+ * `/api/v1/streaming/features` Server-Sent Events endpoint.
+ *
+ * The default SSE transport encoder emits `sourceId=` / `layerId=` query
+ * params and assumes events already use the SDK's `RealtimeFeatureEvent`
+ * vocabulary. honua-server instead expects `serviceId=` / `layers=` query
+ * params and emits its own feature-change envelopes. This module packages the
+ * two hooks (`encodeRequest` + `decodeEvent`) the transport already exposes so
+ * consumers do not have to re-implement the same adapter for every app.
+ *
+ * @example Use the preset options with the SSE transport.
+ * ```ts
+ * import {
+ *   createRealtimeServerSentEventsTransport,
+ *   honuaServerRealtimePreset,
+ * } from "@honua/sdk-js/realtime";
+ *
+ * const transport = createRealtimeServerSentEventsTransport({
+ *   url: "https://honua.example/api/v1/streaming/features",
+ *   ...honuaServerRealtimePreset(),
+ * });
+ * ```
+ *
+ * @example Or use the convenience factory.
+ * ```ts
+ * import { createHonuaServerRealtimeSubscription } from "@honua/sdk-js/realtime";
+ *
+ * const transport = createHonuaServerRealtimeSubscription({
+ *   baseUrl: "https://honua.example",
+ * });
+ * ```
+ *
+ * @module
+ */
+
+import type { FeatureId } from "../contract/types.js";
+import { createRealtimeServerSentEventsTransport } from "./sse.js";
+import type { RealtimeServerSentEventsTransportOptions } from "./sse.js";
+import type {
+  RealtimeFeatureEvent,
+  RealtimeFeaturePatch,
+  RealtimeFeatureTransport,
+  RealtimeSubscriptionRequest,
+} from "./types.js";
+
+/** Default streaming-features path served by honua-server. */
+export const HONUA_SERVER_STREAMING_FEATURES_PATH = "/api/v1/streaming/features";
+
+/**
+ * Encode a `RealtimeSubscriptionRequest` into honua-server's
+ * `/api/v1/streaming/features` query contract: `serviceId=` (not `sourceId=`)
+ * and `layers=` (not `layerId=`). The remaining filter/resume params match the
+ * default encoder so cursors, watermarks, and where-clauses keep working.
+ */
+export function encodeHonuaServerRealtimeRequest(url: URL, request: RealtimeSubscriptionRequest): URL {
+  url.searchParams.set("serviceId", String(request.sourceId));
+  if (request.layerId !== undefined) url.searchParams.set("layers", String(request.layerId));
+  if (request.requestId) url.searchParams.set("requestId", request.requestId);
+  if (request.mode) url.searchParams.set("mode", request.mode);
+  if (request.where) url.searchParams.set("where", request.where);
+  if (request.fields?.length) url.searchParams.set("fields", request.fields.join(","));
+  if (request.cursor ?? request.resumeFrom?.cursor) {
+    url.searchParams.set("cursor", request.cursor ?? request.resumeFrom?.cursor ?? "");
+  }
+  if (request.watermark ?? request.resumeFrom?.watermark) {
+    url.searchParams.set("watermark", request.watermark ?? request.resumeFrom?.watermark ?? "");
+  }
+  if (request.timestamp ?? request.resumeFrom?.timestamp) {
+    url.searchParams.set("timestamp", request.timestamp ?? request.resumeFrom?.timestamp ?? "");
+  }
+  if (request.deltaToken ?? request.resumeFrom?.deltaToken) {
+    url.searchParams.set("deltaToken", request.deltaToken ?? request.resumeFrom?.deltaToken ?? "");
+  }
+  if (request.resumeFrom?.sequence !== undefined) {
+    url.searchParams.set("sequence", String(request.resumeFrom.sequence));
+  }
+  if (request.spatialFilter !== undefined) url.searchParams.set("spatialFilter", JSON.stringify(request.spatialFilter));
+  if (request.metadata !== undefined) url.searchParams.set("metadata", JSON.stringify(request.metadata));
+  return url;
+}
+
+/**
+ * Shape of a single change carried by a honua-server feature-change envelope.
+ * honua-server reports the change kind via `op` (`insert` / `update` / `delete`)
+ * alongside the affected feature or feature id.
+ */
+export interface HonuaServerFeatureChange<TFeature = unknown> {
+  readonly op: "insert" | "update" | "delete" | "snapshot";
+  readonly featureId?: FeatureId;
+  readonly feature?: TFeature;
+  readonly version?: number;
+  readonly updatedAt?: string;
+}
+
+/**
+ * Shape of the envelope honua-server writes to the
+ * `/api/v1/streaming/features` SSE stream. Each envelope carries the service /
+ * layer scope, ordering metadata, and one or more feature changes.
+ */
+export interface HonuaServerFeatureChangeEnvelope<TFeature = unknown> {
+  readonly serviceId?: string;
+  readonly layerId?: string | number;
+  readonly eventId?: string;
+  readonly sequence?: number;
+  readonly cursor?: string;
+  readonly watermark?: string;
+  readonly timestamp?: string;
+  readonly deltaToken?: string;
+  /** `change` (or `feature-change`) is the default envelope kind. */
+  readonly kind?: string;
+  readonly changes?: ReadonlyArray<HonuaServerFeatureChange<TFeature>>;
+  /** Single-change envelopes inline the change instead of a `changes` array. */
+  readonly op?: HonuaServerFeatureChange<TFeature>["op"];
+  readonly featureId?: FeatureId;
+  readonly feature?: TFeature;
+  readonly version?: number;
+  readonly updatedAt?: string;
+  /** Pass-through status / heartbeat / error envelopes. */
+  readonly type?: string;
+}
+
+/**
+ * Decode a honua-server `/api/v1/streaming/features` envelope into the SDK's
+ * `RealtimeFeatureEvent`. Feature-change envelopes become `delta` events
+ * (batching upserts and deletes); status, heartbeat, and error envelopes that
+ * already speak the SDK vocabulary pass through unchanged.
+ */
+export function decodeHonuaServerRealtimeEvent<TFeature = unknown>(payload: unknown): RealtimeFeatureEvent<TFeature> {
+  if (!isRecord(payload)) throw new Error("honua-server streaming payload must be a JSON object.");
+  const envelope = payload as HonuaServerFeatureChangeEnvelope<TFeature>;
+
+  // Status / heartbeat / error envelopes already use the SDK vocabulary.
+  if (typeof envelope.type === "string" && envelope.type !== "change" && envelope.type !== "feature-change") {
+    return payload as unknown as RealtimeFeatureEvent<TFeature>;
+  }
+
+  const changes = collectChanges(envelope);
+  if (changes.length === 0) {
+    throw new Error("honua-server feature-change envelope is missing changes.");
+  }
+
+  const base = {
+    eventId: envelope.eventId,
+    sequence: envelope.sequence,
+    cursor: envelope.cursor,
+    watermark: envelope.watermark,
+    timestamp: envelope.timestamp,
+    deltaToken: envelope.deltaToken,
+  };
+
+  const upserts: RealtimeFeaturePatch<TFeature>[] = [];
+  const deletes: Array<{ readonly id: FeatureId; readonly version?: number; readonly updatedAt?: string }> = [];
+
+  for (const change of changes) {
+    if (change.featureId === undefined) {
+      throw new Error("honua-server feature change is missing featureId.");
+    }
+    if (change.op === "delete") {
+      deletes.push({ id: change.featureId, version: change.version, updatedAt: change.updatedAt });
+      continue;
+    }
+    if (change.feature === undefined) {
+      throw new Error(`honua-server ${change.op} change is missing feature payload.`);
+    }
+    upserts.push({
+      id: change.featureId,
+      sourceId: envelope.serviceId,
+      feature: change.feature,
+      version: change.version,
+      updatedAt: change.updatedAt,
+    });
+  }
+
+  return {
+    type: "delta",
+    ...base,
+    ...(upserts.length ? { upserts } : {}),
+    ...(deletes.length ? { deletes: deletes.map((entry) => ({ ...entry, sourceId: envelope.serviceId })) } : {}),
+  };
+}
+
+/**
+ * Reusable hook bundle for honua-server's streaming-features endpoint. Spread
+ * this into {@link createRealtimeServerSentEventsTransport} options to opt into
+ * honua-server's query-param contract and feature-change decoding.
+ */
+export function honuaServerRealtimePreset<TFeature = unknown>(): Pick<
+  RealtimeServerSentEventsTransportOptions<TFeature>,
+  "encodeRequest" | "decodeEvent"
+> {
+  return {
+    encodeRequest: (url, request) => {
+      encodeHonuaServerRealtimeRequest(url, request);
+    },
+    decodeEvent: decodeHonuaServerRealtimeEvent<TFeature>,
+  };
+}
+
+export interface CreateHonuaServerRealtimeSubscriptionOptions<TFeature = unknown>
+  extends Omit<RealtimeServerSentEventsTransportOptions<TFeature>, "url" | "encodeRequest" | "decodeEvent"> {
+  /**
+   * honua-server origin, e.g. `https://honua.example`. The
+   * `/api/v1/streaming/features` path is appended automatically. Mutually
+   * exclusive with {@link CreateHonuaServerRealtimeSubscriptionOptions.url}.
+   */
+  readonly baseUrl?: string;
+  /**
+   * Full streaming-features URL. Use this when the endpoint lives at a
+   * non-default path. Overrides {@link CreateHonuaServerRealtimeSubscriptionOptions.baseUrl}.
+   */
+  readonly url?: string;
+  /**
+   * Override the honua-server feature-change decoder while keeping the
+   * `serviceId=` / `layers=` query encoding.
+   */
+  readonly decodeEvent?: RealtimeServerSentEventsTransportOptions<TFeature>["decodeEvent"];
+}
+
+/**
+ * Convenience factory that builds a {@link RealtimeFeatureTransport} wired to
+ * honua-server's `/api/v1/streaming/features` endpoint with the
+ * {@link honuaServerRealtimePreset} hooks applied.
+ */
+export function createHonuaServerRealtimeSubscription<TFeature = unknown>(
+  options: CreateHonuaServerRealtimeSubscriptionOptions<TFeature>,
+): RealtimeFeatureTransport<TFeature> {
+  const { baseUrl, url, decodeEvent, ...rest } = options;
+  const resolvedUrl = url ?? resolveStreamingUrl(baseUrl);
+  const preset = honuaServerRealtimePreset<TFeature>();
+  return createRealtimeServerSentEventsTransport<TFeature>({
+    ...rest,
+    url: resolvedUrl,
+    encodeRequest: preset.encodeRequest,
+    decodeEvent: decodeEvent ?? preset.decodeEvent,
+  });
+}
+
+function resolveStreamingUrl(baseUrl: string | undefined): string {
+  if (!baseUrl) {
+    throw new Error("createHonuaServerRealtimeSubscription requires either `url` or `baseUrl`.");
+  }
+  return `${baseUrl.replace(/\/+$/, "")}${HONUA_SERVER_STREAMING_FEATURES_PATH}`;
+}
+
+function collectChanges<TFeature>(
+  envelope: HonuaServerFeatureChangeEnvelope<TFeature>,
+): ReadonlyArray<HonuaServerFeatureChange<TFeature>> {
+  if (Array.isArray(envelope.changes)) return envelope.changes;
+  if (envelope.op !== undefined) {
+    return [
+      {
+        op: envelope.op,
+        featureId: envelope.featureId,
+        feature: envelope.feature,
+        version: envelope.version,
+        updatedAt: envelope.updatedAt,
+      },
+    ];
+  }
+  return [];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/realtime/index.ts
+++ b/src/realtime/index.ts
@@ -17,6 +17,18 @@ export type {
   RealtimeServerSentEventsTransportOptions,
 } from "./sse.js";
 export {
+  createHonuaServerRealtimeSubscription,
+  decodeHonuaServerRealtimeEvent,
+  encodeHonuaServerRealtimeRequest,
+  honuaServerRealtimePreset,
+  HONUA_SERVER_STREAMING_FEATURES_PATH,
+} from "./honua-server.js";
+export type {
+  CreateHonuaServerRealtimeSubscriptionOptions,
+  HonuaServerFeatureChange,
+  HonuaServerFeatureChangeEnvelope,
+} from "./honua-server.js";
+export {
   emptyRealtimeFeatureState,
   reconcileRealtimeStaleness,
   reduceRealtimeFeatureState,

--- a/src/replica-sync/index.ts
+++ b/src/replica-sync/index.ts
@@ -33,6 +33,8 @@ export type {
 export type {
   BatchConflictResolutionResult,
   ConflictFeatureState,
+  FeatureId,
+  SourceId,
   ConflictResolutionChoice,
   ConflictResolutionOption,
   DisconnectedReplica,

--- a/src/replica-sync/types.ts
+++ b/src/replica-sync/types.ts
@@ -11,6 +11,17 @@
  * @module
  */
 
+import type { FeatureId, SourceId } from "../contract/types.js";
+
+/**
+ * Re-exported so replica-sync conflict records compose directly with the
+ * temporal history contracts (honua-sdk-js#227), which key revisions and
+ * timelines by the same {@link FeatureId} / {@link SourceId} aliases. A reviewer
+ * can take a conflict's `featureId` and feed it straight into the temporal
+ * feature-timeline contract without re-typing.
+ */
+export type { FeatureId, SourceId } from "../contract/types.js";
+
 /** Stable identifier for a disconnected replica. */
 export type ReplicaId = string;
 
@@ -98,7 +109,7 @@ export interface DisconnectedReplica {
    */
   readonly name?: string;
   readonly datasetId: string;
-  readonly sourceId?: string;
+  readonly sourceId?: SourceId;
   readonly state: ReplicaState;
   readonly direction: ReplicaSyncDirection;
   readonly conflictPolicy: ReplicaConflictPolicy;
@@ -174,9 +185,11 @@ export interface SyncConflictSummary {
   readonly id: SyncConflictId;
   readonly replicaId: ReplicaId;
   readonly datasetId: string;
-  readonly sourceId?: string;
+  readonly sourceId?: SourceId;
   readonly layerId?: string | number;
-  readonly featureId: string | number;
+  /** Shared with the temporal contracts (#227) so a conflict's feature can be
+   * fed straight into a temporal feature timeline. */
+  readonly featureId: FeatureId;
   readonly kind: SyncConflictKind;
   readonly status: SyncConflictStatus;
   readonly clientOperation: SyncConflictOperation;
@@ -229,7 +242,7 @@ export interface SyncConflictResolutionRecord {
 /** Pageable request for the replica listing. */
 export interface ListReplicasRequest {
   readonly datasetId?: string;
-  readonly sourceId?: string;
+  readonly sourceId?: SourceId;
   readonly states?: ReadonlyArray<ReplicaState>;
   readonly ownerId?: string;
   readonly limit?: number;

--- a/src/web-components/controller.ts
+++ b/src/web-components/controller.ts
@@ -15,10 +15,16 @@ import type {
   HonuaFilterState,
   HonuaLayerModel,
   HonuaLegendItem,
+  HonuaMeasureChangeDetail,
+  HonuaMeasureMode,
+  HonuaMeasureProvider,
   HonuaQueryFeaturesOptions,
   HonuaSearchOptions,
   HonuaSearchResult,
   HonuaSelectionState,
+  HonuaSketchChangeDetail,
+  HonuaSketchMode,
+  HonuaSketchProvider,
   HonuaViewportState,
   HonuaWebComponentController,
   HonuaWebComponentRuntimeLike,
@@ -32,6 +38,8 @@ export class HonuaInMemoryWebComponentController<T = Record<string, unknown>>
   readonly #fieldsBySource = new Map<string, readonly string[]>();
   readonly #searchFields: readonly string[] | undefined;
   readonly #runtime: HonuaWebComponentRuntimeLike<T> | undefined;
+  readonly #measurementGeometry: HonuaMeasureProvider | undefined;
+  readonly #sketchGeometry: HonuaSketchProvider<T> | undefined;
   #runtimeHandle: { remove(): void } | undefined;
   #state: HonuaWebComponentState<T>;
 
@@ -41,6 +49,8 @@ export class HonuaInMemoryWebComponentController<T = Record<string, unknown>>
     } = {},
   ) {
     this.#runtime = options.runtime;
+    this.#measurementGeometry = options.measurementGeometry;
+    this.#sketchGeometry = options.sketchGeometry;
     this.#searchFields = options.searchFields;
     for (const [sourceId, fields] of Object.entries(options.fieldsBySource ?? {})) {
       this.#fieldsBySource.set(sourceId, [...fields]);
@@ -324,7 +334,71 @@ export class HonuaInMemoryWebComponentController<T = Record<string, unknown>>
     this.#notify();
   }
 
+  public canMeasure(): boolean {
+    return this.#measurementGeometry !== undefined;
+  }
+
+  public canSketch(): boolean {
+    return this.#sketchGeometry !== undefined;
+  }
+
+  public async setMeasureMode(mode: HonuaMeasureMode): Promise<HonuaMeasureChangeDetail> {
+    const provider = this.#measurementGeometry;
+    if (!provider) {
+      return {
+        mode,
+        status: "unsupported",
+        message:
+          "Measurement requires a geometry provider. Configure `measurementGeometry` on the controller to enable measuring.",
+      };
+    }
+    try {
+      if (mode === "off") provider.stop?.();
+      const result = await provider.startMode(mode);
+      return {
+        mode,
+        status: "ready",
+        ...(result ? { result } : {}),
+      };
+    } catch (error) {
+      return {
+        mode,
+        status: "error",
+        message: error instanceof Error ? error.message : "Measurement provider failed.",
+      };
+    }
+  }
+
+  public async setSketchMode(mode: HonuaSketchMode): Promise<HonuaSketchChangeDetail<T>> {
+    const provider = this.#sketchGeometry;
+    if (!provider) {
+      return {
+        mode,
+        status: "unsupported",
+        message:
+          "Sketching requires a geometry provider. Configure `sketchGeometry` on the controller to enable drawing.",
+      };
+    }
+    try {
+      if (mode === "off") provider.stop?.();
+      const result = await provider.startMode(mode);
+      return {
+        mode,
+        status: "ready",
+        ...(result ? { result } : {}),
+      };
+    } catch (error) {
+      return {
+        mode,
+        status: "error",
+        message: error instanceof Error ? error.message : "Sketch provider failed.",
+      };
+    }
+  }
+
   public destroy(): void {
+    this.#measurementGeometry?.stop?.();
+    this.#sketchGeometry?.stop?.();
     this.#runtimeHandle?.remove();
     this.#runtimeHandle = undefined;
     this.#listeners.clear();

--- a/src/web-components/elements.ts
+++ b/src/web-components/elements.ts
@@ -1027,6 +1027,15 @@ export class HonuaLocateControlElement<T = Record<string, unknown>> extends Honu
   }
 }
 
+/**
+ * `<honua-measure-control>` renders distance/area measuring modes.
+ *
+ * The control is only interactive when the controller has a measurement
+ * geometry provider configured (`measurementGeometry` on
+ * {@link CreateHonuaWebComponentControllerOptions}). Without one — for example
+ * the bare in-memory controller — the modes render disabled with a "configure
+ * a provider" affordance, by design: the SDK does not bundle a drawing backend.
+ */
 export class HonuaMeasureControlElement<T = Record<string, unknown>> extends HonuaElementBase<T> {
   static get observedAttributes(): string[] {
     return ["for", "label"];
@@ -1039,14 +1048,19 @@ export class HonuaMeasureControlElement<T = Record<string, unknown>> extends Hon
     this.render();
   }
 
+  protected controllerChanged(): void {
+    this.render();
+  }
+
   protected render(): void {
     const label = this.getAttribute("label") ?? "Measure";
+    const enabled = this.controller?.canMeasure() ?? false;
     this.setShadowHtml(`
       <style>${baseStyles()}${controlPanelStyles()}</style>
       <section class="control-panel" part="panel" aria-label="${escapeHtml(label)}">
         <div class="control-panel__bar">
           <h2>${escapeHtml(label)}</h2>
-          <span>unsupported</span>
+          <span>${escapeHtml(enabled ? "ready" : "unsupported")}</span>
         </div>
         <div class="segmented" role="group" aria-label="${escapeAttribute(label)}">
           ${(["off", "distance", "area"] as const)
@@ -1054,30 +1068,49 @@ export class HonuaMeasureControlElement<T = Record<string, unknown>> extends Hon
               (mode) => `
             <button type="button" data-measure-mode="${mode}" aria-pressed="${String(
               this.#mode === mode,
-            )}" aria-disabled="true" disabled>${escapeHtml(modeLabel(mode))}</button>
+            )}"${enabled ? "" : ' aria-disabled="true" disabled'}>${escapeHtml(modeLabel(mode))}</button>
           `,
             )
             .join("")}
         </div>
-        <p class="empty" role="status">Measurement geometry is not available from the current controller.</p>
+        ${
+          enabled
+            ? ""
+            : `<p class="empty" role="status">Measurement is disabled because no geometry provider is configured. Pass a \`measurementGeometry\` provider to the controller to enable distance and area measuring.</p>`
+        }
       </section>
     `);
+    if (!enabled) return;
     this.shadowRoot?.querySelectorAll<HTMLButtonElement>("button[data-measure-mode]").forEach((button) => {
-      button.addEventListener("click", () => this.setMode((button.dataset.measureMode ?? "off") as HonuaMeasureMode));
+      button.addEventListener("click", () => {
+        void this.setMode((button.dataset.measureMode ?? "off") as HonuaMeasureMode);
+      });
     });
   }
 
-  private setMode(mode: HonuaMeasureMode): void {
+  private async setMode(mode: HonuaMeasureMode): Promise<void> {
     this.#mode = mode;
-    this.dispatchTypedEvent<HonuaMeasureChangeDetail>("honua-measure-change", {
-      mode,
-      status: "unsupported",
-      message: "Measurement geometry is not available from the current controller.",
-    });
+    const detail = this.controller
+      ? await this.controller.setMeasureMode(mode)
+      : {
+          mode,
+          status: "unsupported" as HonuaComponentStatus,
+          message:
+            "Measurement requires a geometry provider. Configure `measurementGeometry` on the controller to enable measuring.",
+        };
+    this.dispatchTypedEvent<HonuaMeasureChangeDetail>("honua-measure-change", detail);
     this.render();
   }
 }
 
+/**
+ * `<honua-sketch-control>` renders point/line/polygon drawing modes.
+ *
+ * Like {@link HonuaMeasureControlElement}, the control is only interactive when
+ * the controller has a sketch geometry provider configured (`sketchGeometry` on
+ * {@link CreateHonuaWebComponentControllerOptions}). Without one the modes
+ * render disabled with a "configure a provider" affordance.
+ */
 export class HonuaSketchControlElement<T = Record<string, unknown>> extends HonuaElementBase<T> {
   static get observedAttributes(): string[] {
     return ["for", "label"];
@@ -1090,14 +1123,19 @@ export class HonuaSketchControlElement<T = Record<string, unknown>> extends Honu
     this.render();
   }
 
+  protected controllerChanged(): void {
+    this.render();
+  }
+
   protected render(): void {
     const label = this.getAttribute("label") ?? "Sketch";
+    const enabled = this.controller?.canSketch() ?? false;
     this.setShadowHtml(`
       <style>${baseStyles()}${controlPanelStyles()}</style>
       <section class="control-panel" part="panel" aria-label="${escapeHtml(label)}">
         <div class="control-panel__bar">
           <h2>${escapeHtml(label)}</h2>
-          <span>unsupported</span>
+          <span>${escapeHtml(enabled ? "ready" : "unsupported")}</span>
         </div>
         <div class="segmented" role="group" aria-label="${escapeAttribute(label)}">
           ${(["off", "point", "line", "polygon"] as const)
@@ -1105,26 +1143,37 @@ export class HonuaSketchControlElement<T = Record<string, unknown>> extends Honu
               (mode) => `
             <button type="button" data-sketch-mode="${mode}" aria-pressed="${String(
               this.#mode === mode,
-            )}" aria-disabled="true" disabled>${escapeHtml(modeLabel(mode))}</button>
+            )}"${enabled ? "" : ' aria-disabled="true" disabled'}>${escapeHtml(modeLabel(mode))}</button>
           `,
             )
             .join("")}
         </div>
-        <p class="empty" role="status">Sketch editing is not available from the current controller.</p>
+        ${
+          enabled
+            ? ""
+            : `<p class="empty" role="status">Sketching is disabled because no geometry provider is configured. Pass a \`sketchGeometry\` provider to the controller to enable point, line, and polygon drawing.</p>`
+        }
       </section>
     `);
+    if (!enabled) return;
     this.shadowRoot?.querySelectorAll<HTMLButtonElement>("button[data-sketch-mode]").forEach((button) => {
-      button.addEventListener("click", () => this.setMode((button.dataset.sketchMode ?? "off") as HonuaSketchMode));
+      button.addEventListener("click", () => {
+        void this.setMode((button.dataset.sketchMode ?? "off") as HonuaSketchMode);
+      });
     });
   }
 
-  private setMode(mode: HonuaSketchMode): void {
+  private async setMode(mode: HonuaSketchMode): Promise<void> {
     this.#mode = mode;
-    this.dispatchTypedEvent<HonuaSketchChangeDetail>("honua-sketch-change", {
-      mode,
-      status: "unsupported",
-      message: "Sketch editing is not available from the current controller.",
-    });
+    const detail = this.controller
+      ? await this.controller.setSketchMode(mode)
+      : {
+          mode,
+          status: "unsupported" as HonuaComponentStatus,
+          message:
+            "Sketching requires a geometry provider. Configure `sketchGeometry` on the controller to enable drawing.",
+        };
+    this.dispatchTypedEvent<HonuaSketchChangeDetail<T>>("honua-sketch-change", detail);
     this.render();
   }
 }

--- a/src/web-components/index.ts
+++ b/src/web-components/index.ts
@@ -5,6 +5,14 @@
  * `customElements` registry is present. Node imports are safe; call
  * `defineHonuaWebComponents()` explicitly when using a scoped registry.
  *
+ * The `<honua-measure-control>` and `<honua-sketch-control>` elements need a
+ * drawing backend to be interactive. The SDK does not bundle one (no hard
+ * dependency on maplibre-gl-draw or similar); instead, supply a
+ * {@link HonuaMeasureProvider} via `measurementGeometry` and/or a
+ * {@link HonuaSketchProvider} via `sketchGeometry` to
+ * `createHonuaWebComponentController`. Without a provider both controls render
+ * disabled by design with a "configure a provider" affordance.
+ *
  * @experimental This entrypoint is not yet covered by the SDK's semver contract
  *   — the surface may change in any minor release prior to `1.0.0`.
  * @module
@@ -76,6 +84,8 @@ export type {
   HonuaMapReadyDetail,
   HonuaMeasureChangeDetail,
   HonuaMeasureMode,
+  HonuaMeasureProvider,
+  HonuaMeasureResult,
   HonuaQueryFeaturesOptions,
   HonuaSearchDetail,
   HonuaSearchOptions,
@@ -84,6 +94,8 @@ export type {
   HonuaSelectionState,
   HonuaSketchChangeDetail,
   HonuaSketchMode,
+  HonuaSketchProvider,
+  HonuaSketchResult,
   HonuaViewportChangeDetail,
   HonuaViewportState,
   HonuaWebComponentController,

--- a/src/web-components/types.ts
+++ b/src/web-components/types.ts
@@ -183,6 +183,14 @@ export interface HonuaWebComponentController<T = Record<string, unknown>> {
   ): HonuaControllerSubscription;
   applyEdit?(request: HonuaEditRequest<T>): Promise<HonuaEditorModel>;
   updateFeatures?(sourceId: string, features: readonly HonuaFeatureRecord<T>[]): void;
+  /** Whether a measurement drawing provider is configured. */
+  canMeasure(): boolean;
+  /** Whether a sketch drawing provider is configured. */
+  canSketch(): boolean;
+  /** Activate a measuring mode through the configured provider. */
+  setMeasureMode(mode: HonuaMeasureMode): Promise<HonuaMeasureChangeDetail>;
+  /** Activate a drawing mode through the configured provider. */
+  setSketchMode(mode: HonuaSketchMode): Promise<HonuaSketchChangeDetail<T>>;
   destroy?(): void;
 }
 
@@ -197,6 +205,20 @@ export interface CreateHonuaWebComponentControllerOptions<T = Record<string, unk
   chart?: HonuaChartModel;
   searchFields?: readonly string[];
   status?: HonuaComponentStatus;
+  /**
+   * Optional drawing backend that powers `<honua-measure-control>`. When
+   * omitted the control renders disabled with a "configure a provider"
+   * affordance — measurement geometry is not available from the bare
+   * in-memory controller by design. Supply an adapter (for example one backed
+   * by maplibre-gl-draw) to enable distance/area measuring.
+   */
+  measurementGeometry?: HonuaMeasureProvider;
+  /**
+   * Optional drawing backend that powers `<honua-sketch-control>`. When
+   * omitted the control renders disabled with a "configure a provider"
+   * affordance. Supply an adapter to enable point/line/polygon sketching.
+   */
+  sketchGeometry?: HonuaSketchProvider<T>;
 }
 
 export interface HonuaWebComponentRuntimeLike<T = Record<string, unknown>> {
@@ -307,18 +329,88 @@ export interface HonuaLocateChangeDetail {
 
 export type HonuaMeasureMode = "off" | "distance" | "area";
 
+/**
+ * A drawn measurement geometry plus its computed result.
+ *
+ * Geometry is intentionally protocol-neutral (GeoJSON-style coordinates) so a
+ * provider can be backed by maplibre-gl-draw, Terra Draw, a custom canvas
+ * tool, or an in-memory fixture without the SDK depending on any of them.
+ */
+export interface HonuaMeasureResult {
+  mode: HonuaMeasureMode;
+  /** GeoJSON `[lng, lat]` positions describing the drawn line or ring. */
+  coordinates: readonly (readonly [number, number])[];
+  /** Total length in metres for distance mode. */
+  distance?: number;
+  /** Enclosed area in square metres for area mode. */
+  area?: number;
+}
+
 export interface HonuaMeasureChangeDetail {
   mode: HonuaMeasureMode;
   status: HonuaComponentStatus;
   message?: string;
+  result?: HonuaMeasureResult;
 }
 
 export type HonuaSketchMode = "off" | "point" | "line" | "polygon";
 
-export interface HonuaSketchChangeDetail {
+/**
+ * A drawn sketch feature emitted by a {@link HonuaSketchProvider}.
+ */
+export interface HonuaSketchResult<T = Record<string, unknown>> {
+  mode: HonuaSketchMode;
+  /** Stable id for the drawn feature when the backend assigns one. */
+  id?: FeatureId;
+  /** Protocol-neutral GeoJSON geometry produced by the drawing backend. */
+  geometry: HonuaTypedFeature<T>["geometry"];
+  /** Optional attributes the backend attaches to the drawn feature. */
+  attributes?: T;
+}
+
+/**
+ * Minimal drawing-backend contract for the `<honua-measure-control>` widget.
+ *
+ * Implementations adapt a concrete drawing tool (for example a
+ * maplibre-gl-draw instance) to the protocol-neutral measurement surface. The
+ * SDK never imports a drawing library directly; consumers supply an adapter via
+ * {@link CreateHonuaWebComponentControllerOptions.measurementGeometry}.
+ */
+export interface HonuaMeasureProvider {
+  /**
+   * Enter (or leave, when `mode === "off"`) a measuring mode. Returns the
+   * current/last measurement result when one is immediately available.
+   */
+  startMode(mode: HonuaMeasureMode): HonuaMeasureResult | undefined | Promise<HonuaMeasureResult | undefined>;
+  /** Stop measuring and discard any in-progress geometry. */
+  stop?(): void;
+  /** Subscribe to measurement results as the user draws. */
+  onResult?(listener: (result: HonuaMeasureResult) => void): HonuaControllerSubscription;
+}
+
+/**
+ * Minimal drawing-backend contract for the `<honua-sketch-control>` widget.
+ *
+ * @see HonuaMeasureProvider for the design rationale (no hard drawing-library
+ *   dependency; adapters are supplied by the consumer).
+ */
+export interface HonuaSketchProvider<T = Record<string, unknown>> {
+  /**
+   * Enter (or leave, when `mode === "off"`) a drawing mode. Returns the
+   * current/last sketch result when one is immediately available.
+   */
+  startMode(mode: HonuaSketchMode): HonuaSketchResult<T> | undefined | Promise<HonuaSketchResult<T> | undefined>;
+  /** Stop drawing and discard any in-progress geometry. */
+  stop?(): void;
+  /** Subscribe to sketch results as the user draws. */
+  onResult?(listener: (result: HonuaSketchResult<T>) => void): HonuaControllerSubscription;
+}
+
+export interface HonuaSketchChangeDetail<T = Record<string, unknown>> {
   mode: HonuaSketchMode;
   status: HonuaComponentStatus;
   message?: string;
+  result?: HonuaSketchResult<T>;
 }
 
 export interface HonuaExportDetail {

--- a/test/app-bootstrap.test.ts
+++ b/test/app-bootstrap.test.ts
@@ -174,6 +174,18 @@ function makeWebComponentController<T = Record<string, unknown>>(): {
       async search() {
         return [];
       },
+      canMeasure() {
+        return false;
+      },
+      canSketch() {
+        return false;
+      },
+      async setMeasureMode(mode) {
+        return { mode, status: "unsupported" };
+      },
+      async setSketchMode(mode) {
+        return { mode, status: "unsupported" };
+      },
       destroy() {
         isDestroyed = true;
       },

--- a/test/controls/layer-list.test.ts
+++ b/test/controls/layer-list.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { defineHonuaControls } from "../../src/controls/basemap-switcher.js";
+import { HonuaLayerListElement } from "../../src/controls/layer-list.js";
+import type { HonuaLayerListChangeDetail, HonuaLayerListOverlay } from "../../src/controls/types.js";
+
+interface MockLayer {
+  layout?: Record<string, unknown>;
+}
+
+interface MockMap {
+  layers: Record<string, MockLayer>;
+  calls: Array<[string, string, unknown]>;
+  getLayer(id: string): unknown;
+  getLayoutProperty(layerId: string, name: string): unknown;
+  setLayoutProperty(layerId: string, name: string, value: unknown): void;
+  on(type: string, listener: () => void): void;
+  off(type: string, listener: () => void): void;
+  emit(type: string): void;
+  listenerCount(type: string): number;
+}
+
+/**
+ * Duck-typed MapLibre map stub following the mock pattern of the other
+ * controls tests, with layout bookkeeping and a tiny `styledata` emitter.
+ */
+function makeMockMap(layers: Record<string, MockLayer>): MockMap {
+  const listeners = new Map<string, Set<() => void>>();
+  return {
+    layers,
+    calls: [],
+    getLayer(id) {
+      return layers[id];
+    },
+    getLayoutProperty(layerId, name) {
+      return layers[layerId]?.layout?.[name];
+    },
+    setLayoutProperty(layerId, name, value) {
+      this.calls.push([layerId, name, value]);
+      const layer = layers[layerId];
+      if (!layer) throw new Error(`Layer "${layerId}" does not exist.`);
+      layer.layout = { ...layer.layout, [name]: value };
+    },
+    on(type, listener) {
+      const set = listeners.get(type) ?? new Set();
+      set.add(listener);
+      listeners.set(type, set);
+    },
+    off(type, listener) {
+      listeners.get(type)?.delete(listener);
+    },
+    emit(type) {
+      for (const listener of listeners.get(type) ?? []) listener();
+    },
+    listenerCount(type) {
+      return listeners.get(type)?.size ?? 0;
+    },
+  };
+}
+
+function makeOverlays(): HonuaLayerListOverlay[] {
+  return [
+    { id: "parcels", label: "Parcels", layers: ["parcels-fill", "parcels-outline"], attribution: "County GIS" },
+    { id: "incidents", label: "Incidents", layers: ["incident-points"] },
+  ];
+}
+
+function makeElement(): {
+  element: HonuaLayerListElement;
+  attributes: Map<string, string>;
+  shadow: {
+    innerHTML: string;
+    querySelector: typeof document.querySelector;
+    querySelectorAll: typeof document.querySelectorAll;
+  };
+  events: CustomEvent<HonuaLayerListChangeDetail>[];
+} {
+  const element = new HonuaLayerListElement();
+  const attributes = new Map<string, string>();
+  // A tiny DOM-ish shadow root: parse rows out of innerHTML lazily so the
+  // element can re-sync individual checkboxes via querySelector.
+  const inputs = new Map<string, { checked: boolean }>();
+  const shadow = {
+    innerHTML: "",
+    querySelector(selector: string): unknown {
+      const match = /data-overlay-id="([^"]+)"/.exec(selector);
+      if (!match) return null;
+      const id = match[1];
+      let input = inputs.get(id);
+      if (!input) {
+        input = { checked: false };
+        inputs.set(id, input);
+      }
+      return input;
+    },
+    querySelectorAll(): unknown[] {
+      return [];
+    },
+  } as unknown as {
+    innerHTML: string;
+    querySelector: typeof document.querySelector;
+    querySelectorAll: typeof document.querySelectorAll;
+  };
+  const events: CustomEvent<HonuaLayerListChangeDetail>[] = [];
+  Object.assign(element, {
+    shadowRoot: shadow,
+    getAttribute: (name: string) => attributes.get(name) ?? null,
+    setAttribute: (name: string, value: string) => {
+      attributes.set(name, value);
+    },
+    hasAttribute: (name: string) => attributes.has(name),
+    removeAttribute: (name: string) => {
+      attributes.delete(name);
+    },
+    dispatchEvent: (event: Event) => {
+      events.push(event as CustomEvent<HonuaLayerListChangeDetail>);
+      return true;
+    },
+  });
+  return { element, attributes, shadow, events };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("HonuaLayerListElement", () => {
+  test("is registered for browser registries via defineHonuaControls", () => {
+    const defined: Record<string, CustomElementConstructor> = {};
+    const registry = {
+      get: (name: string) => defined[name],
+      define: (name: string, ctor: CustomElementConstructor) => {
+        defined[name] = ctor;
+      },
+    } as unknown as CustomElementRegistry;
+    defineHonuaControls(registry);
+    expect(defined["honua-layer-list"]).toBe(HonuaLayerListElement);
+    // Idempotent: re-defining must not throw.
+    defineHonuaControls(registry);
+  });
+
+  test("renders a checkbox row per overlay with accessible label/checkbox parts", () => {
+    const { element, shadow } = makeElement();
+    element.connect(
+      makeMockMap({
+        "parcels-fill": {},
+        "parcels-outline": {},
+        "incident-points": {},
+      }),
+    );
+    element.overlays = makeOverlays();
+
+    expect(shadow.innerHTML).toContain('part="root"');
+    expect(shadow.innerHTML).toContain('part="row"');
+    expect(shadow.innerHTML).toContain('part="checkbox"');
+    expect(shadow.innerHTML).toContain('part="label"');
+    expect(shadow.innerHTML).toContain('type="checkbox"');
+    expect(shadow.innerHTML).toContain("Parcels");
+    expect(shadow.innerHTML).toContain("Incidents");
+    expect(shadow.innerHTML).toContain('data-overlay-id="parcels"');
+    // Visible (no visibility:none) overlays render checked.
+    expect(shadow.innerHTML).toContain("checked");
+    // Attribution is rendered as a hint.
+    expect(shadow.innerHTML).toContain("County GIS");
+  });
+
+  test("setVisible writes visibility on every overlay layer and emits change", () => {
+    const { element, events } = makeElement();
+    const map = makeMockMap({ "parcels-fill": {}, "parcels-outline": {}, "incident-points": {} });
+    element.connect(map);
+    element.overlays = makeOverlays();
+
+    expect(element.setVisible("parcels", false)).toBe(true);
+    expect(map.calls).toEqual([
+      ["parcels-fill", "visibility", "none"],
+      ["parcels-outline", "visibility", "none"],
+    ]);
+    expect(map.layers["parcels-fill"].layout?.visibility).toBe("none");
+    expect(map.layers["parcels-outline"].layout?.visibility).toBe("none");
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe("change");
+    expect(events[0]?.bubbles).toBe(true);
+    expect(events[0]?.composed).toBe(true);
+    expect(events[0]?.detail).toEqual({ id: "parcels", visible: false });
+
+    // Toggling back to visible.
+    element.setVisible("parcels", true);
+    expect(map.layers["parcels-fill"].layout?.visibility).toBe("visible");
+    expect(events[1]?.detail).toEqual({ id: "parcels", visible: true });
+  });
+
+  test("auto-refresh subscribes to styledata and re-syncs checked state from the map", () => {
+    const { element, attributes, shadow } = makeElement();
+    attributes.set("auto-refresh", "");
+    const map = makeMockMap({ "parcels-fill": {}, "parcels-outline": {}, "incident-points": {} });
+    element.connect(map);
+    element.overlays = makeOverlays();
+    element.connectedCallback();
+    expect(map.listenerCount("styledata")).toBe(1);
+
+    // Initially the parcels row renders checked (visible).
+    expect(shadow.innerHTML).toMatch(/data-overlay-id="parcels"[\s\S]*?checked/);
+
+    // External edit hides the parcels layers, then styledata fires.
+    map.layers["parcels-fill"].layout = { visibility: "none" };
+    map.layers["parcels-outline"].layout = { visibility: "none" };
+    map.emit("styledata");
+
+    // After re-render the parcels checkbox is unchecked, incidents stays checked.
+    const rows = [...shadow.innerHTML.matchAll(/<label part="row"[\s\S]*?<\/label>/g)].map((m) => m[0]);
+    const parcelsRow = rows.find((row) => row.includes('data-overlay-id="parcels"')) ?? "";
+    const incidentsRow = rows.find((row) => row.includes('data-overlay-id="incidents"')) ?? "";
+    expect(parcelsRow).not.toContain("checked");
+    expect(incidentsRow).toContain("checked");
+
+    // Re-assigning the map moves the subscription; disconnect unsubscribes.
+    const nextMap = makeMockMap({ "parcels-fill": {} });
+    element.map = nextMap;
+    expect(map.listenerCount("styledata")).toBe(0);
+    expect(nextMap.listenerCount("styledata")).toBe(1);
+    element.disconnectedCallback();
+    expect(nextMap.listenerCount("styledata")).toBe(0);
+  });
+
+  test("an overlay whose style layers are all missing renders disabled with a not-seeded badge", () => {
+    const { element, shadow } = makeElement();
+    // Only the incident layer exists; parcels layers are absent.
+    element.connect(makeMockMap({ "incident-points": {} }));
+    element.overlays = makeOverlays();
+
+    const rows = [...shadow.innerHTML.matchAll(/<label part="row"[\s\S]*?<\/label>/g)].map((m) => m[0]);
+    const parcelsRow = rows.find((row) => row.includes('data-overlay-id="parcels"')) ?? "";
+    expect(parcelsRow).toContain("disabled");
+    expect(parcelsRow).toContain('part="badge"');
+    expect(parcelsRow).toContain('<slot name="not-seeded"');
+    expect(parcelsRow).toContain("data-not-seeded");
+    expect(parcelsRow).not.toContain("checked");
+
+    // The seeded incidents overlay is not disabled and carries no badge.
+    const incidentsRow = rows.find((row) => row.includes('data-overlay-id="incidents"')) ?? "";
+    expect(incidentsRow).not.toContain("disabled");
+    expect(incidentsRow).not.toContain('part="badge"');
+
+    // setVisible on an unseeded overlay is a no-op (no layers to write).
+    expect(element.setVisible("parcels", false)).toBe(false);
+  });
+
+  test("accepts overlays as a JSON attribute (matching the switcher's JSON intake)", () => {
+    const { element, shadow } = makeElement();
+    element.connect(makeMockMap({ "parcels-fill": {}, "incident-points": {} }));
+    const json = JSON.stringify([
+      { id: "parcels", label: "Parcels", layers: ["parcels-fill"] },
+      { id: "bogus" }, // missing label/layers: dropped
+      { id: "incidents", label: "Incidents", layers: ["incident-points"], attribution: "Ops" },
+    ]);
+    element.attributeChangedCallback("overlays", null, json);
+
+    expect(element.overlays.map((overlay) => overlay.id)).toEqual(["parcels", "incidents"]);
+    expect(element.overlays[1]?.attribution).toBe("Ops");
+    expect(shadow.innerHTML).toContain("Parcels");
+    expect(shadow.innerHTML).toContain("Incidents");
+    expect(shadow.innerHTML).not.toContain("bogus");
+  });
+
+  test("rendering without a shadow root is a safe no-op", () => {
+    const element = new HonuaLayerListElement();
+    Object.assign(element, { getAttribute: () => null });
+    element.overlays = makeOverlays();
+    expect(() => element.refresh()).not.toThrow();
+    expect(element.overlays).toHaveLength(2);
+  });
+});
+
+// Type-level check: change detail shape is exported and stable.
+const _detail: HonuaLayerListChangeDetail = { id: "parcels", visible: true };
+void _detail;

--- a/test/controls/layer-list.test.ts
+++ b/test/controls/layer-list.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { defineHonuaControls } from "../../src/controls/basemap-switcher.js";
-import { HonuaLayerListElement } from "../../src/controls/layer-list.js";
+import { HonuaLayerListElement, defineHonuaLayerList } from "../../src/controls/layer-list.js";
 import type { HonuaLayerListChangeDetail, HonuaLayerListOverlay } from "../../src/controls/types.js";
 
 interface MockLayer {
@@ -125,7 +125,7 @@ afterEach(() => {
 });
 
 describe("HonuaLayerListElement", () => {
-  test("is registered for browser registries via defineHonuaControls", () => {
+  test("is opt-in via defineHonuaLayerList and not auto-registered by defineHonuaControls", () => {
     const defined: Record<string, CustomElementConstructor> = {};
     const registry = {
       get: (name: string) => defined[name],
@@ -133,10 +133,15 @@ describe("HonuaLayerListElement", () => {
         defined[name] = ctor;
       },
     } as unknown as CustomElementRegistry;
+    // The blanket controls registration must NOT claim honua-layer-list — the
+    // tag is shared with the controller-driven web-components element.
     defineHonuaControls(registry);
+    expect(defined["honua-layer-list"]).toBeUndefined();
+    // Explicit opt-in registers it.
+    defineHonuaLayerList(registry);
     expect(defined["honua-layer-list"]).toBe(HonuaLayerListElement);
     // Idempotent: re-defining must not throw.
-    defineHonuaControls(registry);
+    defineHonuaLayerList(registry);
   });
 
   test("renders a checkbox row per overlay with accessible label/checkbox parts", () => {

--- a/test/controls/swipe-control.test.ts
+++ b/test/controls/swipe-control.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, test } from "vitest";
+
+import { HonuaSwipeControlElement, defineHonuaSwipeControl } from "../../src/controls/swipe-control.js";
+import type { HonuaSwipeChangeDetail, HonuaSwipeMap } from "../../src/controls/types.js";
+
+/**
+ * Headless DOM stubs for the swipe control, mirroring the stub posture of
+ * test/controls/basemap-switcher.test.ts (no jsdom: the controls entry runs
+ * under Node and the element no-ops without a DOM, so the test supplies the
+ * minimal surface it touches — a shadow root with a divider element, a
+ * bounding rect, attributes, and event capture).
+ */
+
+interface DividerStub {
+  style: Record<string, string>;
+  attributes: Map<string, string>;
+  classList: { toggle(name: string, force?: boolean): void; has(name: string): boolean };
+  classes: Set<string>;
+  listeners: Map<string, ((event: unknown) => void)[]>;
+  setAttribute(name: string, value: string): void;
+  getAttribute(name: string): string | null;
+  addEventListener(type: string, listener: (event: unknown) => void): void;
+  removeEventListener(type: string, listener: (event: unknown) => void): void;
+  setPointerCapture(): void;
+  releasePointerCapture(): void;
+  emit(type: string, event: unknown): void;
+}
+
+function makeDivider(): DividerStub {
+  const classes = new Set<string>();
+  const attributes = new Map<string, string>();
+  const listeners = new Map<string, ((event: unknown) => void)[]>();
+  return {
+    style: {},
+    attributes,
+    classes,
+    classList: {
+      toggle(name: string, force?: boolean) {
+        const on = force ?? !classes.has(name);
+        if (on) classes.add(name);
+        else classes.delete(name);
+      },
+      has: (name: string) => classes.has(name),
+    },
+    listeners,
+    setAttribute(name, value) {
+      attributes.set(name, value);
+    },
+    getAttribute(name) {
+      return attributes.get(name) ?? null;
+    },
+    addEventListener(type, listener) {
+      const existing = listeners.get(type) ?? [];
+      existing.push(listener);
+      listeners.set(type, existing);
+    },
+    removeEventListener(type, listener) {
+      const existing = listeners.get(type);
+      if (!existing) return;
+      listeners.set(
+        type,
+        existing.filter((entry) => entry !== listener),
+      );
+    },
+    setPointerCapture() {},
+    releasePointerCapture() {},
+    emit(type, event) {
+      for (const listener of listeners.get(type) ?? []) listener(event);
+    },
+  };
+}
+
+function makeMap(): HonuaSwipeMap & { container: { style: Record<string, string> } } {
+  const container = { style: {} as Record<string, string> };
+  return { container, getContainer: () => container as unknown as HTMLElement };
+}
+
+function makeElement(): {
+  element: HonuaSwipeControlElement;
+  divider: DividerStub;
+  attributes: Map<string, string>;
+  events: CustomEvent<HonuaSwipeChangeDetail>[];
+  rect: { left: number; top: number; width: number; height: number };
+} {
+  const element = new HonuaSwipeControlElement();
+  const attributes = new Map<string, string>();
+  const events: CustomEvent<HonuaSwipeChangeDetail>[] = [];
+  const divider = makeDivider();
+  const rect = { left: 0, top: 0, width: 200, height: 100 };
+  const shadow = {
+    set innerHTML(_value: string) {
+      /* rendered string is irrelevant; the divider stub is resolved below */
+    },
+    querySelector: (selector: string) => (selector === ".divider" ? divider : null),
+  };
+  Object.assign(element, {
+    shadowRoot: shadow,
+    getAttribute: (name: string) => attributes.get(name) ?? null,
+    setAttribute: (name: string, value: string) => {
+      attributes.set(name, value);
+    },
+    getBoundingClientRect: () => ({ ...rect, right: rect.left + rect.width, bottom: rect.top + rect.height }),
+    dispatchEvent: (event: Event) => {
+      events.push(event as CustomEvent<HonuaSwipeChangeDetail>);
+      return true;
+    },
+  });
+  // Drive the same lifecycle the browser would (shadow root already supplied).
+  element.connectedCallback();
+  return { element, divider, attributes, events, rect };
+}
+
+describe("HonuaSwipeControlElement", () => {
+  test("defaults to a 50% vertical divider and positions it", () => {
+    const { element, divider } = makeElement();
+    expect(element.position).toBe(50);
+    expect(element.orientation).toBe("vertical");
+    expect(divider.style.left).toBe("50%");
+    expect(divider.getAttribute("aria-valuenow")).toBe("50");
+  });
+
+  test("clips the top map and leaves the bottom map untouched", () => {
+    const { element } = makeElement();
+    const top = makeMap();
+    const bottom = makeMap();
+    element.connect(top, bottom);
+
+    expect(top.container.style.clipPath).toBe("inset(0 0 0 50%)");
+    expect(bottom.container.style.clipPath).toBeUndefined();
+  });
+
+  test("setting position reapplies the clip, reflects the attribute, and emits change", () => {
+    const { element, attributes, events } = makeElement();
+    const top = makeMap();
+    element.topMap = top;
+
+    element.position = 25;
+
+    expect(element.position).toBe(25);
+    expect(top.container.style.clipPath).toBe("inset(0 0 0 25%)");
+    expect(attributes.get("position")).toBe("25");
+    expect(events.at(-1)?.type).toBe("change");
+    expect(events.at(-1)?.detail).toEqual({ position: 25, orientation: "vertical" });
+  });
+
+  test("clamps the position to the 0–100 range", () => {
+    const { element } = makeElement();
+    element.position = 250;
+    expect(element.position).toBe(100);
+    element.position = -10;
+    expect(element.position).toBe(0);
+  });
+
+  test("dragging the divider updates the clip and emits change", () => {
+    const { element, divider, events } = makeElement();
+    const top = makeMap();
+    element.topMap = top;
+
+    // rect is 200px wide starting at left=0; clientX=150 => 75%.
+    divider.emit("pointerdown", { pointerId: 1, clientX: 150, clientY: 0, preventDefault() {} });
+
+    expect(element.position).toBe(75);
+    expect(top.container.style.clipPath).toBe("inset(0 0 0 75%)");
+    expect(events.at(-1)?.detail.position).toBe(75);
+
+    // Continue dragging to 25% then release.
+    divider.emit("pointermove", { pointerId: 1, clientX: 50, clientY: 0 });
+    expect(element.position).toBe(25);
+    divider.emit("pointerup", { pointerId: 1, clientX: 50, clientY: 0 });
+    // After release, further moves are ignored.
+    divider.emit("pointermove", { pointerId: 1, clientX: 100, clientY: 0 });
+    expect(element.position).toBe(25);
+  });
+
+  test("arrow keys step the divider and emit change", () => {
+    const { element, divider, events } = makeElement();
+    divider.emit("keydown", { key: "ArrowRight", preventDefault() {} });
+    expect(element.position).toBe(51);
+    divider.emit("keydown", { key: "ArrowLeft", shiftKey: true, preventDefault() {} });
+    expect(element.position).toBe(41);
+    divider.emit("keydown", { key: "Home", preventDefault() {} });
+    expect(element.position).toBe(0);
+    divider.emit("keydown", { key: "End", preventDefault() {} });
+    expect(element.position).toBe(100);
+    expect(events.at(-1)?.detail.position).toBe(100);
+  });
+
+  test("horizontal orientation clips along the top edge and drags vertically", () => {
+    const { element, divider } = makeElement();
+    const top = makeMap();
+    element.topMap = top;
+    element.orientation = "horizontal";
+    element.attributeChangedCallback("orientation", null, "horizontal");
+
+    expect(element.orientation).toBe("horizontal");
+    expect(top.container.style.clipPath).toBe("inset(50% 0 0 0)");
+    expect(divider.classList.has("divider-horizontal")).toBe(true);
+
+    // rect is 100px tall starting at top=0; clientY=20 => 20%.
+    divider.emit("pointerdown", { pointerId: 1, clientX: 0, clientY: 20, preventDefault() {} });
+    expect(element.position).toBe(20);
+    expect(top.container.style.clipPath).toBe("inset(20% 0 0 0)");
+  });
+
+  test("reassigning the top map clears the previous map's clip", () => {
+    const { element } = makeElement();
+    const first = makeMap();
+    const second = makeMap();
+    element.topMap = first;
+    expect(first.container.style.clipPath).toBe("inset(0 0 0 50%)");
+
+    element.topMap = second;
+    expect(first.container.style.clipPath).toBe("");
+    expect(second.container.style.clipPath).toBe("inset(0 0 0 50%)");
+  });
+
+  test("defineHonuaSwipeControl is a no-op without a registry", () => {
+    expect(() => defineHonuaSwipeControl(undefined)).not.toThrow();
+  });
+});

--- a/test/playwright/web-components-basic.spec.mjs
+++ b/test/playwright/web-components-basic.spec.mjs
@@ -35,8 +35,12 @@ test("web components compose map, layers, legend, table, search, and editor stat
     );
     await expect(page.locator("honua-bookmarks").getByRole("button", { name: "Home" })).toBeVisible();
     await expect(page.locator("honua-locate-control").getByRole("button", { name: "Use location" })).toBeVisible();
-    await expect(page.locator("honua-measure-control").getByText("Measurement geometry is not available")).toBeVisible();
-    await expect(page.locator("honua-sketch-control").getByText("Sketch editing is not available")).toBeVisible();
+    await expect(
+      page.locator("honua-measure-control").getByText("Measurement is disabled because no geometry provider is configured"),
+    ).toBeVisible();
+    await expect(
+      page.locator("honua-sketch-control").getByText("Sketching is disabled because no geometry provider is configured"),
+    ).toBeVisible();
     await expect(page.locator("honua-measure-control").getByRole("button", { name: "Distance" })).toBeDisabled();
     await expect(page.locator("honua-sketch-control").getByRole("button", { name: "Point" })).toBeDisabled();
     await expect(page.locator("honua-print-export").getByRole("button", { name: "Snapshot" })).toBeVisible();

--- a/test/realtime-honua-server-preset.test.ts
+++ b/test/realtime-honua-server-preset.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HONUA_SERVER_STREAMING_FEATURES_PATH,
+  createHonuaServerRealtimeSubscription,
+  decodeHonuaServerRealtimeEvent,
+  encodeHonuaServerRealtimeRequest,
+  honuaServerRealtimePreset,
+} from "../src/realtime/index.js";
+import type {
+  RealtimeFeatureEvent,
+  RealtimeFeatureObserver,
+  RealtimeServerSentEventSource,
+  RealtimeSubscriptionRequest,
+} from "../src/realtime/index.js";
+
+class MockRealtimeEventSource implements RealtimeServerSentEventSource {
+  public onopen: ((event: Event) => void) | null = null;
+  public onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  public onerror: ((event: Event) => void) | null = null;
+  public readyState = 0;
+  public closed = false;
+  private readonly listeners = new Map<string, Array<(event: MessageEvent<string>) => void>>();
+
+  public constructor(public readonly url: string) {}
+
+  public addEventListener(type: string, listener: (event: MessageEvent<string>) => void): void {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
+  }
+
+  public removeEventListener(type: string, listener: (event: MessageEvent<string>) => void): void {
+    this.listeners.set(
+      type,
+      (this.listeners.get(type) ?? []).filter((candidate) => candidate !== listener),
+    );
+  }
+
+  public close(): void {
+    this.closed = true;
+    this.readyState = 2;
+  }
+
+  public open(): void {
+    this.readyState = 1;
+    this.onopen?.(new Event("open"));
+  }
+
+  public message(payload: unknown): void {
+    this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(payload) }));
+  }
+}
+
+describe("honua-server realtime preset", () => {
+  it("encodes serviceId/layers query params instead of sourceId/layerId", () => {
+    const request: RealtimeSubscriptionRequest = {
+      sourceId: "incidents",
+      layerId: "active-incidents",
+      where: "status <> 'resolved'",
+      fields: ["id", "status"],
+      mode: "snapshot-then-delta",
+    };
+    const url = new URL("https://honua.example/api/v1/streaming/features");
+
+    encodeHonuaServerRealtimeRequest(url, request);
+
+    expect(url.searchParams.get("serviceId")).toBe("incidents");
+    expect(url.searchParams.get("layers")).toBe("active-incidents");
+    expect(url.searchParams.has("sourceId")).toBe(false);
+    expect(url.searchParams.has("layerId")).toBe(false);
+    expect(url.searchParams.get("where")).toBe("status <> 'resolved'");
+    expect(url.searchParams.get("fields")).toBe("id,status");
+    expect(url.searchParams.get("mode")).toBe("snapshot-then-delta");
+  });
+
+  it("decodes a multi-change feature-change envelope into an SDK delta event", () => {
+    const event = decodeHonuaServerRealtimeEvent<{ status: string }>({
+      kind: "feature-change",
+      serviceId: "incidents",
+      eventId: "evt-7",
+      sequence: 42,
+      cursor: "c-42",
+      changes: [
+        { op: "update", featureId: 101, feature: { status: "active" }, version: 3, updatedAt: "2026-06-14T00:00:00Z" },
+        { op: "insert", featureId: 102, feature: { status: "new" } },
+        { op: "delete", featureId: 99, version: 2 },
+      ],
+    });
+
+    expect(event).toEqual({
+      type: "delta",
+      eventId: "evt-7",
+      sequence: 42,
+      cursor: "c-42",
+      watermark: undefined,
+      timestamp: undefined,
+      deltaToken: undefined,
+      upserts: [
+        {
+          id: 101,
+          sourceId: "incidents",
+          feature: { status: "active" },
+          version: 3,
+          updatedAt: "2026-06-14T00:00:00Z",
+        },
+        { id: 102, sourceId: "incidents", feature: { status: "new" }, version: undefined, updatedAt: undefined },
+      ],
+      deletes: [{ id: 99, sourceId: "incidents", version: 2, updatedAt: undefined }],
+    });
+  });
+
+  it("decodes a single inline feature-change envelope", () => {
+    const event = decodeHonuaServerRealtimeEvent<{ status: string }>({
+      type: "feature-change",
+      serviceId: "incidents",
+      op: "insert",
+      featureId: "abc",
+      feature: { status: "new" },
+    });
+
+    expect(event.type).toBe("delta");
+    if (event.type === "delta") {
+      expect(event.upserts).toEqual([
+        { id: "abc", sourceId: "incidents", feature: { status: "new" }, version: undefined, updatedAt: undefined },
+      ]);
+      expect(event.deletes).toBeUndefined();
+    }
+  });
+
+  it("passes through status envelopes unchanged", () => {
+    const event = decodeHonuaServerRealtimeEvent({
+      type: "status",
+      status: "reconnecting",
+      reason: "server-restart",
+    });
+    expect(event).toEqual({ type: "status", status: "reconnecting", reason: "server-restart" });
+  });
+
+  it("throws on a malformed feature-change envelope", () => {
+    expect(() => decodeHonuaServerRealtimeEvent({ kind: "feature-change", changes: [] })).toThrow();
+    expect(() =>
+      decodeHonuaServerRealtimeEvent({ kind: "feature-change", changes: [{ op: "update", feature: {} }] }),
+    ).toThrow();
+  });
+
+  it("wires the preset hooks through createHonuaServerRealtimeSubscription", () => {
+    let created: MockRealtimeEventSource | undefined;
+    const transport = createHonuaServerRealtimeSubscription<{ status: string }>({
+      baseUrl: "https://honua.example/",
+      eventSourceFactory: (url) => {
+        created = new MockRealtimeEventSource(url);
+        return created;
+      },
+    });
+
+    const events: Array<RealtimeFeatureEvent<{ status: string }>> = [];
+    const observer: RealtimeFeatureObserver<{ status: string }> = {
+      next: (event) => events.push(event),
+      error: () => {},
+      complete: () => {},
+    };
+
+    const handle = transport.subscribe({ sourceId: "incidents", layerId: "0" }, observer);
+
+    expect(created).toBeDefined();
+    const requestUrl = new URL(created?.url ?? "", "http://honua.local");
+    expect(requestUrl.pathname).toBe(HONUA_SERVER_STREAMING_FEATURES_PATH);
+    expect(requestUrl.searchParams.get("serviceId")).toBe("incidents");
+    expect(requestUrl.searchParams.get("layers")).toBe("0");
+
+    created?.message({
+      kind: "feature-change",
+      serviceId: "incidents",
+      op: "insert",
+      featureId: 1,
+      feature: { status: "active" },
+    });
+
+    const delta = events.find((event) => event.type === "delta");
+    expect(delta).toBeDefined();
+    handle.close();
+  });
+
+  it("exposes preset hooks as a spreadable options bundle", () => {
+    const preset = honuaServerRealtimePreset<{ status: string }>();
+    expect(typeof preset.encodeRequest).toBe("function");
+    expect(typeof preset.decodeEvent).toBe("function");
+  });
+});

--- a/test/replica-sync.test.ts
+++ b/test/replica-sync.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import type { TemporalFeatureTimelineRequest } from "../src/contract/temporal.js";
+import type { FeatureId } from "../src/replica-sync/index.js";
 import {
   createFixtureReplicaSyncTransport,
   createHonuaReplicaSync,
@@ -156,6 +158,25 @@ describe("unsupported capabilities are explicit", () => {
     await expect(sync.capabilities("does-not-exist")).rejects.toSatisfy((error) =>
       isUnsupportedReplicaSyncError(error),
     );
+  });
+});
+
+describe("composition with temporal history contracts (#227)", () => {
+  it("uses the shared FeatureId so a conflict feeds a temporal feature timeline", async () => {
+    const sync = client();
+    const detail = await sync.getConflict("conflict-pending-1");
+
+    // The conflict's featureId is the shared contract FeatureId alias, so it can
+    // be handed straight to the temporal feature-timeline request without any
+    // re-typing or coercion — the two contracts compose by construction.
+    const featureId: FeatureId = detail.featureId;
+    const timelineRequest: TemporalFeatureTimelineRequest = {
+      sourceId: detail.sourceId ?? detail.datasetId,
+      featureId,
+    };
+
+    expect(timelineRequest.featureId).toBe(detail.featureId);
+    expect(timelineRequest.sourceId).toBe("parcels");
   });
 });
 

--- a/test/share-contracts.test.ts
+++ b/test/share-contracts.test.ts
@@ -180,6 +180,26 @@ describe("anonymous-safe denial states", () => {
     expect(isShareAccessDenied(denied)).toBe(true);
   });
 
+  it("grants a public-content read and denies a forbidden one explicitly", () => {
+    // public (public-content) access kind, granted.
+    const resolution: HonuaPublicLinkResolution = {
+      itemId: "item-9",
+      itemType: "open-data",
+      accessTier: "public-indexed",
+      endpoints: { self: "/api/v1/console/share/content/item-9" },
+    };
+    const granted = grantShareAccess("public-content", resolution);
+    expect(granted.status).toBe("granted");
+    expect(granted.kind).toBe("public-content");
+
+    // forbidden denial built directly (not only via HTTP status mapping).
+    const forbidden = denyShareAccess("embed", "forbidden");
+    expect(forbidden.reason).toBe("forbidden");
+    expect(forbidden.message).toBe(HONUA_SHARE_DENIAL_MESSAGES.embed);
+    // Forbidden carries the same identity-free message as not-found (no oracle).
+    expect(forbidden.message).toBe(denyShareAccess("embed", "not-found").message);
+  });
+
   it("accepts a server ConsoleEmbedRedeemResponse-shaped object", () => {
     const wire = {
       itemId: "item-1",

--- a/test/terrain-elevation.test.ts
+++ b/test/terrain-elevation.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type ElevationCoordinate,
+  decodeElevationPixel,
+  decodeTerrainRgbElevation,
+  decodeTerrariumElevation,
+  haversineMeters,
+  sampleElevationProfile,
+} from "../src/core/terrain-elevation.js";
+
+describe("Terrain-RGB / Terrarium pixel decoding", () => {
+  it("decodes Mapbox Terrain-RGB pixels against known values", () => {
+    // Mapbox docs reference: height = -10000 + (R*256*256 + G*256 + B) * 0.1
+    expect(decodeTerrainRgbElevation(0, 0, 0)).toBe(-10_000);
+    // The "1, 134, 160" sample used by the terrain example decodes to 0 m.
+    expect(decodeTerrainRgbElevation(1, 134, 160)).toBeCloseTo(0, 6);
+    expect(decodeTerrainRgbElevation(1, 134, 161)).toBeCloseTo(0.1, 6);
+    // 100m above sea level => 101000 encoded units => R=1, G=138, B=136.
+    expect(decodeTerrainRgbElevation(1, 138, 136)).toBeCloseTo(100, 6);
+  });
+
+  it("decodes Terrarium pixels against known values", () => {
+    // Terrarium: height = (R*256 + G + B/256) - 32768
+    expect(decodeTerrariumElevation(128, 0, 0)).toBe(0);
+    expect(decodeTerrariumElevation(128, 100, 0)).toBe(100);
+    expect(decodeTerrariumElevation(127, 0, 0)).toBe(-256);
+    expect(decodeTerrariumElevation(128, 0, 128)).toBeCloseTo(0.5, 6);
+  });
+
+  it("dispatches encoding by name and clamps out-of-range channels", () => {
+    expect(decodeElevationPixel("mapbox", 0, 0, 0)).toBe(-10_000);
+    expect(decodeElevationPixel("terrarium", 128, 0, 0)).toBe(0);
+    // Out-of-range channels clamp to the 0–255 byte range.
+    expect(decodeElevationPixel("mapbox", -5, 0, 0)).toBe(decodeTerrainRgbElevation(0, 0, 0));
+    expect(decodeElevationPixel("terrarium", 300, 0, 0)).toBe(decodeTerrariumElevation(255, 0, 0));
+  });
+});
+
+describe("haversineMeters", () => {
+  it("measures roughly 111 km per degree of latitude", () => {
+    const meters = haversineMeters([0, 0], [0, 1]);
+    expect(meters).toBeGreaterThan(110_000);
+    expect(meters).toBeLessThan(112_000);
+  });
+
+  it("returns zero for identical coordinates", () => {
+    expect(haversineMeters([-157.84, 21.42], [-157.84, 21.42])).toBe(0);
+  });
+});
+
+describe("sampleElevationProfile", () => {
+  const line: readonly ElevationCoordinate[] = [
+    [0, 0],
+    [0, 1],
+  ];
+
+  it("samples evenly spaced points with cumulative distance and elevation", async () => {
+    const profile = await sampleElevationProfile({
+      line,
+      sampleCount: 3,
+      // Elevation grows linearly with the second coordinate (latitude).
+      sampler: (coordinate) => coordinate[1] * 1000,
+    });
+
+    expect(profile.samples).toHaveLength(3);
+    expect(profile.samples[0]?.distanceMeters).toBe(0);
+    expect(profile.samples[2]?.distanceMeters).toBeCloseTo(profile.totalDistanceMeters, 6);
+    // Midpoint sits halfway along the line.
+    expect(profile.samples[1]?.coordinate[1]).toBeCloseTo(0.5, 6);
+    expect(profile.samples.map((s) => s.elevationMeters)).toEqual([0, 500, 1000]);
+  });
+
+  it("summarizes gain, loss, min, and max elevation", async () => {
+    const elevations = [100, 250, 120];
+    let call = 0;
+    const profile = await sampleElevationProfile({
+      line,
+      sampleCount: 3,
+      sampler: () => elevations[call++] ?? 0,
+    });
+
+    expect(profile.minElevationMeters).toBe(100);
+    expect(profile.maxElevationMeters).toBe(250);
+    expect(profile.gainMeters).toBe(150);
+    expect(profile.lossMeters).toBe(130);
+  });
+
+  it("awaits async samplers and exposes index + distance context", async () => {
+    const seen: Array<{ index: number; distanceMeters: number }> = [];
+    const profile = await sampleElevationProfile({
+      line,
+      sampleCount: 2,
+      sampler: async (_coordinate, context) => {
+        seen.push(context);
+        return 42;
+      },
+    });
+
+    expect(profile.samples.every((s) => s.elevationMeters === 42)).toBe(true);
+    expect(seen.map((c) => c.index)).toEqual([0, 1]);
+    expect(seen[0]?.distanceMeters).toBe(0);
+  });
+
+  it("treats non-finite sampler results as no-data (0) in the summary", async () => {
+    const profile = await sampleElevationProfile({
+      line,
+      sampleCount: 2,
+      sampler: () => Number.NaN,
+    });
+    expect(profile.samples.map((s) => s.elevationMeters)).toEqual([0, 0]);
+    expect(profile.maxElevationMeters).toBe(0);
+  });
+
+  it("defaults sampleCount to the line vertex count (min 2)", async () => {
+    const polyline: readonly ElevationCoordinate[] = [
+      [0, 0],
+      [0, 0.5],
+      [0, 1],
+    ];
+    const profile = await sampleElevationProfile({ line: polyline, sampler: () => 0 });
+    expect(profile.samples).toHaveLength(3);
+  });
+
+  it("throws on a degenerate line", async () => {
+    await expect(sampleElevationProfile({ line: [[0, 0]], sampler: () => 0 })).rejects.toBeInstanceOf(RangeError);
+  });
+});

--- a/test/web-components-controller.test.ts
+++ b/test/web-components-controller.test.ts
@@ -5,7 +5,12 @@ import {
   createHonuaWebComponentControllerFromRuntime,
   defineHonuaWebComponents,
 } from "../src/web-components/index.js";
-import type { HonuaFeatureRecord, HonuaWebComponentRuntimeLike } from "../src/web-components/index.js";
+import type {
+  HonuaFeatureRecord,
+  HonuaMeasureProvider,
+  HonuaSketchProvider,
+  HonuaWebComponentRuntimeLike,
+} from "../src/web-components/index.js";
 
 const features: HonuaFeatureRecord[] = [
   {
@@ -163,6 +168,89 @@ describe("Honua web component controller", () => {
     expect(table.rows[0]).toMatchObject({ id: 11, title: "Runtime feature" });
     expect(controller.getState().featuresBySource.incidents?.[0]).toMatchObject({ id: 11, title: "Runtime feature" });
     expect(search[0]).toMatchObject({ sourceId: "incidents", featureId: 11, label: "Runtime feature" });
+  });
+
+  it("leaves measure and sketch disabled without a geometry provider", async () => {
+    const controller = createHonuaWebComponentController({ mapPackage: mapPackage() });
+
+    expect(controller.canMeasure()).toBe(false);
+    expect(controller.canSketch()).toBe(false);
+
+    const measure = await controller.setMeasureMode("distance");
+    const sketch = await controller.setSketchMode("polygon");
+
+    expect(measure.status).toBe("unsupported");
+    expect(measure.result).toBeUndefined();
+    expect(measure.message).toContain("measurementGeometry");
+    expect(sketch.status).toBe("unsupported");
+    expect(sketch.message).toContain("sketchGeometry");
+  });
+
+  it("enables measure and sketch when geometry providers are supplied", async () => {
+    const measureProvider: HonuaMeasureProvider = {
+      startMode: (mode) =>
+        mode === "off"
+          ? undefined
+          : {
+              mode,
+              coordinates: [
+                [-157.87, 21.31],
+                [-157.86, 21.29],
+              ],
+              ...(mode === "distance" ? { distance: 2400 } : { area: 180000 }),
+            },
+    };
+    const sketchProvider: HonuaSketchProvider = {
+      startMode: (mode) =>
+        mode === "off"
+          ? undefined
+          : {
+              mode,
+              id: "drawn-1",
+              geometry: { x: -157.86, y: 21.3 },
+            },
+    };
+
+    const controller = createHonuaWebComponentController({
+      mapPackage: mapPackage(),
+      measurementGeometry: measureProvider,
+      sketchGeometry: sketchProvider,
+    });
+
+    expect(controller.canMeasure()).toBe(true);
+    expect(controller.canSketch()).toBe(true);
+
+    const measure = await controller.setMeasureMode("distance");
+    expect(measure.status).toBe("ready");
+    expect(measure.result?.distance).toBe(2400);
+    expect(measure.result?.coordinates).toHaveLength(2);
+
+    const sketch = await controller.setSketchMode("point");
+    expect(sketch.status).toBe("ready");
+    expect(sketch.result?.id).toBe("drawn-1");
+    expect(sketch.result?.geometry).toMatchObject({ x: -157.86, y: 21.3 });
+  });
+
+  it("reports provider failures as error change details and stops on `off`", async () => {
+    const stop = vi.fn();
+    const provider: HonuaMeasureProvider = {
+      startMode: (mode) => {
+        if (mode === "area") throw new Error("draw backend offline");
+        return undefined;
+      },
+      stop,
+    };
+    const controller = createHonuaWebComponentController({
+      mapPackage: mapPackage(),
+      measurementGeometry: provider,
+    });
+
+    const failed = await controller.setMeasureMode("area");
+    expect(failed.status).toBe("error");
+    expect(failed.message).toBe("draw backend offline");
+
+    await controller.setMeasureMode("off");
+    expect(stop).toHaveBeenCalledTimes(1);
   });
 
   it("can be imported in Node and registers only when a registry is supplied", () => {

--- a/test/web-components-measure-sketch-elements.test.ts
+++ b/test/web-components-measure-sketch-elements.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type {
+  HonuaMeasureChangeDetail,
+  HonuaMeasureMode,
+  HonuaMeasureProvider,
+  HonuaSketchChangeDetail,
+  HonuaSketchMode,
+  HonuaSketchProvider,
+} from "../src/web-components/index.js";
+
+/**
+ * The unit-test environment has no DOM. These tests install a deliberately tiny
+ * DOM shim that implements only what the measure/sketch elements touch
+ * (`attachShadow`, an `innerHTML`-backed shadow root, `querySelectorAll`,
+ * attribute access, and `CustomEvent` dispatch) so we can assert the rendered
+ * enabled/disabled affordance and the emitted change-event geometry without
+ * pulling in jsdom/happy-dom as a dependency.
+ */
+
+interface FakeButton {
+  readonly dataset: Record<string, string>;
+  disabled: boolean;
+  ariaDisabled: boolean;
+  readonly handlers: Array<() => void>;
+  addEventListener(type: string, handler: () => void): void;
+  click(): void;
+}
+
+class FakeShadowRoot {
+  #html = "";
+  #buttons: FakeButton[] = [];
+
+  public get innerHTML(): string {
+    return this.#html;
+  }
+
+  public set innerHTML(value: string) {
+    this.#html = value;
+    this.#buttons = parseButtons(value);
+  }
+
+  public querySelectorAll(selector: string): FakeButton[] {
+    const attr = selector.includes("data-measure-mode") ? "measureMode" : "sketchMode";
+    return this.#buttons.filter((button) => attr in button.dataset);
+  }
+
+  public querySelector(): null {
+    return null;
+  }
+}
+
+function parseButtons(html: string): FakeButton[] {
+  const buttons: FakeButton[] = [];
+  const re = /<button\b([^>]*)>/g;
+  let match: RegExpExecArray | null = re.exec(html);
+  while (match !== null) {
+    const tag = match[1] ?? "";
+    const dataset: Record<string, string> = {};
+    const measure = /data-measure-mode="([^"]*)"/.exec(tag);
+    const sketch = /data-sketch-mode="([^"]*)"/.exec(tag);
+    if (measure) dataset.measureMode = measure[1] ?? "";
+    if (sketch) dataset.sketchMode = sketch[1] ?? "";
+    const disabled = /\bdisabled\b/.test(tag);
+    const ariaDisabled = /aria-disabled="true"/.test(tag);
+    const handlers: Array<() => void> = [];
+    buttons.push({
+      dataset,
+      disabled,
+      ariaDisabled,
+      handlers,
+      addEventListener(_type, handler) {
+        handlers.push(handler);
+      },
+      click() {
+        for (const handler of handlers) handler();
+      },
+    });
+    match = re.exec(html);
+  }
+  return buttons;
+}
+
+class FakeCustomEvent<D> {
+  public readonly type: string;
+  public readonly detail: D;
+  public constructor(type: string, init: { detail: D }) {
+    this.type = type;
+    this.detail = init.detail;
+  }
+}
+
+const originalHtmlElement = (globalThis as Record<string, unknown>).HTMLElement;
+const originalCustomEvent = (globalThis as Record<string, unknown>).CustomEvent;
+
+beforeEach(() => {
+  class FakeHTMLElement {
+    public shadowRoot: FakeShadowRoot | undefined;
+    readonly #attributes = new Map<string, string>();
+    public readonly events: Array<FakeCustomEvent<unknown>> = [];
+    public attachShadow(): FakeShadowRoot {
+      this.shadowRoot = new FakeShadowRoot();
+      return this.shadowRoot;
+    }
+    public getAttribute(name: string): string | null {
+      return this.#attributes.get(name) ?? null;
+    }
+    public setAttribute(name: string, value: string): void {
+      this.#attributes.set(name, value);
+    }
+    public getRootNode(): undefined {
+      return undefined;
+    }
+    public dispatchEvent(event: FakeCustomEvent<unknown>): boolean {
+      this.events.push(event);
+      return true;
+    }
+    public addEventListener(): void {}
+    public removeEventListener(): void {}
+  }
+  (globalThis as Record<string, unknown>).HTMLElement = FakeHTMLElement;
+  (globalThis as Record<string, unknown>).CustomEvent = FakeCustomEvent;
+});
+
+afterEach(() => {
+  (globalThis as Record<string, unknown>).HTMLElement = originalHtmlElement;
+  (globalThis as Record<string, unknown>).CustomEvent = originalCustomEvent;
+});
+
+async function loadElements() {
+  // Import after the globals are installed (see `installDom`) so the element
+  // base class binds to the fake HTMLElement. The module is cached after the
+  // first import; the fake DOM is functionally identical on every test.
+  return await import("../src/web-components/elements.js");
+}
+
+interface ControllerStub {
+  getState(): { status: string };
+  subscribe(listener: (state: { status: string }) => void): { remove(): void };
+  canMeasure(): boolean;
+  canSketch(): boolean;
+  setMeasureMode(mode: HonuaMeasureMode): Promise<HonuaMeasureChangeDetail>;
+  setSketchMode(mode: HonuaSketchMode): Promise<HonuaSketchChangeDetail>;
+}
+
+const baseControllerStub = {
+  getState: () => ({ status: "ready" }),
+  subscribe: (listener: (state: { status: string }) => void) => {
+    listener({ status: "ready" });
+    return { remove() {} };
+  },
+};
+
+const measureProvider: HonuaMeasureProvider = {
+  startMode: (mode) =>
+    mode === "off"
+      ? undefined
+      : {
+          mode,
+          coordinates: [
+            [-157.87, 21.31],
+            [-157.86, 21.29],
+          ],
+          distance: 2400,
+        },
+};
+
+const sketchProvider: HonuaSketchProvider = {
+  startMode: (mode) => (mode === "off" ? undefined : { mode, id: "drawn-1", geometry: { x: -157.86, y: 21.3 } }),
+};
+
+describe("measure and sketch control elements", () => {
+  it("renders measure modes disabled with a configure-a-provider affordance when none is supplied", async () => {
+    const { HonuaMeasureControlElement } = await loadElements();
+    const element = new HonuaMeasureControlElement() as unknown as {
+      controller?: ControllerStub;
+      shadowRoot?: FakeShadowRoot;
+      connectedCallback(): void;
+    };
+    element.controller = { ...baseControllerStub, canMeasure: () => false } as unknown as ControllerStub;
+    element.connectedCallback();
+
+    const html = element.shadowRoot?.innerHTML ?? "";
+    expect(html).toContain("no geometry provider is configured");
+    expect(html).toContain("measurementGeometry");
+    const buttons = element.shadowRoot?.querySelectorAll("button[data-measure-mode]") ?? [];
+    expect(buttons.length).toBeGreaterThan(0);
+    expect(buttons.every((button) => button.disabled && button.ariaDisabled)).toBe(true);
+  });
+
+  it("enables measure modes and emits geometry on mode change when a provider is supplied", async () => {
+    const { HonuaMeasureControlElement } = await loadElements();
+    const controller = {
+      ...baseControllerStub,
+      canMeasure: () => true,
+      canSketch: () => false,
+      setMeasureMode: (mode: HonuaMeasureMode) =>
+        Promise.resolve({ mode, status: "ready", result: measureProvider.startMode(mode) } as HonuaMeasureChangeDetail),
+      setSketchMode: () => Promise.resolve({ mode: "off", status: "unsupported" } as HonuaSketchChangeDetail),
+    } satisfies ControllerStub;
+    const element = new HonuaMeasureControlElement() as unknown as {
+      controller?: ControllerStub;
+      shadowRoot?: FakeShadowRoot;
+      events: Array<FakeCustomEvent<HonuaMeasureChangeDetail>>;
+      connectedCallback(): void;
+    };
+    element.controller = controller;
+    element.connectedCallback();
+
+    const buttons = element.shadowRoot?.querySelectorAll("button[data-measure-mode]") ?? [];
+    expect(buttons.every((button) => !button.disabled)).toBe(true);
+    const distance = buttons.find((button) => button.dataset.measureMode === "distance");
+    expect(distance).toBeDefined();
+    distance?.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const change = element.events.at(-1);
+    expect(change?.type).toBe("honua-measure-change");
+    expect(change?.detail.status).toBe("ready");
+    expect(change?.detail.result?.distance).toBe(2400);
+  });
+
+  it("enables sketch modes and emits geometry on mode change when a provider is supplied", async () => {
+    const { HonuaSketchControlElement } = await loadElements();
+    const controller = {
+      ...baseControllerStub,
+      canMeasure: () => false,
+      canSketch: () => true,
+      setMeasureMode: () => Promise.resolve({ mode: "off", status: "unsupported" } as HonuaMeasureChangeDetail),
+      setSketchMode: (mode: HonuaSketchMode) =>
+        Promise.resolve({ mode, status: "ready", result: sketchProvider.startMode(mode) } as HonuaSketchChangeDetail),
+    } satisfies ControllerStub;
+    const element = new HonuaSketchControlElement() as unknown as {
+      controller?: ControllerStub;
+      shadowRoot?: FakeShadowRoot;
+      events: Array<FakeCustomEvent<HonuaSketchChangeDetail>>;
+      connectedCallback(): void;
+    };
+    element.controller = controller;
+    element.connectedCallback();
+
+    const buttons = element.shadowRoot?.querySelectorAll("button[data-sketch-mode]") ?? [];
+    expect(buttons.every((button) => !button.disabled)).toBe(true);
+    const point = buttons.find((button) => button.dataset.sketchMode === "point");
+    point?.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const change = element.events.at(-1);
+    expect(change?.type).toBe("honua-sketch-change");
+    expect(change?.detail.status).toBe("ready");
+    expect(change?.detail.result?.id).toBe("drawn-1");
+  });
+});


### PR DESCRIPTION
## Summary

Second backlog batch — completes the native control kit, adds realtime/imagery/terrain consumption helpers, ships a prebuilt browser bundle, and audits the two contract epics (both already substantially implemented; gap tests added).

Closes #274, #280, #279, #283, #273, #263, #233, #228.

## Changes

### Native control kit (closes umbrella #274)
- **#280** `<honua-layer-list>` — framework-free overlay-toggle element in `@honua/sdk-js/controls` (duck-typed Map, `for=`/`honua-map-ready` wiring, `auto-refresh` on `styledata`, `::part()` hooks, graceful "not seeded" state, `change` event). Last piece of #274.
- **#279** `<honua-swipe-control>` compare/swipe element (draggable clip-path divider, vertical/horizontal, keyboard a11y); `decodeTerrainRgbElevation` / `decodeTerrariumElevation` / `sampleElevationProfile` terrain utilities exported from the package index; STAC browser-bundle guidance docs (HonuaStacSearch was already exported).

### Web components (#283)
- Pluggable measurement/sketch geometry provider seam (`measurementGeometry` / `sketchGeometry` on `CreateHonuaWebComponentControllerOptions`; `HonuaMeasureProvider` / `HonuaSketchProvider` interfaces). With a provider the measure/sketch controls enable, draw, and emit real geometry; without one they stay disabled with a "configure a provider" affordance (no hard maplibre-gl-draw dependency). Documented.

### Realtime (#273)
- First-party `honua-server` SSE preset: `honuaServerRealtimePreset()`, `createHonuaServerRealtimeSubscription()`, request encoder (`serviceId=`/`layers=`) and feature-change `decodeEvent`. Additive; default behavior unchanged.

### Browser bundle (#263)
- `scripts/build-browser-bundle.mjs` (esbuild, already in node_modules) + `build:browser` script producing `dist/browser/honua-sdk.min.js` (IIFE, `window.HonuaSDK`) and `.esm.js`; peers external. `browser`/`unpkg`/`jsdelivr` fields + `./browser` export + `files` entry. Artifacts are gitignored (built at publish time). Docs added.

### Contract epics — audited, already satisfied (gap tests only)
- **#233** Share/embed/open-data: every acceptance criterion already met by `src/share/*` + `docs/`; added a test covering the `public-content` grant + a direct `forbidden` denial.
- **#228** Replica/sync conflict: all criteria met by `src/replica-sync/*`; tightened composition with the (closed) #227 temporal contracts by reusing shared `FeatureId`/`SourceId` aliases + a composition test.

## Validation

Each issue implemented in an isolated worktree, merged here (one expected conflict in the controls barrel/registration, resolved to keep both elements). On the integration branch:
- `npm run typecheck` — clean
- `npm run check` (Biome, 629 files) — clean
- `npm run build` + `npm run verify:split-packages` — ok
- `npm run build:browser` — produces both bundles, `window.HonuaSDK` asserted
- `npm test` — **214 files / 2308 tests pass**
