### PR TITLE
feat(mcp): deterministic MCP certification artifact (conformance + round-trip) (#1956)

### DIFF
--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,1 +1,5 @@
 dist/test/
+
+# Generated MCP certification artifacts (uploaded by CI, not committed)
+mcp-certification-results.json
+mcp-certification-results.md

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -40,3 +40,47 @@ HONUA_BASE_URL="https://honua.example.com" HONUA_TRANSPORT="grpc-web" node dist/
 
 - `honua://services`
 - `honua://services/{encodedServiceId}/layers/{layerId}`
+
+## Certification
+
+The package ships a **deterministic MCP certification harness** that proves the
+advertised MCP surface is well-formed and conformant to the open
+[`geospatial-mcp`](https://github.com/honua-io/geospatial-mcp) standard. It is
+fully offline — no model/API calls, no network in the default path — and is the
+evidence document for the WS-H "Provability" workstream.
+
+For each tool the server advertises (over an in-memory MCP transport) it:
+
+1. Enumerates `tools/list`, `resources/list`, and `prompts/list`.
+2. Validates each `inputSchema` (and any `structuredContent` output schema) is
+   well-formed JSON Schema, accepting both the draft-07 dialect emitted by
+   zod-to-json-schema and the draft 2020-12 dialect of the standard.
+3. Where a vendored standard schema matches the advertised tool (by the
+   standard's `referenceToolName`), checks **conformance** — every standard
+   `required` property must be accepted with a compatible type. Standard tools
+   that are not advertised, and advertised tools outside the standard, are
+   recorded as **known gaps**, not failures.
+4. **Round-trips** every read-only tool (`tools/call` with a fixture input),
+   validating the response. Write/destructive tools are never called.
+
+It emits a stable machine-readable JSON report plus a human-readable Markdown
+summary, and exits non-zero on any conformance/round-trip failure.
+
+```bash
+# Run the certifier against the offline fixture backend and write artifacts:
+npm run certify
+
+# CI entry points (also runnable locally):
+npm run test:certification            # gate: runs harness tests + certifier, exits non-zero on failure
+npm run test:certification:artifact   # evidence: writes artifacts, always exits 0
+```
+
+Artifacts are written to the package root as
+`mcp-certification-results.json` and `mcp-certification-results.md` (gitignored;
+uploaded by CI). To certify against a **live** honua-server, set `HONUA_BASE_URL`
+(and `HONUA_TRANSPORT`, `HONUA_MCP_SERVICE_ID`, `HONUA_MCP_LAYER_ID`); the
+harness then drives a real `HonuaClient` instead of the fixture.
+
+The standard schemas are vendored under
+`certification/geospatial-mcp-schemas/` (see that directory's `PROVENANCE.md`
+for the pinned source revision).

--- a/mcp/certification/geospatial-mcp-schemas/PROVENANCE.md
+++ b/mcp/certification/geospatial-mcp-schemas/PROVENANCE.md
@@ -1,0 +1,33 @@
+# Vendored geospatial-mcp JSON Schemas
+
+These JSON Schema files are a verbatim, vendored copy of the published
+machine-readable schemas from the open **geospatial-mcp** standard.
+
+- **Source repo:** https://github.com/honua-io/geospatial-mcp
+- **Source path:** `spec/schemas/`
+- **Source commit:** `968d7d7709f15d0626f8f3c607532489e48f07d1`
+  (`spec(schemas): publish machine-readable JSON Schemas + conformance fixtures (#1957)`)
+- **Schema index date:** `2026-06-21`
+- **Dialect:** JSON Schema draft 2020-12
+
+## Why vendored
+
+The MCP certification harness (`src/certification/`) must run deterministically
+in CI with **zero network access and zero model/API token spend**. Vendoring the
+published schemas pins the standard the Honua MCP surface is certified against to
+a known, reproducible revision and removes any cross-repo fetch at certify time.
+
+## Refreshing
+
+To re-pin to a newer published revision, re-copy `spec/schemas/` from the
+`geospatial-mcp` repo at the desired tag/commit and update the source commit and
+index date above. Do not hand-edit individual schema files; the standard is owned
+upstream.
+
+## Index
+
+`index.json` maps each standard tool's bare `standardName` (taxonomy.md name) to
+the `referenceToolName` the reference implementation (Honua `/mcp`) advertises,
+plus an `implementationStatus` (`implemented` | `known-gap`). The certifier reads
+this index to decide which advertised tools to conformance-check and which
+standard tools to record as known gaps.

--- a/mcp/certification/geospatial-mcp-schemas/README.md
+++ b/mcp/certification/geospatial-mcp-schemas/README.md
@@ -1,0 +1,90 @@
+# Machine-Readable JSON Schemas
+
+**Status:** Draft
+**Date:** 2026-06-21
+**Scope:** Implementable JSON Schema (draft 2020-12) bindings for the geospatial MCP standard
+
+This directory makes the prose specification **implementable**. It publishes
+[JSON Schema](https://json-schema.org/) (draft 2020-12) documents describing:
+
+- each core MCP **tool** `inputSchema` (the argument shape an agent sends on a
+  `tools/call`), under [`tools/`](tools/);
+- each core MCP **resource** payload shape (the read-only projection a
+  `resources/read` returns), under [`resources/`](resources/).
+
+A machine-readable [`index.json`](index.json) maps every standard tool name and
+resource family URI to its schema file, so a harness can resolve a schema from
+a vocabulary key without hard-coding paths.
+
+A self-check **conformance fixture tree** lives under
+[`../../conformance/fixtures/`](../../conformance/fixtures/): example tool-call
+inputs and resource payloads that validate against these schemas. An
+implementer can run their JSON Schema validator over the fixtures to confirm the
+schemas load and that the examples conform, before testing their own server.
+
+## Relationship to the prose
+
+These schemas are **derived from**, and faithful to, the normative prose:
+
+- Tool families and names come from
+  [`spec/taxonomy.md` §MCP Tools to Workflow Family Mapping](../taxonomy.md#mcp-tools-to-workflow-family-mapping).
+- Resource families, URI grammar, and inspection fields come from
+  [`spec/resources.md`](../resources.md).
+- The canonical concept model (`AnalysisPlan`, `ArtifactRef`, `WorkspaceRef`,
+  `GeoprocessingError`, …) comes from
+  [`spec/taxonomy.md` §Canonical Concept Model](../taxonomy.md#canonical-concept-model).
+
+### Where the prose is intentionally upstream-owned
+
+The prose **defers concrete field spellings** for several canonical objects to
+`honua-server` (`MapPackage`, `AppPackage`, `PublishedService`, `Deployment`
+— see [`resources.md` §2.4 Deferred-Shape Fixtures](../conformance.md#24-deferred-shape-fixtures)
+and the responsibility-level projections in `resources.md`). For those, the
+prose deliberately gives **responsibilities**, not a frozen field table.
+
+Per the task of making the standard implementable, where the prose is ambiguous
+or upstream-owned, **these schemas adopt the shape the reference implementation
+(Honua's `/mcp`) already emits**, and mark it as such with a
+`x-honua-reference-shape: true` annotation and a `description` note. This keeps
+the standard constructible today while remaining honest that the concrete field
+names track the reference implementation until the upstream ticket lands.
+
+Resources whose concrete shape is still fully deferred upstream (e.g.
+`MapPackage`, `AppPackage`, `PublishedService`, `Deployment`,
+`PublishingResultPackage`) carry **responsibility-level** schemas: the stable
+identifier and `honua://` URI are pinned and required, additional properties are
+permitted (`additionalProperties: true`), and the responsibility fields are
+described but not over-constrained. This matches the conformance rubric, which
+scores those resources on stable identifiers, URI grammar, and
+responsibility-level projection while marking concrete-field assertions
+`not_applicable`.
+
+## Draft and dialect
+
+All schemas declare:
+
+```json
+"$schema": "https://json-schema.org/draft/2020-12/schema"
+```
+
+and a stable `$id` of the form
+`https://geospatial-mcp.honua.io/spec/schemas/{tools|resources}/{name}.schema.json`.
+
+## Tool-name prefixing
+
+The standard names tools without a vendor prefix (`plan_analysis`,
+`ground_candidates`, …; see `taxonomy.md`). A conformant server MAY advertise
+the tools under a vendor-namespaced name — the reference implementation
+advertises e.g. `honua_plan_analysis`. The `index.json` lists both the bare
+standard name and the reference implementation's advertised name so a harness
+can resolve either. The schemas validate the **argument object**, which is
+prefix-independent.
+
+## Files
+
+| File | Describes |
+|---|---|
+| [`index.json`](index.json) | Machine-readable tool/resource → schema map |
+| [`common/geoprocessing-error.schema.json`](common/geoprocessing-error.schema.json) | The canonical `GeoprocessingError` envelope (shared) |
+| [`tools/*.schema.json`](tools/) | One `inputSchema` per core tool family |
+| [`resources/*.schema.json`](resources/) | One payload schema per core resource family |

--- a/mcp/certification/geospatial-mcp-schemas/common/geoprocessing-error.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/common/geoprocessing-error.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/common/geoprocessing-error.schema.json",
+  "title": "GeoprocessingError",
+  "description": "Canonical error envelope reused verbatim by every MCP tool and resource failure path. See spec/resources.md §Error Model. No parallel MCP-local error taxonomy is permitted.",
+  "type": "object",
+  "required": ["kind", "message"],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "description": "GeoprocessingErrorKind value.",
+      "enum": [
+        "ValidationFailed",
+        "AuthorizationDenied",
+        "UnknownDataset",
+        "UnknownProcess",
+        "ExecutionFailed",
+        "Timeout",
+        "Cancelled",
+        "OutputBindingFailed"
+      ]
+    },
+    "message": {
+      "type": "string",
+      "description": "Human-readable summary."
+    },
+    "stepId": {
+      "type": "string",
+      "description": "Plan step identifier when applicable."
+    },
+    "violations": {
+      "type": "array",
+      "description": "Structured validation failures.",
+      "items": {
+        "type": "object",
+        "required": ["code", "message"],
+        "properties": {
+          "code": { "type": "string" },
+          "message": { "type": "string" },
+          "fieldPath": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/index.json
+++ b/mcp/certification/geospatial-mcp-schemas/index.json
@@ -1,0 +1,232 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "geospatial-mcp JSON Schema index",
+  "description": "Machine-readable map from standard MCP tool names and resource family URIs to their JSON Schema (draft 2020-12) files. 'standardName' is the bare taxonomy.md tool name; 'referenceToolName' is the name the reference implementation (Honua /mcp) advertises. 'implementationStatus' records whether the reference implementation ships the tool today (implemented) or whether it is a standard family not yet implemented as a discrete tool (known-gap).",
+  "date": "2026-06-21",
+  "dialect": "https://json-schema.org/draft/2020-12/schema",
+  "tools": [
+    {
+      "standardName": "plan_analysis",
+      "referenceToolName": "honua_plan_analysis",
+      "family": "Intent and planning",
+      "schema": "tools/plan_analysis.schema.json",
+      "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "ground_candidates",
+      "referenceToolName": "honua_ground_candidates",
+      "family": "Intent and planning",
+      "schema": "tools/ground_candidates.schema.json",
+      "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "clarify_intent",
+      "referenceToolName": "honua_clarify_intent",
+      "family": "Intent and planning",
+      "schema": "tools/clarify_intent.schema.json",
+      "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "validate_plan",
+      "referenceToolName": "honua_validate_plan",
+      "family": "Intent and planning",
+      "schema": "tools/validate_plan.schema.json",
+      "implementationStatus": "implemented",
+      "notes": "Reference also advertises honua_dry_run_plan with the same partial-plan input schema."
+    },
+    {
+      "standardName": "execute_plan",
+      "referenceToolName": "honua_execute_plan",
+      "family": "Execution",
+      "schema": "tools/execute_plan.schema.json",
+      "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "create_map_package",
+      "referenceToolName": null,
+      "family": "Map composition",
+      "schema": "tools/create_map_package.schema.json",
+      "implementationStatus": "known-gap"
+    },
+    {
+      "standardName": "refine_map_package",
+      "referenceToolName": null,
+      "family": "Map composition",
+      "schema": "tools/refine_map_package.schema.json",
+      "implementationStatus": "known-gap"
+    },
+    {
+      "standardName": "apply_style_preset",
+      "referenceToolName": null,
+      "family": "Map composition",
+      "schema": "tools/apply_style_preset.schema.json",
+      "implementationStatus": "known-gap"
+    },
+    {
+      "standardName": "compose_mixed_protocol_map",
+      "referenceToolName": null,
+      "family": "Map composition",
+      "schema": "tools/compose_mixed_protocol_map.schema.json",
+      "implementationStatus": "known-gap"
+    },
+    {
+      "standardName": "preview_map_package",
+      "referenceToolName": null,
+      "family": "Map composition",
+      "schema": "tools/preview_map_package.schema.json",
+      "implementationStatus": "known-gap"
+    },
+    {
+      "standardName": "create_app_package",
+      "referenceToolName": null,
+      "family": "App composition",
+      "schema": "tools/create_app_package.schema.json",
+      "implementationStatus": "known-gap"
+    },
+    {
+      "standardName": "preview_app_package",
+      "referenceToolName": null,
+      "family": "App composition",
+      "schema": "tools/preview_app_package.schema.json",
+      "implementationStatus": "known-gap"
+    },
+    {
+      "standardName": "publish_result",
+      "referenceToolName": null,
+      "family": "Publishing",
+      "schema": "tools/publish_result.schema.json",
+      "implementationStatus": "known-gap"
+    },
+    {
+      "standardName": "list_layers",
+      "referenceToolName": "honua_list_layers",
+      "family": "Discovery and query (reference shape)",
+      "schema": "tools/list_layers.schema.json",
+      "implementationStatus": "implemented",
+      "notes": "Reference-implementation discovery tool over the open-core data-access surface; the bare taxonomy models discovery as a CapabilityCatalog read."
+    },
+    {
+      "standardName": "query_features",
+      "referenceToolName": "honua_query_features",
+      "family": "Discovery and query (reference shape)",
+      "schema": "tools/query_features.schema.json",
+      "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "render_map",
+      "referenceToolName": "honua_render_map",
+      "family": "Discovery and query (reference shape)",
+      "schema": "tools/render_map.schema.json",
+      "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "geocode_address",
+      "referenceToolName": "honua_geocode_address",
+      "family": "Analysis and geoprocessing (reference shape)",
+      "schema": "tools/geocode_address.schema.json",
+      "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "solve_route",
+      "referenceToolName": "honua_solve_route",
+      "family": "Analysis and geoprocessing (reference shape)",
+      "schema": "tools/solve_route.schema.json",
+      "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "cancel_job",
+      "referenceToolName": "honua_cancel_job",
+      "family": "Execution (reference shape)",
+      "schema": "tools/cancel_job.schema.json",
+      "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "propose_operation",
+      "referenceToolName": "honua_propose_operation",
+      "family": "Control-plane proposal (reference shape)",
+      "schema": "tools/propose_operation.schema.json",
+      "implementationStatus": "implemented"
+    }
+  ],
+  "resources": [
+    {
+      "family": "Result package",
+      "uriForm": "honua://results/{result_package_id}",
+      "schema": "resources/result-package.schema.json",
+      "shapeFidelity": "concrete"
+    },
+    {
+      "family": "Result artifact",
+      "uriForm": "honua://results/{result_package_id}/artifacts/{artifact_id}",
+      "schema": "resources/artifact.schema.json",
+      "shapeFidelity": "concrete"
+    },
+    {
+      "family": "Result provenance",
+      "uriForm": "honua://results/{result_package_id}/provenance",
+      "schema": "resources/provenance.schema.json",
+      "shapeFidelity": "concrete"
+    },
+    {
+      "family": "Workspace",
+      "uriForm": "honua://workspaces/{workspace_id}",
+      "schema": "resources/workspace.schema.json",
+      "shapeFidelity": "concrete-reference"
+    },
+    {
+      "family": "Workspace artifact",
+      "uriForm": "honua://workspaces/{workspace_id}/artifacts/{artifact_id}",
+      "schema": "resources/artifact.schema.json",
+      "shapeFidelity": "concrete"
+    },
+    {
+      "family": "Map package",
+      "uriForm": "honua://maps/{map_package_id}",
+      "schema": "resources/map-package.schema.json",
+      "shapeFidelity": "responsibility-level"
+    },
+    {
+      "family": "App package",
+      "uriForm": "honua://apps/{app_package_id}",
+      "schema": "resources/app-package.schema.json",
+      "shapeFidelity": "responsibility-level"
+    },
+    {
+      "family": "Style",
+      "uriForm": "honua://styles/{style_id}",
+      "schema": "resources/style.schema.json",
+      "shapeFidelity": "responsibility-level"
+    },
+    {
+      "family": "Theme",
+      "uriForm": "honua://themes/{theme_id}",
+      "schema": "resources/theme.schema.json",
+      "shapeFidelity": "responsibility-level"
+    },
+    {
+      "family": "Map template",
+      "uriForm": "honua://templates/maps/{map_template_id}",
+      "schema": "resources/map-template.schema.json",
+      "shapeFidelity": "responsibility-level"
+    },
+    {
+      "family": "Published service",
+      "uriForm": "honua://services/{published_service_id}",
+      "schema": "resources/published-service.schema.json",
+      "shapeFidelity": "responsibility-level"
+    },
+    {
+      "family": "Deployment",
+      "uriForm": "honua://deployments/{deployment_id}",
+      "schema": "resources/deployment.schema.json",
+      "shapeFidelity": "responsibility-level"
+    }
+  ],
+  "common": [
+    {
+      "name": "GeoprocessingError",
+      "schema": "common/geoprocessing-error.schema.json",
+      "role": "Canonical error envelope reused by all tool/resource failure paths."
+    }
+  ]
+}

--- a/mcp/certification/geospatial-mcp-schemas/resources/app-package.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/resources/app-package.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/app-package.schema.json",
+  "title": "App package resource payload",
+  "description": "Responsibility-level projection of an AppPackage at honua://apps/{app_package_id}. Concrete field spellings finalize upstream (honua-server#731); only the stable appPackageId is pinned. Responsibilities: target SDK declaration, template binding, package format/manifest, bundle artifact, delivery asset manifest, map binding, runtime config schema, hosting/route hints, bound data artifacts. See resources.md §honua://apps/{app_package_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["appPackageId"],
+  "properties": {
+    "appPackageId": {
+      "type": "string",
+      "description": "Stable identifier (app_…)."
+    },
+    "templateId": { "type": "string" },
+    "targetSdk": { "type": "string" },
+    "mapPackageId": { "type": "string" },
+    "bundleArtifactId": { "type": "string" },
+    "boundArtifactIds": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/resources/artifact.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/resources/artifact.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/artifact.schema.json",
+  "title": "Artifact resource payload",
+  "description": "Read-only projection of an ArtifactRef, addressable as honua://results/{rpid}/artifacts/{aid} (outcome view) or honua://workspaces/{wsid}/artifacts/{aid} (lifecycle view). lifecycleState is an MCP-layer projection, not a field of ArtifactRef. See resources.md §honua://results/{result_package_id}/artifacts/{artifact_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["artifactId", "kind"],
+  "properties": {
+    "artifactId": {
+      "type": "string",
+      "description": "Stable identifier (artifact_…)."
+    },
+    "kind": {
+      "type": "string",
+      "description": "ArtifactKind.",
+      "enum": ["Scalar", "FeatureLayer", "Table", "Raster", "File", "Report", "Map", "AppBundle"]
+    },
+    "label": { "type": "string", "description": "Human-readable label." },
+    "uri": {
+      "type": "string",
+      "description": "Canonical content locator (workspace-scoped). NOT the inspection URI."
+    },
+    "contentType": { "type": "string", "description": "MIME type." },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Canonical metadata map."
+    },
+    "lifecycleState": {
+      "type": "string",
+      "description": "ArtifactLifecycleState (MCP-layer projection from the workspace lifecycle service).",
+      "enum": ["Pending", "Available", "Promoted", "Expired", "Deleted"]
+    },
+    "promotionSourceReady": {
+      "type": "boolean",
+      "description": "Workspace-rooted reads only: source-side promotion preconditions met. Result-rooted reads do not resolve promotion readiness."
+    },
+    "sourceWorkspaceKind": {
+      "type": "string",
+      "enum": ["Scratch", "Persistent", "TempLayer", "SavedLayer", "ResultCollection"]
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/resources/deployment.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/resources/deployment.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/deployment.schema.json",
+  "title": "Deployment resource payload",
+  "description": "Responsibility-level projection of a Deployment at honua://deployments/{deployment_id}. Concrete field spellings finalize upstream (honua-server#732); only the stable deploymentId is pinned. Responsibilities: deployment kind, target binding (targetRef → AppPackage|MapPackage|PublishedService|opaque Process/Pipeline), hosting mode, route configuration, revision id, runtime profile, delivery artifact refs, runtime config, visibility scope, auth/approval policy refs, publication lifecycle state. Read-only — no control paths. See resources.md §honua://deployments/{deployment_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["deploymentId"],
+  "properties": {
+    "deploymentId": {
+      "type": "string",
+      "description": "Stable identifier (dep_…)."
+    },
+    "kind": {
+      "type": "string",
+      "description": "Package class.",
+      "enum": ["app_package", "published_service", "process", "pipeline"]
+    },
+    "targetRef": {
+      "type": "string",
+      "description": "Resolves to AppPackage | MapPackage | PublishedService; Process/Pipeline targets are opaque identifiers."
+    },
+    "hostingMode": { "type": "string" },
+    "revisionId": { "type": "string", "description": "Revision identifier (rev_…)." },
+    "publicationState": { "type": "string", "description": "Read-only publication lifecycle projection." }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/resources/map-package.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/resources/map-package.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/map-package.schema.json",
+  "title": "Map package resource payload",
+  "description": "Responsibility-level projection of a MapPackage at honua://maps/{map_package_id}. Concrete field spellings finalize upstream (honua-server#731); only the stable mapPackageId is pinned and additional properties are permitted. Responsibilities: package format/template binding, source bindings, styling composition, map-spec document, initial view, legend/popup/label composition, artifact bindings. See resources.md §honua://maps/{map_package_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["mapPackageId"],
+  "properties": {
+    "mapPackageId": {
+      "type": "string",
+      "description": "Stable identifier (map_…)."
+    },
+    "templateId": { "type": "string", "description": "Bound MapTemplate." },
+    "sourceBindings": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+    "styleId": { "type": "string" },
+    "themeId": { "type": "string" },
+    "initialView": { "type": "object", "additionalProperties": true },
+    "previewArtifactId": { "type": "string" }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/resources/map-template.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/resources/map-template.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/map-template.schema.json",
+  "title": "Map template resource payload",
+  "description": "Responsibility-level projection of a MapTemplate at honua://templates/maps/{map_template_id}. The identifier is registry-defined (e.g. analysis_default); concrete field spellings are upstream-owned. Responsibilities: cartographic composition class, named SourceBinding slots, default style/theme composition, layout/view presets. See resources.md §honua://templates/maps/{map_template_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["mapTemplateId"],
+  "properties": {
+    "mapTemplateId": {
+      "type": "string",
+      "description": "Registry-defined map-template identifier (e.g. analysis_default)."
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/resources/provenance.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/resources/provenance.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/provenance.schema.json",
+  "title": "Provenance resource payload",
+  "description": "Read-only projection of a ProvenanceRecord, addressable as honua://results/{result_package_id}/provenance. See resources.md §honua://results/{result_package_id}/provenance.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "sources": {
+      "type": "array",
+      "description": "Dataset sources with version and description.",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "datasetId": { "type": "string" },
+          "version": { "type": "string" },
+          "description": { "type": "string" }
+        }
+      }
+    },
+    "processDefinitions": {
+      "type": "array",
+      "description": "Process identifiers used.",
+      "items": { "type": "string" }
+    },
+    "assumptions": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "clarificationsAsked": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "clarificationsAnswered": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "executedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Execution timestamp."
+    },
+    "generatedArtifactIds": {
+      "type": "array",
+      "description": "Artifacts produced by this execution.",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/resources/published-service.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/resources/published-service.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/published-service.schema.json",
+  "title": "Published service resource payload",
+  "description": "Responsibility-level projection of a PublishedService at honua://services/{published_service_id}. Concrete field spellings finalize upstream (honua-server#730); only the stable serviceId is pinned. Responsibilities: protocol surface enumeration, styling composition, source-to-service lineage summary, refresh state (read-only). Read-only — no control paths. See resources.md §honua://services/{published_service_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["serviceId"],
+  "properties": {
+    "serviceId": {
+      "type": "string",
+      "description": "Upstream serviceId (no MCP-local prefix convention)."
+    },
+    "protocols": {
+      "type": "array",
+      "description": "Protocol surface enumeration (e.g. GeoServices, OGC API Features, WMS, WFS, OData, tiles).",
+      "items": { "type": "string" }
+    },
+    "refreshState": { "type": "string", "description": "Read-only refresh lifecycle signal." }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/resources/result-package.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/resources/result-package.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/result-package.schema.json",
+  "title": "Result package resource payload",
+  "description": "Read-only projection returned for honua://results/{result_package_id} (AnalysisResultPackage). See resources.md §Result Package Resources.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["resultPackageId", "status"],
+  "properties": {
+    "resultPackageId": {
+      "type": "string",
+      "description": "Stable identifier (result_…)."
+    },
+    "status": {
+      "type": "string",
+      "description": "GeoprocessingWorkflowStatus (read-only).",
+      "enum": [
+        "Draft",
+        "AwaitingClarification",
+        "Validated",
+        "AwaitingApproval",
+        "AwaitingExecution",
+        "Running",
+        "Completed",
+        "Failed",
+        "Cancelled"
+      ]
+    },
+    "summary": {
+      "type": "object",
+      "description": "Title and description.",
+      "additionalProperties": true,
+      "properties": {
+        "title": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    },
+    "assumptions": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "artifacts": {
+      "type": "array",
+      "items": { "$ref": "artifact.schema.json" }
+    },
+    "workspaceRefs": {
+      "type": "array",
+      "items": { "$ref": "workspace.schema.json" }
+    },
+    "mapPackageId": {
+      "type": "string",
+      "description": "Deferred reference to a MapPackage (map_…)."
+    },
+    "appPackageId": {
+      "type": "string",
+      "description": "Deferred reference to an AppPackage (app_…)."
+    },
+    "provenance": { "$ref": "provenance.schema.json" },
+    "errors": {
+      "type": "array",
+      "items": { "$ref": "../common/geoprocessing-error.schema.json" }
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/resources/style.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/resources/style.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/style.schema.json",
+  "title": "Style resource payload",
+  "description": "Responsibility-level projection of a StyleRef at honua://styles/{style_id}. Concrete field spellings are upstream-owned; only the stable styleId is pinned. Responsibilities: thematic renderer selection, style preset reuse/composition, label/popup bindings, legend-generation inputs. See resources.md §honua://styles/{style_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["styleId"],
+  "properties": {
+    "styleId": { "type": "string", "description": "Stable identifier (style_…)." }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/resources/theme.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/resources/theme.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/theme.schema.json",
+  "title": "Theme resource payload",
+  "description": "Responsibility-level projection of a ThemeSpec at honua://themes/{theme_id}. Concrete field spellings are upstream-owned; only the stable themeId is pinned. Responsibilities: color-ramp tokens, typography tokens, spacing/panel chrome, semantic status colors. See resources.md §honua://themes/{theme_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["themeId"],
+  "properties": {
+    "themeId": { "type": "string", "description": "Stable identifier (theme_…)." }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/resources/workspace.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/resources/workspace.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/workspace.schema.json",
+  "title": "Workspace resource payload",
+  "description": "Read-only projection of a WorkspaceRef, addressable as honua://workspaces/{workspace_id}. The canonical kind values are Scratch/Persistent/TempLayer/SavedLayer/ResultCollection; the reference implementation projects lower_snake_case wire spellings (x-honua-reference-shape). lifecycleState is an MCP-layer projection. See resources.md §honua://workspaces/{workspace_id}.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["workspaceId"],
+  "properties": {
+    "workspaceId": {
+      "type": "string",
+      "description": "Stable identifier (ws_…)."
+    },
+    "kind": {
+      "type": "string",
+      "description": "WorkspaceKind. Canonical enum names are Scratch/Persistent/TempLayer/SavedLayer/ResultCollection; the reference implementation emits the lower_snake_case wire spelling.",
+      "enum": [
+        "scratch",
+        "persistent",
+        "temp_layer",
+        "saved_layer",
+        "result_collection",
+        "Scratch",
+        "Persistent",
+        "TempLayer",
+        "SavedLayer",
+        "ResultCollection",
+        ""
+      ]
+    },
+    "label": { "type": "string", "description": "Human-readable label." },
+    "uri": { "type": "string", "description": "Canonical URI." },
+    "expiresAt": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "Expiration timestamp when applicable."
+    },
+    "status": {
+      "type": "string",
+      "description": "WorkspaceLifecycleState projection. Reference wire spellings: active, cleanup_pending, sealed, not_found, degraded.",
+      "enum": ["active", "cleanup_pending", "sealed", "not_found", "degraded"]
+    },
+    "cleanupScheduledAt": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "resultsUri": { "type": ["string", "null"] },
+    "notImplementedReason": { "type": "string" }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/apply_style_preset.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/apply_style_preset.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/apply_style_preset.schema.json",
+  "title": "apply_style_preset inputSchema",
+  "description": "Argument shape for apply_style_preset (Analyze, Build App; returns the updated MapPackage). Applies a reusable StyleRef preset to a map package, optionally scoped to a binding. Responsibility-level; concrete styling field set finalizes upstream. See taxonomy.md §Map composition and resources.md §honua://styles/{style_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["mapPackageId", "styleId"],
+  "properties": {
+    "mapPackageId": {
+      "type": "string",
+      "description": "Identifier (map_…) of the MapPackage to style."
+    },
+    "styleId": {
+      "type": "string",
+      "description": "StyleRef preset identifier (style_…) to apply."
+    },
+    "targetBindingId": {
+      "type": "string",
+      "description": "Optional SourceBinding the preset is scoped to; applies map-wide when omitted."
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/cancel_job.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/cancel_job.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/cancel_job.schema.json",
+  "title": "cancel_job inputSchema",
+  "description": "Argument shape for the execution-lifecycle cancel tool (advertised name honua_cancel_job). Requests cancellation of a submitted ExecutionJob. x-honua-reference-shape: lifecycle control over the execution handoff; tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["jobId"],
+  "properties": {
+    "jobId": {
+      "type": "string",
+      "description": "Execution job identifier to request cancellation for."
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/clarify_intent.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/clarify_intent.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/clarify_intent.schema.json",
+  "title": "clarify_intent inputSchema",
+  "description": "Argument shape for the clarify_intent tool (Analyze, Publish Data, Build App). Reference advertised name: honua_clarify_intent. Re-runs grounding with the operator's answers merged in. Extends ground_candidates with required intentId and a response carrying answers keyed by questionId. See planning.md §2.",
+  "type": "object",
+  "required": ["goal", "intentId", "response"],
+  "properties": {
+    "goal": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Freeform natural-language description of the operator's goal."
+    },
+    "intentId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Intent identifier being clarified. Required on a clarification turn."
+    },
+    "workflowFamilyHint": {
+      "type": "string",
+      "enum": ["Analyze", "PublishData", "BuildApp", "AutomateDeploy"]
+    },
+    "assumptionPolicy": {
+      "type": "string",
+      "enum": ["AskAlways", "AskWhenMaterial", "UseDefaults"]
+    },
+    "explicitInputs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "constraints": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "areaOfInterest": { "type": "string" },
+        "spatialReferenceId": { "type": "integer" },
+        "timeWindowStart": { "type": "string", "format": "date-time" },
+        "timeWindowEnd": { "type": "string", "format": "date-time" },
+        "units": { "type": "string" }
+      }
+    },
+    "context": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "workspaceId": { "type": "string" },
+        "priorIntentId": { "type": "string" },
+        "promotionScope": { "type": "string" }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["answers"],
+      "description": "ClarificationResponse: answers keyed by questionId.",
+      "properties": {
+        "answers": {
+          "type": "object",
+          "minProperties": 1,
+          "description": "Answers keyed by question identifier. Each answer is a non-empty list of values to support multi-select questions.",
+          "additionalProperties": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/compose_mixed_protocol_map.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/compose_mixed_protocol_map.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/compose_mixed_protocol_map.schema.json",
+  "title": "compose_mixed_protocol_map inputSchema",
+  "description": "Argument shape for compose_mixed_protocol_map (Analyze, Build App; returns a MapPackage). Composes a single map from layers bound across multiple protocols (GeoServices, OGC API, WMS/WFS, tiles) at the semantic level — protocol adaptation happens below the contract layer (taxonomy.md §Non-Goals 4). Responsibility-level; concrete binding field set finalizes upstream.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["sourceBindings"],
+  "properties": {
+    "templateId": { "type": "string" },
+    "sourceBindings": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Canonical SourceBinding entries, each protocol-aware. The tool does not expose protocol-specific operations.",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "styleId": { "type": "string" },
+    "themeId": { "type": "string" },
+    "initialView": { "type": "object", "additionalProperties": true }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/create_app_package.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/create_app_package.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/create_app_package.schema.json",
+  "title": "create_app_package inputSchema",
+  "description": "Argument shape for create_app_package (Build App; returns an AppPackage). Composes an SDK-native application from a map package, artifacts, and an app template. V1 targets honua-sdk-js with MapLibre GL JS. Responsibility-level: the AppPackage authoring field set finalizes upstream (honua-server#731). See taxonomy.md §App composition and resources.md §honua://apps/{app_package_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "templateId": {
+      "type": "string",
+      "description": "App-template registry identifier (surfaced through AppPackage.templateId)."
+    },
+    "targetSdk": {
+      "type": "string",
+      "description": "Target SDK declaration. V1 default is honua-sdk-js.",
+      "default": "honua-sdk-js"
+    },
+    "mapPackageId": {
+      "type": "string",
+      "description": "MapPackage (map_…) bound into the application."
+    },
+    "boundArtifactIds": {
+      "type": "array",
+      "description": "ArtifactRef identifiers (artifact_…) required at runtime.",
+      "items": { "type": "string" }
+    },
+    "runtimeConfig": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Runtime configuration values projected into the generated app."
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/create_map_package.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/create_map_package.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/create_map_package.schema.json",
+  "title": "create_map_package inputSchema",
+  "description": "Argument shape for create_map_package (Analyze, Build App map-composition family; returns a MapPackage). Responsibility-level: the concrete MapPackage authoring field set is finalizing upstream (honua-server#731), so this schema pins the stable composition inputs (source bindings, style/theme selection, template, initial view) and permits additional properties. See taxonomy.md §Map composition and resources.md §honua://maps/{map_package_id}.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "templateId": {
+      "type": "string",
+      "description": "Registry-defined MapTemplate identifier seeding the composition (e.g. analysis_default)."
+    },
+    "sourceBindings": {
+      "type": "array",
+      "description": "Protocol-aware bindings of map layers to data sources (canonical SourceBinding entries).",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "styleId": {
+      "type": "string",
+      "description": "StyleRef selection (style_… ) applied to the composition."
+    },
+    "themeId": {
+      "type": "string",
+      "description": "ThemeSpec selection (theme_… ) applied to the composition."
+    },
+    "initialView": {
+      "type": "object",
+      "description": "Initial view geometry: bounding box and CRS.",
+      "additionalProperties": true,
+      "properties": {
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "items": { "type": "number" }
+        },
+        "crs": { "type": ["string", "integer"] }
+      }
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/execute_plan.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/execute_plan.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/execute_plan.schema.json",
+  "title": "execute_plan inputSchema",
+  "description": "Argument shape for the execute_plan tool (Analyze, Publish Data; handoff returns an ExecutionJob reference for Analyze). Reference advertised name: honua_execute_plan. Submission rejects a missing planId or empty steps, so the executable plan REQUIRES planId and at least one step (contrast validate_plan). See planning.md §5.2.",
+  "type": "object",
+  "required": ["plan"],
+  "properties": {
+    "plan": { "$ref": "#/$defs/executablePlan" },
+    "idempotencyKey": {
+      "type": "string",
+      "description": "Optional deduplication key. Replays with the same key return the same job record."
+    }
+  },
+  "$defs": {
+    "executablePlan": {
+      "type": "object",
+      "description": "Canonical AnalysisPlan in executable form. planId and a non-empty steps array are mandatory.",
+      "required": ["planId", "steps"],
+      "properties": {
+        "planId": { "type": "string", "minLength": 1 },
+        "intentId": { "type": "string" },
+        "steps": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/planStep" }
+        },
+        "outputs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/artifactKind" }
+        },
+        "warnings": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "planStep": {
+      "type": "object",
+      "required": ["stepId", "kind"],
+      "properties": {
+        "stepId": { "type": "string" },
+        "kind": { "$ref": "#/$defs/planStepKind" },
+        "processId": { "type": "string" },
+        "inputs": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "dependsOn": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "planStepKind": {
+      "type": "string",
+      "enum": ["QueryFeatures", "Geoprocess", "Aggregate", "RenderMap", "Export"]
+    },
+    "artifactKind": {
+      "type": "string",
+      "enum": ["Scalar", "FeatureLayer", "Table", "Raster", "File", "Report", "Map", "AppBundle"]
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/geocode_address.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/geocode_address.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/geocode_address.schema.json",
+  "title": "geocode_address inputSchema",
+  "description": "Argument shape for the analysis/geoprocessing geocode tool (advertised name honua_geocode_address). Resolves a freeform address to ranked candidates. x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["address"],
+  "properties": {
+    "address": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Freeform single-line address text to geocode."
+    },
+    "maxResults": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 50,
+      "default": 5,
+      "description": "Maximum number of candidates to return."
+    },
+    "countryCodes": {
+      "type": "string",
+      "description": "Optional comma-separated ISO 3166 country codes to restrict the search."
+    },
+    "outSrid": {
+      "type": "integer",
+      "default": 4326,
+      "description": "Spatial reference (SRID/WKID) for returned candidate coordinates."
+    },
+    "provider": {
+      "type": "string",
+      "description": "Optional preferred geocoding provider name."
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/ground_candidates.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/ground_candidates.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/ground_candidates.schema.json",
+  "title": "ground_candidates inputSchema",
+  "description": "Argument shape for the ground_candidates tool (Analyze, Publish Data). Reference advertised name: honua_ground_candidates. Grounds a natural-language goal to a workflow family, ranked candidates, a draft intent, and an optional clarification envelope. See taxonomy.md §Intent and planning and planning.md §2.",
+  "type": "object",
+  "required": ["goal"],
+  "properties": {
+    "goal": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Freeform natural-language description of the operator's goal."
+    },
+    "intentId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Intent identifier. Optional on the initial grounding call (server allocates one); required on a clarification turn."
+    },
+    "workflowFamilyHint": {
+      "type": "string",
+      "description": "Optional workflow-family override (one of the canonical WorkflowFamily names).",
+      "enum": ["Analyze", "PublishData", "BuildApp", "AutomateDeploy"]
+    },
+    "assumptionPolicy": {
+      "type": "string",
+      "description": "Policy controlling when inferred assumptions trigger a clarification. See planning.md §2.3.",
+      "enum": ["AskAlways", "AskWhenMaterial", "UseDefaults"]
+    },
+    "explicitInputs": {
+      "type": "array",
+      "description": "Dataset, layer, or artifact identifiers the caller has already pinned.",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "constraints": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional analysis constraints.",
+      "properties": {
+        "areaOfInterest": {
+          "type": "string",
+          "description": "AOI as WKT, bounding-box string, or named area."
+        },
+        "spatialReferenceId": {
+          "type": "integer",
+          "description": "EPSG SRID for the AOI (defaults to 4326)."
+        },
+        "timeWindowStart": { "type": "string", "format": "date-time" },
+        "timeWindowEnd": { "type": "string", "format": "date-time" },
+        "units": {
+          "type": "string",
+          "description": "Preferred unit system (e.g. 'meters', 'feet')."
+        }
+      }
+    },
+    "context": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional workflow context.",
+      "properties": {
+        "workspaceId": { "type": "string" },
+        "priorIntentId": { "type": "string" },
+        "promotionScope": { "type": "string" }
+      }
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/list_layers.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/list_layers.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/list_layers.schema.json",
+  "title": "list_layers inputSchema",
+  "description": "Argument shape for the discovery/query layer-listing tool. The bare standard taxonomy models discovery as a CapabilityCatalog read; the reference implementation exposes it as a tool (advertised name honua_list_layers) over the open-core data-access surface. x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "properties": {
+    "filter": {
+      "type": "string",
+      "description": "Optional case-insensitive substring to match against service and layer name/title. When omitted, all published layers are returned."
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/plan_analysis.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/plan_analysis.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/plan_analysis.schema.json",
+  "title": "plan_analysis inputSchema",
+  "description": "Argument shape for the plan_analysis tool (Analyze family; emits an AnalysisPlan). Reference advertised name: honua_plan_analysis. Compiles a natural-language intent into an analysis plan / canonical spec draft. See taxonomy.md §Intent and planning.",
+  "type": "object",
+  "required": ["intent"],
+  "properties": {
+    "intent": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Natural-language intent to compile into an analysis plan or canonical spec draft."
+    },
+    "context": {
+      "type": "object",
+      "description": "Optional caller context. Echoed back unchanged by the reference implementation."
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/preview_app_package.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/preview_app_package.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/preview_app_package.schema.json",
+  "title": "preview_app_package inputSchema",
+  "description": "Argument shape for preview_app_package (Build App; returns a preview ArtifactRef). Produces a read-only preview artifact for an existing app package. Responsibility-level. See taxonomy.md §App composition.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["appPackageId"],
+  "properties": {
+    "appPackageId": {
+      "type": "string",
+      "description": "Identifier (app_…) of the AppPackage to preview."
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/preview_map_package.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/preview_map_package.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/preview_map_package.schema.json",
+  "title": "preview_map_package inputSchema",
+  "description": "Argument shape for preview_map_package (Analyze, Build App; returns a preview ArtifactRef). Produces a read-only preview artifact for an existing map package. Responsibility-level. See taxonomy.md §Map composition.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["mapPackageId"],
+  "properties": {
+    "mapPackageId": {
+      "type": "string",
+      "description": "Identifier (map_…) of the MapPackage to preview."
+    },
+    "width": { "type": "integer", "minimum": 1 },
+    "height": { "type": "integer", "minimum": 1 }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/propose_operation.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/propose_operation.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/propose_operation.schema.json",
+  "title": "propose_operation inputSchema",
+  "description": "Argument shape for the control-plane proposal tool (advertised name honua_propose_operation). Proposes an in-scope mutating control-plane operation for human approval (never autonomously executed), consistent with the ADR-0028 no-direct-AI-mutation boundary in taxonomy.md §Non-Goals. x-honua-reference-shape: tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["kind"],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "description": "In-scope mutating control-plane operation class to propose.",
+      "enum": ["AdminConfigChange", "Deploy", "MetadataRelease", "Seed"]
+    },
+    "reason": {
+      "type": "string",
+      "description": "Operator-facing reason or change note for the proposal."
+    },
+    "executionPayload": {
+      "type": "string",
+      "description": "Opaque, class-specific JSON execution payload replayed when the proposal is approved."
+    },
+    "idempotencyKey": {
+      "type": "string",
+      "description": "Stable idempotency key for the underlying operation."
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/publish_result.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/publish_result.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/publish_result.schema.json",
+  "title": "publish_result inputSchema",
+  "description": "Argument shape for publish_result (Analyze, Publish Data, Build App). Promotes a result/package to a canonical promotion-surface target: PublishedService for Publish Data, Deployment for Analyze and Build App (resources.md §Promotion-Surface Resources). Publish/PolicyBoundary clarifications fire before handoff (planning.md). Responsibility-level: concrete promotion field set finalizes upstream (honua-server#730/#732).",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["sourceId"],
+  "properties": {
+    "sourceId": {
+      "type": "string",
+      "description": "Identifier of the package or result being promoted (result_…, map_…, app_…)."
+    },
+    "targetKind": {
+      "type": "string",
+      "description": "Promotion-surface target family. Published_service for Publish Data; deployment for Analyze and Build App.",
+      "enum": ["published_service", "deployment"]
+    },
+    "visibility": {
+      "type": "string",
+      "description": "Promotion visibility scope.",
+      "enum": ["workspace_shared", "public"]
+    },
+    "routePrefix": {
+      "type": "string",
+      "description": "Optional route prefix for a deployment target."
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/query_features.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/query_features.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/query_features.schema.json",
+  "title": "query_features inputSchema",
+  "description": "Argument shape for the discovery/query feature-query tool (advertised name honua_query_features). Reads features from a published layer with an optional attribute and spatial filter. x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["serviceId", "layerId"],
+  "properties": {
+    "serviceId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Published service identifier or name (from list_layers.serviceId)."
+    },
+    "layerId": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Service-local layer index (from list_layers.layerId)."
+    },
+    "where": {
+      "type": "string",
+      "description": "Optional attribute filter expressed as an ArcGIS/SQL WHERE clause."
+    },
+    "bbox": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "items": { "type": "number" },
+      "description": "Optional spatial filter envelope as [minX, minY, maxX, maxY]."
+    },
+    "bboxSrid": {
+      "type": "integer",
+      "default": 4326,
+      "description": "Spatial reference (SRID/WKID) of the bbox ordinates."
+    },
+    "outFields": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Optional attribute fields to return; omit for all fields."
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 1000,
+      "default": 100,
+      "description": "Maximum number of features to return (capped at 1000)."
+    },
+    "outSrid": {
+      "type": "integer",
+      "default": 4326,
+      "description": "Output spatial reference (SRID/WKID) for returned geometries."
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/refine_map_package.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/refine_map_package.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/refine_map_package.schema.json",
+  "title": "refine_map_package inputSchema",
+  "description": "Argument shape for refine_map_package (Analyze, Build App; returns the updated MapPackage). Refines an existing map package's composition. Responsibility-level: targets a mapPackageId and carries a refinement delta whose concrete field set finalizes upstream (honua-server#731). See taxonomy.md §Map composition.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["mapPackageId"],
+  "properties": {
+    "mapPackageId": {
+      "type": "string",
+      "description": "Identifier (map_…) of the MapPackage to refine."
+    },
+    "styleId": { "type": "string" },
+    "themeId": { "type": "string" },
+    "sourceBindings": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "initialView": { "type": "object", "additionalProperties": true }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/render_map.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/render_map.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/render_map.schema.json",
+  "title": "render_map inputSchema",
+  "description": "Argument shape for the map-render tool (advertised name honua_render_map). Renders an image of ordered layers over an extent. This is the reference implementation's read-only map preview surface, distinct from the semantic map-composition family (create_map_package, etc.). x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["layers", "bbox"],
+  "properties": {
+    "layers": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Ordered layers to draw, bottom-to-top.",
+      "items": {
+        "type": "object",
+        "required": ["serviceId", "layerId"],
+        "properties": {
+          "serviceId": { "type": "string", "minLength": 1 },
+          "layerId": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "bbox": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "items": { "type": "number" },
+      "description": "Map extent as [minX, minY, maxX, maxY]."
+    },
+    "bboxSrid": {
+      "type": "integer",
+      "default": 4326,
+      "description": "Spatial reference (SRID/WKID) of the bbox and output image."
+    },
+    "width": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 1024,
+      "default": 512,
+      "description": "Output image width in pixels (capped at 1024)."
+    },
+    "height": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 1024,
+      "default": 512,
+      "description": "Output image height in pixels (capped at 1024)."
+    },
+    "transparent": {
+      "type": "boolean",
+      "default": false,
+      "description": "Render a transparent background instead of an opaque one."
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/solve_route.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/solve_route.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/solve_route.schema.json",
+  "title": "solve_route inputSchema",
+  "description": "Argument shape for the analysis/geoprocessing routing tool (advertised name honua_solve_route). Solves an ordered route through a sequence of stops. x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["stops"],
+  "properties": {
+    "stops": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 25,
+      "description": "Ordered stops to route through, in visit order.",
+      "items": {
+        "type": "object",
+        "required": ["lon", "lat"],
+        "properties": {
+          "lon": { "type": "number", "description": "Longitude (X) ordinate." },
+          "lat": { "type": "number", "description": "Latitude (Y) ordinate." }
+        }
+      }
+    },
+    "travelProfile": {
+      "type": "string",
+      "default": "driving",
+      "description": "Travel profile / cost-model selector (e.g. \"driving\", \"walking\")."
+    },
+    "outSrid": {
+      "type": "integer",
+      "default": 4326,
+      "description": "Output spatial reference (SRID/WKID) for the returned route geometry."
+    },
+    "inSrid": {
+      "type": "integer",
+      "description": "Spatial reference of the input stop ordinates; defaults to outSrid."
+    }
+  }
+}

--- a/mcp/certification/geospatial-mcp-schemas/tools/validate_plan.schema.json
+++ b/mcp/certification/geospatial-mcp-schemas/tools/validate_plan.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/validate_plan.schema.json",
+  "title": "validate_plan inputSchema",
+  "description": "Argument shape for the validate_plan tool (Analyze, Publish Data, Build App; also shared by the dry_run_plan preview tool in the reference implementation). Reference advertised name: honua_validate_plan. Accepts a partial AnalysisPlan so the validator can report EMPTY_PLAN_ID / EMPTY_STEPS as structured violations rather than rejecting at ingest — planId and steps are therefore NOT required here (contrast execute_plan). See planning.md §5.1.",
+  "type": "object",
+  "required": ["plan"],
+  "properties": {
+    "plan": { "$ref": "#/$defs/analysisPlan" }
+  },
+  "$defs": {
+    "analysisPlan": {
+      "type": "object",
+      "description": "Canonical AnalysisPlan expressed as MCP plan input. Partial plans are permitted at validate time.",
+      "required": [],
+      "properties": {
+        "planId": { "type": "string" },
+        "intentId": { "type": "string" },
+        "steps": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/planStep" }
+        },
+        "outputs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/artifactKind" }
+        },
+        "warnings": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "planStep": {
+      "type": "object",
+      "required": ["stepId", "kind"],
+      "properties": {
+        "stepId": { "type": "string" },
+        "kind": { "$ref": "#/$defs/planStepKind" },
+        "processId": { "type": "string" },
+        "inputs": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "dependsOn": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "planStepKind": {
+      "type": "string",
+      "description": "Canonical AnalysisPlanStepKind value. Server parsing is case-insensitive but clients should send the canonical PascalCase spelling.",
+      "enum": ["QueryFeatures", "Geoprocess", "Aggregate", "RenderMap", "Export"]
+    },
+    "artifactKind": {
+      "type": "string",
+      "description": "Canonical ArtifactKind value.",
+      "enum": ["Scalar", "FeatureLayer", "Table", "Raster", "File", "Report", "Map", "AppBundle"]
+    }
+  }
+}

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.14-alpha.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "ajv": "^8.20.0",
         "zod": "^3.24.0"
       },
       "bin": {
@@ -26,7 +27,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@honua/sdk-js": "^0.0.12-alpha.0"
+        "@honua/sdk-js": "^0.0.14-alpha.0"
       }
     },
     "..": {
@@ -36,6 +37,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@maplibre/maplibre-gl-style-spec": "^24.7.0"
+      },
+      "bin": {
+        "honua": "dist/src/cli/bin.js"
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
@@ -50,7 +54,7 @@
         "cesium": "^1.139.1",
         "maplibre-gl": "^5.21.1",
         "typescript": "^5.9.2",
-        "vite": "^7.3.1",
+        "vite": "^8.0.16",
         "vitest": "^4.0.16"
       },
       "engines": {
@@ -545,9 +549,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -565,9 +566,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -585,9 +583,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -605,9 +600,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -625,9 +617,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -645,9 +634,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -945,9 +931,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -14,6 +14,9 @@
     "test": "npm run build --silent && vitest run --coverage",
     "test:unit": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "certify": "npm run build --silent && node dist/src/certification/cli.js",
+    "test:certification": "npm run build --silent && vitest run test/certification && node dist/src/certification/cli.js",
+    "test:certification:artifact": "npm run build --silent && node dist/src/certification/cli.js --artifact-only",
     "lint": "biome lint src/ test/",
     "lint:fix": "biome lint --write src/ test/",
     "format": "biome format src/ test/",
@@ -23,6 +26,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "ajv": "^8.20.0",
     "zod": "^3.24.0"
   },
   "overrides": {
@@ -32,8 +36,8 @@
     "@honua/sdk-js": "^0.0.14-alpha.0"
   },
   "devDependencies": {
-    "@honua/sdk-js": "file:..",
     "@biomejs/biome": "1.9.4",
+    "@honua/sdk-js": "file:..",
     "@types/node": "^24.3.1",
     "@vitest/coverage-v8": "^4.0.16",
     "typescript": "^5.9.2",
@@ -41,6 +45,7 @@
   },
   "files": [
     "dist/src",
+    "certification/geospatial-mcp-schemas",
     "README.md"
   ],
   "engines": {

--- a/mcp/src/certification/certifier.ts
+++ b/mcp/src/certification/certifier.ts
@@ -1,0 +1,362 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { buildRoundTripInputs, resolveRoundTripEnv } from "./fixtures.js";
+import { checkConformance, checkWellFormed, validateAgainstSchema } from "./json-schema.js";
+import {
+  type JsonSchema,
+  type StandardToolEntry,
+  buildReferenceToolLookup,
+  loadSchemaFile,
+  loadSchemaIndex,
+} from "./schema-index.js";
+
+/** Per-tool certification record (machine-readable). */
+export interface ToolCertification {
+  name: string;
+  discovered: true;
+  /** inputSchema is structurally valid JSON Schema (draft 2020-12 dialect). */
+  schemaValid: boolean;
+  /** Whether the server advertises a structured-output schema for this tool. */
+  hasOutputSchema: boolean;
+  /** Matched standard tool (by referenceToolName), if any. */
+  standardName: string | null;
+  /** Conformant to the matched standard schema. `null` when no standard match. */
+  conformant: boolean | null;
+  /** Server-advertised read-only hint; round-trip only runs for read-only tools. */
+  readOnly: boolean;
+  /** Round-trip outcome. `skipped` when not read-only or no fixture input. */
+  roundTrip: "passed" | "failed" | "skipped";
+  errors: string[];
+  notes: string[];
+}
+
+/** Per-resource certification record. */
+export interface ResourceCertification {
+  name: string;
+  uri: string;
+  discovered: true;
+}
+
+/** A standard capability advertised by the spec but not implemented here. */
+export interface KnownGap {
+  kind: "standard-tool" | "advertised-tool";
+  name: string;
+  family?: string;
+  detail: string;
+}
+
+export interface CertificationReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  server: { name: string; version: string };
+  protocol: { mcpTransport: string; honuaTransport: string | null; backend: "fixture" | "live" };
+  standard: { source: string; indexDate: string; dialect: string };
+  summary: {
+    pass: boolean;
+    toolsDiscovered: number;
+    toolsSchemaValid: number;
+    toolsConformanceChecked: number;
+    toolsConformant: number;
+    toolsRoundTripped: number;
+    resourcesDiscovered: number;
+    promptsDiscovered: number;
+    knownGaps: number;
+    failures: number;
+  };
+  tools: ToolCertification[];
+  resources: ResourceCertification[];
+  prompts: { name: string; discovered: true }[];
+  knownGaps: KnownGap[];
+}
+
+export interface CertifyOptions {
+  /** MCP server to certify. */
+  server: McpServer;
+  /** Logical Honua backend transport (grpc-web/rest) for the artifact, if known. */
+  honuaTransport?: string | null;
+  /** Whether the backend is the offline fixture or a live server. */
+  backend?: "fixture" | "live";
+  /** Environment used to resolve round-trip identifiers. */
+  env?: NodeJS.ProcessEnv;
+}
+
+const STANDARD_SOURCE = "geospatial-mcp@968d7d7 (spec/schemas)";
+
+/** Determine whether a discovered tool is safe to round-trip (read-only). */
+export function isReadOnlyTool(tool: { name: string; annotations?: { readOnlyHint?: boolean } }): boolean {
+  // Honor an explicit server annotation when present (forward-compatible with
+  // the honua-server /mcp surface that advertises readOnlyHint).
+  if (tool.annotations && typeof tool.annotations.readOnlyHint === "boolean") {
+    return tool.annotations.readOnlyHint;
+  }
+  // The @honua/mcp-server tool surface is read-only by construction: every tool
+  // is an inspection/projection that never mutates server state. Tools whose
+  // names imply mutation are conservatively treated as NOT read-only.
+  const mutating = /(create|update|delete|publish|apply_.*write|execute|edit|deploy|cancel)/i;
+  return !mutating.test(tool.name);
+}
+
+/**
+ * Connect an MCP client to the given server over an in-memory transport and
+ * produce a deterministic certification report. No network access, no model
+ * calls — the only I/O is the in-process MCP round-trip and reading vendored
+ * schema files.
+ */
+export async function certify(options: CertifyOptions): Promise<CertificationReport> {
+  const { server } = options;
+  const backend = options.backend ?? "fixture";
+  const roundTripEnv = resolveRoundTripEnv(options.env);
+  const roundTripInputs = buildRoundTripInputs(roundTripEnv);
+
+  const index = loadSchemaIndex();
+  const referenceLookup = buildReferenceToolLookup(index);
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "honua-mcp-certifier", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  try {
+    const serverInfo = client.getServerVersion() ?? { name: "unknown", version: "0.0.0" };
+
+    const toolsResponse = await client.listTools();
+    const resourcesResponse = await client.listResources();
+    const prompts = await listPromptsSafely(client);
+
+    const tools: ToolCertification[] = [];
+    const advertisedNames = new Set<string>();
+
+    for (const tool of toolsResponse.tools) {
+      advertisedNames.add(tool.name);
+      const record = await certifyTool(client, tool, referenceLookup, roundTripInputs);
+      tools.push(record);
+    }
+
+    const resources: ResourceCertification[] = resourcesResponse.resources.map((r) => ({
+      name: r.name,
+      uri: r.uri,
+      discovered: true,
+    }));
+
+    const knownGaps = collectKnownGaps(index, advertisedNames, referenceLookup);
+
+    const report = assembleReport({
+      serverInfo: serverInfo as { name: string; version: string },
+      index,
+      backend,
+      honuaTransport: options.honuaTransport ?? null,
+      tools,
+      resources,
+      prompts,
+      knownGaps,
+    });
+
+    return report;
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+async function listPromptsSafely(client: Client): Promise<{ name: string; discovered: true }[]> {
+  try {
+    const response = await client.listPrompts();
+    return response.prompts.map((p) => ({ name: p.name, discovered: true as const }));
+  } catch {
+    // Server does not advertise the prompts capability — not a failure.
+    return [];
+  }
+}
+
+interface AdvertisedTool {
+  name: string;
+  inputSchema?: unknown;
+  outputSchema?: unknown;
+  annotations?: { readOnlyHint?: boolean };
+}
+
+async function certifyTool(
+  client: Client,
+  tool: AdvertisedTool,
+  referenceLookup: Map<string, StandardToolEntry>,
+  roundTripInputs: Record<string, Record<string, unknown>>,
+): Promise<ToolCertification> {
+  const errors: string[] = [];
+  const notes: string[] = [];
+
+  // 1. inputSchema well-formedness.
+  const wellFormed = checkWellFormed(tool.inputSchema);
+  if (!wellFormed.wellFormed) {
+    errors.push(...wellFormed.errors.map((e) => `inputSchema not well-formed: ${e}`));
+  }
+
+  const hasOutputSchema = tool.outputSchema !== undefined && tool.outputSchema !== null;
+  if (hasOutputSchema) {
+    const outputWellFormed = checkWellFormed(tool.outputSchema);
+    if (!outputWellFormed.wellFormed) {
+      errors.push(...outputWellFormed.errors.map((e) => `outputSchema not well-formed: ${e}`));
+    }
+  } else {
+    notes.push("no structured output schema advertised");
+  }
+
+  // 2. Conformance against the matched standard schema (if any).
+  const standardEntry = referenceLookup.get(tool.name);
+  let conformant: boolean | null = null;
+  if (standardEntry) {
+    const standardSchema = loadSchemaFile(standardEntry.schema);
+    if (wellFormed.wellFormed) {
+      const result = checkConformance(tool.inputSchema as JsonSchema, standardSchema);
+      conformant = result.conformant;
+      if (!result.conformant) {
+        errors.push(...result.violations.map((v) => `conformance: ${v}`));
+      }
+      notes.push(...result.notes);
+    } else {
+      conformant = false;
+      errors.push("conformance: skipped — inputSchema is not well-formed");
+    }
+  }
+
+  // 3. Round-trip for read-only tools with a fixture input.
+  const readOnly = isReadOnlyTool(tool);
+  let roundTrip: ToolCertification["roundTrip"] = "skipped";
+  const fixtureInput = roundTripInputs[tool.name];
+  if (readOnly && fixtureInput !== undefined) {
+    roundTrip = await roundTripTool(client, tool, fixtureInput, errors, notes);
+  } else if (!readOnly) {
+    notes.push("round-trip skipped: tool is not read-only");
+  } else {
+    notes.push("round-trip skipped: no fixture input");
+  }
+
+  return {
+    name: tool.name,
+    discovered: true,
+    schemaValid: wellFormed.wellFormed,
+    hasOutputSchema,
+    standardName: standardEntry?.standardName ?? null,
+    conformant,
+    readOnly,
+    roundTrip,
+    errors,
+    notes,
+  };
+}
+
+async function roundTripTool(
+  client: Client,
+  tool: AdvertisedTool,
+  input: Record<string, unknown>,
+  errors: string[],
+  notes: string[],
+): Promise<ToolCertification["roundTrip"]> {
+  try {
+    const result = (await client.callTool({ name: tool.name, arguments: input })) as {
+      isError?: boolean;
+      content?: unknown;
+      structuredContent?: unknown;
+    };
+    if (result.isError) {
+      errors.push("round-trip: tool returned isError=true");
+      return "failed";
+    }
+    // Validate structured output against the advertised output schema, if any.
+    if (tool.outputSchema && result.structuredContent !== undefined) {
+      const validation = validateAgainstSchema(tool.outputSchema as JsonSchema, result.structuredContent);
+      if (!validation.valid) {
+        errors.push(...validation.errors.map((e) => `round-trip output: ${e}`));
+        return "failed";
+      }
+    } else if (tool.outputSchema && result.structuredContent === undefined) {
+      notes.push("round-trip: output schema advertised but no structuredContent returned");
+    }
+    return "passed";
+  } catch (err) {
+    errors.push(`round-trip: ${err instanceof Error ? err.message : String(err)}`);
+    return "failed";
+  }
+}
+
+function collectKnownGaps(
+  index: ReturnType<typeof loadSchemaIndex>,
+  advertisedNames: Set<string>,
+  referenceLookup: Map<string, StandardToolEntry>,
+): KnownGap[] {
+  const gaps: KnownGap[] = [];
+
+  // Standard tools not advertised by this server (absence is a gap, not a fail).
+  for (const tool of index.tools) {
+    const referenceName = tool.referenceToolName;
+    const advertised = referenceName ? advertisedNames.has(referenceName) : false;
+    if (!advertised) {
+      gaps.push({
+        kind: "standard-tool",
+        name: tool.standardName,
+        family: tool.family,
+        detail:
+          tool.implementationStatus === "known-gap"
+            ? "standard family not yet implemented as a discrete tool"
+            : `reference tool ${referenceName ?? "(unnamed)"} not advertised by @honua/mcp-server`,
+      });
+    }
+  }
+
+  // Tools this server advertises that are not in the standard index.
+  for (const name of advertisedNames) {
+    if (!referenceLookup.has(name)) {
+      gaps.push({
+        kind: "advertised-tool",
+        name,
+        detail: "advertised tool has no matching geospatial-mcp standard schema (validated for well-formedness only)",
+      });
+    }
+  }
+
+  return gaps;
+}
+
+function assembleReport(args: {
+  serverInfo: { name: string; version: string };
+  index: ReturnType<typeof loadSchemaIndex>;
+  backend: "fixture" | "live";
+  honuaTransport: string | null;
+  tools: ToolCertification[];
+  resources: ResourceCertification[];
+  prompts: { name: string; discovered: true }[];
+  knownGaps: KnownGap[];
+}): CertificationReport {
+  const { serverInfo, index, backend, honuaTransport, tools, resources, prompts, knownGaps } = args;
+
+  const toolsSchemaValid = tools.filter((t) => t.schemaValid).length;
+  const conformanceChecked = tools.filter((t) => t.conformant !== null);
+  const toolsConformant = conformanceChecked.filter((t) => t.conformant === true).length;
+  const toolsRoundTripped = tools.filter((t) => t.roundTrip === "passed").length;
+  const failures = tools.reduce((acc, t) => acc + t.errors.length, 0);
+  const pass = failures === 0;
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    server: serverInfo,
+    protocol: { mcpTransport: "in-memory", honuaTransport, backend },
+    standard: { source: STANDARD_SOURCE, indexDate: index.date, dialect: index.dialect },
+    summary: {
+      pass,
+      toolsDiscovered: tools.length,
+      toolsSchemaValid,
+      toolsConformanceChecked: conformanceChecked.length,
+      toolsConformant,
+      toolsRoundTripped,
+      resourcesDiscovered: resources.length,
+      promptsDiscovered: prompts.length,
+      knownGaps: knownGaps.length,
+      failures,
+    },
+    tools,
+    resources,
+    prompts,
+    knownGaps,
+  };
+}

--- a/mcp/src/certification/cli.ts
+++ b/mcp/src/certification/cli.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { type ArtifactPaths, runCertification, writeArtifacts } from "./run.js";
+
+/**
+ * MCP certification CLI.
+ *
+ * Modes (selected by flag):
+ *   (default)          Run certification, write artifacts, exit non-zero on any
+ *                      conformance/round-trip failure. Drives the `test:certification`
+ *                      gate in CI.
+ *   --artifact-only    Run certification, write artifacts, ALWAYS exit 0. Drives
+ *                      the `test:certification:artifact` evidence step in CI (it
+ *                      runs with `always()` and must upload artifacts even when
+ *                      the gate above failed).
+ *
+ * Artifact paths default to the package root so CI can upload
+ * `mcp-certification-results.{json,md}` from `honua-sdk-js/mcp`. Override with
+ * `--out-dir <dir>`.
+ *
+ * Deterministic and offline by default: zero model/API calls. Uses a live
+ * honua-server only when `HONUA_BASE_URL` is set (CI integration path).
+ */
+
+interface CliOptions {
+  artifactOnly: boolean;
+  outDir: string;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  let artifactOnly = false;
+  // Default to the package root (two levels up from dist/src/certification/).
+  let outDir = fileURLToPath(new URL("../../../", import.meta.url));
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--artifact-only") {
+      artifactOnly = true;
+    } else if (arg === "--out-dir") {
+      const value = argv[++i];
+      if (!value) {
+        throw new Error("--out-dir requires a directory argument");
+      }
+      outDir = resolve(value);
+    }
+  }
+  return { artifactOnly, outDir };
+}
+
+function artifactPaths(outDir: string): ArtifactPaths {
+  return {
+    json: resolve(outDir, "mcp-certification-results.json"),
+    markdown: resolve(outDir, "mcp-certification-results.md"),
+  };
+}
+
+async function main(): Promise<void> {
+  const { artifactOnly, outDir } = parseArgs(process.argv.slice(2));
+  const report = await runCertification();
+  const paths = artifactPaths(outDir);
+  writeArtifacts(report, paths);
+
+  const s = report.summary;
+  const status = s.pass ? "PASS" : "FAIL";
+  process.stdout.write(
+    `MCP certification ${status}: ${s.toolsConformant}/${s.toolsConformanceChecked} conformant, ` +
+      `${s.toolsRoundTripped} round-tripped, ${s.knownGaps} known gaps, ${s.failures} failures.\n`,
+  );
+  process.stdout.write(`Artifacts: ${paths.json}\n           ${paths.markdown}\n`);
+
+  if (!artifactOnly && !report.summary.pass) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`Certification error: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`);
+  process.exit(1);
+});

--- a/mcp/src/certification/fixture-client.ts
+++ b/mcp/src/certification/fixture-client.ts
@@ -1,0 +1,128 @@
+import type {
+  HonuaClient,
+  HonuaLayerMetadata,
+  HonuaQueryResponse,
+  HonuaServiceMetadata,
+  HonuaServicesResponse,
+} from "@honua/sdk-js";
+
+/**
+ * Offline fixture `HonuaClient` for deterministic certification.
+ *
+ * This is the standalone (non-vitest) counterpart of `test/test-helpers.ts`:
+ * it returns canned, schema-shaped responses for every method the MCP tools and
+ * resources call, so the certifier can run `tools/call` round-trips with no live
+ * backend, no network access, and no model/API calls. CI instead points the
+ * certifier at a live honua-server via `createClientFromEnv`.
+ */
+
+const STYLES_LIST = {
+  styles: [
+    { id: "topographic", title: "Topographic", links: [] },
+    { id: "imagery", title: "Imagery", links: [] },
+  ],
+  default: "topographic",
+};
+
+const TOPOGRAPHIC_METADATA = {
+  id: "topographic",
+  title: "Topographic",
+  description: "Default topographic basemap style",
+  version: "3",
+  links: [{ rel: "preview", type: "image/png", href: "https://example.test/ogc/styles/topographic/preview" }],
+};
+
+const TOPOGRAPHIC_STYLESHEET = {
+  version: 8,
+  name: "Topographic",
+  layers: [{ id: "background", type: "background" }],
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function fixtureFetch(_method: string, path: string): Promise<Response> {
+  if (path === "/ogc/styles") {
+    return jsonResponse(STYLES_LIST);
+  }
+  if (path === "/ogc/styles/topographic/metadata") {
+    return jsonResponse(TOPOGRAPHIC_METADATA);
+  }
+  if (path === "/ogc/styles/topographic") {
+    return jsonResponse(TOPOGRAPHIC_STYLESHEET);
+  }
+  return jsonResponse({ error: "not found" }, 404);
+}
+
+/** Build an offline fixture client usable anywhere a `HonuaClient` is expected. */
+export function createFixtureClient(): HonuaClient {
+  const client = {
+    serverBaseUrl: "https://example.test",
+    async listServices(): Promise<HonuaServicesResponse> {
+      return {
+        services: [
+          { name: "Parks", type: "FeatureServer" },
+          { name: "Basemap", type: "MapServer" },
+          { name: "Census", type: "FeatureServer" },
+        ],
+      };
+    },
+    async getFeatureServiceMetadata(_serviceId: string): Promise<HonuaServiceMetadata> {
+      return {
+        serviceDescription: "Test service",
+        layers: [
+          { id: 0, name: "Layer 0" },
+          { id: 1, name: "Layer 1" },
+        ],
+        spatialReference: { wkid: 4326 },
+      };
+    },
+    async getLayerMetadata(_serviceId: string, _layerId: number): Promise<HonuaLayerMetadata> {
+      return {
+        id: 0,
+        name: "Test Layer",
+        description: "A test layer",
+        geometryType: "esriGeometryPoint",
+        fields: [
+          { name: "OBJECTID", type: "esriFieldTypeOID" },
+          { name: "NAME", type: "esriFieldTypeString", alias: "Feature Name" },
+          { name: "VALUE", type: "esriFieldTypeDouble" },
+        ],
+        extent: { xmin: -180, ymin: -90, xmax: 180, ymax: 90 },
+        spatialReference: { wkid: 4326 },
+        relationships: [{ id: 0, name: "rel_0", relatedTableId: 1 }],
+      };
+    },
+    async queryFeatures(request?: { extraParams?: Record<string, unknown> }): Promise<HonuaQueryResponse> {
+      const extraParams = request?.extraParams ?? {};
+      // count-only and extent-only projections mirror the GeoServices query
+      // surface the tools exercise (returnCountOnly / returnExtentOnly).
+      if (extraParams.returnCountOnly === true) {
+        return { count: 2 } as unknown as HonuaQueryResponse;
+      }
+      if (extraParams.returnExtentOnly === true) {
+        return {
+          count: 2,
+          extent: { xmin: -180, ymin: -90, xmax: 180, ymax: 90, spatialReference: { wkid: 4326 } },
+        } as unknown as HonuaQueryResponse;
+      }
+      return {
+        objectIdFieldName: "OBJECTID",
+        geometryType: "esriGeometryPoint",
+        spatialReference: { wkid: 4326 },
+        features: [
+          { attributes: { OBJECTID: 1, NAME: "Park A", VALUE: 100 } },
+          { attributes: { OBJECTID: 2, NAME: "Park B", VALUE: 200 } },
+        ],
+        exceededTransferLimit: false,
+      };
+    },
+    pipelineFetch: fixtureFetch,
+  };
+
+  return client as unknown as HonuaClient;
+}

--- a/mcp/src/certification/fixtures.ts
+++ b/mcp/src/certification/fixtures.ts
@@ -1,0 +1,45 @@
+/**
+ * Deterministic round-trip fixture inputs for read-only tools.
+ *
+ * Certification calls `tools/call` only for tools the server marks read-only
+ * (see `isReadOnlyTool`). The inputs below are resolved from environment
+ * overrides so the same harness drives both the offline fixture backend (tests)
+ * and a live honua-server in CI, without ever calling a write/destructive tool.
+ */
+
+export interface RoundTripEnv {
+  serviceId: string;
+  layerId: number;
+  styleId: string | undefined;
+}
+
+/** Resolve round-trip identifiers from the environment, with safe fallbacks. */
+export function resolveRoundTripEnv(env: NodeJS.ProcessEnv = process.env): RoundTripEnv {
+  const serviceId = env.HONUA_MCP_SERVICE_ID ?? env.HONUA_SERVICE_ID ?? "Parks";
+  const layerRaw = env.HONUA_MCP_LAYER_ID ?? env.HONUA_LAYER_ID ?? "0";
+  const parsedLayer = Number.parseInt(layerRaw, 10);
+  const layerId = Number.isFinite(parsedLayer) && parsedLayer >= 0 ? parsedLayer : 0;
+  const styleId = env.HONUA_MCP_STYLE_ID ?? env.HONUA_STYLE_ID;
+  return { serviceId, layerId, styleId };
+}
+
+/**
+ * Build the fixture argument map keyed by advertised tool name. Tools without a
+ * fixture entry are still discovered and schema/conformance checked, but are not
+ * round-tripped (no call is made).
+ */
+export function buildRoundTripInputs(env: RoundTripEnv): Record<string, Record<string, unknown>> {
+  const { serviceId, layerId } = env;
+  const styleId = env.styleId;
+  return {
+    honua_list_services: {},
+    honua_describe_layer: { serviceId, layerId },
+    honua_query_features: { serviceId, layerId, limit: 1 },
+    honua_count_features: { serviceId, layerId },
+    honua_get_extent: { serviceId, layerId },
+    honua_statistics: { serviceId, layerId, statisticType: "count", onField: "OBJECTID" },
+    honua_explain_capability_gap: { protocol: "wmts", capability: "query" },
+    honua_get_style: styleId ? { styleId } : {},
+    honua_apply_style_preset: styleId ? { styleId } : { styleId: "topographic" },
+  };
+}

--- a/mcp/src/certification/json-schema.ts
+++ b/mcp/src/certification/json-schema.ts
@@ -1,0 +1,200 @@
+import { Ajv2020 } from "ajv/dist/2020.js";
+import type { AnySchema, AnySchemaObject, ErrorObject, ValidateFunction } from "ajv/dist/2020.js";
+import draft07MetaSchema from "ajv/dist/refs/json-schema-draft-07.json" with { type: "json" };
+import type { JsonSchema } from "./schema-index.js";
+
+/**
+ * Deterministic JSON Schema utilities for certification.
+ *
+ * Two dialects appear in practice:
+ *   - The vendored geospatial-mcp standard schemas declare draft 2020-12.
+ *   - MCP tool `inputSchema`s emitted via zod-to-json-schema declare draft-07.
+ *
+ * A single Ajv 2020-12 core handles both: we register the draft-07 meta-schema
+ * so a schema that declares `$schema: ".../draft-07/schema#"` resolves instead
+ * of erroring with "no schema with key/ref". All work is in-process: no network
+ * access, no model calls.
+ *
+ * `strict: false` tolerates non-standard annotation keywords (e.g.
+ * `x-honua-reference-shape`); `validateFormats: false` keeps well-formedness
+ * purely structural and offline.
+ */
+function createAjv(): Ajv2020 {
+  const ajv = new Ajv2020({ strict: false, allErrors: true, validateFormats: false });
+  ajv.addMetaSchema(draft07MetaSchema as AnySchemaObject);
+  return ajv;
+}
+
+export interface WellFormedResult {
+  wellFormed: boolean;
+  errors: string[];
+}
+
+/**
+ * Check that a value is a structurally well-formed JSON Schema by asking Ajv to
+ * compile it. A schema that compiles is usable as a validator; a schema Ajv
+ * refuses to compile is malformed.
+ */
+export function checkWellFormed(schema: unknown): WellFormedResult {
+  if (schema === undefined || schema === null) {
+    return { wellFormed: false, errors: ["schema is missing (null/undefined)"] };
+  }
+  if (typeof schema !== "object") {
+    return { wellFormed: false, errors: [`schema must be an object, got ${typeof schema}`] };
+  }
+  try {
+    const ajv = createAjv();
+    ajv.compile(schema as AnySchema);
+    return { wellFormed: true, errors: [] };
+  } catch (err) {
+    return { wellFormed: false, errors: [err instanceof Error ? err.message : String(err)] };
+  }
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+function formatErrors(errors: ErrorObject[] | null | undefined): string[] {
+  if (!errors) {
+    return [];
+  }
+  return errors.map((e) => `${e.instancePath || "(root)"} ${e.message ?? "is invalid"}`.trim());
+}
+
+/** Compile a schema into a reusable validator, or throw a descriptive error. */
+export function compileValidator(schema: JsonSchema): ValidateFunction {
+  const ajv = createAjv();
+  return ajv.compile(schema);
+}
+
+/** Validate a value against a JSON Schema and collect human-readable errors. */
+export function validateAgainstSchema(schema: JsonSchema, value: unknown): ValidationResult {
+  try {
+    const validate = compileValidator(schema);
+    const valid = validate(value) as boolean;
+    return { valid, errors: valid ? [] : formatErrors(validate.errors) };
+  } catch (err) {
+    return { valid: false, errors: [err instanceof Error ? err.message : String(err)] };
+  }
+}
+
+/**
+ * Extract the top-level property names a JSON Schema accepts, when discoverable
+ * from a plain `type: object` shape. Returns undefined when the property set is
+ * not statically enumerable (e.g. additionalProperties / combinators only).
+ */
+function objectPropertyNames(schema: JsonSchema): Set<string> | undefined {
+  const props = schema.properties;
+  if (props && typeof props === "object") {
+    return new Set(Object.keys(props as Record<string, unknown>));
+  }
+  return undefined;
+}
+
+function requiredPropertyNames(schema: JsonSchema): string[] {
+  const required = schema.required;
+  return Array.isArray(required) ? (required.filter((r) => typeof r === "string") as string[]) : [];
+}
+
+/** Normalize a JSON Schema `type` (string or array) into a set. */
+function schemaTypes(schema: JsonSchema | undefined): Set<string> {
+  if (!schema) {
+    return new Set();
+  }
+  const t = schema.type;
+  if (typeof t === "string") {
+    return new Set([t]);
+  }
+  if (Array.isArray(t)) {
+    return new Set(t.filter((x): x is string => typeof x === "string"));
+  }
+  return new Set();
+}
+
+export interface ConformanceResult {
+  conformant: boolean;
+  /** Required standard properties the advertised schema honors. */
+  matchedRequired: string[];
+  /** Conformance violations (missing or type-incompatible required properties). */
+  violations: string[];
+  /** Non-fatal observations (e.g. advertised extra properties, type widenings). */
+  notes: string[];
+}
+
+/**
+ * Deterministically compare an advertised tool inputSchema against a standard
+ * geospatial-mcp tool schema.
+ *
+ * Conformance contract (intentionally permissive to avoid false negatives — we
+ * fail only on demonstrable non-conformance, never on the absence of a tool):
+ *
+ *   1. Every property the standard marks `required` MUST be present in the
+ *      advertised schema's properties (a client that follows the standard will
+ *      send it, so the tool must accept it).
+ *   2. For each such required property, when both schemas declare a `type`, the
+ *      advertised type must be compatible (equal, or a superset, or `integer`
+ *      accepted where the standard says `number`).
+ *
+ * Extra advertised properties and looser-but-compatible types are recorded as
+ * notes, not violations: a richer reference shape is allowed to extend the
+ * bare standard.
+ */
+export function checkConformance(advertised: JsonSchema, standard: JsonSchema): ConformanceResult {
+  const violations: string[] = [];
+  const notes: string[] = [];
+  const matchedRequired: string[] = [];
+
+  const standardRequired = requiredPropertyNames(standard);
+  const standardProps = (standard.properties ?? {}) as Record<string, JsonSchema>;
+  const advertisedProps = (advertised.properties ?? {}) as Record<string, JsonSchema>;
+  const advertisedNames = objectPropertyNames(advertised);
+
+  for (const name of standardRequired) {
+    const present = advertisedNames ? advertisedNames.has(name) : name in advertisedProps;
+    if (!present) {
+      violations.push(`missing required standard property "${name}"`);
+      continue;
+    }
+
+    const standardTypes = schemaTypes(standardProps[name]);
+    const advertisedTypes = schemaTypes(advertisedProps[name]);
+    if (standardTypes.size > 0 && advertisedTypes.size > 0) {
+      const compatible = [...standardTypes].every((st) => {
+        if (advertisedTypes.has(st)) {
+          return true;
+        }
+        // `integer` is a refinement of `number`: a standard `number` is
+        // satisfied by an advertised `integer`, and vice versa is acceptable.
+        if (st === "number" && advertisedTypes.has("integer")) {
+          return true;
+        }
+        if (st === "integer" && advertisedTypes.has("number")) {
+          notes.push(`property "${name}" widens standard integer to number`);
+          return true;
+        }
+        return false;
+      });
+      if (!compatible) {
+        violations.push(
+          `property "${name}" type ${[...advertisedTypes].join("|")} is incompatible with standard ${[...standardTypes].join("|")}`,
+        );
+        continue;
+      }
+    }
+    matchedRequired.push(name);
+  }
+
+  // Record advertised-only properties as informational coverage notes.
+  if (advertisedNames) {
+    const standardNames = new Set(Object.keys(standardProps));
+    for (const name of advertisedNames) {
+      if (!standardNames.has(name)) {
+        notes.push(`advertises non-standard property "${name}"`);
+      }
+    }
+  }
+
+  return { conformant: violations.length === 0, matchedRequired, violations, notes };
+}

--- a/mcp/src/certification/report.ts
+++ b/mcp/src/certification/report.ts
@@ -1,0 +1,89 @@
+import type { CertificationReport } from "./certifier.js";
+
+/** Render a human-readable Markdown summary of a certification report. */
+export function renderMarkdown(report: CertificationReport): string {
+  const s = report.summary;
+  const status = s.pass ? "✅ PASS" : "❌ FAIL";
+  const lines: string[] = [];
+
+  lines.push(`# MCP Certification — ${report.server.name} v${report.server.version}`);
+  lines.push("");
+  lines.push(`**Result:** ${status}`);
+  lines.push("");
+  lines.push(`- Generated: \`${report.generatedAt}\``);
+  lines.push(`- MCP transport: \`${report.protocol.mcpTransport}\``);
+  lines.push(
+    `- Honua backend: \`${report.protocol.backend}\`${
+      report.protocol.honuaTransport ? ` (transport: \`${report.protocol.honuaTransport}\`)` : ""
+    }`,
+  );
+  lines.push(
+    `- Standard: \`${report.standard.source}\` (index ${report.standard.indexDate}, ${report.standard.dialect})`,
+  );
+  lines.push("");
+
+  lines.push("## Summary");
+  lines.push("");
+  lines.push("| Metric | Value |");
+  lines.push("| --- | ---: |");
+  lines.push(`| Tools discovered | ${s.toolsDiscovered} |`);
+  lines.push(`| Tools with valid inputSchema | ${s.toolsSchemaValid} / ${s.toolsDiscovered} |`);
+  lines.push(`| Tools conformance-checked | ${s.toolsConformanceChecked} |`);
+  lines.push(`| Tools conformant | ${s.toolsConformant} / ${s.toolsConformanceChecked} |`);
+  lines.push(`| Tools round-tripped | ${s.toolsRoundTripped} |`);
+  lines.push(`| Resources discovered | ${s.resourcesDiscovered} |`);
+  lines.push(`| Prompts discovered | ${s.promptsDiscovered} |`);
+  lines.push(`| Known gaps | ${s.knownGaps} |`);
+  lines.push(`| Failures | ${s.failures} |`);
+  lines.push("");
+
+  lines.push("## Tools");
+  lines.push("");
+  lines.push("| Tool | Schema | Standard | Conformant | Round-trip | Output schema |");
+  lines.push("| --- | :---: | --- | :---: | :---: | :---: |");
+  for (const t of report.tools) {
+    const conformant = t.conformant === null ? "n/a" : t.conformant ? "yes" : "**NO**";
+    lines.push(
+      `| \`${t.name}\` | ${t.schemaValid ? "valid" : "**invalid**"} | ${t.standardName ?? "—"} | ${conformant} | ${t.roundTrip} | ${t.hasOutputSchema ? "yes" : "no"} |`,
+    );
+  }
+  lines.push("");
+
+  const toolErrors = report.tools.filter((t) => t.errors.length > 0);
+  if (toolErrors.length > 0) {
+    lines.push("### Failures");
+    lines.push("");
+    for (const t of toolErrors) {
+      lines.push(`- \`${t.name}\``);
+      for (const e of t.errors) {
+        lines.push(`  - ${e}`);
+      }
+    }
+    lines.push("");
+  }
+
+  if (report.resources.length > 0) {
+    lines.push("## Resources");
+    lines.push("");
+    for (const r of report.resources) {
+      lines.push(`- \`${r.name}\` — \`${r.uri}\``);
+    }
+    lines.push("");
+  }
+
+  if (report.knownGaps.length > 0) {
+    lines.push("## Known gaps");
+    lines.push("");
+    lines.push(
+      "These are standard capabilities not yet implemented as discrete tools, or advertised tools outside the standard. They are recorded, not failed.",
+    );
+    lines.push("");
+    for (const g of report.knownGaps) {
+      const family = g.family ? ` _(${g.family})_` : "";
+      lines.push(`- **${g.kind}** \`${g.name}\`${family} — ${g.detail}`);
+    }
+    lines.push("");
+  }
+
+  return `${lines.join("\n")}\n`;
+}

--- a/mcp/src/certification/run.ts
+++ b/mcp/src/certification/run.ts
@@ -1,0 +1,49 @@
+import { writeFileSync } from "node:fs";
+import { createClientFromEnv, createServer } from "../index.js";
+import { type CertificationReport, certify } from "./certifier.js";
+import { createFixtureClient } from "./fixture-client.js";
+import { renderMarkdown } from "./report.js";
+
+/**
+ * Programmatic certification runner.
+ *
+ * Backend selection is deterministic and offline-first:
+ *   - If `HONUA_BASE_URL` is set (CI live path), the certifier drives a real
+ *     `HonuaClient` over the configured Honua transport (grpc-web/rest).
+ *   - Otherwise it uses the offline fixture client — no network, no model calls.
+ *
+ * In both cases the MCP transport is in-memory and fully deterministic.
+ */
+
+export interface RunOptions {
+  env?: NodeJS.ProcessEnv;
+  /** Force the fixture backend even when HONUA_BASE_URL is present (tests). */
+  forceFixture?: boolean;
+}
+
+export async function runCertification(options: RunOptions = {}): Promise<CertificationReport> {
+  const env = options.env ?? process.env;
+  const live = !options.forceFixture && typeof env.HONUA_BASE_URL === "string" && env.HONUA_BASE_URL.length > 0;
+
+  const client = live ? createClientFromEnv(env) : createFixtureClient();
+  const server = createServer(client);
+  const honuaTransport = live ? (env.HONUA_TRANSPORT ?? "grpc-web") : null;
+
+  return certify({
+    server,
+    backend: live ? "live" : "fixture",
+    honuaTransport,
+    env,
+  });
+}
+
+export interface ArtifactPaths {
+  json: string;
+  markdown: string;
+}
+
+/** Write the JSON + Markdown certification artifacts to disk. */
+export function writeArtifacts(report: CertificationReport, paths: ArtifactPaths): void {
+  writeFileSync(paths.json, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  writeFileSync(paths.markdown, renderMarkdown(report), "utf8");
+}

--- a/mcp/src/certification/schema-index.ts
+++ b/mcp/src/certification/schema-index.ts
@@ -1,0 +1,107 @@
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Loader for the vendored geospatial-mcp JSON Schemas and their index.
+ *
+ * The schemas are vendored under `certification/geospatial-mcp-schemas/` (see
+ * that directory's `PROVENANCE.md`). Loading is filesystem-only and fully
+ * deterministic — no network access and no model/API calls.
+ */
+
+export interface StandardToolEntry {
+  /** Bare taxonomy.md tool name (e.g. `query_features`). */
+  standardName: string;
+  /** Name the reference implementation advertises, or null when unimplemented. */
+  referenceToolName: string | null;
+  family: string;
+  /** Relative path of the schema file, e.g. `tools/query_features.schema.json`. */
+  schema: string;
+  implementationStatus: "implemented" | "known-gap";
+  notes?: string;
+}
+
+export interface StandardResourceEntry {
+  family: string;
+  uriForm: string;
+  schema: string;
+  shapeFidelity: string;
+}
+
+export interface SchemaIndex {
+  title: string;
+  date: string;
+  dialect: string;
+  tools: StandardToolEntry[];
+  resources: StandardResourceEntry[];
+  common: { name: string; schema: string; role: string }[];
+}
+
+export type JsonSchema = Record<string, unknown>;
+
+/**
+ * Resolved root of the vendored schema tree.
+ *
+ * The vendored schemas live at the package root under
+ * `certification/geospatial-mcp-schemas/`. This module runs from two locations:
+ *   - compiled: `dist/src/certification/schema-index.js` (3 levels deep)
+ *   - vitest:   `src/certification/schema-index.ts` (2 levels deep)
+ * so we probe candidate depths and pick the one that exists on disk.
+ */
+function resolveSchemaRoot(): URL {
+  const candidates = ["../../../certification/geospatial-mcp-schemas/", "../../certification/geospatial-mcp-schemas/"];
+  for (const candidate of candidates) {
+    const url = new URL(candidate, import.meta.url);
+    if (existsSync(new URL("index.json", url))) {
+      return url;
+    }
+  }
+  // Fall back to the compiled-layout path; the loader will surface a clear
+  // ENOENT if the vendored schemas are genuinely missing.
+  return new URL(candidates[0], import.meta.url);
+}
+
+export const SCHEMA_ROOT = resolveSchemaRoot();
+
+let cachedIndex: SchemaIndex | undefined;
+const schemaCache = new Map<string, JsonSchema>();
+
+/** Load and cache the machine-readable schema index. */
+export function loadSchemaIndex(): SchemaIndex {
+  if (!cachedIndex) {
+    const indexPath = new URL("index.json", SCHEMA_ROOT);
+    cachedIndex = JSON.parse(readFileSync(indexPath, "utf8")) as SchemaIndex;
+  }
+  return cachedIndex;
+}
+
+/** Load and cache a single vendored schema by its index-relative path. */
+export function loadSchemaFile(relativePath: string): JsonSchema {
+  const cached = schemaCache.get(relativePath);
+  if (cached) {
+    return cached;
+  }
+  const path = new URL(relativePath, SCHEMA_ROOT);
+  const schema = JSON.parse(readFileSync(path, "utf8")) as JsonSchema;
+  schemaCache.set(relativePath, schema);
+  return schemaCache.get(relativePath) as JsonSchema;
+}
+
+/** Resolve the absolute on-disk path of the vendored schema root (for diagnostics). */
+export function schemaRootPath(): string {
+  return fileURLToPath(SCHEMA_ROOT);
+}
+
+/**
+ * Build a lookup from the name a tool advertises (`referenceToolName`) to its
+ * standard schema entry. Only entries that name a reference tool are included.
+ */
+export function buildReferenceToolLookup(index: SchemaIndex): Map<string, StandardToolEntry> {
+  const lookup = new Map<string, StandardToolEntry>();
+  for (const tool of index.tools) {
+    if (tool.referenceToolName) {
+      lookup.set(tool.referenceToolName, tool);
+    }
+  }
+  return lookup;
+}

--- a/mcp/test/certification/certifier.test.ts
+++ b/mcp/test/certification/certifier.test.ts
@@ -1,0 +1,211 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { certify, isReadOnlyTool } from "../../src/certification/certifier.js";
+import { createFixtureClient } from "../../src/certification/fixture-client.js";
+import { checkConformance, checkWellFormed } from "../../src/certification/json-schema.js";
+import { renderMarkdown } from "../../src/certification/report.js";
+import { runCertification, writeArtifacts } from "../../src/certification/run.js";
+import { loadSchemaFile, loadSchemaIndex } from "../../src/certification/schema-index.js";
+import { createServer } from "../../src/index.js";
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTmpDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "mcp-cert-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+describe("MCP certification harness", () => {
+  it("certifies the fixture-backed server with a PASS summary", async () => {
+    const server = createServer(createFixtureClient());
+    const report = await certify({ server, backend: "fixture" });
+
+    expect(report.summary.pass).toBe(true);
+    expect(report.summary.failures).toBe(0);
+    expect(report.summary.toolsDiscovered).toBeGreaterThan(0);
+    // Every advertised tool must expose a well-formed inputSchema.
+    expect(report.summary.toolsSchemaValid).toBe(report.summary.toolsDiscovered);
+  });
+
+  it("round-trips every read-only tool with a fixture input", async () => {
+    const server = createServer(createFixtureClient());
+    const report = await certify({ server, backend: "fixture" });
+
+    for (const tool of report.tools) {
+      if (tool.readOnly) {
+        expect(tool.roundTrip, `${tool.name} round-trip`).toBe("passed");
+      }
+      // Certification must never report a write/destructive round-trip.
+      expect(tool.roundTrip).not.toBe("failed");
+    }
+  });
+
+  it("conforms honua_query_features to the standard query_features schema", async () => {
+    const server = createServer(createFixtureClient());
+    const report = await certify({ server, backend: "fixture" });
+
+    const queryFeatures = report.tools.find((t) => t.name === "honua_query_features");
+    expect(queryFeatures).toBeDefined();
+    expect(queryFeatures?.standardName).toBe("query_features");
+    expect(queryFeatures?.conformant).toBe(true);
+  });
+
+  it("records known gaps for unimplemented standard tools without failing", async () => {
+    const server = createServer(createFixtureClient());
+    const report = await certify({ server, backend: "fixture" });
+
+    expect(report.summary.knownGaps).toBeGreaterThan(0);
+    const standardGap = report.knownGaps.find((g) => g.kind === "standard-tool" && g.name === "render_map");
+    expect(standardGap).toBeDefined();
+    // Absence of a standard tool is a recorded gap, not a failure.
+    expect(report.summary.pass).toBe(true);
+  });
+
+  it("discovers MCP resources", async () => {
+    const server = createServer(createFixtureClient());
+    const report = await certify({ server, backend: "fixture" });
+
+    expect(report.resources.length).toBeGreaterThan(0);
+    expect(report.resources.map((r) => r.uri)).toContain("honua://services");
+  });
+
+  it("writes JSON and Markdown artifacts to a stable location", async () => {
+    const dir = makeTmpDir();
+    const report = await runCertification({ forceFixture: true });
+    const paths = {
+      json: join(dir, "mcp-certification-results.json"),
+      markdown: join(dir, "mcp-certification-results.md"),
+    };
+    writeArtifacts(report, paths);
+
+    const json = JSON.parse(readFileSync(paths.json, "utf8"));
+    expect(json.schemaVersion).toBe(1);
+    expect(json.summary.pass).toBe(true);
+
+    const md = readFileSync(paths.markdown, "utf8");
+    expect(md).toContain("# MCP Certification");
+    expect(md).toContain("PASS");
+  });
+});
+
+describe("JSON Schema utilities", () => {
+  it("accepts well-formed draft-07 and draft 2020-12 schemas", () => {
+    const draft07 = { $schema: "http://json-schema.org/draft-07/schema#", type: "object" };
+    const draft2020 = loadSchemaFile("tools/query_features.schema.json");
+    expect(checkWellFormed(draft07).wellFormed).toBe(true);
+    expect(checkWellFormed(draft2020).wellFormed).toBe(true);
+  });
+
+  it("rejects a malformed schema", () => {
+    const bad = { type: 123 };
+    expect(checkWellFormed(bad).wellFormed).toBe(false);
+    expect(checkWellFormed(null).wellFormed).toBe(false);
+  });
+
+  it("flags a missing required standard property as non-conformant", () => {
+    const standard = loadSchemaFile("tools/query_features.schema.json");
+    const advertised = { type: "object", properties: { serviceId: { type: "string" } } };
+    const result = checkConformance(advertised, standard);
+    expect(result.conformant).toBe(false);
+    expect(result.violations.join(" ")).toContain("layerId");
+  });
+
+  it("treats integer as compatible with a standard number", () => {
+    const standard = { type: "object", required: ["n"], properties: { n: { type: "number" } } };
+    const advertised = { type: "object", properties: { n: { type: "integer" } } };
+    expect(checkConformance(advertised, standard).conformant).toBe(true);
+  });
+});
+
+describe("conformance edge cases", () => {
+  it("flags an incompatible required property type as non-conformant", () => {
+    const standard = { type: "object", required: ["layerId"], properties: { layerId: { type: "integer" } } };
+    const advertised = { type: "object", properties: { layerId: { type: "string" } } };
+    const result = checkConformance(advertised, standard);
+    expect(result.conformant).toBe(false);
+    expect(result.violations.join(" ")).toContain("incompatible");
+  });
+
+  it("records advertised-only properties as informational notes", () => {
+    const standard = { type: "object", required: ["a"], properties: { a: { type: "string" } } };
+    const advertised = { type: "object", properties: { a: { type: "string" }, extra: { type: "number" } } };
+    const result = checkConformance(advertised, standard);
+    expect(result.conformant).toBe(true);
+    expect(result.notes.join(" ")).toContain("extra");
+  });
+});
+
+describe("read-only classification", () => {
+  it("honors an explicit readOnlyHint annotation", () => {
+    expect(isReadOnlyTool({ name: "honua_anything", annotations: { readOnlyHint: false } })).toBe(false);
+    expect(isReadOnlyTool({ name: "honua_delete_thing", annotations: { readOnlyHint: true } })).toBe(true);
+  });
+
+  it("treats mutation-shaped names as not read-only by default", () => {
+    expect(isReadOnlyTool({ name: "honua_create_map_package" })).toBe(false);
+    expect(isReadOnlyTool({ name: "honua_query_features" })).toBe(true);
+  });
+});
+
+describe("markdown rendering", () => {
+  it("renders a FAIL report with a failures section", () => {
+    const md = renderMarkdown({
+      schemaVersion: 1,
+      generatedAt: "2026-06-21T00:00:00.000Z",
+      server: { name: "honua", version: "0.0.0" },
+      protocol: { mcpTransport: "in-memory", honuaTransport: "rest", backend: "live" },
+      standard: { source: "x", indexDate: "2026-06-21", dialect: "draft-2020-12" },
+      summary: {
+        pass: false,
+        toolsDiscovered: 1,
+        toolsSchemaValid: 0,
+        toolsConformanceChecked: 1,
+        toolsConformant: 0,
+        toolsRoundTripped: 0,
+        resourcesDiscovered: 0,
+        promptsDiscovered: 0,
+        knownGaps: 0,
+        failures: 1,
+      },
+      tools: [
+        {
+          name: "honua_bad",
+          discovered: true,
+          schemaValid: false,
+          hasOutputSchema: false,
+          standardName: "query_features",
+          conformant: false,
+          readOnly: true,
+          roundTrip: "failed",
+          errors: ["inputSchema not well-formed: boom"],
+          notes: [],
+        },
+      ],
+      resources: [],
+      prompts: [],
+      knownGaps: [],
+    });
+    expect(md).toContain("FAIL");
+    expect(md).toContain("### Failures");
+    expect(md).toContain("boom");
+    expect(md).toContain("transport: `rest`");
+  });
+});
+
+describe("vendored schema index", () => {
+  it("maps reference tool names to standard schemas", () => {
+    const index = loadSchemaIndex();
+    const queryFeatures = index.tools.find((t) => t.standardName === "query_features");
+    expect(queryFeatures?.referenceToolName).toBe("honua_query_features");
+    expect(queryFeatures?.implementationStatus).toBe("implemented");
+  });
+});

--- a/mcp/vitest.config.ts
+++ b/mcp/vitest.config.ts
@@ -8,7 +8,10 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "lcov"],
       include: ["src/**/*.ts"],
-      exclude: ["dist/**"],
+      // The certification CLI is a thin bin entry (arg parsing + process exit)
+      // exercised end-to-end by the `node dist/src/certification/cli.js` step in
+      // the `test:certification` script; its logic lives in run.ts/certifier.ts.
+      exclude: ["dist/**", "src/certification/cli.ts"],
       thresholds: {
         lines: 80,
         functions: 80,


### PR DESCRIPTION
Related to #1956

## Summary

First slice of WS-H (Provability) for epic #1948 / workstream #1956: a **deterministic MCP certification artifact** in `@honua/mcp-server` that proves Honua's MCP surface is well-formed and conformant to the open [`geospatial-mcp`](https://github.com/honua-io/geospatial-mcp) standard whose JSON Schemas were just published (geospatial-mcp #21 / commit `968d7d7`).

The harness connects an MCP client to the server over an in-memory transport, enumerates the surface, validates and conformance-checks every advertised tool, round-trips read-only tools, and emits a machine-readable JSON report plus a human-readable Markdown summary. It is **fully deterministic with zero LLM/API token spend** — pure conformance, no model calls. It gates CI (exits non-zero on non-conformance/round-trip failure).

This fills the existing honua-server CI stub `MCP Certification (${{ matrix.transport }})`, which already auto-detects and invokes `test:certification` / `test:certification:artifact` in `honua-sdk-js/mcp`. The companion `MCP LLM Smoke Tests` job (the cross-model Claude+GPT eval that **does** spend API tokens) is intentionally **deferred to a separate, gated slice** — no `test:llm-smoke` script is added here.

## Changes

- **Vendored standard schemas:** `mcp/certification/geospatial-mcp-schemas/` — verbatim copy of geospatial-mcp `spec/schemas/` (tools, resources, common, and the machine-readable `index.json`), pinned to `geospatial-mcp@968d7d7`. See `PROVENANCE.md`. Vendoring keeps certification offline and reproducible.
- **Certification harness:** `mcp/src/certification/`
  - `schema-index.ts` — loads the vendored index + schemas; maps each standard tool's `referenceToolName` → schema.
  - `json-schema.ts` — Ajv (draft 2020-12 core + registered draft-07 meta) well-formedness + a deterministic conformance comparison (every standard `required` property must be accepted with a compatible type; `integer`/`number` treated as compatible).
  - `certifier.ts` — in-memory MCP client; `tools/list` + `resources/list` + `prompts/list`; per-tool schema validity, conformance, read-only round-trip; known-gap collection; report assembly.
  - `fixture-client.ts` / `fixtures.ts` — offline `HonuaClient` + deterministic round-trip inputs.
  - `report.ts` — Markdown renderer.
  - `run.ts` / `cli.ts` — runner + bin entry; live backend when `HONUA_BASE_URL` is set, fixture otherwise.
- **npm scripts** (`mcp/package.json`): `certify`, `test:certification` (gate: harness tests + certifier), `test:certification:artifact` (evidence: always exits 0). Added `ajv` as an explicit dependency; vendored schemas added to published `files`.
- **Tests:** `mcp/test/certification/certifier.test.ts` (16 cases) — fixture PASS, read-only round-trips, query_features conformance, known gaps, artifact emission, schema/dialect/conformance edge cases, markdown rendering. CLI excluded from coverage (thin bin entry exercised end-to-end by the script).
- `.gitignore` ignores the generated `mcp-certification-results.{json,md}`.

## Artifact shape

JSON (`schemaVersion: 1`): `server`, `protocol {mcpTransport, honuaTransport, backend}`, `standard {source, indexDate, dialect}`, `summary {pass, toolsDiscovered/SchemaValid/ConformanceChecked/Conformant/RoundTripped, resources, prompts, knownGaps, failures}`, per-tool `{name, schemaValid, hasOutputSchema, standardName, conformant, readOnly, roundTrip, errors, notes}`, `resources`, `prompts`, `knownGaps`. Plus a Markdown twin. Stable paths: `mcp/mcp-certification-results.{json,md}` (what the CI `upload-artifact` step expects).

## Transports

The MCP wire is in-memory (deterministic). The CI `transport` matrix (`grpc-web`, `rest`) is the **Honua backend** transport, recorded in `protocol.honuaTransport` on the live path; the artifact name is per-transport. Offline default uses the fixture backend.

## Known gaps found (recorded, not failed)

Current run against the fixture surface: **9 tools discovered, all schema-valid, 9 round-tripped, 1 standard-matched (`honua_query_features`) conformant, 27 known gaps.** Gaps = 19 standard tools not yet advertised by `@honua/mcp-server` (e.g. `render_map`, `list_layers`, `geocode_address`, `plan_analysis`, the map/app-package families) + 8 advertised tools outside the standard (e.g. `honua_list_services`, `honua_describe_layer`, `honua_statistics`), validated for well-formedness only. No tool advertises a structured output schema yet (recorded as a note).

## How the CI stub invokes it

honua-server `.github/workflows/ci.yml` job `MCP Certification` (via `./.github/actions/setup-honua-mcp`) already:
1. detects `scripts["test:certification"]` and `scripts["test:certification:artifact"]` in `honua-sdk-js/mcp/package.json`,
2. runs `npm run test:certification` (gate) then `npm run test:certification:artifact` (`always()`),
3. uploads `honua-sdk-js/mcp/mcp-certification-results.{json,md}`.

No honua-server edit in this PR. **Cross-repo follow-up:** bump `MCP_SDK_REF` in honua-server `ci.yml` from `404242d…` to this PR's merge commit (or a tag) to activate the gate against this code.

## Testing

- `npm run typecheck`, `npm run check` (Biome), `npm run build` — green.
- `npm run test:coverage` (mcp) — 101 tests pass; coverage gates met (lines 89.2 / branches 76.8 / funcs 88.0 / stmts 88.5).
- `npm run test:certification` — PASS, exit 0, artifacts emitted.
- `npm run test:certification:artifact` — artifacts written, exit 0.

## Deferred next slice

The cross-model **Claude + GPT LLM smoke** eval (honua-server `MCP LLM Smoke Tests` job / `test:llm-smoke`) — that one **spends API tokens** and is a separate, gated slice. Not included here.