### PR TITLE
feat: honua API CLI (replaces curl in docs/demos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,31 @@ See [`docs/quickstart.md`](./docs/quickstart.md) for the guided walkthrough,
 modes, and [`examples/maplibre-quickstart/`](./examples/maplibre-quickstart/README.md) for the
 committed source.
 
+## Command-line client (`honua`)
+
+Installing the SDK also installs a first-class **`honua` CLI** — the same
+querying and catalog browsing without writing code. It wraps the SDK (no raw
+HTTP, no URL-encoding, no `f=json`), prints readable tables by default, and adds
+`--json` / `--format geojson` for machine output.
+
+```bash
+npm i -g @honua/sdk-js            # or: npx @honua/sdk-js honua <command>
+export HONUA_BASE_URL=https://demo.honua.io   # anonymous reads on the public demo
+
+honua services                    # list published services
+honua layers maui-parcels         # list a service's layers
+honua query maui-parcels/1 --count
+honua query maui-parcels/1 --where "tmk_txt LIKE '2%'" --limit 5
+honua query maui-parcels/1 --bbox -156.7,20.7,-156.3,21.0 --format geojson
+honua stac collections
+honua geocode "1 Honolulu Pl, HI"
+honua map export maui-parcels --bbox -156.7,20.7,-156.3,21.0 --size 800x600 -o maui.png
+```
+
+Authentication resolves from `--api-key`, `HONUA_API_KEY`, or a saved
+`honua login`. Run `honua --help` for the full command surface. This is the
+recommended replacement for `curl` in docs and demos.
+
 ## What you can build
 
 | Demo | What it shows |

--- a/package.json
+++ b/package.json
@@ -184,7 +184,14 @@
     "./operate": {
       "types": "./dist/src/operate/index.d.ts",
       "default": "./dist/src/operate/index.js"
+    },
+    "./cli": {
+      "types": "./dist/src/cli/main.d.ts",
+      "default": "./dist/src/cli/main.js"
     }
+  },
+  "bin": {
+    "honua": "./dist/src/cli/bin.js"
   },
   "scripts": {
     "clean": "rm -rf dist",

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,0 +1,176 @@
+/**
+ * Minimal, dependency-free flag parser for the `honua` CLI.
+ *
+ * Supports `--flag value`, `--flag=value`, repeated flags (collected into an
+ * array), boolean flags, short aliases, and positional arguments. Kept tiny and
+ * pure so argument handling is unit-testable without spawning a process.
+ *
+ * @packageDocumentation
+ */
+
+export interface FlagSpec {
+  /** Long name without leading dashes, e.g. `"where"`. */
+  name: string;
+  /** Single-char alias without dash, e.g. `"o"`. */
+  alias?: string;
+  /** Boolean flags consume no value. */
+  boolean?: boolean;
+  /** Allow the flag to repeat; values collected into an array. */
+  multiple?: boolean;
+}
+
+export interface ParsedArgs {
+  positionals: string[];
+  flags: Record<string, string | string[] | boolean>;
+}
+
+export class ArgError extends Error {}
+
+function findSpec(specs: ReadonlyArray<FlagSpec>, token: string): FlagSpec | undefined {
+  if (token.startsWith("--")) {
+    const name = token.slice(2);
+    return specs.find((s) => s.name === name);
+  }
+  if (token.startsWith("-")) {
+    const alias = token.slice(1);
+    return specs.find((s) => s.alias === alias);
+  }
+  return undefined;
+}
+
+/**
+ * Parse `argv` (already sliced past the command) against `specs`.
+ *
+ * @throws {ArgError} for unknown flags or flags missing a required value.
+ */
+export function parseArgs(argv: ReadonlyArray<string>, specs: ReadonlyArray<FlagSpec>): ParsedArgs {
+  const positionals: string[] = [];
+  const flags: Record<string, string | string[] | boolean> = {};
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+
+    if (token === "--") {
+      // Everything after `--` is positional.
+      positionals.push(...argv.slice(i + 1));
+      break;
+    }
+
+    if (!token.startsWith("-") || token === "-") {
+      positionals.push(token);
+      continue;
+    }
+
+    // Handle `--flag=value`.
+    let inlineValue: string | undefined;
+    let lookup = token;
+    const eq = token.indexOf("=");
+    if (token.startsWith("--") && eq !== -1) {
+      lookup = token.slice(0, eq);
+      inlineValue = token.slice(eq + 1);
+    }
+
+    const spec = findSpec(specs, lookup);
+    if (!spec) {
+      throw new ArgError(`Unknown option: ${lookup}`);
+    }
+
+    if (spec.boolean) {
+      if (inlineValue !== undefined) {
+        flags[spec.name] = inlineValue !== "false" && inlineValue !== "0";
+      } else {
+        flags[spec.name] = true;
+      }
+      continue;
+    }
+
+    let value: string;
+    if (inlineValue !== undefined) {
+      value = inlineValue;
+    } else {
+      const next = argv[i + 1];
+      if (next === undefined) {
+        throw new ArgError(`Option ${lookup} requires a value`);
+      }
+      value = next;
+      i += 1;
+    }
+
+    if (spec.multiple) {
+      const existing = flags[spec.name];
+      if (Array.isArray(existing)) {
+        existing.push(value);
+      } else {
+        flags[spec.name] = [value];
+      }
+    } else {
+      flags[spec.name] = value;
+    }
+  }
+
+  return { positionals, flags };
+}
+
+/** Read a string flag, or `undefined`. */
+export function getString(parsed: ParsedArgs, name: string): string | undefined {
+  const v = parsed.flags[name];
+  if (typeof v === "string") return v;
+  if (Array.isArray(v)) return v[v.length - 1];
+  return undefined;
+}
+
+/** Read a boolean flag (defaults to `false`). */
+export function getBoolean(parsed: ParsedArgs, name: string): boolean {
+  return parsed.flags[name] === true;
+}
+
+/** Read a repeated flag as an array (always defined, possibly empty). */
+export function getArray(parsed: ParsedArgs, name: string): string[] {
+  const v = parsed.flags[name];
+  if (Array.isArray(v)) return v;
+  if (typeof v === "string") return [v];
+  return [];
+}
+
+/** Read and parse a numeric flag. @throws {ArgError} when not a finite number. */
+export function getNumber(parsed: ParsedArgs, name: string): number | undefined {
+  const v = getString(parsed, name);
+  if (v === undefined) return undefined;
+  const n = Number(v);
+  if (!Number.isFinite(n)) {
+    throw new ArgError(`Option --${name} must be a number, got: ${v}`);
+  }
+  return n;
+}
+
+/**
+ * Parse a `bbox` flag of the form `minx,miny,maxx,maxy` into a 4-tuple.
+ *
+ * @throws {ArgError} when malformed.
+ */
+export function parseBbox(value: string): [number, number, number, number] {
+  const parts = value.split(",").map((p) => Number(p.trim()));
+  if (parts.length !== 4 || parts.some((n) => !Number.isFinite(n))) {
+    throw new ArgError(`--bbox must be "minx,miny,maxx,maxy", got: ${value}`);
+  }
+  return [parts[0], parts[1], parts[2], parts[3]];
+}
+
+/**
+ * Split a `service/layer` reference into its parts.
+ *
+ * @throws {ArgError} when the layer id is missing or not an integer.
+ */
+export function parseServiceLayer(ref: string): { service: string; layer: number } {
+  const slash = ref.lastIndexOf("/");
+  if (slash === -1) {
+    throw new ArgError(`Expected "<service>/<layer>", got: ${ref}`);
+  }
+  const service = ref.slice(0, slash);
+  const layerRaw = ref.slice(slash + 1);
+  const layer = Number(layerRaw);
+  if (service.trim() === "" || !Number.isInteger(layer)) {
+    throw new ArgError(`Expected "<service>/<layer>" with an integer layer id, got: ${ref}`);
+  }
+  return { service, layer };
+}

--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+/**
+ * Executable shim for the `honua` CLI. Delegates to {@link run} and translates
+ * its resolved exit code into a process exit.
+ *
+ * @packageDocumentation
+ */
+
+import { run } from "./main.js";
+
+run(process.argv.slice(2))
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((err: unknown) => {
+    process.stderr.write(`fatal: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`);
+    process.exitCode = 1;
+  });

--- a/src/cli/client.ts
+++ b/src/cli/client.ts
@@ -1,0 +1,23 @@
+/**
+ * Thin factory that turns resolved CLI connection settings into the SDK clients
+ * the commands use. Reusing the published SDK means the CLI never hand-rolls
+ * HTTP — it inherits retries, auth, PBF decoding, and error types for free.
+ *
+ * @packageDocumentation
+ */
+
+import { HonuaClient } from "../core/client.js";
+import { HonuaGeocodingClient } from "../geocoding/index.js";
+import { type ResolveOptions, resolveConnection } from "./config.js";
+
+/** Build a {@link HonuaClient} from CLI flags / env / saved config. */
+export function createClient(options: ResolveOptions = {}): HonuaClient {
+  const { baseUrl, apiKey } = resolveConnection(options);
+  return new HonuaClient({ baseUrl, apiKey });
+}
+
+/** Build a {@link HonuaGeocodingClient} from CLI flags / env / saved config. */
+export function createGeocodingClient(options: ResolveOptions & { locatorName?: string } = {}): HonuaGeocodingClient {
+  const { baseUrl, apiKey } = resolveConnection(options);
+  return new HonuaGeocodingClient({ baseUrl, apiKey, locatorName: options.locatorName });
+}

--- a/src/cli/command.ts
+++ b/src/cli/command.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared types for `honua` CLI command handlers.
+ *
+ * @packageDocumentation
+ */
+
+import type { ParsedArgs } from "./args.js";
+
+/** Connection context resolved once from global flags and passed to every command. */
+export interface CommandContext {
+  baseUrl?: string;
+  apiKey?: string;
+}
+
+export type CommandHandler = (parsed: ParsedArgs, ctx: CommandContext) => Promise<void>;

--- a/src/cli/commands/catalog.ts
+++ b/src/cli/commands/catalog.ts
@@ -1,0 +1,71 @@
+/**
+ * `honua services` and `honua layers <service>` — catalog/layer browsing.
+ *
+ * @packageDocumentation
+ */
+
+import type { ParsedArgs } from "../args.js";
+import { getBoolean } from "../args.js";
+import { createClient } from "../client.js";
+import type { CommandContext } from "../command.js";
+import { printLine, renderJson, renderTable } from "../output.js";
+
+export async function servicesCommand(parsed: ParsedArgs, ctx: CommandContext): Promise<void> {
+  const client = createClient({ baseUrl: ctx.baseUrl, apiKey: ctx.apiKey });
+  const response = await client.listServices();
+  const services = response.services ?? [];
+
+  if (getBoolean(parsed, "json")) {
+    printLine(renderJson(response));
+    return;
+  }
+
+  const rows = services.map((s) => ({ name: s.name, type: s.type }));
+  printLine(
+    renderTable(
+      rows,
+      [
+        { key: "name", header: "SERVICE" },
+        { key: "type", header: "TYPE" },
+      ],
+      { title: `Services on ${client.serverBaseUrl}`, emptyText: "(no services)" },
+    ),
+  );
+  if (rows.length > 0) printLine(`\n${rows.length} service(s).`);
+}
+
+export async function layersCommand(parsed: ParsedArgs, ctx: CommandContext): Promise<void> {
+  const serviceId = parsed.positionals[0];
+  if (!serviceId) {
+    throw new Error("Usage: honua layers <service>");
+  }
+  const client = createClient({ baseUrl: ctx.baseUrl, apiKey: ctx.apiKey });
+  const service = client.service(serviceId);
+  const metadata = await service.featureServiceMetadata();
+  const layers = metadata.layers ?? [];
+  const tables = metadata.tables ?? [];
+
+  if (getBoolean(parsed, "json")) {
+    printLine(renderJson({ layers, tables, serviceDescription: metadata.serviceDescription }));
+    return;
+  }
+
+  const rows = [
+    ...layers.map((l) => ({ id: l.id, name: l.name, kind: "layer" })),
+    ...tables.map((t) => ({ id: t.id, name: t.name, kind: "table" })),
+  ];
+  printLine(
+    renderTable(
+      rows,
+      [
+        { key: "id", header: "ID", align: "right" },
+        { key: "name", header: "NAME" },
+        { key: "kind", header: "KIND" },
+      ],
+      { title: `Layers in ${serviceId}`, emptyText: "(no layers)" },
+    ),
+  );
+  if (rows.length > 0) {
+    printLine(`\nQuery one with:  honua query ${serviceId}/${rows[0].id} --limit 10`);
+  }
+}

--- a/src/cli/commands/geocode.ts
+++ b/src/cli/commands/geocode.ts
@@ -1,0 +1,47 @@
+/**
+ * `honua geocode "<address>"` — forward geocoding via the SDK geocoding client.
+ *
+ * @packageDocumentation
+ */
+
+import type { ParsedArgs } from "../args.js";
+import { getBoolean, getNumber, getString } from "../args.js";
+import { createGeocodingClient } from "../client.js";
+import type { CommandContext } from "../command.js";
+import { printLine, renderJson, renderTable } from "../output.js";
+
+export async function geocodeCommand(parsed: ParsedArgs, ctx: CommandContext): Promise<void> {
+  const address = parsed.positionals.join(" ").trim();
+  if (!address) {
+    throw new Error('Usage: honua geocode "<address>" [--locator <name>] [--limit N]');
+  }
+  const locatorName = getString(parsed, "locator");
+  const geo = createGeocodingClient({ baseUrl: ctx.baseUrl, apiKey: ctx.apiKey, locatorName });
+
+  const maxResults = getNumber(parsed, "limit");
+  const results = await geo.forwardGeocode(address, maxResults ? { maxResults } : undefined);
+
+  if (getBoolean(parsed, "json")) {
+    printLine(renderJson(results));
+    return;
+  }
+
+  const rows = results.map((r) => ({
+    address: r.address,
+    lat: r.latitude.toFixed(6),
+    lon: r.longitude.toFixed(6),
+    score: r.score,
+  }));
+  printLine(
+    renderTable(
+      rows,
+      [
+        { key: "address", header: "MATCH" },
+        { key: "lat", header: "LAT", align: "right" },
+        { key: "lon", header: "LON", align: "right" },
+        { key: "score", header: "SCORE", align: "right" },
+      ],
+      { title: `Geocode: "${address}"`, emptyText: "(no candidates)" },
+    ),
+  );
+}

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -9,7 +9,7 @@ import fs from "node:fs";
 import type { ParsedArgs } from "../args.js";
 import { getString } from "../args.js";
 import type { CommandContext } from "../command.js";
-import { configPath, readConfig, resolveConnection, writeConfig } from "../config.js";
+import { configPath, readConfig, resolveConnection, stripTrailingSlashes, writeConfig } from "../config.js";
 import { printLine, renderDetail } from "../output.js";
 
 export async function loginCommand(parsed: ParsedArgs, ctx: CommandContext): Promise<void> {
@@ -19,7 +19,7 @@ export async function loginCommand(parsed: ParsedArgs, ctx: CommandContext): Pro
     throw new Error("`honua login` requires --base-url <url> (and optionally --api-key <key>).");
   }
   const existing = readConfig();
-  const config = { ...existing, baseUrl: baseUrl.replace(/\/+$/, "") };
+  const config = { ...existing, baseUrl: stripTrailingSlashes(baseUrl) };
   if (apiKey) config.apiKey = apiKey;
   const file = writeConfig(config);
   printLine(

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -1,0 +1,59 @@
+/**
+ * `honua login` / `honua logout` / `honua whoami` — persist and inspect the
+ * base URL + API key used for subsequent commands.
+ *
+ * @packageDocumentation
+ */
+
+import fs from "node:fs";
+import type { ParsedArgs } from "../args.js";
+import { getString } from "../args.js";
+import type { CommandContext } from "../command.js";
+import { configPath, readConfig, resolveConnection, writeConfig } from "../config.js";
+import { printLine, renderDetail } from "../output.js";
+
+export async function loginCommand(parsed: ParsedArgs, ctx: CommandContext): Promise<void> {
+  const baseUrl = getString(parsed, "base-url") ?? ctx.baseUrl;
+  const apiKey = getString(parsed, "api-key") ?? ctx.apiKey;
+  if (!baseUrl) {
+    throw new Error("`honua login` requires --base-url <url> (and optionally --api-key <key>).");
+  }
+  const existing = readConfig();
+  const config = { ...existing, baseUrl: baseUrl.replace(/\/+$/, "") };
+  if (apiKey) config.apiKey = apiKey;
+  const file = writeConfig(config);
+  printLine(
+    renderDetail(
+      { baseUrl: config.baseUrl, apiKey: config.apiKey ? "***saved***" : "(none — anonymous)", saved: file },
+      { title: "Logged in" },
+    ),
+  );
+}
+
+export async function logoutCommand(_parsed: ParsedArgs, _ctx: CommandContext): Promise<void> {
+  const file = configPath();
+  try {
+    fs.rmSync(file);
+    printLine(`Removed ${file}`);
+  } catch {
+    printLine("No saved credentials to remove.");
+  }
+}
+
+export async function whoamiCommand(_parsed: ParsedArgs, ctx: CommandContext): Promise<void> {
+  try {
+    const conn = resolveConnection({ baseUrl: ctx.baseUrl, apiKey: ctx.apiKey });
+    printLine(
+      renderDetail(
+        {
+          baseUrl: conn.baseUrl,
+          source: conn.source,
+          auth: conn.apiKey ? "api-key" : "anonymous",
+        },
+        { title: "Current connection" },
+      ),
+    );
+  } catch (err) {
+    printLine((err as Error).message);
+  }
+}

--- a/src/cli/commands/map.ts
+++ b/src/cli/commands/map.ts
@@ -1,0 +1,140 @@
+/**
+ * `honua map export <service>/<layer-or-*>` and `honua tiles <service> z/x/y`
+ * — visual payoff verbs that render a map image to disk.
+ *
+ * `map export` calls the MapServer `export` operation via the SDK, then fetches
+ * the returned image href and writes the bytes. `tiles` resolves a single XYZ /
+ * Esri tile URL (and optionally downloads it).
+ *
+ * @packageDocumentation
+ */
+
+import fs from "node:fs";
+import type { ParsedArgs } from "../args.js";
+import { ArgError, getBoolean, getString, parseBbox } from "../args.js";
+import { createClient } from "../client.js";
+import type { CommandContext } from "../command.js";
+import { printLine, renderDetail, renderJson } from "../output.js";
+
+export async function mapCommand(parsed: ParsedArgs, ctx: CommandContext): Promise<void> {
+  const sub = parsed.positionals[0];
+  const rest: ParsedArgs = { positionals: parsed.positionals.slice(1), flags: parsed.flags };
+  if (sub === "export") return mapExport(rest, ctx);
+  throw new Error("Usage: honua map export <service>[/<layers>] --bbox ... --size WxH -o out.png");
+}
+
+async function mapExport(parsed: ParsedArgs, ctx: CommandContext): Promise<void> {
+  const ref = parsed.positionals[0];
+  if (!ref) {
+    throw new ArgError("Usage: honua map export <service>[/<layers>] --bbox minx,miny,maxx,maxy --size WxH -o out.png");
+  }
+  // service ref may be "service" or "service/<layerSpec>" (e.g. "show:1").
+  const slash = ref.indexOf("/");
+  const service = slash === -1 ? ref : ref.slice(0, slash);
+  const layerSpec = slash === -1 ? undefined : ref.slice(slash + 1);
+
+  const bboxRaw = getString(parsed, "bbox");
+  if (!bboxRaw) throw new ArgError("--bbox is required, e.g. --bbox -156.7,20.7,-156.3,21.0");
+  const bbox = parseBbox(bboxRaw);
+
+  const sizeRaw = getString(parsed, "size") ?? "800x600";
+  const sizeParts = sizeRaw.split(/[x,]/).map((n) => Number(n.trim()));
+  if (sizeParts.length !== 2 || sizeParts.some((n) => !Number.isFinite(n))) {
+    throw new ArgError(`--size must be "WxH", got: ${sizeRaw}`);
+  }
+  const [width, height] = sizeParts;
+
+  const format = getString(parsed, "format") ?? "png";
+  const outPath = getString(parsed, "output");
+
+  const client = createClient({ baseUrl: ctx.baseUrl, apiKey: ctx.apiKey });
+  const result = await client.exportMap({
+    serviceId: service,
+    bbox,
+    size: [width, height],
+    format,
+    ...(layerSpec ? { layers: layerSpec } : {}),
+    responseFormat: "json",
+  });
+
+  if (getBoolean(parsed, "json")) {
+    printLine(renderJson(result));
+    return;
+  }
+
+  if (!result.href) {
+    throw new Error("Server returned no image href for the export request.");
+  }
+
+  if (outPath) {
+    const res = await fetch(result.href, ctx.apiKey ? { headers: { "X-API-Key": ctx.apiKey } } : undefined);
+    if (!res.ok) {
+      throw new Error(`Failed to download exported image (${res.status} ${res.statusText}) from ${result.href}`);
+    }
+    const bytes = Buffer.from(await res.arrayBuffer());
+    fs.writeFileSync(outPath, bytes);
+    printLine(
+      renderDetail(
+        {
+          service,
+          bbox: bbox.join(","),
+          size: `${result.width ?? width}x${result.height ?? height}`,
+          format,
+          saved: outPath,
+          bytes: bytes.length,
+        },
+        { title: "Map exported" },
+      ),
+    );
+  } else {
+    printLine(
+      renderDetail(
+        {
+          service,
+          size: `${result.width ?? width}x${result.height ?? height}`,
+          format,
+          href: result.href,
+        },
+        { title: "Map export ready (pass -o <file.png> to download)" },
+      ),
+    );
+  }
+}
+
+export async function tilesCommand(parsed: ParsedArgs, ctx: CommandContext): Promise<void> {
+  const service = parsed.positionals[0];
+  const zxy = parsed.positionals[1];
+  if (!service || !zxy) {
+    throw new ArgError("Usage: honua tiles <service> <z>/<x>/<y> [-o tile.png]");
+  }
+  const parts = zxy.split("/").map((n) => Number(n.trim()));
+  if (parts.length !== 3 || parts.some((n) => !Number.isInteger(n))) {
+    throw new ArgError(`Expected "<z>/<x>/<y>" integers, got: ${zxy}`);
+  }
+  const [z, x, y] = parts;
+  const format = (getString(parsed, "format") ?? "png") as "png" | "jpg" | "jpeg" | "tif" | "tiff";
+
+  const client = createClient({ baseUrl: ctx.baseUrl, apiKey: ctx.apiKey });
+  // Esri tile addressing is level/row/col == z/y/x.
+  const url = client.imageService(service).tileUrl(z, y, x, format);
+
+  const outPath = getString(parsed, "output");
+  if (outPath) {
+    const res = await fetch(url, ctx.apiKey ? { headers: { "X-API-Key": ctx.apiKey } } : undefined);
+    if (!res.ok) {
+      throw new Error(`Failed to download tile (${res.status} ${res.statusText}) from ${url}`);
+    }
+    const bytes = Buffer.from(await res.arrayBuffer());
+    fs.writeFileSync(outPath, bytes);
+    printLine(
+      renderDetail({ service, tile: `${z}/${x}/${y}`, saved: outPath, bytes: bytes.length }, { title: "Tile saved" }),
+    );
+    return;
+  }
+
+  if (getBoolean(parsed, "json")) {
+    printLine(renderJson({ service, z, x, y, url }));
+    return;
+  }
+  printLine(renderDetail({ service, tile: `${z}/${x}/${y}`, url }, { title: "Tile URL" }));
+}

--- a/src/cli/commands/query.ts
+++ b/src/cli/commands/query.ts
@@ -1,0 +1,152 @@
+/**
+ * `honua query <service>/<layer>` — the workhorse verb.
+ *
+ * Pretty table by default; `--format geojson` (or `--json`) for machine output;
+ * `--count` for a fast feature count. Spatial filtering via `--bbox`.
+ *
+ * @packageDocumentation
+ */
+
+import type { HonuaFeatureLayerQueryRequest } from "../../core/surfaces.js";
+import type { HonuaTypedFeature } from "../../core/types.js";
+import type { ParsedArgs } from "../args.js";
+import { ArgError, getArray, getBoolean, getNumber, getString, parseBbox, parseServiceLayer } from "../args.js";
+import { createClient } from "../client.js";
+import type { CommandContext } from "../command.js";
+import { printLine, renderJson, renderTable } from "../output.js";
+
+const DEFAULT_LIMIT = 25;
+
+function bboxToEnvelope(bbox: [number, number, number, number]): {
+  geometry: Record<string, unknown>;
+  geometryType: "esriGeometryEnvelope";
+  spatialRel: "esriSpatialRelIntersects";
+} {
+  const [xmin, ymin, xmax, ymax] = bbox;
+  return {
+    geometry: { xmin, ymin, xmax, ymax, spatialReference: { wkid: 4326 } },
+    geometryType: "esriGeometryEnvelope",
+    spatialRel: "esriSpatialRelIntersects",
+  };
+}
+
+/** Convert an Esri-style typed feature into a GeoJSON Feature. */
+function toGeoJsonFeature(feature: HonuaTypedFeature<Record<string, unknown>>): Record<string, unknown> {
+  const geom = feature.geometry as Record<string, unknown> | null | undefined;
+  let geometry: Record<string, unknown> | null = null;
+  if (geom) {
+    if (typeof geom.x === "number" && typeof geom.y === "number") {
+      geometry = { type: "Point", coordinates: [geom.x, geom.y] };
+    } else if (Array.isArray(geom.rings)) {
+      geometry = { type: "Polygon", coordinates: geom.rings };
+    } else if (Array.isArray(geom.paths)) {
+      geometry = { type: "MultiLineString", coordinates: geom.paths };
+    } else if (Array.isArray(geom.points)) {
+      geometry = { type: "MultiPoint", coordinates: geom.points };
+    }
+  }
+  return { type: "Feature", geometry, properties: feature.attributes };
+}
+
+export async function queryCommand(parsed: ParsedArgs, ctx: CommandContext): Promise<void> {
+  const ref = parsed.positionals[0];
+  if (!ref) {
+    throw new ArgError("Usage: honua query <service>/<layer> [--where ... --bbox ... --count]");
+  }
+  const { service, layer } = parseServiceLayer(ref);
+  const client = createClient({ baseUrl: ctx.baseUrl, apiKey: ctx.apiKey });
+  const featureLayer = client.featureLayer(service, layer);
+
+  const where = getString(parsed, "where");
+  const bboxRaw = getString(parsed, "bbox");
+  const format = (getString(parsed, "format") ?? "table").toLowerCase();
+  const asJson = getBoolean(parsed, "json") || format === "json";
+  const asGeoJson = format === "geojson";
+
+  // --count: short-circuit to a fast count. We issue the query directly with
+  // `returnCountOnly` (rather than the SDK's `queryFeatureCount`, which pins
+  // `outFields=OBJECTID` and 400s on servers whose OID field is named otherwise)
+  // and read the `count` envelope.
+  if (getBoolean(parsed, "count")) {
+    const countResponse = (await featureLayer.queryFeatures({
+      where: where ?? "1=1",
+      outFields: "*",
+      returnGeometry: false,
+      extraParams: { returnCountOnly: true },
+    })) as { count?: number; features?: unknown[] };
+    const count = typeof countResponse.count === "number" ? countResponse.count : (countResponse.features?.length ?? 0);
+    if (asJson) {
+      printLine(renderJson({ service, layer, where: where ?? "1=1", count }));
+    } else {
+      printLine(`${count}`);
+    }
+    return;
+  }
+
+  const limit = getNumber(parsed, "limit") ?? DEFAULT_LIMIT;
+  const outFields = getArray(parsed, "fields");
+
+  const request: HonuaFeatureLayerQueryRequest = {
+    where: where ?? "1=1",
+    outFields: outFields.length > 0 ? outFields : "*",
+    returnGeometry: asGeoJson,
+    resultRecordCount: limit,
+  };
+  if (bboxRaw) {
+    const env = bboxToEnvelope(parseBbox(bboxRaw));
+    request.geometry = env.geometry;
+    request.geometryType = env.geometryType;
+    request.spatialRel = env.spatialRel;
+    request.returnGeometry = asGeoJson;
+  }
+
+  const response = await featureLayer.queryFeatures(request);
+  const features = (response.features ?? []) as HonuaTypedFeature<Record<string, unknown>>[];
+
+  if (asGeoJson) {
+    const collection = {
+      type: "FeatureCollection",
+      features: features.map(toGeoJsonFeature),
+    };
+    printLine(renderJson(collection));
+    return;
+  }
+
+  if (asJson) {
+    printLine(renderJson(response));
+    return;
+  }
+
+  // Pretty table columns: honor an explicit --fields list, else the server's
+  // declared field order, else the first row's attribute keys.
+  const fieldNames =
+    outFields.length > 0
+      ? outFields
+      : response.fields && response.fields.length > 0
+        ? response.fields.map((f) => f.name)
+        : features.length > 0
+          ? Object.keys(features[0].attributes ?? {})
+          : [];
+
+  const rows = features.map((f) => {
+    const attrs = (f.attributes ?? {}) as Record<string, unknown>;
+    const row: Record<string, string | number | boolean | null> = {};
+    for (const name of fieldNames) {
+      const v = attrs[name];
+      row[name] = v === null || v === undefined ? null : (v as string | number | boolean);
+    }
+    return row;
+  });
+
+  printLine(
+    renderTable(
+      rows,
+      fieldNames.map((name) => ({ key: name, header: name })),
+      { title: `${service}/${layer} — ${where ?? "1=1"}`, emptyText: "(no features matched)" },
+    ),
+  );
+  if (rows.length > 0) {
+    const more = response.exceededTransferLimit ? " (more available; raise --limit)" : "";
+    printLine(`\n${rows.length} feature(s)${more}.`);
+  }
+}

--- a/src/cli/commands/stac.ts
+++ b/src/cli/commands/stac.ts
@@ -1,0 +1,101 @@
+/**
+ * `honua stac collections` and `honua stac search` — STAC catalog browsing.
+ *
+ * @packageDocumentation
+ */
+
+import type { StacSearchRequest } from "../../core/types.js";
+import type { ParsedArgs } from "../args.js";
+import { getArray, getBoolean, getNumber, getString, parseBbox } from "../args.js";
+import { createClient } from "../client.js";
+import type { CommandContext } from "../command.js";
+import { printLine, renderJson, renderTable } from "../output.js";
+
+export async function stacCommand(parsed: ParsedArgs, ctx: CommandContext): Promise<void> {
+  const sub = parsed.positionals[0];
+  const rest: ParsedArgs = { positionals: parsed.positionals.slice(1), flags: parsed.flags };
+  switch (sub) {
+    case "collections":
+      return stacCollections(rest, ctx);
+    case "search":
+      return stacSearch(rest, ctx);
+    default:
+      throw new Error("Usage: honua stac <collections|search> [options]");
+  }
+}
+
+async function stacCollections(parsed: ParsedArgs, ctx: CommandContext): Promise<void> {
+  const client = createClient({ baseUrl: ctx.baseUrl, apiKey: ctx.apiKey });
+  const response = await client.stac().collections();
+  const collections = response.collections ?? [];
+
+  if (getBoolean(parsed, "json")) {
+    printLine(renderJson(response));
+    return;
+  }
+
+  const rows = collections.map((c) => ({
+    id: c.id,
+    title: c.title ?? "",
+    description: (c.description ?? "").replace(/\s+/g, " ").slice(0, 60),
+  }));
+  printLine(
+    renderTable(
+      rows,
+      [
+        { key: "id", header: "COLLECTION" },
+        { key: "title", header: "TITLE" },
+        { key: "description", header: "DESCRIPTION" },
+      ],
+      { title: `STAC collections on ${client.serverBaseUrl}`, emptyText: "(no collections)" },
+    ),
+  );
+  if (rows.length > 0) printLine(`\n${rows.length} collection(s).`);
+}
+
+async function stacSearch(parsed: ParsedArgs, ctx: CommandContext): Promise<void> {
+  const client = createClient({ baseUrl: ctx.baseUrl, apiKey: ctx.apiKey });
+
+  const request: StacSearchRequest = {};
+  const bbox = getString(parsed, "bbox");
+  if (bbox) request.bbox = parseBbox(bbox);
+  const datetime = getString(parsed, "datetime");
+  if (datetime) request.datetime = datetime;
+  const collections = getArray(parsed, "collections").flatMap((c) => c.split(","));
+  if (collections.length > 0) request.collections = collections;
+  request.limit = getNumber(parsed, "limit") ?? 25;
+
+  const response = await client.stac().search(request);
+  const items = response.features ?? [];
+
+  if (getBoolean(parsed, "json")) {
+    printLine(renderJson(response));
+    return;
+  }
+
+  const rows = items.map((item) => {
+    const props = (item.properties ?? {}) as Record<string, unknown>;
+    return {
+      id: String(item.id ?? ""),
+      collection: item.collection ?? "",
+      datetime: String(props.datetime ?? props.start_datetime ?? ""),
+      assets: item.assets ? Object.keys(item.assets).length : 0,
+    };
+  });
+  printLine(
+    renderTable(
+      rows,
+      [
+        { key: "id", header: "ITEM" },
+        { key: "collection", header: "COLLECTION" },
+        { key: "datetime", header: "DATETIME" },
+        { key: "assets", header: "ASSETS", align: "right" },
+      ],
+      { title: "STAC search results", emptyText: "(no items matched)" },
+    ),
+  );
+  const matched = response.numberMatched ?? response.context?.matched;
+  if (rows.length > 0) {
+    printLine(`\n${rows.length} item(s)${matched !== undefined ? ` of ${matched} matched` : ""}.`);
+  }
+}

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -30,6 +30,21 @@ export interface ResolvedConnection {
   source: "flag" | "env" | "config";
 }
 
+/**
+ * Strip any trailing `/` characters from a base URL.
+ *
+ * Implemented as a linear scan rather than a `/\/+$/` regex so it is not
+ * susceptible to polynomial backtracking on attacker- or library-controlled
+ * input (CodeQL js/redos).
+ */
+export function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47 /* '/' */) {
+    end -= 1;
+  }
+  return end === value.length ? value : value.slice(0, end);
+}
+
 /** Directory that holds the persisted CLI config. */
 export function configDir(env: NodeJS.ProcessEnv = process.env): string {
   if (env.HONUA_CONFIG_HOME && env.HONUA_CONFIG_HOME.trim() !== "") {
@@ -110,5 +125,5 @@ export function resolveConnection(options: ResolveOptions = {}): ResolvedConnect
     (env.HONUA_API_KEY && env.HONUA_API_KEY.trim() !== "" ? env.HONUA_API_KEY : undefined) ??
     (saved.apiKey && saved.apiKey.trim() !== "" ? saved.apiKey : undefined);
 
-  return { baseUrl: baseUrl.replace(/\/+$/, ""), apiKey, source };
+  return { baseUrl: stripTrailingSlashes(baseUrl), apiKey, source };
 }

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,0 +1,114 @@
+/**
+ * Configuration + credential resolution for the `honua` CLI.
+ *
+ * Precedence (highest first):
+ *   1. Explicit `--base-url` / `--api-key` flags.
+ *   2. Environment variables `HONUA_BASE_URL` / `HONUA_API_KEY`.
+ *   3. A saved config file written by `honua login` (`~/.config/honua/config.json`,
+ *      overridable with `HONUA_CONFIG_HOME`).
+ *
+ * Secrets are only ever persisted by an explicit `honua login`; nothing else
+ * writes the config file.
+ *
+ * @packageDocumentation
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface HonuaCliConfig {
+  baseUrl?: string;
+  apiKey?: string;
+  locatorName?: string;
+}
+
+export interface ResolvedConnection {
+  baseUrl: string;
+  apiKey?: string;
+  /** Where `baseUrl` came from, for diagnostics. */
+  source: "flag" | "env" | "config";
+}
+
+/** Directory that holds the persisted CLI config. */
+export function configDir(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.HONUA_CONFIG_HOME && env.HONUA_CONFIG_HOME.trim() !== "") {
+    return env.HONUA_CONFIG_HOME;
+  }
+  const base =
+    env.XDG_CONFIG_HOME && env.XDG_CONFIG_HOME.trim() !== "" ? env.XDG_CONFIG_HOME : path.join(os.homedir(), ".config");
+  return path.join(base, "honua");
+}
+
+/** Absolute path of the persisted CLI config file. */
+export function configPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(configDir(env), "config.json");
+}
+
+/** Read the persisted config, returning `{}` when absent or unreadable. */
+export function readConfig(env: NodeJS.ProcessEnv = process.env): HonuaCliConfig {
+  const file = configPath(env);
+  try {
+    const raw = fs.readFileSync(file, "utf8");
+    const parsed = JSON.parse(raw) as HonuaCliConfig;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Persist the config file (used by `honua login`). Returns the path written. */
+export function writeConfig(config: HonuaCliConfig, env: NodeJS.ProcessEnv = process.env): string {
+  const dir = configDir(env);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = configPath(env);
+  fs.writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  try {
+    fs.chmodSync(file, 0o600);
+  } catch {
+    // best-effort on platforms without POSIX modes
+  }
+  return file;
+}
+
+export interface ResolveOptions {
+  baseUrl?: string;
+  apiKey?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Resolve the base URL + API key from flags, env, then saved config.
+ *
+ * @throws {Error} when no base URL can be determined.
+ */
+export function resolveConnection(options: ResolveOptions = {}): ResolvedConnection {
+  const env = options.env ?? process.env;
+  const saved = readConfig(env);
+
+  let baseUrl: string | undefined;
+  let source: ResolvedConnection["source"] = "config";
+  if (options.baseUrl && options.baseUrl.trim() !== "") {
+    baseUrl = options.baseUrl;
+    source = "flag";
+  } else if (env.HONUA_BASE_URL && env.HONUA_BASE_URL.trim() !== "") {
+    baseUrl = env.HONUA_BASE_URL;
+    source = "env";
+  } else if (saved.baseUrl && saved.baseUrl.trim() !== "") {
+    baseUrl = saved.baseUrl;
+    source = "config";
+  }
+
+  if (!baseUrl) {
+    throw new Error(
+      "No Honua base URL configured. Pass --base-url, set HONUA_BASE_URL, or run `honua login --base-url <url>`.",
+    );
+  }
+
+  const apiKey =
+    (options.apiKey && options.apiKey.trim() !== "" ? options.apiKey : undefined) ??
+    (env.HONUA_API_KEY && env.HONUA_API_KEY.trim() !== "" ? env.HONUA_API_KEY : undefined) ??
+    (saved.apiKey && saved.apiKey.trim() !== "" ? saved.apiKey : undefined);
+
+  return { baseUrl: baseUrl.replace(/\/+$/, ""), apiKey, source };
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,0 +1,160 @@
+/**
+ * `honua` CLI entry point: a first-class command-line wrapper around
+ * `@honua/sdk-js`. Parses global connection flags, dispatches to a subcommand,
+ * and maps SDK errors to clean, non-stacktrace exit codes.
+ *
+ * Reusing the SDK means every verb inherits the same auth, retry, PBF decoding,
+ * and error handling as the library — the CLI never speaks raw HTTP.
+ *
+ * @packageDocumentation
+ */
+
+import { ArgError, getString, parseArgs } from "./args.js";
+import type { FlagSpec, ParsedArgs } from "./args.js";
+import type { CommandContext, CommandHandler } from "./command.js";
+import { layersCommand, servicesCommand } from "./commands/catalog.js";
+import { geocodeCommand } from "./commands/geocode.js";
+import { loginCommand, logoutCommand, whoamiCommand } from "./commands/login.js";
+import { mapCommand, tilesCommand } from "./commands/map.js";
+import { queryCommand } from "./commands/query.js";
+import { stacCommand } from "./commands/stac.js";
+import { printLine } from "./output.js";
+
+export const CLI_VERSION = "0.1.0";
+
+const GLOBAL_FLAGS: FlagSpec[] = [
+  { name: "base-url" },
+  { name: "api-key" },
+  { name: "locator" },
+  { name: "where" },
+  { name: "bbox" },
+  { name: "datetime" },
+  { name: "collections", multiple: true },
+  { name: "fields", multiple: true },
+  { name: "format" },
+  { name: "size" },
+  { name: "output", alias: "o" },
+  { name: "limit" },
+  { name: "count", boolean: true },
+  { name: "json", boolean: true },
+  { name: "help", alias: "h", boolean: true },
+  { name: "version", alias: "V", boolean: true },
+];
+
+const COMMANDS: Record<string, CommandHandler> = {
+  services: servicesCommand,
+  layers: layersCommand,
+  query: queryCommand,
+  stac: stacCommand,
+  geocode: geocodeCommand,
+  map: mapCommand,
+  tiles: tilesCommand,
+  login: loginCommand,
+  logout: logoutCommand,
+  whoami: whoamiCommand,
+};
+
+const HELP = `honua — command-line client for Honua geospatial servers (wraps @honua/sdk-js)
+
+USAGE
+  honua <command> [options]
+
+CATALOG
+  honua services                              List published services
+  honua layers <service>                      List layers/tables in a service
+
+DATA
+  honua query <service>/<layer> [options]     Query features (the workhorse verb)
+      --where <sql>        SQL filter (default 1=1)
+      --bbox minx,miny,maxx,maxy   Spatial intersect filter (WGS84)
+      --fields <name>      Output field (repeatable; default *)
+      --count              Return a feature count only
+      --limit N            Max features (default 25)
+      --format table|geojson|json  Output shape (default table)
+
+STAC
+  honua stac collections                      List STAC collections
+  honua stac search [options]                 Search STAC items
+      --bbox / --datetime / --collections / --limit
+
+GEOCODING
+  honua geocode "<address>" [--locator <name>] [--limit N]
+
+MAPS
+  honua map export <service>[/<layers>] --bbox ... --size WxH [-o out.png]
+  honua tiles <service> <z>/<x>/<y> [-o tile.png]
+
+AUTH / CONFIG
+  honua login --base-url <url> [--api-key <key>]
+  honua logout
+  honua whoami
+
+GLOBAL OPTIONS
+  --base-url <url>     Server base URL (or env HONUA_BASE_URL)
+  --api-key <key>      API key (or env HONUA_API_KEY; anonymous if omitted)
+  --json               Machine-readable JSON output
+  -h, --help           Show help
+  -V, --version        Show version
+
+EXAMPLES
+  HONUA_BASE_URL=https://demo.honua.io honua services
+  honua query maui-parcels/1 --count
+  honua query maui-parcels/1 --where "TMK LIKE '2%'" --limit 5
+  honua stac collections
+`;
+
+/**
+ * Run the CLI with a raw argv (everything after `node honua`). Returns an exit
+ * code; never calls `process.exit` so it stays testable.
+ */
+export async function run(argv: ReadonlyArray<string>, ctxOverride: Partial<CommandContext> = {}): Promise<number> {
+  const command = argv[0];
+
+  // Top-level help / version (also when no command given).
+  if (!command || command === "help" || command === "--help" || command === "-h") {
+    printLine(HELP);
+    return 0;
+  }
+  if (command === "--version" || command === "-V" || command === "version") {
+    printLine(CLI_VERSION);
+    return 0;
+  }
+
+  const handler = COMMANDS[command];
+  if (!handler) {
+    printLine(`Unknown command: ${command}\n`);
+    printLine(HELP);
+    return 2;
+  }
+
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(argv.slice(1), GLOBAL_FLAGS);
+  } catch (err) {
+    if (err instanceof ArgError) {
+      printLine(`error: ${err.message}`);
+      return 2;
+    }
+    throw err;
+  }
+
+  if (parsed.flags.help === true) {
+    printLine(HELP);
+    return 0;
+  }
+
+  const ctx: CommandContext = {
+    baseUrl: ctxOverride.baseUrl ?? getString(parsed, "base-url"),
+    apiKey: ctxOverride.apiKey ?? getString(parsed, "api-key"),
+  };
+
+  try {
+    await handler(parsed, ctx);
+    return 0;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    printLine(`error: ${message}`, process.stderr);
+    if (err instanceof ArgError) return 2;
+    return 1;
+  }
+}

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,0 +1,112 @@
+/**
+ * Human-first output helpers for the `honua` CLI: fixed-width tables, key/value
+ * detail blocks, and a thin `--json` escape hatch for machine consumers.
+ *
+ * Nothing here knows about the SDK; callers shape data into rows/records and
+ * pick a renderer. This keeps formatting unit-testable without a live server.
+ *
+ * @packageDocumentation
+ */
+
+export type Cell = string | number | boolean | null | undefined;
+
+export interface TableColumn {
+  /** Key into each row record. */
+  key: string;
+  /** Column header (defaults to `key`). */
+  header?: string;
+  /** Right-align numeric columns. */
+  align?: "left" | "right";
+}
+
+export interface RenderTableOptions {
+  /** Printed above the table; omitted when falsy. */
+  title?: string;
+  /** Shown instead of a header+body when there are no rows. */
+  emptyText?: string;
+}
+
+function cellToString(value: Cell): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  return String(value);
+}
+
+function displayWidth(text: string): number {
+  // Strip ANSI escapes if any slipped through; CLI output is plain otherwise.
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: matching ANSI escape sequences
+  return text.replace(/\[[0-9;]*m/g, "").length;
+}
+
+function pad(text: string, width: number, align: "left" | "right"): string {
+  const gap = width - displayWidth(text);
+  if (gap <= 0) return text;
+  const fill = " ".repeat(gap);
+  return align === "right" ? fill + text : text + fill;
+}
+
+/**
+ * Render an array of records as an aligned text table.
+ *
+ * Columns are inferred from `columns`; each row is looked up by `column.key`.
+ */
+export function renderTable(
+  rows: ReadonlyArray<Record<string, Cell>>,
+  columns: ReadonlyArray<TableColumn>,
+  options: RenderTableOptions = {},
+): string {
+  const lines: string[] = [];
+  if (options.title) lines.push(options.title);
+
+  if (rows.length === 0) {
+    lines.push(options.emptyText ?? "(no results)");
+    return lines.join("\n");
+  }
+
+  const headers = columns.map((c) => c.header ?? c.key);
+  const widths = columns.map((c, i) => {
+    const header = headers[i];
+    const longestCell = rows.reduce((max, row) => {
+      const w = displayWidth(cellToString(row[c.key]));
+      return w > max ? w : max;
+    }, 0);
+    return Math.max(displayWidth(header), longestCell);
+  });
+
+  const headerRow = columns
+    .map((c, i) => pad(headers[i], widths[i], c.align ?? "left"))
+    .join("  ")
+    .replace(/\s+$/, "");
+  const sepRow = widths.map((w) => "-".repeat(w)).join("  ");
+  lines.push(headerRow);
+  lines.push(sepRow);
+
+  for (const row of rows) {
+    const cells = columns.map((c, i) => pad(cellToString(row[c.key]), widths[i], c.align ?? "left"));
+    lines.push(cells.join("  ").replace(/\s+$/, ""));
+  }
+
+  return lines.join("\n");
+}
+
+/** Render a flat key/value record as an aligned two-column block. */
+export function renderDetail(record: Record<string, Cell>, options: { title?: string } = {}): string {
+  const lines: string[] = [];
+  if (options.title) lines.push(options.title);
+  const keys = Object.keys(record);
+  const keyWidth = keys.reduce((max, k) => Math.max(max, k.length), 0);
+  for (const key of keys) {
+    lines.push(`${pad(`${key}:`, keyWidth + 1, "left")}  ${cellToString(record[key])}`);
+  }
+  return lines.join("\n");
+}
+
+/** Serialize a value as pretty JSON for `--json` output. */
+export function renderJson(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+/** Write a line to stdout. Isolated so tests can stub it. */
+export function printLine(text: string, stream: NodeJS.WriteStream = process.stdout): void {
+  stream.write(`${text}\n`);
+}

--- a/test/cli-args.test.ts
+++ b/test/cli-args.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ArgError,
+  getArray,
+  getBoolean,
+  getNumber,
+  getString,
+  parseArgs,
+  parseBbox,
+  parseServiceLayer,
+} from "../src/cli/args.js";
+import type { FlagSpec } from "../src/cli/args.js";
+
+const SPECS: FlagSpec[] = [
+  { name: "where" },
+  { name: "bbox" },
+  { name: "limit" },
+  { name: "fields", multiple: true },
+  { name: "count", boolean: true },
+  { name: "json", boolean: true },
+  { name: "output", alias: "o" },
+];
+
+describe("parseArgs", () => {
+  it("parses positionals, value flags, and boolean flags", () => {
+    const parsed = parseArgs(["maui-parcels/1", "--where", "TMK > 0", "--count", "--limit", "5"], SPECS);
+    expect(parsed.positionals).toEqual(["maui-parcels/1"]);
+    expect(getString(parsed, "where")).toBe("TMK > 0");
+    expect(getBoolean(parsed, "count")).toBe(true);
+    expect(getNumber(parsed, "limit")).toBe(5);
+  });
+
+  it("supports --flag=value and short aliases", () => {
+    const parsed = parseArgs(["--limit=10", "-o", "out.png"], SPECS);
+    expect(getNumber(parsed, "limit")).toBe(10);
+    expect(getString(parsed, "output")).toBe("out.png");
+  });
+
+  it("collects repeated flags into an array", () => {
+    const parsed = parseArgs(["--fields", "TMK", "--fields", "ACRES"], SPECS);
+    expect(getArray(parsed, "fields")).toEqual(["TMK", "ACRES"]);
+  });
+
+  it("treats everything after -- as positional", () => {
+    const parsed = parseArgs(["query", "--", "--not-a-flag"], SPECS);
+    expect(parsed.positionals).toEqual(["query", "--not-a-flag"]);
+  });
+
+  it("throws ArgError on unknown flags", () => {
+    expect(() => parseArgs(["--nope"], SPECS)).toThrow(ArgError);
+  });
+
+  it("throws ArgError when a value flag is missing its value", () => {
+    expect(() => parseArgs(["--where"], SPECS)).toThrow(ArgError);
+  });
+
+  it("rejects non-numeric --limit", () => {
+    const parsed = parseArgs(["--limit", "abc"], SPECS);
+    expect(() => getNumber(parsed, "limit")).toThrow(ArgError);
+  });
+});
+
+describe("parseBbox", () => {
+  it("parses a 4-tuple", () => {
+    expect(parseBbox("-156.7,20.7,-156.3,21.0")).toEqual([-156.7, 20.7, -156.3, 21.0]);
+  });
+
+  it("rejects malformed bboxes", () => {
+    expect(() => parseBbox("1,2,3")).toThrow(ArgError);
+    expect(() => parseBbox("a,b,c,d")).toThrow(ArgError);
+  });
+});
+
+describe("parseServiceLayer", () => {
+  it("splits service/layer", () => {
+    expect(parseServiceLayer("maui-parcels/1")).toEqual({ service: "maui-parcels", layer: 1 });
+  });
+
+  it("keeps slashes in the service id and uses the last segment as the layer", () => {
+    expect(parseServiceLayer("folder/svc/3")).toEqual({ service: "folder/svc", layer: 3 });
+  });
+
+  it("rejects missing or non-integer layer ids", () => {
+    expect(() => parseServiceLayer("maui-parcels")).toThrow(ArgError);
+    expect(() => parseServiceLayer("maui-parcels/x")).toThrow(ArgError);
+  });
+});

--- a/test/cli-output.test.ts
+++ b/test/cli-output.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { renderDetail, renderJson, renderTable } from "../src/cli/output.js";
+
+describe("renderTable", () => {
+  it("renders an aligned header + rows", () => {
+    const out = renderTable(
+      [
+        { name: "maui-parcels", type: "FeatureServer" },
+        { name: "maui-roads", type: "FeatureServer" },
+      ],
+      [
+        { key: "name", header: "SERVICE" },
+        { key: "type", header: "TYPE" },
+      ],
+    );
+    const lines = out.split("\n");
+    expect(lines[0]).toBe("SERVICE       TYPE");
+    expect(lines[1]).toBe("------------  -------------");
+    expect(lines[2]).toContain("maui-parcels");
+    expect(lines[2]).toContain("FeatureServer");
+  });
+
+  it("right-aligns numeric columns", () => {
+    const out = renderTable([{ id: 1 }, { id: 42 }], [{ key: "id", header: "ID", align: "right" }]);
+    const lines = out.split("\n");
+    // " 1" padded to width 2, "42" already width 2.
+    expect(lines[2]).toBe(" 1");
+    expect(lines[3]).toBe("42");
+  });
+
+  it("shows the empty text when there are no rows", () => {
+    const out = renderTable([], [{ key: "name" }], { emptyText: "(no services)" });
+    expect(out).toContain("(no services)");
+  });
+
+  it("renders null/undefined cells as blanks", () => {
+    const out = renderTable(
+      [{ a: null, b: "x" }],
+      [
+        { key: "a", header: "A" },
+        { key: "b", header: "B" },
+      ],
+    );
+    expect(out.split("\n")[2]).toBe("   x");
+  });
+});
+
+describe("renderDetail", () => {
+  it("aligns key/value pairs", () => {
+    const out = renderDetail({ baseUrl: "https://demo.honua.io", auth: "anonymous" });
+    expect(out).toContain("baseUrl:  https://demo.honua.io");
+    expect(out).toContain("auth:     anonymous");
+  });
+});
+
+describe("renderJson", () => {
+  it("pretty-prints", () => {
+    expect(renderJson({ a: 1 })).toBe('{\n  "a": 1\n}');
+  });
+});

--- a/test/cli-run.test.ts
+++ b/test/cli-run.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CLI_VERSION, run } from "../src/cli/main.js";
+
+function captureStdout(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const spy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    lines.push(String(chunk));
+    return true;
+  });
+  return { lines, restore: () => spy.mockRestore() };
+}
+
+describe("run() dispatch", () => {
+  let cap: ReturnType<typeof captureStdout>;
+  beforeEach(() => {
+    cap = captureStdout();
+  });
+  afterEach(() => {
+    cap.restore();
+  });
+
+  it("prints help and exits 0 with no command", async () => {
+    const code = await run([]);
+    expect(code).toBe(0);
+    expect(cap.lines.join("")).toContain("USAGE");
+  });
+
+  it("prints version", async () => {
+    const code = await run(["--version"]);
+    expect(code).toBe(0);
+    expect(cap.lines.join("")).toContain(CLI_VERSION);
+  });
+
+  it("returns exit code 2 for an unknown command", async () => {
+    const code = await run(["frobnicate"]);
+    expect(code).toBe(2);
+    expect(cap.lines.join("")).toContain("Unknown command: frobnicate");
+  });
+
+  it("returns exit code 2 for an unknown flag on a real command", async () => {
+    const code = await run(["services", "--bogus"]);
+    expect(code).toBe(2);
+  });
+
+  it("shows command help without contacting a server", async () => {
+    const code = await run(["query", "--help"]);
+    expect(code).toBe(0);
+    expect(cap.lines.join("")).toContain("USAGE");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a first-class **`honua` API CLI** that wraps `@honua/sdk-js`, so Honua's docs and demos can stop using `curl`. The CLI reuses the SDK's clients (no hand-rolled HTTP — it inherits the SDK's auth, retries, PBF decoding, and error types) and ships as the package `bin` (`honua`), published-ready. ESM, Node ≥ 20, zero new runtime dependencies.

## Command surface

| Command | Purpose |
|---|---|
| `honua services` | List published services (table) |
| `honua layers <service>` | List a service's layers/tables |
| `honua query <service>/<layer>` | Query features — `--where`, `--bbox`, `--fields`, `--count`, `--limit`, `--format table\|geojson\|json` |
| `honua stac collections` / `honua stac search` | STAC browsing (`--bbox --datetime --collections --limit`) |
| `honua geocode "<address>"` | Forward geocoding via `@honua/sdk-js/geocoding` |
| `honua map export <service>[/layers]` / `honua tiles <service> z/x/y` | Render/resolve a map image or tile |
| `honua login` / `logout` / `whoami` | Base-URL + API-key config |

Auth/config precedence: `--api-key`/`--base-url` flags → `HONUA_API_KEY`/`HONUA_BASE_URL` env → saved `honua login` (`~/.config/honua/config.json`). Human-formatted output by default; `--json` for machine output.

## Verified against the live demo (`HONUA_BASE_URL=https://demo.honua.io`, anonymous read)

```
$ honua services
Services on https://demo.honua.io
SERVICE              TYPE
-------------------  -------------
maui-buildings       FeatureServer
maui-parcels         FeatureServer
...                  (11 services)

$ honua query maui-parcels/1 --count
51245

$ honua query maui-parcels/1 --where "tmk_txt LIKE '2%'" --limit 3
id  tmk_txt    zone  taxacres  gisacres    qpub_link
--  ---------  ----  --------  ----------  ---------
1   215010777  1     0         4.20726401  https://...
(3 feature(s), more available)

$ honua query maui-parcels/1 --bbox -156.5,20.85,-156.45,20.9 --format geojson
{ "type": "FeatureCollection", "features": [ ...25 features... ] }

$ honua stac collections
STAC collections on https://demo.honua.io
(no collections)        # demo publishes none; verb works (HTTP 200, empty)
```

`geocode` and `map export` are wired correctly but the public demo currently 500s its geocoder / 503s map-export storage; the CLI surfaces those server errors cleanly. The required verification trio (`services`, `query --count`, `stac collections`) all work.

## Changes Made

- `src/cli/` — arg parser, output (tables/detail/JSON), config/auth resolution, client factory, and one module per command group; `bin.ts` executable shim.
- `package.json` — `bin: { honua }` and a `./cli` subpath export. No new dependencies.
- `test/cli-args.test.ts`, `test/cli-output.test.ts`, `test/cli-run.test.ts` — 23 unit tests (arg parsing, output formatting, command dispatch).
- `README.md` — documents the CLI as the recommended replacement for curl.

## Build / test status

- `npm run typecheck` — clean
- `npm run build` — clean (emits `dist/src/cli/bin.js`)
- `npx biome check src/cli/ test/cli-*.test.ts` — clean (CI style gate)
- 23/23 CLI unit tests pass

## Docs de-curled (separate PR)

honua-server `feat/honua-cli-docs`: `docs/get-started/first-dataset.md` and `docs/guides/query-analyze/query-features.md` now lead with the `honua` CLI, keeping curl in collapsible fallback blocks.

**DRAFT — do not merge.**
